### PR TITLE
Flying mount fixes and self-bot

### DIFF
--- a/src/Ai/Base/Actions/CheckMountStateAction.cpp
+++ b/src/Ai/Base/Actions/CheckMountStateAction.cpp
@@ -16,7 +16,6 @@
 #include "ServerFacade.h"
 #include "SpellAuraEffects.h"
 
-// Cold Weather Flying — required to fly anywhere on the Northrend continent.
 static constexpr uint32 SPELL_COLD_WEATHER_FLYING = 54197;
 
 // Define the static map / init bool for caching bot preferred mount data globally
@@ -467,8 +466,6 @@ bool CheckMountStateAction::ShouldDismountForMaster(Player* master) const
 
 static bool BotCanUseFlyingMount(Player const* bot)
 {
-    // Cheap eligibility: without Expert Riding or higher, no flight spell
-    // could be cast anyway. Lets us skip the DBC lookup for low-level bots.
     if (bot->GetPureSkillValue(SKILL_RIDING) < 225)
         return false;
 
@@ -499,7 +496,6 @@ int32 CheckMountStateAction::CalculateMasterMountSpeed(Player* master, const Mou
 
     if (!noRealMaster && !bot->InBattleground())
     {
-        // Following a real master — mirror their current mount or shapeshift.
         auto auraEffects = master->GetAuraEffectsByType(SPELL_AURA_MOUNTED);
         if (!auraEffects.empty())
         {
@@ -512,7 +508,7 @@ int32 CheckMountStateAction::CalculateMasterMountSpeed(Player* master, const Mou
             return 279;
         else if (masterInShapeshiftForm == FORM_FLIGHT)
             return 149;
-        return 59;  // master not currently mounted/formed → walk pace
+        return 59;  // walk pace
     }
 
     // No real master OR battleground: pick speed by skill tier.
@@ -530,11 +526,7 @@ uint32 CheckMountStateAction::GetMountType(Player* master) const
     bool const noRealMaster = (!master || master == bot);
 
     if (noRealMaster)
-    {
-        // Same map+skill check CalculateMasterMountSpeed uses — keeps
-        // type/speed consistent so the mount filter finds a matching spell.
         return (!bot->InBattleground() && BotCanUseFlyingMount(bot)) ? 1 : 0;
-    }
 
     auto auraEffects = master->GetAuraEffectsByType(SPELL_AURA_MOUNTED);
     if (!auraEffects.empty())

--- a/src/Ai/Base/Actions/CheckMountStateAction.cpp
+++ b/src/Ai/Base/Actions/CheckMountStateAction.cpp
@@ -4,15 +4,20 @@
  */
 
 #include "CheckMountStateAction.h"
+#include "AreaDefines.h"
 #include "BattleGroundTactics.h"
 #include "BattlegroundEY.h"
 #include "BattlegroundWS.h"
+#include "DBCStores.h"
 #include "Event.h"
 #include "PlayerbotAI.h"
 #include "PlayerbotAIConfig.h"
 #include "Playerbots.h"
 #include "ServerFacade.h"
 #include "SpellAuraEffects.h"
+
+// Cold Weather Flying — required to fly anywhere on the Northrend continent.
+static constexpr uint32 SPELL_COLD_WEATHER_FLYING = 54197;
 
 // Define the static map / init bool for caching bot preferred mount data globally
 std::unordered_map<uint32, PreferredMountCache> CheckMountStateAction::mountCache;
@@ -94,9 +99,10 @@ bool CheckMountStateAction::Execute(Event /*event*/)
     }
 
     bool inBattleground = bot->InBattleground();
+    bool const noRealMaster = (!master || master == bot);
 
     // If there is a master and bot not in BG, follow master's mount state regardless of group leader
-    if (master && !inBattleground)
+    if (!noRealMaster && !inBattleground)
     {
         if (ShouldFollowMasterMountState(master, noAttackers, shouldMount))
             return Mount();
@@ -110,8 +116,8 @@ bool CheckMountStateAction::Execute(Event /*event*/)
         return false;
     }
 
-    // If there is no master or bot in BG
-    if ((!master || inBattleground) && !bot->IsMounted() &&
+    // No real master (random bot or self-bot) OR bot in BG
+    if ((noRealMaster || inBattleground) && !bot->IsMounted() &&
         noAttackers && shouldMount && !bot->IsInCombat())
         return Mount();
 
@@ -228,6 +234,25 @@ void CheckMountStateAction::Dismount()
 
     WorldPacket emptyPacket;
     bot->GetSession()->HandleCancelMountAuraOpcode(emptyPacket);
+
+    float const x = bot->GetPositionX();
+    float const y = bot->GetPositionY();
+    float const startZ = bot->GetPositionZ();
+    float groundZ = startZ;
+    bot->UpdateAllowedPositionZ(x, y, groundZ);
+    float const fallHeight = startZ - groundZ;
+
+    //quick snap to the ground without animation
+    if (fallHeight < 1.0f)
+    {
+        bot->UpdatePosition(x, y, groundZ, bot->GetOrientation(), false);
+        return;
+    }
+
+    bot->GetMotionMaster()->MoveFall();
+    MovementInfo fallInfo = bot->m_movementInfo;
+    fallInfo.pos.Relocate(x, y, groundZ);
+    bot->HandleFall(fallInfo);
 }
 
 bool CheckMountStateAction::TryForms(Player* master, int32 masterMountType, int32 masterSpeed) const
@@ -434,6 +459,26 @@ bool CheckMountStateAction::ShouldDismountForMaster(Player* master) const
     return !isMasterMounted && bot->IsMounted();
 }
 
+static bool BotCanUseFlyingMount(Player const* bot)
+{
+    // Cheap eligibility: without Expert Riding or higher, no flight spell
+    // could be cast anyway. Lets us skip the DBC lookup for low-level bots.
+    if (bot->GetPureSkillValue(SKILL_RIDING) < 225)
+        return false;
+
+    AreaTableEntry const* area = sAreaTableStore.LookupEntry(bot->GetAreaId());
+    if (!area || !area->IsFlyable())
+        return false;
+    if (area->flags & AREA_FLAG_NO_FLY_ZONE)
+        return false;
+
+    uint32 const vmap = GetVirtualMapForMapAndZone(bot->GetMapId(), bot->GetZoneId());
+    if (vmap == MAP_NORTHREND && !bot->HasSpell(SPELL_COLD_WEATHER_FLYING))
+        return false;
+
+    return true;
+}
+
 int32 CheckMountStateAction::CalculateMasterMountSpeed(Player* master, const MountData& mountData) const
 {
     // Check riding skill and level requirements
@@ -443,9 +488,12 @@ int32 CheckMountStateAction::CalculateMasterMountSpeed(Player* master, const Mou
     if (ridingSkill <= 75 && botLevel < static_cast<int32>(sPlayerbotAIConfig.useFastGroundMountAtMinLevel))
         return 59;
 
-    // If there is a master and bot not in BG, use master's aura effects.
-    if (master && !bot->InBattleground())
+    // check if bot has master and if master is self
+    bool const noRealMaster = (!master || master == bot);
+
+    if (!noRealMaster && !bot->InBattleground())
     {
+        // Following a real master — mirror their current mount or shapeshift.
         auto auraEffects = master->GetAuraEffectsByType(SPELL_AURA_MOUNTED);
         if (!auraEffects.empty())
         {
@@ -458,27 +506,31 @@ int32 CheckMountStateAction::CalculateMasterMountSpeed(Player* master, const Mou
             return 279;
         else if (masterInShapeshiftForm == FORM_FLIGHT)
             return 149;
-    }
-    else
-    {
-        // Bots on their own.
-        int32 speed = mountData.maxSpeed;
-        if (bot->InBattleground() && speed > 99)
-            return 99;
-
-        return speed;
+        return 59;  // master not currently mounted/formed → walk pace
     }
 
-    return 59;
+    // No real master OR battleground: pick speed by skill tier.
+    if (!bot->InBattleground() && BotCanUseFlyingMount(bot))
+        return (ridingSkill >= 300) ? 279 : 149;
+
+    int32 maxGround = (ridingSkill >= 150) ? 99 : 59;
+    if (bot->InBattleground() && maxGround > 99)
+        maxGround = 99;
+    return maxGround;
 }
 
 uint32 CheckMountStateAction::GetMountType(Player* master) const
 {
-    if (!master)
-        return 0;
+    bool const noRealMaster = (!master || master == bot);
+
+    if (noRealMaster)
+    {
+        // Same map+skill check CalculateMasterMountSpeed uses — keeps
+        // type/speed consistent so the mount filter finds a matching spell.
+        return (!bot->InBattleground() && BotCanUseFlyingMount(bot)) ? 1 : 0;
+    }
 
     auto auraEffects = master->GetAuraEffectsByType(SPELL_AURA_MOUNTED);
-
     if (!auraEffects.empty())
     {
         SpellInfo const* masterSpell = auraEffects.front()->GetSpellInfo();

--- a/src/Ai/Base/Actions/CheckMountStateAction.cpp
+++ b/src/Ai/Base/Actions/CheckMountStateAction.cpp
@@ -234,6 +234,12 @@ void CheckMountStateAction::Dismount()
 
     WorldPacket emptyPacket;
     bot->GetSession()->HandleCancelMountAuraOpcode(emptyPacket);
+}
+
+void CheckMountStateAction::CompleteDismountFall(Player* bot)
+{
+    if (!bot || !bot->IsInWorld())
+        return;
 
     float const x = bot->GetPositionX();
     float const y = bot->GetPositionY();

--- a/src/Ai/Base/Actions/CheckMountStateAction.cpp
+++ b/src/Ai/Base/Actions/CheckMountStateAction.cpp
@@ -254,11 +254,15 @@ void CheckMountStateAction::CompleteDismount(Player* bot)
 
     float const x = bot->GetPositionX();
     float const y = bot->GetPositionY();
-    float groundZ = bot->GetPositionZ();
+    float const startZ = bot->GetPositionZ();
+
+    float groundZ = startZ;
     bot->UpdateAllowedPositionZ(x, y, groundZ);
 
     bot->GetMotionMaster()->MoveFall();
     MovementInfo fallInfo = bot->m_movementInfo;
+    // Need to set the start of the fall, otherwise the fall may start from too high of a Z and kill the bot.
+    bot->SetFallInformation(0, startZ);
     fallInfo.pos.Relocate(x, y, groundZ);
     bot->HandleFall(fallInfo);
     bot->RemoveUnitMovementFlag(MOVEMENTFLAG_FALLING | MOVEMENTFLAG_FALLING_FAR);

--- a/src/Ai/Base/Actions/CheckMountStateAction.cpp
+++ b/src/Ai/Base/Actions/CheckMountStateAction.cpp
@@ -247,7 +247,7 @@ void CheckMountStateAction::Dismount()
     }
 }
 
-void CheckMountStateAction::CompleteDismountFall(Player* bot)
+void CheckMountStateAction::CompleteDismount(Player* bot)
 {
     if (!bot || !bot->IsInWorld())
         return;

--- a/src/Ai/Base/Actions/CheckMountStateAction.cpp
+++ b/src/Ai/Base/Actions/CheckMountStateAction.cpp
@@ -233,6 +233,18 @@ void CheckMountStateAction::Dismount()
 
     WorldPacket emptyPacket;
     bot->GetSession()->HandleCancelMountAuraOpcode(emptyPacket);
+
+    bool const wantsFly = bot->HasIncreaseMountedFlightSpeedAura() || bot->HasFlyAura();
+    bool const isWaterWalking = bot->HasUnitMovementFlag(MOVEMENTFLAG_WATERWALKING);
+    bool const isFlying = bot->HasUnitMovementFlag(MOVEMENTFLAG_FLYING);
+    bool const hasGravityDisabled = bot->HasUnitMovementFlag(MOVEMENTFLAG_DISABLE_GRAVITY);
+    if (!wantsFly && !isWaterWalking && (isFlying || hasGravityDisabled))
+    {
+        bot->RemoveUnitMovementFlag(
+            MOVEMENTFLAG_FLYING | MOVEMENTFLAG_CAN_FLY | MOVEMENTFLAG_DISABLE_GRAVITY);
+        if (!bot->IsRooted())
+            bot->SendMovementFlagUpdate();
+    }
 }
 
 void CheckMountStateAction::CompleteDismountFall(Player* bot)
@@ -242,22 +254,14 @@ void CheckMountStateAction::CompleteDismountFall(Player* bot)
 
     float const x = bot->GetPositionX();
     float const y = bot->GetPositionY();
-    float const startZ = bot->GetPositionZ();
-    float groundZ = startZ;
+    float groundZ = bot->GetPositionZ();
     bot->UpdateAllowedPositionZ(x, y, groundZ);
-    float const fallHeight = startZ - groundZ;
-
-    //quick snap to the ground without animation
-    if (fallHeight < 1.0f)
-    {
-        bot->UpdatePosition(x, y, groundZ, bot->GetOrientation(), false);
-        return;
-    }
 
     bot->GetMotionMaster()->MoveFall();
     MovementInfo fallInfo = bot->m_movementInfo;
     fallInfo.pos.Relocate(x, y, groundZ);
     bot->HandleFall(fallInfo);
+    bot->RemoveUnitMovementFlag(MOVEMENTFLAG_FALLING | MOVEMENTFLAG_FALLING_FAR);
 }
 
 bool CheckMountStateAction::TryForms(Player* master, int32 masterMountType, int32 masterSpeed) const

--- a/src/Ai/Base/Actions/CheckMountStateAction.h
+++ b/src/Ai/Base/Actions/CheckMountStateAction.h
@@ -42,6 +42,8 @@ public:
     bool isPossible() override { return true; }
     bool Mount();
 
+    static void CompleteDismountFall(Player* bot);
+
 private:
     Player* master;
     ShapeshiftForm masterInShapeshiftForm;

--- a/src/Ai/Base/Actions/CheckMountStateAction.h
+++ b/src/Ai/Base/Actions/CheckMountStateAction.h
@@ -42,7 +42,7 @@ public:
     bool isPossible() override { return true; }
     bool Mount();
 
-    static void CompleteDismountFall(Player* bot);
+    static void CompleteDismount(Player* bot);
 
 private:
     Player* master;

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -1373,7 +1373,7 @@ void PlayerbotAI::HandleBotOutgoingPacket(WorldPacket const& packet)
             p >> guid.ReadAsPacked();
             if (guid != bot->GetGUID())
                 return;
-            CheckMountStateAction::CompleteDismountFall(bot);
+            CheckMountStateAction::CompleteDismount(bot);
             return;
         }
         default:

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -15,6 +15,7 @@
 #include "ChannelMgr.h"
 #include "CharacterPackets.h"
 #include "ChatHelper.h"
+#include "CheckMountStateAction.h"
 #include "Common.h"
 #include "CreatureData.h"
 #include "EmoteAction.h"
@@ -1362,6 +1363,17 @@ void PlayerbotAI::HandleBotOutgoingPacket(WorldPacket const& packet)
             // bot->Heart();
 
             // */
+            return;
+        }
+        case SMSG_DISMOUNT:
+        {
+            WorldPacket p(packet);
+            p.rpos(0);
+            ObjectGuid guid;
+            p >> guid.ReadAsPacked();
+            if (guid != bot->GetGUID())
+                return;
+            CheckMountStateAction::CompleteDismountFall(bot);
             return;
         }
         default:


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
This PR does a few things.
1. Enable Selfbots to mount up. Because they have masters, but are their own masters, they would never mount up because their master never mounted. 
2. Fix flag state handling after processing the aura change. 
3. Add in the Dismount packet handler. This is intended to implement fall animations and have bots touch the ground when dismounting instead of floating off the ground. (It was cleared anyway after the first move, but this should make it more seamless.)



## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.



## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
self bot should mount up, and select area appropriate mounts. 

Bots in your team should mount up, and on your dismount properly snap to the ground. 

should test at low Z (<1.0 off the ground) and higher z (> 1.0 off the ground)




## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)
The processing of a fall path has some impact, but I dont think itll be too much. 


- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)
Add natural falling when dismounting. May incurr fall damange.... 


- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->
Comparison of code bases, searching for flags, adding diagnostic logging, and processing of said logging. 
iterating and brainstorming. 
Code was also written, but fully reviewed by me, and fixed where appropriate. 


<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


