### PR TITLE
Expand rpg status command to allow manual state changes. 

### DIFF
--- a/data/sql/playerbots/updates/2026_05_08_00_ai_playerbot_rpg_status_texts.sql
+++ b/data/sql/playerbots/updates/2026_05_08_00_ai_playerbot_rpg_status_texts.sql
@@ -1,0 +1,195 @@
+-- #########################################################
+-- Playerbots - Add rpg debug command texts
+-- Localized for all WotLK locales (koKR, frFR, deDE, zhCN,
+-- zhTW, esES, esMX, ruRU)
+-- #########################################################
+
+DELETE FROM ai_playerbot_texts WHERE name IN (
+    'rpg_debug_permission_error',
+    'rpg_status_changed',
+    'rpg_no_grind_pos_error',
+    'rpg_no_camp_pos_error',
+    'rpg_no_flight_path_error',
+    'rpg_no_quest_error',
+    'rpg_invalid_quest_error',
+    'rpg_unknown_status_error'
+);
+DELETE FROM ai_playerbot_texts_chance WHERE name IN (
+    'rpg_debug_permission_error',
+    'rpg_status_changed',
+    'rpg_no_grind_pos_error',
+    'rpg_no_camp_pos_error',
+    'rpg_no_flight_path_error',
+    'rpg_no_quest_error',
+    'rpg_invalid_quest_error',
+    'rpg_unknown_status_error'
+);
+
+-- rpg_debug_permission_error
+INSERT INTO `ai_playerbot_texts`
+    (`id`, `name`, `text`, `say_type`, `reply_type`,
+     `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`,
+     `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`)
+VALUES (
+    1759,
+    'rpg_debug_permission_error',
+    'Only your master or a GM can change my rpg status.',
+    0, 0,
+    '주인이나 GM만 제 RPG 상태를 변경할 수 있습니다.',
+    'Seul votre maître ou un MJ peut changer mon statut RPG.',
+    'Nur dein Meister oder ein GM kann meinen RPG-Status ändern.',
+    '只有你的主人或GM才能更改我的RPG状态。',
+    '只有你的主人或GM才能更改我的RPG狀態。',
+    'Solo tu maestro o un GM puede cambiar mi estado de RPG.',
+    'Solo tu maestro o un GM puede cambiar mi estado de RPG.',
+    'Только ваш хозяин или GM может изменить мой RPG-статус.');
+
+INSERT INTO ai_playerbot_texts_chance (name, probability) VALUES ('rpg_debug_permission_error', 100);
+
+-- rpg_status_changed: %status is replaced with the new status name (e.g. IDLE, REST, DO_QUEST 1234)
+INSERT INTO `ai_playerbot_texts`
+    (`id`, `name`, `text`, `say_type`, `reply_type`,
+     `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`,
+     `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`)
+VALUES (
+    1760,
+    'rpg_status_changed',
+    'rpg status -> %status',
+    0, 0,
+    'RPG 상태 -> %status',
+    'statut RPG -> %status',
+    'RPG-Status -> %status',
+    'RPG状态 -> %status',
+    'RPG狀態 -> %status',
+    'estado RPG -> %status',
+    'estado RPG -> %status',
+    'RPG-статус -> %status');
+
+INSERT INTO ai_playerbot_texts_chance (name, probability) VALUES ('rpg_status_changed', 100);
+
+-- rpg_no_grind_pos_error
+INSERT INTO `ai_playerbot_texts`
+    (`id`, `name`, `text`, `say_type`, `reply_type`,
+     `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`,
+     `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`)
+VALUES (
+    1761,
+    'rpg_no_grind_pos_error',
+    'No grind position available.',
+    0, 0,
+    '사냥 위치를 찾을 수 없습니다.',
+    'Aucune position de farm disponible.',
+    'Keine Grindposition verfügbar.',
+    '没有可用的练级位置。',
+    '沒有可用的練級位置。',
+    'No hay posición de grindeo disponible.',
+    'No hay posición de grindeo disponible.',
+    'Нет доступной позиции для гринда.');
+
+INSERT INTO ai_playerbot_texts_chance (name, probability) VALUES ('rpg_no_grind_pos_error', 100);
+
+-- rpg_no_camp_pos_error
+INSERT INTO `ai_playerbot_texts`
+    (`id`, `name`, `text`, `say_type`, `reply_type`,
+     `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`,
+     `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`)
+VALUES (
+    1762,
+    'rpg_no_camp_pos_error',
+    'No camp position available.',
+    0, 0,
+    '캠프 위치를 찾을 수 없습니다.',
+    'Aucune position de campement disponible.',
+    'Keine Lagerposition verfügbar.',
+    '没有可用的营地位置。',
+    '沒有可用的營地位置。',
+    'No hay posición de campamento disponible.',
+    'No hay posición de campamento disponible.',
+    'Нет доступной позиции для лагеря.');
+
+INSERT INTO ai_playerbot_texts_chance (name, probability) VALUES ('rpg_no_camp_pos_error', 100);
+
+-- rpg_no_flight_path_error
+INSERT INTO `ai_playerbot_texts`
+    (`id`, `name`, `text`, `say_type`, `reply_type`,
+     `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`,
+     `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`)
+VALUES (
+    1763,
+    'rpg_no_flight_path_error',
+    'No flight path available.',
+    0, 0,
+    '이용 가능한 비행 경로가 없습니다.',
+    'Aucun chemin de vol disponible.',
+    'Keine Flugroute verfügbar.',
+    '没有可用的飞行路径。',
+    '沒有可用的飛行路徑。',
+    'No hay ruta de vuelo disponible.',
+    'No hay ruta de vuelo disponible.',
+    'Нет доступного маршрута полёта.');
+
+INSERT INTO ai_playerbot_texts_chance (name, probability) VALUES ('rpg_no_flight_path_error', 100);
+
+-- rpg_no_quest_error
+INSERT INTO `ai_playerbot_texts`
+    (`id`, `name`, `text`, `say_type`, `reply_type`,
+     `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`,
+     `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`)
+VALUES (
+    1764,
+    'rpg_no_quest_error',
+    'No quest available; use ''do quest <id>''.',
+    0, 0,
+    '사용 가능한 퀘스트가 없습니다; ''do quest <id>''를 사용하세요.',
+    'Aucune quête disponible ; utilisez ''do quest <id>''.',
+    'Keine Quest verfügbar; nutze ''do quest <id>''.',
+    '没有可用的任务；请使用 ''do quest <id>''。',
+    '沒有可用的任務；請使用 ''do quest <id>''。',
+    'No hay misión disponible; usa ''do quest <id>''.',
+    'No hay misión disponible; usa ''do quest <id>''.',
+    'Нет доступных квестов; используйте ''do quest <id>''.');
+
+INSERT INTO ai_playerbot_texts_chance (name, probability) VALUES ('rpg_no_quest_error', 100);
+
+-- rpg_invalid_quest_error: %quest_id is replaced with the quest id
+INSERT INTO `ai_playerbot_texts`
+    (`id`, `name`, `text`, `say_type`, `reply_type`,
+     `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`,
+     `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`)
+VALUES (
+    1765,
+    'rpg_invalid_quest_error',
+    'Invalid quest %quest_id',
+    0, 0,
+    '유효하지 않은 퀘스트 %quest_id',
+    'Quête invalide %quest_id',
+    'Ungültige Quest %quest_id',
+    '无效任务 %quest_id',
+    '無效任務 %quest_id',
+    'Misión no válida %quest_id',
+    'Misión no válida %quest_id',
+    'Неверный квест %quest_id');
+
+INSERT INTO ai_playerbot_texts_chance (name, probability) VALUES ('rpg_invalid_quest_error', 100);
+
+-- rpg_unknown_status_error: option keywords stay in English because they
+-- are the actual command tokens parsed by NewRpgInfo::StatusFromString
+INSERT INTO `ai_playerbot_texts`
+    (`id`, `name`, `text`, `say_type`, `reply_type`,
+     `text_loc1`, `text_loc2`, `text_loc3`, `text_loc4`,
+     `text_loc5`, `text_loc6`, `text_loc7`, `text_loc8`)
+VALUES (
+    1766,
+    'rpg_unknown_status_error',
+    'Unknown rpg status. Options: idle, rest, wander random, wander npc, go grind, go camp, do quest [<id>], travel flight, outdoor pvp.',
+    0, 0,
+    '알 수 없는 RPG 상태입니다. 옵션: idle, rest, wander random, wander npc, go grind, go camp, do quest [<id>], travel flight, outdoor pvp.',
+    'Statut RPG inconnu. Options: idle, rest, wander random, wander npc, go grind, go camp, do quest [<id>], travel flight, outdoor pvp.',
+    'Unbekannter RPG-Status. Optionen: idle, rest, wander random, wander npc, go grind, go camp, do quest [<id>], travel flight, outdoor pvp.',
+    '未知的RPG状态。选项: idle, rest, wander random, wander npc, go grind, go camp, do quest [<id>], travel flight, outdoor pvp。',
+    '未知的RPG狀態。選項: idle, rest, wander random, wander npc, go grind, go camp, do quest [<id>], travel flight, outdoor pvp。',
+    'Estado RPG desconocido. Opciones: idle, rest, wander random, wander npc, go grind, go camp, do quest [<id>], travel flight, outdoor pvp.',
+    'Estado RPG desconocido. Opciones: idle, rest, wander random, wander npc, go grind, go camp, do quest [<id>], travel flight, outdoor pvp.',
+    'Неизвестный RPG-статус. Опции: idle, rest, wander random, wander npc, go grind, go camp, do quest [<id>], travel flight, outdoor pvp.');
+
+INSERT INTO ai_playerbot_texts_chance (name, probability) VALUES ('rpg_unknown_status_error', 100);

