### PR TITLE
feat(RPG/Crafting): Add profession crafting flow

### DIFF
--- a/CRAFTING_RPG_FLOW.md
+++ b/CRAFTING_RPG_FLOW.md
@@ -1,0 +1,103 @@
+# Crafting RPG flow
+
+This file visualizes the currently live crafting-related behavior in `mod-playerbots`.
+
+It covers two connected systems:
+
+- **Public crafting reply flow**: a player asks in `General` or `Trade` for a crafted item and one eligible bot whispers back.
+- **New RPG crafting flow**: random bots can now enter a dedicated `RPG_DO_CRAFT` state and perform profession work on their own.
+
+## Mermaid overview
+
+```mermaid
+flowchart TB
+    subgraph CHAT[Public crafting request flow]
+        C1[Player posts linked item in General or Trade] --> C2[Chat hook receives channel message]
+        C2 --> C3[RandomPlayerbotMgr HandleCommand]
+        C3 --> C4{Crafting replies enabled}
+        C4 -- no --> C99[Normal chat handling]
+        C4 -- yes --> C5{Message contains linked item plus craft or make keyword}
+        C5 -- no --> C99
+        C5 -- yes --> C6[Scan online random bots in same channel]
+        C6 --> C7[Reject bots outside resolved General or Trade source]
+        C7 --> C8[Evaluate recipes professions and skill requirements]
+        C8 --> C9[Compute owned and missing reagents]
+        C9 --> C10[Choose one best-fit bot]
+        C10 --> C11{Cooldown active for player and item}
+        C11 -- yes --> C98[Suppress duplicate whisper]
+        C11 -- no --> C12[Format reply with fee and mats status]
+        C12 --> C13[Bot whispers player]
+        C13 --> C14[Update crafting reply cooldown]
+        C5 --> C15[Generic chatter path sees valid craft request]
+        C15 --> C16[Suppress normal social reply]
+    end
+
+    subgraph RPG[New RPG crafting flow]
+        R1[New RPG status update] --> R2{Current status is idle}
+        R2 -- yes --> R3[Evaluate available statuses]
+        R3 --> R4[Check DoCraft availability]
+        R4 --> R5{Has recipe item craftable spell enchant target or disenchant target}
+        R5 -- no --> R6[Do not include DoCraft]
+        R5 -- yes --> R7[Add RPG_DO_CRAFT candidate]
+        R7 --> R8[Apply RpgStatusProbWeight.DoCraft]
+        R8 --> R9{DoCraft selected}
+        R9 -- yes --> R10[ChangeToDoCraft]
+        R10 --> R11[Run new rpg do craft action]
+
+        R11 --> R12{Quest giver accept or reward needed}
+        R12 -- yes --> R13[Do quest interaction first]
+        R12 -- no --> R14{Bot is moving}
+        R14 -- yes --> R15[Wait until stationary]
+        R14 -- no --> R16[Try use random recipe]
+        R16 --> R17{Recipe learned}
+        R17 -- yes --> R11
+        R17 -- no --> R18[Try craft random item]
+        R18 --> R19{Craft succeeded}
+        R19 -- yes --> R20[Increment crafted count]
+        R20 --> R11
+        R19 -- no --> R21[Try enchant random item]
+        R21 --> R22{Enchant succeeded}
+        R22 -- yes --> R20
+        R22 -- no --> R23[Try disenchant random item]
+        R23 --> R24{Disenchant succeeded}
+        R24 -- yes --> R20
+        R24 -- no --> R25[No useful crafting work left]
+        R25 --> R26[Change status to idle]
+    end
+
+    subgraph SHARED[Shared craft evaluation]
+        S1[SetCraftAction helpers]
+        S2[Recipe profession and skill validation]
+        S3[Reagent owned and missing calculation]
+        S4[Formatted crafting reply text]
+    end
+
+    C8 --> S1 --> S2 --> S3 --> S4
+    R5 --> S2
+
+    subgraph NOTES[Important behavior]
+        N1[Legacy Rpg craft remains legacy and separate]
+        N2[New RPG DoCraft is now live]
+        N3[Public chat reply crafting is also live]
+        N4[One best-fit bot replies in chat path]
+        N5[DoCraft exits back to idle when no work remains or timeout expires]
+    end
+
+    C13 --> N3
+    R26 --> N2
+    C10 --> N4
+    R25 --> N5
+    N1 -.-> R11
+```
+
+## Reading guide
+
+- The **left side** shows the player-facing service flow.
+- The **right side** shows the autonomous bot-side crafting loop in the new RPG system.
+- The **shared block** highlights the common validation logic reused by the chat crafting features.
+
+## Config knobs
+
+- `AiPlayerbot.EnableCraftingReplies`
+- `AiPlayerbot.CraftingReplyCooldown`
+- `AiPlayerbot.RpgStatusProbWeight.DoCraft`

