### PR TITLE
Fix bots in Oculus not using Drake Mount

### DIFF
--- a/src/strategy/dungeons/wotlk/oculus/OculusActions.cpp
+++ b/src/strategy/dungeons/wotlk/oculus/OculusActions.cpp
@@ -66,7 +66,7 @@ bool MountDrakeAction::Execute(Event event)
     for (auto& member : members)
     {
         Player* player = botAI->GetPlayer(member);
-        if (!player) { continue; }
+        if (!sPlayerbotsMgr->GetPlayerbotAI(player)) { continue; }
 
         for (int i = 0; i < composition.size(); i++)
         {

--- a/src/strategy/dungeons/wotlk/oculus/OculusActions.cpp
+++ b/src/strategy/dungeons/wotlk/oculus/OculusActions.cpp
@@ -66,7 +66,7 @@ bool MountDrakeAction::Execute(Event event)
     for (auto& member : members)
     {
         Player* player = botAI->GetPlayer(member);
-        if (!sPlayerbotsMgr->GetPlayerbotAI(player)) { continue; }
+        if (!player->GetSession()->IsBot()) { continue; }
 
         for (int i = 0; i < composition.size(); i++)
         {


### PR DESCRIPTION
## What is this change?
When doing Oculus with bots, the player is counted as a bot when assigning drakes. This results in the last bot not being assigned a drake, unless the player is the last index in the party. 

This change checks if the party member being assigned a drake is actually a player, and if so, skips them. 

## Testing
I have tested multiple LFG groups (me + 4 bots, both altbots and rndbots in different tests) and before this PR, one bot is not assigned a drake and will not function. After this pr is applied, all bots are properly assigned drakes and use them when the player does.  