--- a/src/Ai/World/Rpg/Action/NewRpgAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.cpp
@@ -181,7 +181,7 @@ bool TellRpgStatusAction::Execute(Event event)
             return false;
         }
         Quest const* quest = sObjectMgr->GetQuestTemplate(questId);
-S        QuestStatus questStatus = bot->GetQuestStatus(questId);
+        QuestStatus questStatus = bot->GetQuestStatus(questId);
         if (!quest || (questStatus != QUEST_STATUS_INCOMPLETE && questStatus != QUEST_STATUS_COMPLETE))
         {
             std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(

--- a/src/Ai/World/Rpg/Action/NewRpgAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.cpp
@@ -26,6 +26,14 @@
 #include "Timer.h"
 #include "TravelMgr.h"
 
+void TellRpgStatusAction::WhisperStatusChange(Player* owner, std::string const& statusName)
+{
+    std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
+        RPG_STATUS_CHANGED_KEY, RPG_STATUS_CHANGED_DEFAULT,
+        {{"%status", statusName}});
+    bot->Whisper(msg, LANG_UNIVERSAL, owner);
+}
+
 bool TellRpgStatusAction::Execute(Event event)
 {
     Player* owner = event.getOwner();
@@ -54,10 +62,20 @@ bool TellRpgStatusAction::Execute(Event event)
 
     std::string name = text;
     uint32 questId = 0;
-    if (text.find("do quest ") != std::string::npos)
+    static std::string const doQuestPrefix = "do quest ";
+    size_t doQuestPos = text.find(doQuestPrefix);
+    if (doQuestPos != std::string::npos)
     {
-        questId = stoi(text.substr(9));
         name = "do quest";
+        std::string idStr = text.substr(doQuestPos + doQuestPrefix.length());
+        try
+        {
+            questId = static_cast<uint32>(std::stoul(idStr));
+        }
+        catch (std::exception const&)
+        {
+            questId = 0;
+        }
     }
 
     NewRpgStatus status = NewRpgInfo::StatusFromString(name);
@@ -66,38 +84,26 @@ bool TellRpgStatusAction::Execute(Event event)
     if (status == RPG_IDLE)
     {
         info.ChangeToIdle();
-        std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
-            "rpg_status_changed", "rpg status -> %status",
-            {{"status", "IDLE"}});
-        bot->Whisper(msg, LANG_UNIVERSAL, owner);
+        WhisperStatusChange(owner, "IDLE");
         return true;
     }
     else if (status == RPG_REST)
     {
         info.ChangeToRest();
         bot->SetStandState(UNIT_STAND_STATE_SIT);
-        std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
-            "rpg_status_changed", "rpg status -> %status",
-            {{"status", "REST"}});
-        bot->Whisper(msg, LANG_UNIVERSAL, owner);
+        WhisperStatusChange(owner, "REST");
         return true;
     }
     else if (status == RPG_WANDER_RANDOM)
     {
         info.ChangeToWanderRandom();
-        std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
-            "rpg_status_changed", "rpg status -> %status",
-            {{"status", "WANDER_RANDOM"}});
-        bot->Whisper(msg, LANG_UNIVERSAL, owner);
+        WhisperStatusChange(owner, "WANDER_RANDOM");
         return true;
     }
     else if (status == RPG_WANDER_NPC)
     {
         info.ChangeToWanderNpc();
-        std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
-            "rpg_status_changed", "rpg status -> %status",
-            {{"status", "WANDER_NPC"}});
-        bot->Whisper(msg, LANG_UNIVERSAL, owner);
+        WhisperStatusChange(owner, "WANDER_NPC");
         return true;
     }
     else if (status == RPG_GO_GRIND)
