### PR TITLE
Respect worldserver's PreventAFKLogout value

### DIFF
--- a/src/Bot/PlayerbotMgr.cpp
+++ b/src/Bot/PlayerbotMgr.cpp
@@ -1570,6 +1570,24 @@ void PlayerbotMgr::HandleMasterIncomingPacket(WorldPacket const& packet)
         // if master is logging out, log out all bots
         case CMSG_LOGOUT_REQUEST:
         {
+            Player* master = GetMaster();
+            if (master)
+            {
+                // Replicate the AFK logout prevention checks from WorldSession::HandleLogoutRequestOpcode
+                // so bots are not logged out when the master's own logout is going to be prevented.
+                AreaTableEntry const* areaEntry = sAreaTableStore.LookupEntry(master->GetAreaId());
+                bool preventAfkSanctuaryLogout = sWorld->getIntConfig(CONFIG_AFK_PREVENT_LOGOUT) == 1
+                                                 && master->isAFK() && areaEntry && areaEntry->IsSanctuary();
+
+                bool preventAfkLogout = sWorld->getIntConfig(CONFIG_AFK_PREVENT_LOGOUT) == 2
+                                        && master->isAFK();
+
+                if (preventAfkSanctuaryLogout || preventAfkLogout)
+                {
+                    break;
+                }
+            }
+
             LogoutAllBots();
             break;
         }


### PR DESCRIPTION
## Pull Request Description
This adds checks to prevent bots from logging out when the master isn't actually logging out, respecting the `PreventAFKLogout` setting in `worldserver.conf`. Otherwise, returning to the game after a long pause means your bots are offline and you have to re-add them, which is annoying.



## Feature Evaluation
N/A



## How to Test the Changes
1. Set `PreventAFKLogout` to 1 or 2 in `worldserver.conf`.
2. Start the server, log in, add some bots to your party.
3. Go to a sanctuary if you set `PreventAFKLogout` to 1 or just start idling anywhere otherwise.
4. Both you and the bots will stay in-game no matter how much time has passed.



## Impact Assessment
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
Researching the issue and determining what checks need to be implemented.



## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
N/A