--- a/RPG_FLOWS.md
+++ b/RPG_FLOWS.md
@@ -1,0 +1,239 @@
+# mod-playerbots RPG flows and interactions
+
+This file documents the currently wired RPG behavior in `mod-playerbots`, including:
+
+- legacy `rpg`
+- `new rpg`
+- shared systems such as travel, combat, and loot
+- legacy side branches that exist in code but are not fully wired into `RpgStrategy`
+
+## Full Mermaid map
+
+```mermaid
+flowchart TB
+    subgraph ACT[Activation and engine setup]
+        A1[Random bot non combat engine init] --> A2[Always add grind strategy for free random leader bots]
+        A2 --> A3{Enable new rpg strategy}
+        A3 -- yes --> A4[Add new rpg strategy]
+        A3 -- no and auto do quests --> A5[Add legacy rpg strategy]
+        A3 -- no and no auto quest --> A6[Fallback to move random]
+        A7[Full reset] --> A8[Clear rpg target loot target ignore rpg target travel target and rpg info]
+    end
+
+    subgraph SH[Shared systems]
+        S1[Travel target system]
+        S2[Grind target value]
+        S3[Combat attack and pull systems]
+        S4[Available loot stack]
+        S5[Loot target value]
+        S6[Loot actions]
+        S7[Possible target values for npc go and friendly player]
+        S8[Quest vendor trainer taxi and gossip systems]
+    end
+
+    subgraph LEG[Legacy rpg flow]
+        L1[Default action rpg] --> L2{Has rpg target}
+        L2 -- no --> L3[Choose rpg target trigger]
+        L3 --> L4[Scan possible rpg targets nearby game objects and friendly players]
+        L4 --> L5[Drop ignored invalid and unfollowable targets]
+        L5 --> L6[Evaluate trigger relevance for each candidate]
+        L6 --> L7[Weighted pick best target]
+        L7 --> L8[Store rpg target]
+
+        L2 -- yes --> L9{Far from target}
+        L9 -- yes --> L10[Move to rpg target]
+        L10 --> L11[Move near npc go or player]
+        L11 --> L12{Move failed or target invalid}
+        L12 -- yes --> L13[Add target to ignore list and clear rpg target]
+        L12 -- no --> L14[Stay with target]
+
+        L9 -- no --> L15[Rpg dispatcher]
+        L15 --> L16[Scan supported strategies containing rpg]
+        L16 --> L17[Collect active rpg enabled actions]
+        L17 --> L18[Weighted pick next sub action]
+        L18 --> L19[Set next rpg action]
+        L19 --> L20[Rpg action multiplier suppresses other rpg actions]
+
+        L20 --> L21{Near target action family}
+        L21 --> L22[Rpg stay]
+        L21 --> L23[Rpg work]
+        L21 --> L24[Rpg emote]
+        L21 --> L25[Rpg cancel]
+        L21 --> L26[Rpg discover]
+        L21 --> L27[Rpg start quest]
+        L21 --> L28[Rpg end quest]
+        L21 --> L29[Rpg buy]
+        L21 --> L30[Rpg repair]
+        L21 --> L31[Rpg heal]
+        L21 --> L32[Rpg home bind]
+        L21 --> L33[Rpg buy petition]
+        L21 --> L34[Rpg use]
+
+        L22 --> L40[Idle at target]
+        L23 --> L41[Use standing work emote]
+        L24 --> L42[Gossip hello and random emote]
+        L25 --> L43[Clear rpg target]
+        L26 --> L44[Learn taxi node]
+        L27 --> L45[Accept all quests]
+        L28 --> L46[Talk to quest giver and complete quest]
+        L29 --> L47[Vendor flow]
+        L30 --> L48[Repair flow]
+        L31 --> L49[Class heal on party]
+        L32 --> L50[Bind home]
+        L33 --> L51[Buy guild petition]
+        L34 --> L52[Use game object]
+
+        L40 --> L60[After execute keep facing target and set rpg delay]
+        L41 --> L60
+        L42 --> L60
+        L44 --> L60
+        L45 --> L60
+        L46 --> L60
+        L47 --> L60
+        L48 --> L60
+        L49 --> L60
+        L50 --> L60
+        L51 --> L60
+        L52 --> L60
+        L43 --> L61[Back to target selection]
+        L60 --> L15
+    end
+
+    subgraph LEGX[Legacy side branches not fully wired]
+        LX1[Rpg queue bg exists]
+        LX2[Rpg spell exists]
+        LX3[Rpg craft exists]
+        LX4[Rpg trade useful exists]
+        LX5[Rpg duel exists]
+        LX6[Rpg mount anim exists]
+        LX7[Rpg mount anim comes from emote strategy often]
+        LX8[These branches exist in code but are not wired in the main legacy rpg strategy]
+        LX1 -.-> LX8
+        LX2 -.-> LX8
+        LX3 -.-> LX8
+        LX4 -.-> LX8
+        LX5 -.-> LX8
+        LX6 -.-> LX7
+    end
+
+    subgraph NEW[New rpg flow]
+        N1[Default action new rpg status update] --> N2{Current rpg info status}
+        N2 -- idle --> N3[Random change status]
+        N3 --> N4[Filter by availability]
+        N4 --> N5[Weight by config]
+        N5 --> N6{Choose status}
+
+        N6 --> N7[Go grind]
+        N6 --> N8[Go camp]
+        N6 --> N9[Wander random]
+        N6 --> N10[Wander npc]
+        N6 --> N11[Do quest]
+        N6 --> N12[Travel flight]
+        N6 --> N13[Farming]
+        N6 --> N14[Rest]
+        N6 --> N15[Outdoor pvp]
+
+        N7 --> N20[Store grind position]
+        N8 --> N21[Store camp position]
+        N9 --> N22[Enter random wander]
+        N10 --> N23[Enter npc wander]
+        N11 --> N24[Store selected quest state]
+        N12 --> N25[Store flight master and path]
+        N13 --> N26[Store farming position and gather state]
+        N14 --> N27[Sit and idle]
+        N15 --> N28[Store outdoor pvp objective state]
+
+        N20 --> NT1[Go grind status action]
+        N21 --> NT2[Go camp status action]
+        N22 --> NT3[Wander random status action]
+        N23 --> NT4[Wander npc status action]
+        N24 --> NT5[Do quest status action]
+        N25 --> NT6[Travel flight status action]
+        N26 --> NT7[Farming status action]
+        N28 --> NT8[Outdoor pvp status action]
+
+        NT1 --> NA1[Quest giver check then move far to grind spot]
+        NT2 --> NA2[Quest giver check then move far to camp]
+        NT3 --> NA3[Move random near]
+        NT4 --> NA4[Choose npc or go move interact and linger]
+        NT5 --> NA5[Quest giver pass choose poi move and rely on normal combat and loot]
+        NT6 --> NA6[Move to flight master activate taxi and wait for landing]
+        NT7 --> NA7{Tracked gather node}
+        NT8 --> NA8[Choose and patrol outdoor pvp capture point]
+
+        NA7 -- yes --> NA9[Queue node into available loot and loot target]
+        NA9 --> NA10[Move to node if needed]
+        NA10 --> NA11[Normal loot and gather pipeline handles interaction]
+        NA7 -- no --> NA12{Gather search delay elapsed}
+        NA12 -- yes --> NA13[Find nearby gathering target]
+        NA13 --> NA14[Prefer reachable herb ore skinning and cloth opportunities]
+        NA14 --> NA9
+        NA12 -- no --> NA15[Stay near farming area and move far or move random near]
+
+        N2 -- go grind --> NX1{Reached grind spot}
+        NX1 -- yes --> N22
+        N2 -- go camp --> NX2{Reached camp}
+        NX2 -- yes --> N23
+        N2 -- wander random --> NX3{Expired}
+        NX3 -- yes --> N16[Set status to idle]
+        N2 -- wander npc --> NX4{Expired}
+        NX4 -- yes --> N16
+        N2 -- do quest --> NX5{Done timeout or abandon}
+        NX5 -- yes --> N16
+        N2 -- travel flight --> NX6{Flight finished}
+        NX6 -- yes --> N16
+        N2 -- farming --> NX7{Expired}
+        NX7 -- yes --> N16
+        N2 -- rest --> NX8{Expired}
+        NX8 -- yes --> N16
+        N2 -- outdoor pvp --> NX9{No valid objective or invalid zone}
+        NX9 -- yes --> N16
+        N16 --> N1
+    end
+
+    subgraph X[Cross system interactions]
+        X1[Choosing a new travel target clears rpg target and pull target]
+        X2[Travel work state may set rpg target to a nearby friendly or neutral unit]
+        X3[Legacy rpg end quest may stay relevant when target entry matches travel target entry]
+        X4[New rpg quest and farming reuse normal combat and loot execution]
+        X5[Grind target value is farming aware in farming status]
+        X6[Farming combat priority becomes skinnable mobs first and cloth humanoids second]
+    end
+
+    L4 --> S7
+    L27 --> S8
+    L28 --> S8
+    L29 --> S8
+    L30 --> S8
+    L32 --> S8
+    L33 --> S8
+    L34 --> S8
+    N25 --> S8
+    NA5 --> S2
+    NA9 --> S4
+    NA9 --> S5
+    NA11 --> S6
+    NA8 --> S1
+    N13 --> X5 --> X6 --> S2
+    S2 --> S3 --> S4
+
+    S1 --> X1
+    S1 --> X2
+    X2 --> L8
+    X1 --> L43
+    X3 --> L28
+    X4 --> S2
+    X4 --> S4
+    X4 --> S5
+    X4 --> S6
+
+    A4 --> N1
+    A5 --> L1
+```
+
+## Notes
+
+- The **legacy `rpg`** system is target-centric: choose a target, move to it, then choose a target-specific RPG sub-action.
+- The **`new rpg`** system is state-centric: choose a state, store state in `rpgInfo`, then run the action attached to that state.
+- `RPG_FARMING` is distinct from legacy grind logic, but it still reuses shared combat and loot systems.
+- Several legacy RPG actions exist in code but are **not currently wired into `RpgStrategy::InitTriggers`**.

--- a/RPG_FLOWS.md
+++ b/RPG_FLOWS.md
@@ -4,6 +4,7 @@ This file documents the currently wired RPG behavior in `mod-playerbots`, includ
 
 - legacy `rpg`
 - `new rpg`
+- public crafting request replies in chat
 - shared systems such as travel, combat, and loot
 - legacy side branches that exist in code but are not fully wired into `RpgStrategy`
 
@@ -29,6 +30,7 @@ flowchart TB
         S6[Loot actions]
         S7[Possible target values for npc go and friendly player]
         S8[Quest vendor trainer taxi and gossip systems]
+        S9[Chat routing and reply systems]
     end
 
     subgraph LEG[Legacy rpg flow]
@@ -116,6 +118,28 @@ flowchart TB
         LX6 -.-> LX7
     end
 