@@ -111,10 +117,7 @@ bool TellRpgStatusAction::Execute(Event event)
             return false;
         }
         info.ChangeToGoGrind(pos);
-        std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
-            "rpg_status_changed", "rpg status -> %status",
-            {{"status", "GO_GRIND"}});
-        bot->Whisper(msg, LANG_UNIVERSAL, owner);
+        WhisperStatusChange(owner, "GO_GRIND");
         return true;
     }
     else if (status == RPG_GO_CAMP)
@@ -128,10 +131,7 @@ bool TellRpgStatusAction::Execute(Event event)
             return false;
         }
         info.ChangeToGoCamp(pos);
-        std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
-            "rpg_status_changed", "rpg status -> %status",
-            {{"status", "GO_CAMP"}});
-        bot->Whisper(msg, LANG_UNIVERSAL, owner);
+        WhisperStatusChange(owner, "GO_CAMP");
         return true;
     }
     else if (status == RPG_TRAVEL_FLIGHT)
@@ -147,19 +147,13 @@ bool TellRpgStatusAction::Execute(Event event)
             return false;
         }
         info.ChangeToTravelFlight(flightMasterEntry, flightMasterPos, std::move(path));
-        std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
-            "rpg_status_changed", "rpg status -> %status",
-            {{"status", "TRAVEL_FLIGHT"}});
-        bot->Whisper(msg, LANG_UNIVERSAL, owner);
+        WhisperStatusChange(owner, "TRAVEL_FLIGHT");
         return true;
     }
     else if (status == RPG_OUTDOOR_PVP)
     {
         info.ChangeToOutdoorPvp();
-        std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
-            "rpg_status_changed", "rpg status -> %status",
-            {{"status", "OUTDOOR_PVP"}});
-        bot->Whisper(msg, LANG_UNIVERSAL, owner);
+        WhisperStatusChange(owner, "OUTDOOR_PVP");
         return true;
     }
     else if (status == RPG_DO_QUEST)
