### PR TITLE
Exclude Invalid Weapons from Shaman Enchants & Refactor Temporary Enchant Spellcasting

### DIFF
--- a/src/Ai/Base/Actions/GenericSpellActions.cpp
+++ b/src/Ai/Base/Actions/GenericSpellActions.cpp
@@ -17,7 +17,7 @@
 #include "WorldPacket.h"
 #include "Group.h"
 #include "Chat.h"
-#include "Ai/Base/Util/GenericBuffUtils.h"
+#include "GenericBuffUtils.h"
 #include "PlayerbotAI.h"
 
 using ai::buff::MakeAuraQualifierForBuff;
@@ -134,7 +134,8 @@ bool CastSpellAction::isPossible()
     return botAI->CanCastSpell(spell, GetTarget());
 }
 
-CastMeleeSpellAction::CastMeleeSpellAction(PlayerbotAI* botAI, std::string const spell) : CastSpellAction(botAI, spell)
+CastMeleeSpellAction::CastMeleeSpellAction(
+    PlayerbotAI* botAI, std::string const spell) : CastSpellAction(botAI, spell)
 {
     range = ATTACK_DISTANCE;
 }
@@ -182,56 +183,47 @@ bool CastAuraSpellAction::isUseful()
     return false;
 }
 
-CastEnchantItemAction::CastEnchantItemAction(PlayerbotAI* botAI, std::string const spell)
-    : CastSpellAction(botAI, spell)
+CastEnchantItemMainHandAction::CastEnchantItemMainHandAction(
+    PlayerbotAI* botAI, std::string const spell) : CastSpellAction(botAI, spell) {}
+
+bool CastEnchantItemMainHandAction::Execute(Event /*event*/)
 {
-    range = botAI->GetRange("spell");
+    Item* item = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+    return item && botAI->CastSpell(spell, bot, item);
 }
-
-bool CastEnchantItemAction::isPossible()
-{
-    // if (!CastSpellAction::isPossible())
-    // {
-    //     botAI->TellMasterNoFacing("Impossible: " + spell);
-    //     return false;
-    // }
-
-    uint32 spellId = AI_VALUE2(uint32, "spell id", spell);
-
-    // bool ok = AI_VALUE2(Item*, "item for spell", spellId);
-    // Item* item = AI_VALUE2(Item*, "item for spell", spellId);
-    // botAI->TellMasterNoFacing("spell: " + spell + ", spell id: " + std::to_string(spellId) + " item for spell: " +
-    // std::to_string(ok));
-    return spellId && AI_VALUE2(Item*, "item for spell", spellId);
-}
-
-CastEnchantItemMainHandAction::CastEnchantItemMainHandAction(PlayerbotAI* botAI, std::string const spell)
-    : CastEnchantItemAction(botAI, spell) {}
 
 bool CastEnchantItemMainHandAction::isPossible()
 {
-    if (!CastEnchantItemAction::isPossible())
-        return false;
-
     Item* item = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
-    return item && !item->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) &&
-           item->GetTemplate()->Class == ITEM_CLASS_WEAPON;
+    if (!item || item->GetTemplate()->SubClass == ITEM_SUBCLASS_WEAPON_MISC ||
+        item->GetTemplate()->SubClass == ITEM_SUBCLASS_WEAPON_FISHING_POLE ||
+        item->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT))
+    {
+        return false;
+    }
+
+    return botAI->CanCastSpell(spell, bot, item);
 }
 
-CastEnchantItemOffHandAction::CastEnchantItemOffHandAction(PlayerbotAI* botAI, std::string const spell)
-    : CastEnchantItemAction(botAI, spell) {}
+CastEnchantItemOffHandAction::CastEnchantItemOffHandAction(
+    PlayerbotAI* botAI, std::string const spell) : CastSpellAction(botAI, spell) {}
+
+bool CastEnchantItemOffHandAction::Execute(Event /*event*/)
+{
+    Item* item = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
+    return item && botAI->CastSpell(spell, bot, item);
+}
 
 bool CastEnchantItemOffHandAction::isPossible()
 {
-    if (!CastEnchantItemAction::isPossible())
-        return false;
-
     Item* item = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
-    if (!item || item->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT))
+    if (!item || item->GetTemplate()->SubClass == ITEM_SUBCLASS_WEAPON_MISC ||
+        item->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT))
+    {
         return false;
+    }
 
