### PR TITLE
Add EnableAutoTradeOnItemMention config option

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -2092,6 +2092,14 @@ AiPlayerbot.CommandPrefix = ""
 # Separator for bot chat commands
 AiPlayerbot.CommandSeparator = "\\\\"
 
+# Enable automatic item count/trade trigger when a chat message contains
+# item-related keywords. When enabled (1), mentioning items in chat
+# (e.g. "food", "potion", "ammo") will automatically show inventory and
+# open a trade window with the bot. Explicit "c" and "t" commands still
+# work regardless of this setting.
+# Default: 1 (enabled)
+AiPlayerbot.EnableAutoTradeOnItemMention = 1
+
 # Enable bots talking (say / yell / general chatting / lfg)
 AiPlayerbot.RandomBotTalk = 1
 # Enable bots emoting

--- a/src/Bot/Engine/ExternalEventHelper.cpp
+++ b/src/Bot/Engine/ExternalEventHelper.cpp
@@ -33,8 +33,11 @@ bool ExternalEventHelper::ParseChatCommand(std::string const command, Player* ow
     if (!ChatHelper::parseableItem(command))
         return false;
 
-    HandleCommand("c", command, owner);
-    HandleCommand("t", command, owner);
+    if (sPlayerbotAIConfig.enableAutoTradeOnItemMention)
+    {
+        HandleCommand("c", command, owner);
+        HandleCommand("t", command, owner);
+    }
 
     return true;
 }

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -517,6 +517,7 @@ bool PlayerbotAIConfig::Initialize()
 
     LoadListString<std::vector<std::string>>(sConfigMgr->GetOption<std::string>("AiPlayerbot.AllowedLogFiles", ""),
                                              allowedLogFiles);
+    enableAutoTradeOnItemMention = sConfigMgr->GetOption<bool>("AiPlayerbot.EnableAutoTradeOnItemMention", true);
     LoadListString<std::vector<std::string>>(sConfigMgr->GetOption<std::string>("AiPlayerbot.TradeActionExcludedPrefixes", ""),
                                              tradeActionExcludedPrefixes);
 

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -304,6 +304,7 @@ public:
     uint32 iterationsPerTick;
 
     std::mutex m_logMtx;
+    bool enableAutoTradeOnItemMention;
     std::vector<std::string> tradeActionExcludedPrefixes;
     std::vector<std::string> allowedLogFiles;
     std::unordered_map<std::string, std::pair<FILE*, bool>> logFiles;


### PR DESCRIPTION
## Pull Request Description
This PR adds a config parameter `AiPlayerbot.EnableAutoTradeOnItemMention` that controls whether trade dialogues and inventory listings will be triggered for messages that contain keywords anywhere in their text (for example "got some food?"). The default value is `1/true`, so for existing installs there will be no change.

This is useful for other mods that could utilise game chats for other purposes, specifically my [mod-playerbots-characters](https://github.com/deseven/mod-playerbots-characters) and @DustinHendrickson 's [mod-ollama-chat](https://github.com/DustinHendrickson/mod-ollama-chat). Individual users might also benefit from the ability to disable this functionality.



## Feature Evaluation
N/A



## How to Test the Changes
1. Start the server with default config and join the game.
2. Get into a party with one or more bots.
3. Write `got some food?` to the party chat.
4. A trade dialogue along with the whispers from the bots should pop up.
5. Stop the server, change `AiPlayerbot.EnableAutoTradeOnItemMention` to `0`.
6. Start the server, join the game.
7. Get into a party with one or more bots.
8. Write `got some food?` to the party chat.
9. Nothing should happen.

> [!NOTE]
> In both cases the commands `t something` and `c something` should still work. 

## Impact Assessment
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
Was AI assistance used while working on this change?
- - [x] No
- - [ ] Yes (**explain below**)



## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
N/A