@@ -187,19 +181,17 @@ bool TellRpgStatusAction::Execute(Event event)
             return false;
         }
         Quest const* quest = sObjectMgr->GetQuestTemplate(questId);
-        if (!quest)
+S        QuestStatus questStatus = bot->GetQuestStatus(questId);
+        if (!quest || (questStatus != QUEST_STATUS_INCOMPLETE && questStatus != QUEST_STATUS_COMPLETE))
         {
             std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
                 "rpg_invalid_quest_error", "Invalid quest %quest_id",
-                {{"quest_id", std::to_string(questId)}});
+                {{"%quest_id", std::to_string(questId)}});
             bot->Whisper(msg, LANG_UNIVERSAL, owner);
             return false;
         }
         info.ChangeToDoQuest(questId, quest);
-        std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
-            "rpg_status_changed", "rpg status -> %status",
-            {{"status", "DO_QUEST " + std::to_string(questId)}});
-        bot->Whisper(msg, LANG_UNIVERSAL, owner);
+        WhisperStatusChange(owner, "DO_QUEST " + std::to_string(questId));
         return true;
     }
 

--- a/src/Ai/World/Rpg/Action/NewRpgAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.cpp
@@ -19,6 +19,7 @@
 #include "PathGenerator.h"
 #include "Player.h"
 #include "PlayerbotAI.h"