+    subgraph PUB[Public crafting request flow]
+        P1[Player posts linked item request in General or Trade] --> P2[Playerbots chat hook receives channel message]
+        P2 --> P3[Pass channel name to RandomPlayerbotMgr HandleCommand]
+        P3 --> P4{Crafting replies enabled}
+        P4 -- no --> P99[Fall back to normal channel handling]
+        P4 -- yes --> P5{Message contains linked item and craft or make keyword}
+        P5 -- no --> P99
+        P5 -- yes --> P6[Iterate online random bots in same channel]
+        P6 --> P7[Reject bots not resolved to General or Trade reply source]
+        P7 --> P8[Build craft reply data from learned recipes and supported professions]
+        P8 --> P9[Validate profession recipe and required skill]
+        P9 --> P10[Calculate required available and missing reagents]
+        P10 --> P11[Pick one best-fit bot]
+        P11 --> P12{Per player and item cooldown active}
+        P12 -- yes --> P98[Suppress duplicate whisper]
+        P12 -- no --> P13[Format reply with profession skill fee and mats status]
+        P13 --> P14[Selected bot whispers player]
+        P14 --> P15[Update last said chat cooldown]
+        P5 --> P16[Generic chat reply path notices craft request]
+        P16 --> P17[Suppress normal social chatter for valid craft requests]
+    end
+
     subgraph NEW[New rpg flow]
         N1[Default action new rpg status update] --> N2{Current rpg info status}
         N2 -- idle --> N3[Random change status]
@@ -132,6 +156,7 @@ flowchart TB
         N6 --> N13[Farming]
         N6 --> N14[Rest]
         N6 --> N15[Outdoor pvp]
+        N6 --> N17[Do craft]
 
         N7 --> N20[Store grind position]
         N8 --> N21[Store camp position]
@@ -142,6 +167,7 @@ flowchart TB
         N13 --> N26[Store farming position and gather state]
         N14 --> N27[Sit and idle]
         N15 --> N28[Store outdoor pvp objective state]
+        N17 --> N29[Store craft work state]
 
         N20 --> NT1[Go grind status action]
         N21 --> NT2[Go camp status action]
@@ -151,6 +177,7 @@ flowchart TB
         N25 --> NT6[Travel flight status action]
         N26 --> NT7[Farming status action]
         N28 --> NT8[Outdoor pvp status action]
+        N29 --> NT9[Do craft status action]
 
         NT1 --> NA1[Quest giver check then move far to grind spot]
         NT2 --> NA2[Quest giver check then move far to camp]
@@ -160,6 +187,7 @@ flowchart TB
         NT6 --> NA6[Move to flight master activate taxi and wait for landing]
         NT7 --> NA7{Tracked gather node}
         NT8 --> NA8[Choose and patrol outdoor pvp capture point]
+        NT9 --> NA16[Learn random recipe then craft enchant or disenchant if useful]
 
         NA7 -- yes --> NA9[Queue node into available loot and loot target]
         NA9 --> NA10[Move to node if needed]
@@ -188,6 +216,8 @@ flowchart TB
         NX8 -- yes --> N16
         N2 -- outdoor pvp --> NX9{No valid objective or invalid zone}
         NX9 -- yes --> N16
+        N2 -- do craft --> NX10{No craft work left or expired}
+        NX10 -- yes --> N16
         N16 --> N1
     end
 
@@ -198,6 +228,7 @@ flowchart TB
         X4[New rpg quest and farming reuse normal combat and loot execution]
         X5[Grind target value is farming aware in farming status]
         X6[Farming combat priority becomes skinnable mobs first and cloth humanoids second]
+        X7[Legacy Rpg craft is still unwired but new rpg do craft and public crafting replies are live]
     end
 
     L4 --> S7
@@ -208,6 +239,8 @@ flowchart TB
     L32 --> S8
     L33 --> S8
     L34 --> S8
+    P2 --> S9
+    P8 --> S9
     N25 --> S8
     NA5 --> S2
     NA9 --> S4
@@ -226,6 +259,8 @@ flowchart TB
     X4 --> S4
     X4 --> S5
     X4 --> S6
+    LX3 --> X7
+    X7 --> P3
 
     A4 --> N1
     A5 --> L1
@@ -235,5 +270,9 @@ flowchart TB
 
 - The **legacy `rpg`** system is target-centric: choose a target, move to it, then choose a target-specific RPG sub-action.
 - The **`new rpg`** system is state-centric: choose a state, store state in `rpgInfo`, then run the action attached to that state.
+- The **public crafting reply** system is chat-centric: a player posts a linked item request in General or Trade, `RandomPlayerbotMgr` evaluates online bots, then exactly one best-fit crafter whispers back.
 - `RPG_FARMING` is distinct from legacy grind logic, but it still reuses shared combat and loot systems.
-- Several legacy RPG actions exist in code but are **not currently wired into `RpgStrategy::InitTriggers`**.
+- Public crafting replies are gated by `AiPlayerbot.EnableCraftingReplies` and rate-limited by `AiPlayerbot.CraftingReplyCooldown`.
+- `SetCraftAction` is now shared infrastructure: it still powers direct craft setup, but it also parses public craft requests, validates recipes and profession skill, and formats the reply text.
+- `ChatReplyAction` suppresses generic chatter on valid craft requests so the public whisper path does not compete with normal social replies.
+- Several legacy RPG actions exist in code but are **not currently wired into `RpgStrategy::InitTriggers`**. That still includes legacy `Rpg craft`, which is separate from the live public crafting-request reply path.

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1070,6 +1070,7 @@ AiPlayerbot.RpgStatusProbWeight.WanderNpc = 20
 AiPlayerbot.RpgStatusProbWeight.GoGrind = 15
 AiPlayerbot.RpgStatusProbWeight.GoCamp = 10
 AiPlayerbot.RpgStatusProbWeight.DoQuest = 60
+AiPlayerbot.RpgStatusProbWeight.DoCraft = 10
 AiPlayerbot.RpgStatusProbWeight.TravelFlight = 15
 AiPlayerbot.RpgStatusProbWeight.Rest = 5
 AiPlayerbot.RpgStatusProbWeight.OutdoorPvp = 10

--- a/src/Ai/Base/ActionContext.h
+++ b/src/Ai/Base/ActionContext.h
@@ -273,6 +273,7 @@ public:
         creators["new rpg wander random"] = &ActionContext::new_rpg_wander_random;
         creators["new rpg wander npc"] = &ActionContext::new_rpg_wander_npc;
         creators["new rpg do quest"] = &ActionContext::new_rpg_do_quest;
+        creators["new rpg do craft"] = &ActionContext::new_rpg_do_craft;
         creators["new rpg travel flight"] = &ActionContext::new_rpg_travel_flight;
         creators["new rpg outdoor pvp"] = &ActionContext::new_rpg_outdoor_pvp;
         creators["wait for attack keep safe distance"] = &ActionContext::wait_for_attack_keep_safe_distance;
@@ -478,6 +479,7 @@ private:
     static Action* new_rpg_wander_random(PlayerbotAI* ai) { return new NewRpgWanderRandomAction(ai); }
     static Action* new_rpg_wander_npc(PlayerbotAI* ai) { return new NewRpgWanderNpcAction(ai); }
     static Action* new_rpg_do_quest(PlayerbotAI* ai) { return new NewRpgDoQuestAction(ai); }
+    static Action* new_rpg_do_craft(PlayerbotAI* ai) { return new NewRpgDoCraftAction(ai); }
     static Action* new_rpg_travel_flight(PlayerbotAI* ai) { return new NewRpgTravelFlightAction(ai); }
     static Action* new_rpg_outdoor_pvp(PlayerbotAI* ai) { return new NewRpgOutdoorPvpAction(ai); }
     static Action* wait_for_attack_keep_safe_distance(PlayerbotAI* ai) { return new WaitForAttackKeepSafeDistanceAction(ai); }

--- a/src/Ai/Base/Actions/SayAction.cpp
+++ b/src/Ai/Base/Actions/SayAction.cpp
@@ -5,6 +5,7 @@
 
 #include "AiFactory.h"
 #include "SayAction.h"
+#include "SetCraftAction.h"
 
 #include <regex>
 #include <string>
