### PR TITLE
Blood dk rotation update

### DIFF
--- a/src/Ai/Class/Dk/Action/DKActions.cpp
+++ b/src/Ai/Class/Dk/Action/DKActions.cpp
@@ -48,3 +48,55 @@ bool CastRaiseDeadAction::Execute(Event event)
 
     return true;
 }
+
+Unit* CastHysteriaAction::GetTarget()
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+    {
+        if (!bot->HasAura(49016))
+            return bot;
+        return nullptr;
+    }
+
+    Unit* rangedDps = nullptr;
+    Unit* tank = nullptr;
+    
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member || !member->IsAlive())
+            continue;
+
+        if (member->GetMap() != bot->GetMap() || bot->GetDistance(member) > sPlayerbotAIConfig.spellDistance)
+            continue;
+
+        // Skip if already has hysteria
+        if (member->HasAura(49016))
+            continue;
+
+        // Priority 1: Melee DPS
+        if (botAI->IsMelee(member) && botAI->IsDps(member))
+            return member;
+
+        // Priority 2: Ranged DPS (physical, not casters)
+        if (!rangedDps && botAI->IsRanged(member) && botAI->IsDps(member) && !botAI->IsCaster(member))
+            rangedDps = member;
+
+        // Priority 3: Tank
+        if (!tank && botAI->IsTank(member))
+            tank = member;
+    }
+
+    if (rangedDps)
+        return rangedDps;
+
+    if (tank)
+        return tank;
+
+    // Fallback to self if no hysteria
+    if (!bot->HasAura(49016))
+        return bot;
+
+    return nullptr;
+}

--- a/src/Ai/Class/Dk/Action/DKActions.cpp
+++ b/src/Ai/Class/Dk/Action/DKActions.cpp
@@ -61,7 +61,7 @@ Unit* CastHysteriaAction::GetTarget()
 
     Unit* rangedDps = nullptr;
     Unit* tank = nullptr;
-    
+
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
         Player* member = ref->GetSource();

--- a/src/Ai/Class/Dk/Action/DKActions.h
+++ b/src/Ai/Class/Dk/Action/DKActions.h
@@ -340,4 +340,11 @@ public:
     CastBloodTapAction(PlayerbotAI* botAI) : CastMeleeSpellAction(botAI, "blood tap") {}
 };
 
+class CastHysteriaAction : public CastSpellAction
+{
+public:
+    CastHysteriaAction(PlayerbotAI* botAI) : CastSpellAction(botAI, "hysteria") {}
+    Unit* GetTarget() override;
+};
+
 #endif

--- a/src/Ai/Class/Dk/DKAiObjectContext.cpp
+++ b/src/Ai/Class/Dk/DKAiObjectContext.cpp
@@ -209,7 +209,7 @@ public:
         creators["vampiric blood"] = &DeathKnightAiObjectContextInternal::vampiric_blood;
         creators["death pact"] = &DeathKnightAiObjectContextInternal::death_pact;
         creators["death rune_mastery"] = &DeathKnightAiObjectContextInternal::death_rune_mastery;
-        // creators["hysteria"] = &DeathKnightAiObjectContextInternal::hysteria;
+        creators["hysteria"] = &DeathKnightAiObjectContextInternal::hysteria;
         creators["dancing rune weapon"] = &DeathKnightAiObjectContextInternal::dancing_rune_weapon;
         creators["dark command"] = &DeathKnightAiObjectContextInternal::dark_command;
     }
@@ -265,7 +265,7 @@ private:
     static Action* vampiric_blood(PlayerbotAI* botAI) { return new CastVampiricBloodAction(botAI); }
     static Action* death_pact(PlayerbotAI* botAI) { return new CastDeathPactAction(botAI); }
     static Action* death_rune_mastery(PlayerbotAI* botAI) { return new CastDeathRuneMasteryAction(botAI); }
-    // static Action* hysteria(PlayerbotAI* botAI) { return new CastHysteriaAction(botAI); }
+    static Action* hysteria(PlayerbotAI* botAI) { return new CastHysteriaAction(botAI); }
     static Action* dancing_rune_weapon(PlayerbotAI* botAI) { return new CastDancingRuneWeaponAction(botAI); }
     static Action* dark_command(PlayerbotAI* botAI) { return new CastDarkCommandAction(botAI); }
     static Action* mind_freeze_on_enemy_healer(PlayerbotAI* botAI)

--- a/src/Ai/Class/Dk/DKAiObjectContext.cpp
+++ b/src/Ai/Class/Dk/DKAiObjectContext.cpp
@@ -100,6 +100,7 @@ public:
         creators["dd cd and no desolation"] = &DeathKnightTriggerFactoryInternal::dd_cd_and_no_desolation;
         creators["death and decay cooldown"] = &DeathKnightTriggerFactoryInternal::death_and_decay_cooldown;
         creators["army of the dead"] = &DeathKnightTriggerFactoryInternal::army_of_the_dead;