+#include "PlayerbotTextMgr.h"
 #include "QuestDef.h"
 #include "Random.h"
 #include "SharedDefines.h"
@@ -30,9 +31,184 @@ bool TellRpgStatusAction::Execute(Event event)
     Player* owner = event.getOwner();
     if (!owner)
         return false;
-    std::string out = botAI->rpgInfo.ToString();
-    bot->Whisper(out.c_str(), LANG_UNIVERSAL, owner);
-    return true;
+
+    std::string const text = event.getParam();
+    if (text.empty())
+    {
+        std::string out = botAI->rpgInfo.ToString();
+        bot->Whisper(out.c_str(), LANG_UNIVERSAL, owner);
+        return true;
+    }
+
+    Player* master = botAI->GetMaster();
+    bool isMaster = master && master->GetGUID() == owner->GetGUID();
+    bool isGM = owner->GetSession() && owner->GetSession()->GetSecurity() >= SEC_GAMEMASTER;
+    if (!isMaster && !isGM)
+    {
+        std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
+            "rpg_debug_permission_error",
+            "Only your master or a GM can change my rpg status.", {});
+        bot->Whisper(msg, LANG_UNIVERSAL, owner);
+        return false;
+    }
+
+    std::string name = text;
+    uint32 questId = 0;
+    if (text.find("do quest ") != std::string::npos)
+    {
+        questId = stoi(text.substr(9));
+        name = "do quest";
+    }
+
+    NewRpgStatus status = NewRpgInfo::StatusFromString(name);
+    NewRpgInfo& info = botAI->rpgInfo;
+
+    if (status == RPG_IDLE)
+    {
+        info.ChangeToIdle();
+        std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
+            "rpg_status_changed", "rpg status -> %status",
+            {{"status", "IDLE"}});
+        bot->Whisper(msg, LANG_UNIVERSAL, owner);
+        return true;
+    }
+    else if (status == RPG_REST)
+    {
+        info.ChangeToRest();
+        bot->SetStandState(UNIT_STAND_STATE_SIT);
+        std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
+            "rpg_status_changed", "rpg status -> %status",
+            {{"status", "REST"}});
+        bot->Whisper(msg, LANG_UNIVERSAL, owner);
+        return true;
+    }
+    else if (status == RPG_WANDER_RANDOM)
+    {
+        info.ChangeToWanderRandom();
+        std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
+            "rpg_status_changed", "rpg status -> %status",
+            {{"status", "WANDER_RANDOM"}});
+        bot->Whisper(msg, LANG_UNIVERSAL, owner);
+        return true;
+    }
+    else if (status == RPG_WANDER_NPC)
+    {
+        info.ChangeToWanderNpc();
+        std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
+            "rpg_status_changed", "rpg status -> %status",
+            {{"status", "WANDER_NPC"}});
+        bot->Whisper(msg, LANG_UNIVERSAL, owner);
+        return true;
+    }
+    else if (status == RPG_GO_GRIND)
+    {
+        WorldPosition pos = SelectRandomGrindPos(bot);
+        if (pos == WorldPosition())
+        {
+            std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
+                "rpg_no_grind_pos_error", "No grind position available.", {});
+            bot->Whisper(msg, LANG_UNIVERSAL, owner);
+            return false;
+        }
+        info.ChangeToGoGrind(pos);
+        std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
+            "rpg_status_changed", "rpg status -> %status",
+            {{"status", "GO_GRIND"}});
+        bot->Whisper(msg, LANG_UNIVERSAL, owner);
+        return true;
+    }
+    else if (status == RPG_GO_CAMP)
+    {
+        WorldPosition pos = SelectRandomCampPos(bot);
+        if (pos == WorldPosition())
+        {
+            std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
+                "rpg_no_camp_pos_error", "No camp position available.", {});
+            bot->Whisper(msg, LANG_UNIVERSAL, owner);
+            return false;
+        }
+        info.ChangeToGoCamp(pos);
+        std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
+            "rpg_status_changed", "rpg status -> %status",
+            {{"status", "GO_CAMP"}});
+        bot->Whisper(msg, LANG_UNIVERSAL, owner);
+        return true;
+    }
+    else if (status == RPG_TRAVEL_FLIGHT)
+    {
+        uint32 flightMasterEntry = 0;
+        WorldPosition flightMasterPos;
+        std::vector<uint32> path;
+        if (!SelectRandomFlightTaxiNode(flightMasterEntry, flightMasterPos, path))
+        {
+            std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
+                "rpg_no_flight_path_error", "No flight path available.", {});
+            bot->Whisper(msg, LANG_UNIVERSAL, owner);
+            return false;
+        }
+        info.ChangeToTravelFlight(flightMasterEntry, flightMasterPos, std::move(path));
+        std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
+            "rpg_status_changed", "rpg status -> %status",
+            {{"status", "TRAVEL_FLIGHT"}});
+        bot->Whisper(msg, LANG_UNIVERSAL, owner);
+        return true;
+    }
+    else if (status == RPG_OUTDOOR_PVP)
+    {
+        info.ChangeToOutdoorPvp();
+        std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
+            "rpg_status_changed", "rpg status -> %status",
+            {{"status", "OUTDOOR_PVP"}});
+        bot->Whisper(msg, LANG_UNIVERSAL, owner);
+        return true;
+    }
+    else if (status == RPG_DO_QUEST)
+    {
+        if (!questId)
+        {
+            for (uint8 slot = 0; slot < MAX_QUEST_LOG_SIZE; ++slot)
+            {
+                uint32 qid = bot->GetQuestSlotQuestId(slot);
+                if (!qid)
+                    continue;
+                std::vector<POIInfo> poi;
+                if (GetQuestPOIPosAndObjectiveIdx(qid, poi, true))
+                {
+                    questId = qid;
+                    break;
+                }
+            }
+        }
+        if (!questId)
+        {
+            std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
+                "rpg_no_quest_error", "No quest available; use 'do quest <id>'.", {});
+            bot->Whisper(msg, LANG_UNIVERSAL, owner);
+            return false;
+        }
+        Quest const* quest = sObjectMgr->GetQuestTemplate(questId);
+        if (!quest)
+        {
+            std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
+                "rpg_invalid_quest_error", "Invalid quest %quest_id",
+                {{"quest_id", std::to_string(questId)}});
+            bot->Whisper(msg, LANG_UNIVERSAL, owner);
+            return false;
+        }
+        info.ChangeToDoQuest(questId, quest);
+        std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
+            "rpg_status_changed", "rpg status -> %status",
+            {{"status", "DO_QUEST " + std::to_string(questId)}});
+        bot->Whisper(msg, LANG_UNIVERSAL, owner);
+        return true;
+    }
+
+    std::string msg = PlayerbotTextMgr::instance().GetBotTextOrDefault(
+        "rpg_unknown_status_error",
+        "Unknown rpg status. Options: idle, rest, wander random, wander npc, "
+        "go grind, go camp, do quest [<id>], travel flight, outdoor pvp.", {});
+    bot->Whisper(msg, LANG_UNIVERSAL, owner);
+    return false;
 }
 
 bool StartRpgDoQuestAction::Execute(Event event)

