### PR TITLE
Feat: Selective reset to default of combat or non-combat strategies

### DIFF
--- a/src/Ai/Base/Actions/ChangeStrategyAction.cpp
+++ b/src/Ai/Base/Actions/ChangeStrategyAction.cpp
@@ -26,6 +26,10 @@ bool ChangeCombatStrategyAction::Execute(Event event)
                 case '~':
                     PlayerbotRepository::instance().Save(botAI);
                     break;
+                case '!':
+                    botAI->SelectiveResetStrategies(BOT_STATE_COMBAT);
+                    PlayerbotRepository::instance().Save(botAI);
+                    break;
                 case '?':
                     break;
             }
@@ -62,6 +66,10 @@ bool ChangeNonCombatStrategyAction::Execute(Event event)
                 case '+':
                 case '-':
                 case '~':
+                    PlayerbotRepository::instance().Save(botAI);
+                    break;
+                case '!':
+                    botAI->SelectiveResetStrategies(BOT_STATE_NON_COMBAT);
                     PlayerbotRepository::instance().Save(botAI);
                     break;
                 case '?':

--- a/src/Ai/Base/Actions/ChangeStrategyAction.cpp
+++ b/src/Ai/Base/Actions/ChangeStrategyAction.cpp
@@ -9,32 +9,36 @@
 #include "PlayerbotRepository.h"
 #include "Playerbots.h"
 
+// Helper function for prefixes used by combat and non-combat strategy commands.
+static void HandleStrategyCommon(PlayerbotAI* botAI, std::string const& text, BotState state)
+{
+    std::vector<std::string> splitted = split(text, ',');
+    for (std::vector<std::string>::iterator i = splitted.begin(); i != splitted.end(); i++)
+    {
+        const char* name = i->c_str();
+        switch (name[0])
+        {
+            case '+':
+            case '-':
+            case '~':
+                PlayerbotRepository::instance().Save(botAI);
+                break;
+            case '!':
+                botAI->SelectiveResetStrategies(state);
+                PlayerbotRepository::instance().Save(botAI);
+                break;
+            case '?':
+                break;
+        }
+    }
+}
+
 bool ChangeCombatStrategyAction::Execute(Event event)
 {
     std::string const text = event.getParam();
     botAI->ChangeStrategy(text.empty() ? getName() : text, BOT_STATE_COMBAT);
     if (event.GetSource() == "co")
-    {
-        std::vector<std::string> splitted = split(text, ',');
-        for (std::vector<std::string>::iterator i = splitted.begin(); i != splitted.end(); i++)
-        {
-            const char* name = i->c_str();
-            switch (name[0])
-            {
-                case '+':
-                case '-':
-                case '~':
-                    PlayerbotRepository::instance().Save(botAI);
-                    break;
-                case '!':
-                    botAI->SelectiveResetStrategies(BOT_STATE_COMBAT);
-                    PlayerbotRepository::instance().Save(botAI);
-                    break;
-                case '?':
-                    break;
-            }
-        }
-    }
+        HandleStrategyCommon(botAI, text, BOT_STATE_COMBAT);
 
     return true;
 }
@@ -56,27 +60,7 @@ bool ChangeNonCombatStrategyAction::Execute(Event event)
 
     botAI->ChangeStrategy(text, BOT_STATE_NON_COMBAT);
     if (event.GetSource() == "nc")
-    {
-        std::vector<std::string> splitted = split(text, ',');
-        for (std::vector<std::string>::iterator i = splitted.begin(); i != splitted.end(); i++)
-        {
-            const char* name = i->c_str();
-            switch (name[0])
-            {
-                case '+':
-                case '-':
-                case '~':
-                    PlayerbotRepository::instance().Save(botAI);
-                    break;
-                case '!':
-                    botAI->SelectiveResetStrategies(BOT_STATE_NON_COMBAT);
-                    PlayerbotRepository::instance().Save(botAI);
-                    break;
-                case '?':
-                    break;
-            }
-        }
-    }
+        HandleStrategyCommon(botAI, text, BOT_STATE_NON_COMBAT);
 
     return true;
 }

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -1573,6 +1573,27 @@ void PlayerbotAI::ClearStrategies(BotState type)
     e->removeAllStrategies();
 }
 