+        creators["hysteria no cd"] = &DeathKnightTriggerFactoryInternal::hysteria_no_cd;
     }
 
 private:
@@ -152,6 +153,7 @@ private:
     }
     static Trigger* death_and_decay_cooldown(PlayerbotAI* botAI) { return new DeathAndDecayCooldownTrigger(botAI); }
     static Trigger* army_of_the_dead(PlayerbotAI* botAI) { return new ArmyOfTheDeadTrigger(botAI); }
+    static Trigger* hysteria_no_cd(PlayerbotAI* botAI) { return new HysteriaNoCooldownTrigger(botAI); }
 };
 
 class DeathKnightAiObjectContextInternal : public NamedObjectContext<Action>

--- a/src/Ai/Class/Dk/Strategy/BloodDKStrategy.cpp
+++ b/src/Ai/Class/Dk/Strategy/BloodDKStrategy.cpp
@@ -91,7 +91,6 @@ BloodDKStrategy::BloodDKStrategy(PlayerbotAI* botAI) : GenericDKStrategy(botAI)
 std::vector<NextAction> BloodDKStrategy::getDefaultActions()
 {
     return {
-        NextAction("hysteria", ACTION_DEFAULT + 0.7f),
         NextAction("rune strike", ACTION_DEFAULT + 0.6f),
         NextAction("icy touch", ACTION_DEFAULT + 0.5f),
         NextAction("heart strike", ACTION_DEFAULT + 0.4f),
@@ -106,6 +105,14 @@ void BloodDKStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
     GenericDKStrategy::InitTriggers(triggers);
 
+    triggers.push_back(
+        new TriggerNode(
+            "hysteria no cd",
+            {
+                NextAction("hysteria", ACTION_NORMAL + 4)
+            }
+        )
+    );
     triggers.push_back(
         new TriggerNode(
             "rune strike",

--- a/src/Ai/Class/Dk/Strategy/BloodDKStrategy.cpp
+++ b/src/Ai/Class/Dk/Strategy/BloodDKStrategy.cpp
@@ -91,6 +91,7 @@ BloodDKStrategy::BloodDKStrategy(PlayerbotAI* botAI) : GenericDKStrategy(botAI)
 std::vector<NextAction> BloodDKStrategy::getDefaultActions()
 {
     return {
+        NextAction("hysteria", ACTION_DEFAULT + 0.7f),
         NextAction("rune strike", ACTION_DEFAULT + 0.6f),
         NextAction("icy touch", ACTION_DEFAULT + 0.5f),
         NextAction("heart strike", ACTION_DEFAULT + 0.4f),

--- a/src/Ai/Class/Dk/Strategy/BloodDKStrategy.cpp
+++ b/src/Ai/Class/Dk/Strategy/BloodDKStrategy.cpp
@@ -91,8 +91,9 @@ BloodDKStrategy::BloodDKStrategy(PlayerbotAI* botAI) : GenericDKStrategy(botAI)
 std::vector<NextAction> BloodDKStrategy::getDefaultActions()
 {
     return {
-        NextAction("rune strike", ACTION_DEFAULT + 0.5f),
-        NextAction("icy touch", ACTION_DEFAULT + 0.4f),
+        NextAction("rune strike", ACTION_DEFAULT + 0.6f),
+        NextAction("icy touch", ACTION_DEFAULT + 0.5f),
+        NextAction("heart strike", ACTION_DEFAULT + 0.4f),
         NextAction("dancing rune weapon", ACTION_DEFAULT + 0.3f),
         NextAction("death coil", ACTION_DEFAULT + 0.2f),
         NextAction("horn of winter", ACTION_DEFAULT + 0.1f),
@@ -158,14 +159,6 @@ void BloodDKStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
             "plague strike",
             {
                 NextAction("plague strike", ACTION_HIGH + 2)
-            }
-        )
-    );
-    triggers.push_back(
-        new TriggerNode(
-            "high blood rune",
-            {
-                NextAction("heart strike", ACTION_HIGH + 1)
             }
         )
     );

--- a/src/Ai/Class/Dk/Strategy/BloodDKStrategy.cpp
+++ b/src/Ai/Class/Dk/Strategy/BloodDKStrategy.cpp
@@ -50,7 +50,9 @@ private:
             {
                 NextAction("frost presence")
             },
-            /*A*/ {},
+            /*A*/ {
+                NextAction("blood strike")
+            },
             /*C*/ {}
         );
     }
@@ -89,13 +91,10 @@ BloodDKStrategy::BloodDKStrategy(PlayerbotAI* botAI) : GenericDKStrategy(botAI)
 std::vector<NextAction> BloodDKStrategy::getDefaultActions()
 {
     return {
-        NextAction("rune strike", ACTION_DEFAULT + 0.8f),
-        NextAction("icy touch", ACTION_DEFAULT + 0.7f),
-        NextAction("heart strike", ACTION_DEFAULT + 0.6f),
-        NextAction("blood strike", ACTION_DEFAULT + 0.5f),
-        NextAction("dancing rune weapon", ACTION_DEFAULT + 0.4f),
-        NextAction("death coil", ACTION_DEFAULT + 0.3f),
-        NextAction("plague strike", ACTION_DEFAULT + 0.2f),
+        NextAction("rune strike", ACTION_DEFAULT + 0.5f),
+        NextAction("icy touch", ACTION_DEFAULT + 0.4f),
+        NextAction("dancing rune weapon", ACTION_DEFAULT + 0.3f),
+        NextAction("death coil", ACTION_DEFAULT + 0.2f),
         NextAction("horn of winter", ACTION_DEFAULT + 0.1f),
         NextAction("melee", ACTION_DEFAULT)
     };
@@ -159,6 +158,22 @@ void BloodDKStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
             "plague strike",
             {
                 NextAction("plague strike", ACTION_HIGH + 2)
+            }
+        )
+    );
+    triggers.push_back(
+        new TriggerNode(
+            "high blood rune",
+            {
+                NextAction("heart strike", ACTION_HIGH + 1)
+            }
+        )
+    );
+    triggers.push_back(
+        new TriggerNode(
+            "high unholy rune",
+            {
+                NextAction("death strike", ACTION_HIGH + 1)
             }
         )
     );

--- a/src/Ai/Class/Dk/Strategy/FrostDKStrategy.cpp
+++ b/src/Ai/Class/Dk/Strategy/FrostDKStrategy.cpp
@@ -91,7 +91,6 @@ std::vector<NextAction> FrostDKStrategy::getDefaultActions()
     return {
         NextAction("obliterate", ACTION_DEFAULT + 0.7f),
         NextAction("frost strike", ACTION_DEFAULT + 0.4f),
-        NextAction("empower rune weapon", ACTION_DEFAULT + 0.3f),
         NextAction("horn of winter", ACTION_DEFAULT + 0.1f),
         NextAction("melee", ACTION_DEFAULT)
     };

--- a/src/Ai/Class/Dk/Strategy/GenericDKNonCombatStrategy.cpp
+++ b/src/Ai/Class/Dk/Strategy/GenericDKNonCombatStrategy.cpp
@@ -42,15 +42,9 @@ void GenericDKNonCombatStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
     NonCombatStrategy::InitTriggers(triggers);
 
     triggers.push_back(
-        new TriggerNode("no pet", { NextAction("raise dead", ACTION_NORMAL + 1) }));
-    triggers.push_back(
         new TriggerNode("horn of winter", { NextAction("horn of winter", 21.0f) }));
     triggers.push_back(
         new TriggerNode("bone shield", { NextAction("bone shield", 21.0f) }));
-    triggers.push_back(
-        new TriggerNode("has pet", { NextAction("toggle pet spell", 60.0f) }));
-    triggers.push_back(
-        new TriggerNode("new pet", { NextAction("set pet stance", 60.0f) }));
 }
 
 void DKBuffDpsStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)

--- a/src/Ai/Class/Dk/Strategy/GenericDKStrategy.cpp
+++ b/src/Ai/Class/Dk/Strategy/GenericDKStrategy.cpp
@@ -185,4 +185,11 @@ void GenericDKStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
                                                         NextAction("blood boil", ACTION_NORMAL + 3) }));
     triggers.push_back(
         new TriggerNode("pestilence glyph", { NextAction("pestilence", ACTION_HIGH + 9) }));