--- a/src/Ai/World/Rpg/Action/NewRpgAction.h
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.h
@@ -13,10 +13,10 @@
 #include "QuestDef.h"
 #include "TravelMgr.h"
 
-class TellRpgStatusAction : public Action
+class TellRpgStatusAction : public NewRpgBaseAction
 {
 public:
-    TellRpgStatusAction(PlayerbotAI* botAI) : Action(botAI, "rpg status") {}
+    TellRpgStatusAction(PlayerbotAI* botAI) : NewRpgBaseAction(botAI, "rpg status") {}
 
     bool Execute(Event event) override;
 };

--- a/src/Ai/World/Rpg/Action/NewRpgAction.h
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.h
@@ -1,6 +1,8 @@
 #ifndef _PLAYERBOT_NEWRPGACTION_H
 #define _PLAYERBOT_NEWRPGACTION_H
 
+#include <string>
+
 #include "Duration.h"
 #include "MovementActions.h"
 #include "NewRpgBaseAction.h"
@@ -13,12 +15,20 @@
 #include "QuestDef.h"
 #include "TravelMgr.h"
 
+class Player;
+
 class TellRpgStatusAction : public NewRpgBaseAction
 {
 public:
     TellRpgStatusAction(PlayerbotAI* botAI) : NewRpgBaseAction(botAI, "rpg status") {}
 
     bool Execute(Event event) override;
+
+private:
+    static constexpr char const* RPG_STATUS_CHANGED_KEY = "rpg_status_changed";
+    static constexpr char const* RPG_STATUS_CHANGED_DEFAULT = "rpg status -> %status";
+
+    void WhisperStatusChange(Player* owner, std::string const& statusName);
 };
 
 class StartRpgDoQuestAction : public Action