+// Resets only the combat or non-combat engine: wipe strategies, repopulate with class/spec defaults,
+// re-apply current map's instance strategy (if any), and call Init() to rebuild trigger/action lists.
+void PlayerbotAI::SelectiveResetStrategies(BotState type)
+{
+    Engine* e = engines[type];
+    if (!e)
+        return;
+
+    e->removeAllStrategies();
+
+    if (type == BOT_STATE_COMBAT)
+        AiFactory::AddDefaultCombatStrategies(bot, this, e);
+    else if (type == BOT_STATE_NON_COMBAT)
+        AiFactory::AddDefaultNonCombatStrategies(bot, this, e);
+
+    if (sPlayerbotAIConfig.applyInstanceStrategies)
+        ApplyInstanceStrategies(bot->GetMapId());
+
+    e->Init();
+}
+
 std::vector<std::string> PlayerbotAI::GetStrategies(BotState type)
 {
     Engine* e = engines[type];

--- a/src/Bot/PlayerbotAI.h
+++ b/src/Bot/PlayerbotAI.h
@@ -404,6 +404,7 @@ public:
                                   std::string const qualifier = "");
     void ChangeStrategy(std::string const name, BotState type);
     void ClearStrategies(BotState type);
+    void SelectiveResetStrategies(BotState type);
     std::vector<std::string> GetStrategies(BotState type);
     Strategy* GetStrategy(std::string const name, BotState type);
     void ApplyInstanceStrategies(uint32 mapId, bool tellMaster = false);


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
Adds the commands `co !` and `nc !`, which would reset either the combat or non-combat strategies of a follower bot, without affecting the other strategies or any other values.

Also ChangeStrategyAction.cpp was refactored for duplicate code by introducing the helper function `HandleStrategyCommon`, that gets called by `ChangeCombatStrategyAction` and `ChangeNonCombatStrategyAction`


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

`reset botAI` already resets strategies back to default, but it resets ALL strategies and wipes values such as formations, stances, and everything else under the `value` key in playerbots_db_store>value. The new commands don't run across many bots, only on the bot the command is run on.


## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
1. Run either `co ?` and `nc ?` to see current list of combat and non-combat strategies the bot has.
2. Add and remove strategies to both `co` and `nc`.
3. Confirm your changes with `co ?` and `nc ?`.
4. Run `co !` only.
5. Run `co ?` to confirm combat strategies have been reset to default, and `nc ?` to confirm it has not been affected. Then run `nc !` to reset it as well.
6. Do another test [inside an instance](https://github.com/mod-playerbots/mod-playerbots/wiki/Playerbot-Commands#raid-specific-strategies). Remove a bunch of `nc` strategies, including the strategy for the raid itself.
7. Run `nc !` and check that the defaults have been reset, but that the instance strategy has been re-added as well.



## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [x] Yes (**explain below**)
Technically it adds a new case to ChangeCombatStrategyAction, but it's straightforward.


## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->
Review only in case I was missing something, and then to easily refactor duplicate code with HandleStrategyCommon.



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->

[Commands wiki](https://github.com/mod-playerbots/mod-playerbots/wiki/Playerbot-Commands#strategies) need to be modified to read:

---
You can query the bot to report what strategies are currently being used:

```
co ?
nc ?
```
You can reset either of the bot's strategies back to defaults:

```
co !
nc !
```
---

Tangentially I also recommend [this section](https://github.com/mod-playerbots/mod-playerbots/wiki/Playerbot-Commands#non-combat-strategies) to be edit to this for more accuracy:

---
General
strategy | description
:---|:---
``food`` | enable bot's ability to eat/drink
``pvp`` | enable bot's ability to engage in PVP combat. Note: PVP mode wouldn't appear active until the bot starts combat
``loot`` | enable bot's ability to loot. Note: adding or removing that strategy for randombots requires GM level