@@ -201,6 +202,13 @@ void ChatReplyAction::ChatReplyDo(Player* bot, uint32& type, uint32& guid1, std:
         return;
     }
 
+    if ((chatChannelSource == ChatChannelSource::SRC_GENERAL ||
+         chatChannelSource == ChatChannelSource::SRC_TRADE) &&
+        HandleCraftRequestMessage(msg))
+    {
+        return;
+    }
+
     //toxic links
     if (msg.starts_with(sPlayerbotAIConfig.toxicLinksPrefix)
         && (GET_PLAYERBOT_AI(bot)->GetChatHelper()->ExtractAllItemIds(msg).size() > 0 || GET_PLAYERBOT_AI(bot)->GetChatHelper()->ExtractAllQuestIds(msg).size() > 0))
@@ -218,6 +226,12 @@ void ChatReplyAction::ChatReplyDo(Player* bot, uint32& type, uint32& guid1, std:
 
     auto messageRepy = GenerateReplyMessage(bot, msg, guid1, name);
     SendGeneralResponse(bot, chatChannelSource, messageRepy, name);
+}
+
+bool ChatReplyAction::HandleCraftRequestMessage(std::string const& msg)
+{
+    std::set<uint32> itemIds;
+    return SetCraftAction::ParseCraftRequest(msg, itemIds);
 }
 
 bool ChatReplyAction::HandleThunderfuryReply(Player* bot, ChatChannelSource chatChannelSource)

--- a/src/Ai/Base/Actions/SayAction.h
+++ b/src/Ai/Base/Actions/SayAction.h
@@ -37,6 +37,7 @@ public:
     static bool HandleToxicLinksReply(Player* bot, ChatChannelSource chatChannelSource);
     static bool HandleWTBItemsReply(Player* bot, ChatChannelSource chatChannelSource, std::string& msg, std::string& name);
     static bool HandleLFGQuestsReply(Player* bot, ChatChannelSource chatChannelSource, std::string& msg, std::string& name);
+    static bool HandleCraftRequestMessage(std::string const& msg);
     static bool SendGeneralResponse(Player* bot, ChatChannelSource chatChannelSource, std::string& responseMessage, std::string& name);
     static std::string GenerateReplyMessage(Player* bot, std::string& incomingMessage, uint32& guid1, std::string& name);
 };

--- a/src/Ai/Base/Actions/SetCraftAction.cpp
+++ b/src/Ai/Base/Actions/SetCraftAction.cpp
@@ -5,12 +5,73 @@
 
 #include "SetCraftAction.h"
 
+#include <algorithm>
+#include <cctype>
+
 #include "ChatHelper.h"
 #include "CraftValue.h"
 #include "Event.h"
+#include "PlayerbotSpellRepository.h"
 #include "Playerbots.h"
 