+    triggers.push_back(
+        new TriggerNode("no rune",
+            {
+                NextAction("empower rune weapon", ACTION_HIGH + 1)
+            }
+        )
+    );
 }

--- a/src/Ai/Class/Dk/Strategy/GenericDKStrategy.cpp
+++ b/src/Ai/Class/Dk/Strategy/GenericDKStrategy.cpp
@@ -166,12 +166,6 @@ void GenericDKStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     MeleeCombatStrategy::InitTriggers(triggers);
 
     triggers.push_back(
-        new TriggerNode("no pet", { NextAction("raise dead", ACTION_NORMAL + 5) }));
-    triggers.push_back(
-        new TriggerNode("has pet", { NextAction("toggle pet spell", 60.0f) }));
-    triggers.push_back(
-        new TriggerNode("new pet", { NextAction("set pet stance", 60.0f) }));
-    triggers.push_back(
         new TriggerNode("mind freeze", { NextAction("mind freeze", ACTION_HIGH + 1) }));
     triggers.push_back(
         new TriggerNode("mind freeze on enemy healer",
@@ -179,7 +173,8 @@ void GenericDKStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(new TriggerNode(
         "horn of winter", { NextAction("horn of winter", ACTION_NORMAL + 1) }));
     triggers.push_back(new TriggerNode("critical health",
-                                       { NextAction("death pact", ACTION_HIGH + 5) }));
+                                       { NextAction("raise dead", ACTION_HIGH + 6),
+                                         NextAction("death pact", ACTION_HIGH + 5) }));
 
     triggers.push_back(
         new TriggerNode("low health", { NextAction("icebound fortitude", ACTION_HIGH + 5),

--- a/src/Ai/Class/Dk/Strategy/UnholyDKStrategy.cpp
+++ b/src/Ai/Class/Dk/Strategy/UnholyDKStrategy.cpp
@@ -88,6 +88,13 @@ void UnholyDKStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     GenericDKStrategy::InitTriggers(triggers);
 
     triggers.push_back(
+        new TriggerNode("no pet", { NextAction("raise dead", ACTION_NORMAL + 5) }));
+    triggers.push_back(
+        new TriggerNode("has pet", { NextAction("toggle pet spell", 60.0f) }));
+    triggers.push_back(
+        new TriggerNode("new pet", { NextAction("set pet stance", 60.0f) }));
+
+    triggers.push_back(
         new TriggerNode(
             "death and decay cooldown",
             {

--- a/src/Ai/Class/Dk/Strategy/UnholyDKStrategy.cpp
+++ b/src/Ai/Class/Dk/Strategy/UnholyDKStrategy.cpp
@@ -154,13 +154,6 @@ void UnholyDKStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
         )
     );
     triggers.push_back(
-        new TriggerNode("no rune",
-            {
-                NextAction("empower rune weapon", ACTION_HIGH + 1)
-            }
-        )
-    );
-    triggers.push_back(
         new TriggerNode(
             "army of the dead",
             {

--- a/src/Ai/Class/Dk/Trigger/DKTriggers.h
+++ b/src/Ai/Class/Dk/Trigger/DKTriggers.h
@@ -198,4 +198,10 @@ public:
     ArmyOfTheDeadTrigger(PlayerbotAI* botAI) : BoostTrigger(botAI, "army of the dead") {}
 };
 
+class HysteriaNoCooldownTrigger : public SpellNoCooldownTrigger
+{
+public:
+    HysteriaNoCooldownTrigger(PlayerbotAI* botAI) : SpellNoCooldownTrigger(botAI, "hysteria") {}
+};
+
 #endif


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
Improve the blood DK rotation, add hysteria use, improve blood pact use. Basic Blood priority should be:
1. Keep diseases up
2. Use rune strike whenever possible
3. Use frost and death runes on Icy Touch (highest threat ability)
4. Use unholy runes on death strike to trigger more death runes
5. use blood runes on heart/blood strike

Hysteria should be used on a physical dps, or a tank if no physical dps is available. Never a caster or healer.
Summon ghoul should be saved for death pact usage. They are honestly a liability that aggros everything in range without the unholy talent that turns them into a pet anyways.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
Removed plague strike from the general rotation. It should only be used for disease application.
Added death strike on "high unholy rune" trigger instead.
Remove raise dead from generic dk. Only cast it right before death pact.
Add hysteria to bloods default actions.
- Describe the **processing cost** when this logic executes across many bots.
Minimal change



## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

To test rotation changes:
Use a combat parsing addon such as Details! or watch the combat log of a Blood DK bot.
They should now use death strike instead of using unholy runes on plague strike.

To test hysteria:
Ungrouped blood dk bots can be observed using it on themselves.
Create a group with the blood dk + casters/healers only. Observe that they never use hysteria on the casters.
Create a group with blood dk + physical dps. Observe that they use hysteria on a dps and not themselves.

To test blood pact:
I used GM command .damage to get my Blood DK bot into "critical health" trigger. They will use raise dead then blood pact.

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## Messages to Translate
<!--
Bot messages have to be translatable, but you don't need to do the translations here. You only need to make sure
the message is in a translatable format, and list in the table the message_key and the default English message.
Search for GetBotTextOrDefault in the codebase for examples.
-->
Does this change add bot messages to translate?
    - - [x] No
    - - [ ] Yes (**list messages in the table**)

| Message key  | Default message |
| --------------- | ------------------ |
|			 |			      |
|			 |			      |

## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
    - - [ ] No
    - - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->
Used for brainstorming and exploring the codebase to find similar patterns.


## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->