--- a/src/Ai/World/Rpg/NewRpgInfo.cpp
+++ b/src/Ai/World/Rpg/NewRpgInfo.cpp
@@ -87,6 +87,20 @@ void NewRpgInfo::SetMoveFarTo(WorldPosition pos)
     moveFarPos = pos;
 }
 
+NewRpgStatus NewRpgInfo::StatusFromString(std::string const& name)
+{
+    if (name == "idle")           return RPG_IDLE;
+    if (name == "rest")           return RPG_REST;
+    if (name == "wander random")  return RPG_WANDER_RANDOM;
+    if (name == "wander npc")     return RPG_WANDER_NPC;
+    if (name == "go grind")       return RPG_GO_GRIND;
+    if (name == "go camp")        return RPG_GO_CAMP;
+    if (name == "do quest")       return RPG_DO_QUEST;
+    if (name == "travel flight")  return RPG_TRAVEL_FLIGHT;
+    if (name == "outdoor pvp")    return RPG_OUTDOOR_PVP;
+    return RPG_STATUS_END;
+}
+
 NewRpgStatus NewRpgInfo::GetStatus()
 {
     return std::visit([](auto&& arg) -> NewRpgStatus {

--- a/src/Ai/World/Rpg/NewRpgInfo.h
+++ b/src/Ai/World/Rpg/NewRpgInfo.h
@@ -91,6 +91,7 @@ struct NewRpgInfo
     RpgData data;
 
     NewRpgStatus GetStatus();
+    static NewRpgStatus StatusFromString(std::string const& name);
     bool HasStatusPersisted(uint32 maxDuration) { return GetMSTimeDiffToNow(startT) > maxDuration; }
     void ChangeToGoGrind(WorldPosition pos);
     void ChangeToGoCamp(WorldPosition pos);


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
This expands the chat command functionality for bots rpg status allowing you to set your own state. 


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.



## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
as a GM or bot master try to change a bots status and see if they execute it. 


## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