-std::map<uint32, SkillLineAbilityEntry const*> SetCraftAction::skillSpells;
+namespace
+{
+std::string ToLower(std::string const& text)
+{
+    std::string lower = text;
+    std::transform(lower.begin(), lower.end(), lower.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    return lower;
+}
+
+bool IsBetterCraftReplyData(SetCraftAction::CraftReplyData const& candidate,
+                            SetCraftAction::CraftReplyData const& current)
+{
+    if (current.IsEmpty())
+        return true;
+
+    if (candidate.HasAllReagents() != current.HasAllReagents())
+        return candidate.HasAllReagents();
+
+    if (candidate.GetTotalMissingCount() != current.GetTotalMissingCount())
+        return candidate.GetTotalMissingCount() < current.GetTotalMissingCount();
+
+    if (candidate.skillValue != current.skillValue)
+        return candidate.skillValue > current.skillValue;
+
+    if (candidate.requiredSkillValue != current.requiredSkillValue)
+        return candidate.requiredSkillValue < current.requiredSkillValue;
+
+    return candidate.spellId < current.spellId;
+}
+
+void AppendFormattedItems(PlayerbotAI* botAI, std::ostringstream& out,
+                          std::map<uint32, uint32> const& items)
+{
+    bool first = true;
+    for (auto const& [itemId, count] : items)
+    {
+        if (!first)
+            out << ", ";
+
+        first = false;
+
+        if (ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId))
+            out << botAI->GetChatHelper()->FormatItem(proto, count);
+        else
+            out << "item " << itemId << " x" << count;
+    }
+}
+} // namespace
+
+uint32 SetCraftAction::CraftReplyData::GetTotalMissingCount() const
+{
+    uint32 totalMissingCount = 0;
+    for (auto const& [itemId, count] : missing)
+        totalMissingCount += count;
+
+    return totalMissingCount;
+}
 
 bool SetCraftAction::Execute(Event event)
 {
@@ -46,16 +107,51 @@ bool SetCraftAction::Execute(Event event)
     if (!proto)
         return false;
 
-    if (skillSpells.empty())
-    {
-        for (SkillLineAbilityEntry const* skillLine : sSkillLineAbilityStore)
-            skillSpells[skillLine->Spell] = skillLine;
-    }
-
     data.required.clear();
     data.obtained.clear();
 
-    for (PlayerSpellMap::iterator itr = bot->GetSpellMap().begin(); itr != bot->GetSpellMap().end(); ++itr)
+    CraftReplyData craftReplyData;
+    if (!BuildCraftReplyData(bot, itemId, craftReplyData))
+    {
+        botAI->TellMaster("I cannot craft this");
+        return false;
+    }
+
+    data.itemId = itemId;
+    data.required = craftReplyData.required;
+    for (auto const& [reagentId, count] : craftReplyData.required)
+        data.obtained[reagentId] = 0;
+
+    TellCraft();
+    return true;
+}
+
+bool SetCraftAction::ParseCraftRequest(std::string const& text,
+                                       std::set<uint32>& itemIds)
+{
+    itemIds = ChatHelper::ExtractAllItemIds(text);
+    if (itemIds.empty())
+        return false;
+
+    std::string const lower = ToLower(text);
+    return lower.find("craft") != std::string::npos ||
+           lower.find("make") != std::string::npos;
+}
+
+bool SetCraftAction::BuildCraftReplyData(Player* bot, uint32 itemId,
+                                         CraftReplyData& data)
+{
+    if (!bot || !itemId)
+        return false;
+
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+    if (!botAI)
+        return false;
+
+    CraftReplyData bestCandidate;
+
+    for (PlayerSpellMap::iterator itr = bot->GetSpellMap().begin();
+         itr != bot->GetSpellMap().end(); ++itr)
     {
         uint32 spellId = itr->first;
 
@@ -66,42 +162,115 @@ bool SetCraftAction::Execute(Event event)
         if (!spellInfo)
             continue;
 
-        SkillLineAbilityEntry const* skillLine = skillSpells[spellId];
-        if (skillLine != nullptr)
-        {
-            for (uint8 i = 0; i < 3; ++i)
-            {
-                if (spellInfo->Effects[i].Effect == SPELL_EFFECT_CREATE_ITEM &&
-                    itemId == spellInfo->Effects[i].ItemType)
-                {
-                    for (uint32 x = 0; x < MAX_SPELL_REAGENTS; ++x)
-                    {
-                        if (spellInfo->Reagent[x] <= 0)
-                            continue;
+        SkillLineAbilityEntry const* skillLine =
+            PlayerbotSpellRepository::Instance().GetSkillLine(spellId);
+        if (!skillLine || !skillLine->SkillLine ||
+            !IsSupportedCraftSkill(skillLine->SkillLine))
+            continue;
 
-                        uint32 itemid = spellInfo->Reagent[x];
-                        uint32 reagentsRequired = spellInfo->ReagentCount[x];
-                        if (itemid)
-                        {
-                            data.required[itemid] = reagentsRequired;
-                            data.obtained[itemid] = 0;
-                        }
-                    }
-                }
+        if (!botAI->HasSkill(static_cast<SkillType>(skillLine->SkillLine)))
+            continue;
+
+        uint32 skillValue = bot->GetSkillValue(skillLine->SkillLine);
+        if (skillValue < skillLine->MinSkillLineRank)
+            continue;
+
+        bool craftsRequestedItem = false;
+        for (uint8 i = 0; i < 3; ++i)
+        {
+            if (spellInfo->Effects[i].Effect == SPELL_EFFECT_CREATE_ITEM &&
+                itemId == spellInfo->Effects[i].ItemType)
+            {
+                craftsRequestedItem = true;
+                break;
             }
         }
+
+        if (!craftsRequestedItem)
+            continue;
+
+        CraftReplyData candidate;
+        candidate.itemId = itemId;
+        candidate.spellId = spellId;
+        candidate.skillId = skillLine->SkillLine;
+        candidate.skillValue = skillValue;
+        candidate.requiredSkillValue = skillLine->MinSkillLineRank;
+
+        for (uint32 x = 0; x < MAX_SPELL_REAGENTS; ++x)
+        {
+            if (spellInfo->Reagent[x] <= 0)
+                continue;
+
+            uint32 reagentId = spellInfo->Reagent[x];
+            uint32 reagentCount = spellInfo->ReagentCount[x];
+            if (!reagentId || !reagentCount)
+                continue;
+
+            candidate.required[reagentId] = reagentCount;
+
+            uint32 availableCount =
+                std::min<uint32>(reagentCount, bot->GetItemCount(reagentId, false));
+            if (availableCount)
+                candidate.available[reagentId] = availableCount;
+
+            if (availableCount < reagentCount)
+                candidate.missing[reagentId] = reagentCount - availableCount;
+        }
+
+        if (IsBetterCraftReplyData(candidate, bestCandidate))
+            bestCandidate = candidate;
     }
 
-    if (data.required.empty())
-    {
-        botAI->TellMaster("I cannot craft this");
+    if (bestCandidate.IsEmpty())
         return false;
+
+    data = bestCandidate;
+    return true;
+}
+
+std::string SetCraftAction::FormatCraftReply(PlayerbotAI* botAI,
+                                             CraftReplyData const& data)
+{
+    if (!botAI || data.IsEmpty())
+        return "";
+
+    ItemTemplate const* proto = sObjectMgr->GetItemTemplate(data.itemId);
+    if (!proto)
+        return "";
+
+    CraftData craftData;
+    craftData.itemId = data.itemId;
+
+    std::ostringstream out;
+    out << "I can craft " << botAI->GetChatHelper()->FormatItem(proto)
+        << " with " << ChatHelper::FormatSkill(data.skillId) << " ("
+        << data.skillValue << ") for "
+        << ChatHelper::formatMoney(GetCraftFee(craftData))
+        << ". ";
+
+    if (data.HasAllReagents())
+    {
+        out << "I already have all required materials.";
+    }
+    else
+    {
+        if (!data.available.empty())
+        {
+            out << "I have: ";
+            AppendFormattedItems(botAI, out, data.available);
+            out << ". ";
+        }
+
+        out << "I still need: ";
+        AppendFormattedItems(botAI, out, data.missing);
+        out << ".";
     }
 
-    data.itemId = itemId;
+    std::string message = out.str();
+    if (message.size() > 255)
+        message = message.substr(0, 252) + "...";
 
-    TellCraft();
-    return true;
+    return message;
 }
 
 void SetCraftAction::TellCraft()
@@ -157,4 +326,22 @@ uint32 SetCraftAction::GetCraftFee(CraftData& data)
 
     uint32 level = std::max(proto->ItemLevel, proto->RequiredLevel);
     return level * level / 40;
+}
+
+bool SetCraftAction::IsSupportedCraftSkill(uint32 skillId)
+{
+    switch (skillId)
+    {
+        case SKILL_ALCHEMY:
+        case SKILL_BLACKSMITHING:
+        case SKILL_ENCHANTING:
+        case SKILL_ENGINEERING:
+        case SKILL_INSCRIPTION:
+        case SKILL_JEWELCRAFTING:
+        case SKILL_LEATHERWORKING:
+        case SKILL_TAILORING:
+            return true;
+        default:
+            return false;
+    }
 }

--- a/src/Ai/Base/Actions/SetCraftAction.h
+++ b/src/Ai/Base/Actions/SetCraftAction.h
@@ -6,26 +6,52 @@
 #ifndef _PLAYERBOT_SETCRAFTACTION_H
 #define _PLAYERBOT_SETCRAFTACTION_H
 
+#include <map>
+#include <set>
+#include <string>
+
 #include "Action.h"
 #include "CraftValue.h"
 
 class PlayerbotAI;
+class Player;
 
 struct SkillLineAbilityEntry;
 
 class SetCraftAction : public Action
 {
 public:
+    struct CraftReplyData
+    {
+        uint32 itemId = 0;
+        uint32 spellId = 0;
+        uint32 skillId = 0;
+        uint32 skillValue = 0;
+        uint32 requiredSkillValue = 0;
+        std::map<uint32, uint32> required;
+        std::map<uint32, uint32> available;
+        std::map<uint32, uint32> missing;
+
+        bool IsEmpty() const { return !itemId || !spellId || !skillId; }
+        bool HasAllReagents() const { return missing.empty(); }
+        uint32 GetTotalMissingCount() const;
+    };
+
     SetCraftAction(PlayerbotAI* botAI) : Action(botAI, "craft") {}
 
     bool Execute(Event event) override;
 
     static uint32 GetCraftFee(CraftData& craftData);
+    static bool ParseCraftRequest(std::string const& text,
+                                  std::set<uint32>& itemIds);
+    static bool BuildCraftReplyData(Player* bot, uint32 itemId,
+                                    CraftReplyData& data);
+    static std::string FormatCraftReply(PlayerbotAI* botAI,
+                                        CraftReplyData const& data);
 
 private:
     void TellCraft();
-
-    static std::map<uint32, SkillLineAbilityEntry const*> skillSpells;
+    static bool IsSupportedCraftSkill(uint32 skillId);
 };
 
 #endif

--- a/src/Ai/World/Rpg/Action/NewRpgAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.cpp
@@ -63,7 +63,7 @@ bool NewRpgStatusUpdateAction::Execute(Event /*event*/)
     {
         case RPG_IDLE:
             return RandomChangeStatus({RPG_GO_CAMP, RPG_GO_GRIND, RPG_WANDER_RANDOM, RPG_WANDER_NPC, RPG_DO_QUEST,
-                                       RPG_TRAVEL_FLIGHT, RPG_REST, RPG_OUTDOOR_PVP});
+                                       RPG_TRAVEL_FLIGHT, RPG_REST, RPG_OUTDOOR_PVP, RPG_DO_CRAFT});
 
         case RPG_GO_GRIND:
         {
@@ -114,6 +114,16 @@ bool NewRpgStatusUpdateAction::Execute(Event /*event*/)
         {
             // DO_QUEST -> IDLE
             if (info.HasStatusPersisted(statusDoQuestDuration))
+            {
+                info.ChangeToIdle();
+                return true;
+            }
+            break;
+        }
+        case RPG_DO_CRAFT:
+        {
+            if (!CheckRpgStatusAvailable(RPG_DO_CRAFT) ||
+                info.HasStatusPersisted(statusDoCraftDuration))
             {
                 info.ChangeToIdle();
                 return true;
@@ -454,6 +464,43 @@ bool NewRpgDoQuestAction::DoCompletedQuest(NewRpgInfo::DoQuest& data)
         return true;
     }
     return false;
+}
+
+bool NewRpgDoCraftAction::Execute(Event /*event*/)
+{
+    if (SearchQuestGiverAndAcceptOrReward())
+        return true;
+
+    if (bot->isMoving())
+        return false;
+
+    auto* data = std::get_if<NewRpgInfo::DoCraft>(&botAI->rpgInfo.data);
+    if (!data)
+        return false;
+
+    if (botAI->DoSpecificAction("use random recipe", Event(), true))
+        return true;
+
+    if (botAI->DoSpecificAction("craft random item", Event(), true))
+    {
+        ++data->craftedCount;
+        return true;
+    }
+
+    if (botAI->DoSpecificAction("enchant random item", Event(), true))
+    {
+        ++data->craftedCount;
+        return true;
+    }
+
+    if (botAI->DoSpecificAction("disenchant random item", Event(), true))
+    {
+        ++data->craftedCount;
+        return true;
+    }
+
+    botAI->rpgInfo.ChangeToIdle();
+    return true;
 }
 
 bool NewRpgTravelFlightAction::Execute(Event /*event*/)

--- a/src/Ai/World/Rpg/Action/NewRpgAction.h
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.h
@@ -51,6 +51,7 @@ protected:
     const int32 statusWanderRandomDuration = 5 * MINUTE  * IN_MILLISECONDS ;
     const int32 statusRestDuration = 30 * IN_MILLISECONDS ;
     const int32 statusDoQuestDuration = 30 * MINUTE  * IN_MILLISECONDS ;
+    const int32 statusDoCraftDuration = 2 * MINUTE * IN_MILLISECONDS;
     const int32 statusOutDoorPvPDuration = HOUR * IN_MILLISECONDS ;
 };
 
@@ -95,6 +96,13 @@ protected:
     bool DoCompletedQuest(NewRpgInfo::DoQuest& data);
 
     const uint32 poiStayTime = 5 * 60 * 1000;
+};
+
+class NewRpgDoCraftAction : public NewRpgBaseAction
+{
+public:
+    NewRpgDoCraftAction(PlayerbotAI* botAI) : NewRpgBaseAction(botAI, "new rpg do craft") {}
+    bool Execute(Event event) override;
 };
 
 class NewRpgTravelFlightAction : public NewRpgBaseAction