-    uint32 invType = item->GetTemplate()->InventoryType;
-    return invType == INVTYPE_WEAPON || invType == INVTYPE_WEAPONOFFHAND;
+    return botAI->CanCastSpell(spell, bot, item);
 }
 
 CastHealingSpellAction::CastHealingSpellAction(PlayerbotAI* botAI, std::string const spell, uint8 estAmount,
@@ -245,7 +237,8 @@ bool CastHealingSpellAction::isUseful() { return CastAuraSpellAction::isUseful()
 
 bool CastAoeHealSpellAction::isUseful() { return CastSpellAction::isUseful(); }
 
-CastCureSpellAction::CastCureSpellAction(PlayerbotAI* botAI, std::string const spell) : CastSpellAction(botAI, spell)
+CastCureSpellAction::CastCureSpellAction(
+    PlayerbotAI* botAI, std::string const spell) : CastSpellAction(botAI, spell)
 {
     range = botAI->GetRange("heal");
 }
@@ -267,13 +260,15 @@ bool BuffOnPartyAction::Execute(Event /*event*/)
     std::string castName = spell; // default = mono
 
     auto SendGroupRP = ai::chat::MakeGroupAnnouncer(bot);
-    castName = ai::buff::UpgradeToGroupIfAppropriate(bot, botAI, castName, /*announceOnMissing=*/true, SendGroupRP);
+    castName = ai::buff::UpgradeToGroupIfAppropriate(
+        bot, botAI, castName, /*announceOnMissing=*/true, SendGroupRP);
 
     return botAI->CastSpell(castName, GetTarget());
 }
 // End greater buff fix
 
-CastShootAction::CastShootAction(PlayerbotAI* botAI) : CastSpellAction(botAI, "shoot"), shootSpellId(0)
+CastShootAction::CastShootAction(
+    PlayerbotAI* botAI) : CastSpellAction(botAI, "shoot"), shootSpellId(0)
 {
     if (Item* const pItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_RANGED))
     {
@@ -327,7 +322,8 @@ Value<Unit*>* CastDebuffSpellOnMeleeAttackerAction::GetTargetValue()
     return context->GetValue<Unit*>("melee attacker without aura", spell);
 }
 
-CastBuffSpellAction::CastBuffSpellAction(PlayerbotAI* botAI, std::string const spell, bool checkIsOwner, uint32 beforeDuration)
+CastBuffSpellAction::CastBuffSpellAction(
+    PlayerbotAI* botAI, std::string const spell, bool checkIsOwner, uint32 beforeDuration)
     : CastAuraSpellAction(botAI, spell, checkIsOwner, false, beforeDuration)
 {
     range = botAI->GetRange("spell");
@@ -448,7 +444,8 @@ bool UseTrinketAction::UseTrinket(Item* item)
     uint32 spellId = 0;
     for (uint8 i = 0; i < MAX_ITEM_PROTO_SPELLS; ++i)
     {
-        if (item->GetTemplate()->Spells[i].SpellId > 0 && item->GetTemplate()->Spells[i].SpellTrigger == ITEM_SPELLTRIGGER_ON_USE)
+        if (item->GetTemplate()->Spells[i].SpellId > 0 &&
+            item->GetTemplate()->Spells[i].SpellTrigger == ITEM_SPELLTRIGGER_ON_USE)
         {
             spellId = item->GetTemplate()->Spells[i].SpellId;
             const SpellInfo* spellInfo = sSpellMgr->GetSpellInfo(spellId);

--- a/src/Ai/Base/Actions/GenericSpellActions.h
+++ b/src/Ai/Base/Actions/GenericSpellActions.h
@@ -121,26 +121,21 @@ public:
     std::string const GetTargetName() override { return "self target"; }
 };
 
-class CastEnchantItemAction : public CastSpellAction
-{
-public:
-    CastEnchantItemAction(PlayerbotAI* botAI, std::string const spell);
-
-    bool isPossible() override;
-    std::string const GetTargetName() override { return "self target"; }
-};
-
-class CastEnchantItemMainHandAction : public CastEnchantItemAction
+class CastEnchantItemMainHandAction : public CastSpellAction
 {
 public:
     CastEnchantItemMainHandAction(PlayerbotAI* botAI, std::string const spell);
+    std::string const GetTargetName() override { return "self target"; }
+    bool Execute(Event event) override;
     bool isPossible() override;
 };
 
-class CastEnchantItemOffHandAction : public CastEnchantItemAction
+class CastEnchantItemOffHandAction : public CastSpellAction
 {
 public:
     CastEnchantItemOffHandAction(PlayerbotAI* botAI, std::string const spell);
+    std::string const GetTargetName() override { return "self target"; }
+    bool Execute(Event event) override;
     bool isPossible() override;
 };
 


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
Fix for issue #2343 

I excluded the MISC and FISHING POLE weapon subclasses from weapon enchants. MISC includes the entry profession "weapons" (skinning knife, mining pick, blacksmithing hammer, arclight spanner) and some other crap that I suspect is not enchantable, but even if it is there's no good reason to do so (like Brewfest steins). The subclass doesn't include weapons that can be used for professions but you might actually want to use for fighting (like Finkle's Skinner).

To clean things up overall, I removed the intermediate class CastEnchantItemAction between CastSpellAction and CastEnchantItemMainHandAction and CastEnchantItemOffHandAction. CastEnchantItemAction is not doing anything helpful that can't easily be replicated in the MH/OH classes, and I can't think of any future reason for keeping CastEnchantItemAction. I also brought the CanCastSpell check into the MH/OH classes--previously it just wasn't run for the weapon enchant spells, and I can't think of any good reason why it shouldn't be.

I also added Execute functions to both CastEnchantItemMainHandAction and CastEnchantItemOffHandAction so they actually directly cast the enchant on the specified hand instead of running through CastSpellAction's Execute (and thus going through item for spell). I wasn't having problems with the wrong hand being applied under the prior approach, but this is a more direct and better approach anyway.

Other changes are just formatting.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

The new path is very similar to the old one but just adds a check that is common to all spells and early returns to avoid invalid results.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

1. Log into a Shaman and activate selfbot
2. Check to make sure the correct enchantments are applied (e.g., MH Windfury and OH Flametongue for a dual-wielding Enhancement Shaman)
3. Equip a profession weapon such as a skinning knife and make sure the Shaman does not attempt to enchant it

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

This just stops Shamans from trying to enchant stuff that they can't.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

I kicked around some ideas with GPT-5.4 with respect to the refactoring aspect of the PR after I had fixed the bug.
<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