--- a/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp
@@ -1162,6 +1162,11 @@ bool NewRpgBaseAction::RandomChangeStatus(std::vector<NewRpgStatus> candidateSta
             bot->SetStandState(UNIT_STAND_STATE_SIT);
             return true;
         }
+        case RPG_DO_CRAFT:
+        {
+            botAI->rpgInfo.ChangeToDoCraft();
+            return true;
+        }
         case RPG_OUTDOOR_PVP:
         {
             botAI->rpgInfo.ChangeToOutdoorPvp();
@@ -1239,8 +1244,67 @@ bool NewRpgBaseAction::CheckRpgStatusAvailable(NewRpgStatus status)
             OutdoorPvP* outdoorPvP = sOutdoorPvPMgr->GetOutdoorPvPToZoneId(zoneId);
             return outdoorPvP != nullptr;
         }
+        case RPG_DO_CRAFT:
+        {
+            return AI_VALUE2(uint32, "item count", "recipe") > 0 ||
+                   CanCraftSomething() ||
+                   CanEnchantSomething() ||
+                   CanDisenchantSomething();
+        }
         default:
             return false;
     }
     return false;
+}
+
+bool NewRpgBaseAction::CanCraftSomething()
+{
+    CraftRandomItemAction craftAction(botAI);
+
+    for (PlayerSpellMap::iterator itr = bot->GetSpellMap().begin();
+         itr != bot->GetSpellMap().end(); ++itr)
+    {
+        uint32 spellId = itr->first;
+        if (itr->second->State == PLAYERSPELL_REMOVED || !itr->second->Active)
+            continue;
+
+        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+        if (!spellInfo || !craftAction.AcceptSpell(spellInfo))
+            continue;
+
+        if (botAI->CanCastSpell(spellId, bot, true))
+            return true;
+    }
+
+    return false;
+}
+
+bool NewRpgBaseAction::CanEnchantSomething()
+{
+    EnchantRandomItemAction enchantAction(botAI);
+
+    for (PlayerSpellMap::iterator itr = bot->GetSpellMap().begin();
+         itr != bot->GetSpellMap().end(); ++itr)
+    {
+        uint32 spellId = itr->first;
+        if (itr->second->State == PLAYERSPELL_REMOVED || !itr->second->Active)
+            continue;
+
+        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+        if (!spellInfo || !enchantAction.AcceptSpell(spellInfo))
+            continue;
+
+        if (AI_VALUE2(Item*, "item for spell", spellId) &&
+            botAI->CanCastSpell(spellId, bot, true))
+            return true;
+    }
+
+    return false;
+}
+
+bool NewRpgBaseAction::CanDisenchantSomething()
+{
+    return botAI->HasSkill(SKILL_ENCHANTING) &&
+           AI_VALUE2(uint32, "item count",
+                     "usage " + std::to_string(ITEM_USAGE_DISENCHANT)) > 0;
 }

--- a/src/Ai/World/Rpg/Action/NewRpgBaseAction.h
+++ b/src/Ai/World/Rpg/Action/NewRpgBaseAction.h
@@ -2,6 +2,7 @@
 #define _PLAYERBOT_NEWRPGBASEACTION_H
 
 #include "Duration.h"
+#include "CastCustomSpellAction.h"
 #include "LastMovementValue.h"
 #include "MovementActions.h"
 #include "NewRpgInfo.h"
@@ -57,6 +58,9 @@ protected:
     bool SelectRandomFlightTaxiNode(uint32& flightMasterEntry, WorldPosition& flightMasterPos, std::vector<uint32>& path);
     bool RandomChangeStatus(std::vector<NewRpgStatus> candidateStatus);
     bool CheckRpgStatusAvailable(NewRpgStatus status);
+    bool CanCraftSomething();
+    bool CanEnchantSomething();
+    bool CanDisenchantSomething();
 
 protected:
     /* FOR MOVE FAR */

--- a/src/Ai/World/Rpg/NewRpgInfo.cpp
+++ b/src/Ai/World/Rpg/NewRpgInfo.cpp
@@ -37,6 +37,12 @@ void NewRpgInfo::ChangeToDoQuest(uint32 questId, const Quest* quest)
     data = do_quest;
 }
 
+void NewRpgInfo::ChangeToDoCraft()
+{
+    startT = getMSTime();
+    data = DoCraft{};
+}
+
 void NewRpgInfo::ChangeToTravelFlight(uint32 flightMasterEntry, WorldPosition flightMasterPos, std::vector<uint32> path)
 {
     startT = getMSTime();
@@ -98,6 +104,7 @@ NewRpgStatus NewRpgInfo::GetStatus()
         if constexpr (std::is_same_v<T, WanderRandom>) return RPG_WANDER_RANDOM;
         if constexpr (std::is_same_v<T, Rest>) return RPG_REST;
         if constexpr (std::is_same_v<T, DoQuest>) return RPG_DO_QUEST;
+        if constexpr (std::is_same_v<T, DoCraft>) return RPG_DO_CRAFT;
         if constexpr (std::is_same_v<T, TravelFlight>) return RPG_TRAVEL_FLIGHT;
         if constexpr (std::is_same_v<T, OutdoorPvP>) return RPG_OUTDOOR_PVP;
         return RPG_IDLE;
@@ -154,6 +161,12 @@ std::string NewRpgInfo::ToString()
             out << "\npoiPos: " << arg.pos.GetMapId() << " " << arg.pos.GetPositionX() << " "
                 << arg.pos.GetPositionY() << " " << arg.pos.GetPositionZ();
             out << "\nlastReachPOI: " << (arg.lastReachPOI ? GetMSTimeDiffToNow(arg.lastReachPOI) : 0);
+        }
+        else if constexpr (std::is_same_v<T, DoCraft>)
+        {
+            out << "DO_CRAFT";
+            out << "\ncraftedCount: " << arg.craftedCount;
+            out << "\nlastCraft: " << startT;
         }
         else if constexpr (std::is_same_v<T, TravelFlight>)
         {

--- a/src/Ai/World/Rpg/NewRpgInfo.h
+++ b/src/Ai/World/Rpg/NewRpgInfo.h
@@ -54,6 +54,11 @@ struct NewRpgInfo
         std::vector<uint32> path;
         bool inFlight{false};
     };
+    // RPG_DO_CRAFT
+    struct DoCraft
+    {
+        uint32 craftedCount{0};
+    };
     // RPG_REST
     struct Rest
     {
@@ -84,6 +89,7 @@ struct NewRpgInfo
         WanderNpc,
         WanderRandom,
         DoQuest,
+        DoCraft,
         Rest,
         TravelFlight,
         OutdoorPvP
@@ -97,6 +103,7 @@ struct NewRpgInfo
     void ChangeToWanderNpc();
     void ChangeToWanderRandom();
     void ChangeToDoQuest(uint32 questId, const Quest* quest);
+    void ChangeToDoCraft();
     void ChangeToTravelFlight(uint32 flightMasterEntry, WorldPosition flightMasterPos, std::vector<uint32> path);
     void ChangeToOutdoorPvp(ObjectGuid::LowType capturePointSpawnId = 0);
     void ChangeToRest();

--- a/src/Ai/World/Rpg/Strategy/NewRpgStrategy.cpp
+++ b/src/Ai/World/Rpg/Strategy/NewRpgStrategy.cpp
@@ -59,6 +59,14 @@ void NewRpgStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     );
     triggers.push_back(
         new TriggerNode(
+            "do craft status",
+            {
+                NextAction("new rpg do craft", 3.0f)
+            }
+        )
+    );
+    triggers.push_back(
+        new TriggerNode(
             "travel flight status",
             {
                 NextAction("new rpg travel flight", 3.0f)

--- a/src/Bot/Factory/RandomPlayerbotFactory.cpp
+++ b/src/Bot/Factory/RandomPlayerbotFactory.cpp
@@ -619,7 +619,7 @@ void RandomPlayerbotFactory::CreateRandomBots()
         else
             password = accountName;
 
-        sAccountMgr->CreateAccount(accountName, password);
+        AccountMgr::CreateAccount(accountName, password);
 
         LOG_DEBUG("playerbots", "Account {} created for random bots", accountName.c_str());
     }

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -40,6 +40,7 @@
 #include "Random.h"
 #include "RandomPlayerbotFactory.h"
 #include "ServerFacade.h"
+#include "SetCraftAction.h"
 #include "SharedDefines.h"
 #include "TravelMgr.h"
 #include "Unit.h"
@@ -55,6 +56,71 @@ struct GuidClassRaceInfo
     uint32 rClass;
     uint32 rRace;
 };
+
+namespace
+{
+bool IsCraftReplyChannel(ChatChannelSource source)
+{
+    return source == ChatChannelSource::SRC_GENERAL ||
+           source == ChatChannelSource::SRC_TRADE;
+}
+
+std::string MakeCraftReplyKey(Player* requester, uint32 itemId)
+{
+    std::ostringstream key;
+    key << requester->GetGUID().GetCounter() << ':' << itemId;
+    return key.str();
+}
+
+bool IsBetterCraftCandidate(Player* candidateBot,
+                            SetCraftAction::CraftReplyData const& candidate,
+                            Player* currentBot,
+                            SetCraftAction::CraftReplyData const& current)
+{
+    if (!currentBot)
+        return true;
+
+    if (candidate.HasAllReagents() != current.HasAllReagents())
+        return candidate.HasAllReagents();
+
+    if (candidate.GetTotalMissingCount() != current.GetTotalMissingCount())
+        return candidate.GetTotalMissingCount() < current.GetTotalMissingCount();
+
+    if (candidate.skillValue != current.skillValue)
+        return candidate.skillValue > current.skillValue;
+
+    return candidateBot->GetGUID().GetCounter() <
+           currentBot->GetGUID().GetCounter();
+}
+} // namespace
+
+bool RandomPlayerbotMgr::ShouldThrottleCraftReply(Player* requester,
+                                                  uint32 itemId,
+                                                  time_t now)
+{
+    std::lock_guard<std::mutex> guard(recentCraftRepliesLock);
+    PruneCraftRepliesLocked(now);
+
+    std::string const replyKey = MakeCraftReplyKey(requester, itemId);
+    auto const recentReply = recentCraftReplies.find(replyKey);
+    if (recentReply != recentCraftReplies.end() && recentReply->second > now)
+        return true;
+
+    recentCraftReplies[replyKey] =
+        now + sPlayerbotAIConfig.craftingReplyCooldown;
+    return false;
+}
+
+void RandomPlayerbotMgr::PruneCraftRepliesLocked(time_t now)
+{
+    for (auto it = recentCraftReplies.begin(); it != recentCraftReplies.end();)
+    {
+        if (it->second <= now)
+            it = recentCraftReplies.erase(it);
+        else
+            ++it;
+    }
+}
 
 void PrintStatsThread() { sRandomPlayerbotMgr.PrintStats(); }
 
@@ -2486,6 +2552,81 @@ bool RandomPlayerbotMgr::HandlePlayerbotConsoleCommand(ChatHandler* handler, cha
 
 void RandomPlayerbotMgr::HandleCommand(uint32 type, std::string const text, Player* fromPlayer, std::string channelName)
 {
+    if (sPlayerbotAIConfig.enableCraftingReplies && fromPlayer &&
+        type == CHAT_MSG_CHANNEL && !channelName.empty())
+    {
+        std::set<uint32> requestedItemIds;
+        if (SetCraftAction::ParseCraftRequest(text, requestedItemIds))
+        {
+            Player* bestBot = nullptr;
+            SetCraftAction::CraftReplyData bestCraftReply;
+
+            for (PlayerBotMap::const_iterator it = GetPlayerBotsBegin();
+                 it != GetPlayerBotsEnd(); ++it)
+            {
+                Player* const bot = it->second;
+                if (!bot)
+                    continue;
+
+                if (!channelName.empty())
+                {
+                    if (ChannelMgr* cMgr = ChannelMgr::forTeam(bot->GetTeamId()))
+                    {
+                        Channel* chn = cMgr->GetChannel(channelName, bot);
+                        if (!chn)
+                            continue;
+                    }
+                }
+
+                PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+                if (!botAI)
+                    continue;
+
+                if (!IsCraftReplyChannel(
+                        botAI->GetChatChannelSource(bot, type, channelName)))
+                    continue;
+
+                for (uint32 itemId : requestedItemIds)
+                {
+                    SetCraftAction::CraftReplyData candidate;
+                    if (!SetCraftAction::BuildCraftReplyData(bot, itemId,
+                                                            candidate))
+                        continue;
+
+                    if (IsBetterCraftCandidate(bot, candidate, bestBot,
+                                               bestCraftReply))
+                    {
+                        bestBot = bot;
+                        bestCraftReply = candidate;
+                    }
+                }
+            }
+
+            if (!bestBot)
+                return;
+
+            time_t now = time(nullptr);
+            if (ShouldThrottleCraftReply(fromPlayer, bestCraftReply.itemId,
+                                         now))
+                return;
+
+            if (PlayerbotAI* bestAI = GET_PLAYERBOT_AI(bestBot))
+            {
+                std::string const message =
+                    SetCraftAction::FormatCraftReply(bestAI, bestCraftReply);
+                if (!message.empty())
+                {
+                    bestAI->Whisper(message, fromPlayer->GetName());
+                    bestAI->GetAiObjectContext()
+                        ->GetValue<time_t>("last said", "chat")
+                        ->Set(now + urand(5, 25));
+                }
+            }
+
+            return;
+        }
+    }
+
     for (PlayerBotMap::const_iterator it = GetPlayerBotsBegin(); it != GetPlayerBotsEnd(); ++it)
     {
         Player* const bot = it->second;

--- a/src/Bot/RandomPlayerbotMgr.h
+++ b/src/Bot/RandomPlayerbotMgr.h
@@ -12,6 +12,8 @@
 #include "GameTime.h"
 #include "PlayerbotCommandServer.h"
 
+#include <mutex>
+
 struct BattlegroundInfo
 {
     std::vector<uint32> bgInstances;
@@ -176,6 +178,9 @@ protected:
     void OnBotLoginInternal(Player* const bot) override;
 
 private:
+    bool ShouldThrottleCraftReply(Player* requester, uint32 itemId, time_t now);
+    void PruneCraftRepliesLocked(time_t now);
+
     RandomPlayerbotMgr() : PlayerbotHolder(), processTicks(0)
     {
         this->playersLevel = sPlayerbotAIConfig.randombotStartingLevel;
@@ -246,6 +251,8 @@ private:
     std::map<uint32, std::map<uint32, std::vector<WorldLocation>>> rpgLocsCacheLevel;
     std::map<TeamId, std::map<BattlegroundTypeId, std::vector<uint32>>> BattleMastersCache;
     std::unordered_map<uint32, BotEventCache> eventCache;
+    std::mutex recentCraftRepliesLock;
+    std::unordered_map<std::string, time_t> recentCraftReplies;
     std::list<uint32> currentBots;
     uint32 bgBotsCount;
     uint32 playersLevel;

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -244,6 +244,8 @@ bool PlayerbotAIConfig::Initialize()
     endFishingWithMaster = sConfigMgr->GetOption<float>("AiPlayerbot.EndFishingWithMaster", 30.0f);
     fishingDistance = sConfigMgr->GetOption<float>("AiPlayerbot.FishingDistance", 40.0f);
     enableFishingWithMaster = sConfigMgr->GetOption<bool>("AiPlayerbot.EnableFishingWithMaster", true);
+    enableCraftingReplies = sConfigMgr->GetOption<bool>("AiPlayerbot.EnableCraftingReplies", true);
+    craftingReplyCooldown = sConfigMgr->GetOption<uint32>("AiPlayerbot.CraftingReplyCooldown", 15);
     //////////////////////////// CHAT
     enableBroadcasts = sConfigMgr->GetOption<bool>("AiPlayerbot.EnableBroadcasts", true);
     randomBotTalk = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotTalk", false);

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -662,6 +662,7 @@ bool PlayerbotAIConfig::Initialize()
     RpgStatusProbWeight[RPG_TRAVEL_FLIGHT] = sConfigMgr->GetOption<int32>("AiPlayerbot.RpgStatusProbWeight.TravelFlight", 15);
     RpgStatusProbWeight[RPG_REST] = sConfigMgr->GetOption<int32>("AiPlayerbot.RpgStatusProbWeight.Rest", 5);
     RpgStatusProbWeight[RPG_OUTDOOR_PVP] = sConfigMgr->GetOption<int32>("AiPlayerbot.RpgStatusProbWeight.OutdoorPvp", 10);
+    RpgStatusProbWeight[RPG_DO_CRAFT] = sConfigMgr->GetOption<int32>("AiPlayerbot.RpgStatusProbWeight.DoCraft", 10);
 
     syncLevelWithPlayers = sConfigMgr->GetOption<bool>("AiPlayerbot.SyncLevelWithPlayers", false);
     randomBotGroupNearby = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotGroupNearby", false);

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -57,7 +57,8 @@ enum NewRpgStatus : int
     // Taking a break
     RPG_REST = 7,
     RPG_OUTDOOR_PVP = 8,
-    RPG_STATUS_END = 9
+    RPG_DO_CRAFT = 9,
+    RPG_STATUS_END = 10
 };
 
 #define MAX_SPECNO 20

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -154,6 +154,8 @@ public:
 
     // Professions
     bool enableFishingWithMaster;
+    bool enableCraftingReplies;
+    uint32 craftingReplyCooldown;
     uint32 classMatchingProfessionChance;
     float fishingDistanceFromMaster, fishingDistance, endFishingWithMaster;
 

--- a/src/Script/Playerbots.cpp
+++ b/src/Script/Playerbots.cpp
@@ -259,7 +259,7 @@ public:
         if (playerbotMgr != nullptr && channel->GetFlags() & 0x18)
             playerbotMgr->HandleCommand(type, msg);
 
-        sRandomPlayerbotMgr.HandleCommand(type, msg, player);
+        sRandomPlayerbotMgr.HandleCommand(type, msg, player, channel->GetName());
 
         return true;
     }


### PR DESCRIPTION
## Pull Request Description
This change expands playerbot crafting in two connected ways:

1. Players can request crafted items in `General` or `Trade` using a linked item plus `craft`/`make`, and one eligible bot will whisper back with whether it can craft the item, whether it has the reagents, what reagents are missing, and the craft fee.
2. Crafting is now wired into the **new RPG system** through a dedicated `RPG_DO_CRAFT` state so bots can autonomously learn recipes and perform crafting, enchanting, and disenchanting work when useful.

The change also adds config support for crafting replies, adds thread-safe reply throttling, updates the new RPG state machine, and documents the flow in `RPG_FLOWS.md` and `CRAFTING_RPG_FLOW.md`.

## Feature Evaluation
- Describe the **minimum logic** required to achieve the intended behavior.
  - Only parse channel messages that look like crafting requests in `General` or `Trade`.
  - Reuse shared craft-evaluation helpers to validate recipe/profession/skill/material availability.
  - Select a single best-fit bot instead of broadcasting from many bots.
  - Add a single new `RPG_DO_CRAFT` state to the new RPG state machine and reuse existing `use random recipe`, `craft random item`, `enchant random item`, and `disenchant random item` actions.

- Describe the **processing cost** when this logic executes across many bots.
  - Public reply logic only runs for channel messages that match the craft-request pattern; normal chat traffic falls through quickly.
  - The request path scans online random bots in the same channel and stops at one best-fit reply, with cooldown throttling to suppress repeated responses.
  - The new RPG craft availability check runs during idle status selection and inspects learned spells / available work only when considering `RPG_DO_CRAFT`.
  - Overall expected impact is minimal compared with always-on per-tick behavior because both paths are gated by specific triggers.

## How to Test the Changes
1. Build the module and `worldserver`.
2. Enable random bots with professions and ensure `AiPlayerbot.EnableNewRpgStrategy = 1`.
3. Leave `AiPlayerbot.EnableCraftingReplies = 1` and set `AiPlayerbot.CraftingReplyCooldown` to a small test value such as `15`.
4. Log in with a player on a map with online playerbots in `General` or `Trade`.
5. Post a linked craftable item in channel chat with a `craft` or `make` request.
6. Verify that only one best-fit bot whispers back, and that the reply reports either available reagents or missing reagents plus the fee.
7. Repeat the same request immediately and verify the cooldown suppresses duplicate whispers.
8. Observe random bots over time and verify that bots using the new RPG strategy can enter `RPG_DO_CRAFT`, learn recipe items, and perform crafting / enchanting / disenchanting work before returning to idle.
9. Confirm that normal social chatter is suppressed on valid craft requests.

## Impact Assessment
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

  Minimal impact because the public reply path is event-driven on matching chat messages, and the new RPG crafting path is only considered during idle status selection instead of being added as an always-running per-tick behavior.

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

  Yes. Bots can now respond to public crafting requests by default when crafting replies are enabled, and bots using the new RPG strategy can choose a new `RPG_DO_CRAFT` state when crafting work is available.

- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [x] Yes (**explain below**)

  Yes, but in a bounded way: one new new-RPG status, one new status action, one new config weight, and one public craft-request path in `RandomPlayerbotMgr` that reuses shared craft-evaluation helpers rather than duplicating logic.

## AI Assistance
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)

AI assistance was used for code exploration, drafting/refactoring, and documentation. GitHub Copilot using GPT-5.4 helped with implementation, debugging, and preparing the flow documentation / PR text. The resulting changes were reviewed, built, and validated in-game.

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [ ] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
- Build verification completed locally for `modules` and `worldserver`.
- In-game validation was performed and the feature worked as expected.
- Documentation added in `RPG_FLOWS.md` and `CRAFTING_RPG_FLOW.md`.
- One unrelated compatibility fix is included in `RandomPlayerbotFactory.cpp` to match the current account-creation API used by the branch.
- The final checklist keeps translation unchecked because the new crafting reply text is dynamically generated and should be reviewed against the project’s localization expectations.