### PR TITLE
Make Vashj Strategy Compatible with Acore Bug & Use AI Instance for Targeting

### DIFF
--- a/src/Ai/Raid/GruulsLair/Action/RaidGruulsLairActions.cpp
+++ b/src/Ai/Raid/GruulsLair/Action/RaidGruulsLairActions.cpp
@@ -19,7 +19,7 @@ bool HighKingMaulgarMainTankAttackMaulgarAction::Execute(Event /*event*/)
     MarkTargetWithSquare(bot, maulgar);
     SetRtiTarget(botAI, "square", maulgar);
 
-    if (bot->GetVictim() != maulgar)
+    if (AI_VALUE(Unit*, "current target") != maulgar)
         return Attack(maulgar);
 
     if (maulgar->GetVictim() == bot)
@@ -53,7 +53,7 @@ bool HighKingMaulgarFirstAssistTankAttackOlmAction::Execute(Event /*event*/)
     MarkTargetWithCircle(bot, olm);
     SetRtiTarget(botAI, "circle", olm);
 
-    if (bot->GetVictim() != olm)
+    if (AI_VALUE(Unit*, "current target") != olm)
         return Attack(olm);
 
     if (olm->GetVictim() == bot)
@@ -88,7 +88,7 @@ bool HighKingMaulgarSecondAssistTankAttackBlindeyeAction::Execute(Event /*event*
     MarkTargetWithStar(bot, blindeye);
     SetRtiTarget(botAI, "star", blindeye);
 
-    if (bot->GetVictim() != blindeye)
+    if (AI_VALUE(Unit*, "current target") != blindeye)
         return Attack(blindeye);
 
     if (blindeye->GetVictim() == bot)
@@ -128,7 +128,7 @@ bool HighKingMaulgarMageTankAttackKroshAction::Execute(Event /*event*/)
     if (!bot->HasAura(SPELL_SPELL_SHIELD) && botAI->CanCastSpell("fire ward", bot))
         return botAI->CastSpell("fire ward", bot);
 
-    if (bot->GetTarget() != krosh->GetGUID())
+    if (AI_VALUE(Unit*, "current target") != krosh)
         return Attack(krosh);
 
     if (krosh->GetVictim() == bot)
@@ -175,7 +175,7 @@ bool HighKingMaulgarMoonkinTankAttackKigglerAction::Execute(Event /*event*/)
     MarkTargetWithDiamond(bot, kiggler);
     SetRtiTarget(botAI, "diamond", kiggler);
 
-    if (bot->GetTarget() != kiggler->GetGUID())
+    if (AI_VALUE(Unit*, "current target") != kiggler)
         return Attack(kiggler);
 
     Position safePos;
@@ -205,7 +205,7 @@ bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
 
         SetRtiTarget(botAI, "star", blindeye);
 
-        if (bot->GetTarget() != blindeye->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != blindeye)
             return Attack(blindeye);
 
         return false;
@@ -226,7 +226,7 @@ bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
 
         SetRtiTarget(botAI, "circle", olm);
 
-        if (bot->GetTarget() != olm->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != olm)
             return Attack(olm);
 
         return false;
@@ -247,7 +247,7 @@ bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
 
         SetRtiTarget(botAI, "triangle", krosh);
 
-        if (bot->GetTarget() != krosh->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != krosh)
             return Attack(krosh);
 
         return false;
@@ -268,7 +268,7 @@ bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
 
         SetRtiTarget(botAI, "diamond", kiggler);
 
-        if (bot->GetTarget() != kiggler->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != kiggler)
             return Attack(kiggler);
 
         return false;
@@ -289,7 +289,7 @@ bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
 
         SetRtiTarget(botAI, "square", maulgar);
 
-        if (bot->GetTarget() != maulgar->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != maulgar)
             return Attack(maulgar);
     }
 
@@ -499,7 +499,7 @@ bool GruulTheDragonkillerTanksPositionBossAction::Execute(Event /*event*/)
     if (!gruul)
         return false;
 
-    if (bot->GetVictim() != gruul)
+    if (AI_VALUE(Unit*, "current target") != gruul)
         return Attack(gruul);
 
     if (gruul->GetVictim() == bot)

--- a/src/Ai/Raid/GruulsLair/Multiplier/RaidGruulsLairMultipliers.cpp
+++ b/src/Ai/Raid/GruulsLair/Multiplier/RaidGruulsLairMultipliers.cpp
@@ -15,6 +15,9 @@ using namespace GruulsLairHelpers;
 
 float HighKingMaulgarDisableTankAssistMultiplier::GetValue(Action* action)
 {
+    if (bot->GetVictim() == nullptr)
+        return 1.0f;
+
     if (IsAnyOgreBossAlive(botAI) && dynamic_cast<TankAssistAction*>(action))
         return 0.0f;
 
@@ -46,9 +49,8 @@ float HighKingMaulgarAvoidWhirlwindMultiplier::GetValue(Action* action)
 float HighKingMaulgarDisableArcaneShotOnKroshMultiplier::GetValue(Action* action)
 {
     Unit* krosh = AI_VALUE2(Unit*, "find target", "krosh firehand");
-    Unit* target = AI_VALUE(Unit*, "current target");
 
-    if (krosh && target && target->GetGUID() == krosh->GetGUID() &&
+    if (krosh && AI_VALUE(Unit*, "current target") == krosh &&
         dynamic_cast<CastArcaneShotAction*>(action))
         return 0.0f;
 

--- a/src/Ai/Raid/HyjalSummit/Action/RaidHyjalSummitActions.cpp
+++ b/src/Ai/Raid/HyjalSummit/Action/RaidHyjalSummitActions.cpp
@@ -97,7 +97,7 @@ bool RageWinterchillMainTankPositionBossAction::Execute(Event /*event*/)
     if (!winterchill)
         return false;
 
-    if (bot->GetVictim() != winterchill)
+    if (AI_VALUE(Unit*, "current target") != winterchill)
         return Attack(winterchill);
 
     if (winterchill->GetVictim() == bot)
@@ -265,7 +265,7 @@ bool AnetheronMainTankPositionBossAction::Execute(Event /*event*/)
     MarkTargetWithSquare(bot, anetheron);
     SetRtiTarget(botAI, "square", anetheron);
 
-    if (bot->GetVictim() != anetheron)
+    if (AI_VALUE(Unit*, "current target") != anetheron)
         return Attack(anetheron);
 
     if (anetheron->GetVictim() == bot)
@@ -395,7 +395,7 @@ bool AnetheronFirstAssistTankPickUpInfernalsAction::Execute(Event /*event*/)
     MarkTargetWithDiamond(bot, infernal);
     SetRtiTarget(botAI, "diamond", infernal);
 
-    if (bot->GetVictim() != infernal)
+    if (AI_VALUE(Unit*, "current target") != infernal)
         return Attack(infernal);
 
     if ((infernoTarget && infernoTarget == bot) ||
@@ -432,7 +432,7 @@ bool AnetheronAssignDpsPriorityAction::Execute(Event /*event*/)
     {
         SetRtiTarget(botAI, "square", anetheron);
 
-        if (bot->GetVictim() != anetheron)
+        if (AI_VALUE(Unit*, "current target") != anetheron)
             return Attack(anetheron);
 
         return false;
@@ -455,7 +455,7 @@ bool AnetheronAssignDpsPriorityAction::Execute(Event /*event*/)
             {
                 SetRtiTarget(botAI, "diamond", infernal);
 
-                if (bot->GetTarget() != infernal->GetGUID())
+                if (AI_VALUE(Unit*, "current target") != infernal)
                     return Attack(infernal);
             }
         }
@@ -464,7 +464,7 @@ bool AnetheronAssignDpsPriorityAction::Execute(Event /*event*/)
     {
         SetRtiTarget(botAI, "square", anetheron);
 
-        if (bot->GetTarget() != anetheron->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != anetheron)
             return Attack(anetheron);
     }
 
@@ -500,7 +500,7 @@ bool KazrogalMainTankPositionBossAction::Execute(Event /*event*/)
     if (!kazrogal)
         return false;
 
-    if (bot->GetVictim() != kazrogal)
+    if (AI_VALUE(Unit*, "current target") != kazrogal)
         return Attack(kazrogal);
 
     if (kazrogal->GetVictim() == bot && bot->IsWithinMeleeRange(kazrogal))
@@ -734,7 +734,7 @@ bool AzgalorMainTankPositionBossAction::Execute(Event /*event*/)
     MarkTargetWithStar(bot, azgalor);
     SetRtiTarget(botAI, "star", azgalor);
 
-    if (bot->GetVictim() != azgalor)
+    if (AI_VALUE(Unit*, "current target") != azgalor)
         return Attack(azgalor);
 
     if (azgalor->GetVictim() == bot && bot->IsWithinMeleeRange(azgalor))
@@ -801,7 +801,7 @@ bool AzgalorDisperseRangedAction::Execute(Event /*event*/)
     {
         return FleePosition(doomguard->GetPosition(), safeDistFromDoomguard);
     }
-    else if (!doomguard || bot->GetTarget() != doomguard->GetGUID())
+    else if (!doomguard || AI_VALUE(Unit*, "current target") != doomguard)
     {
         Unit* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistFromPlayer);
         if (nearestPlayer)
@@ -848,7 +848,7 @@ bool AzgalorMeleeGetOutOfFireAndSwapTargetsAction::Execute(Event /*event*/)
         }
     }
 
-    if (bot->GetVictim() != desiredTarget || bot->GetTarget() != desiredTarget->GetGUID())
+    if (AI_VALUE(Unit*, "current target") != desiredTarget)
         return Attack(desiredTarget);
 
     return false;
@@ -912,7 +912,7 @@ bool AzgalorFirstAssistTankPositionDoomguardAction::Execute(Event /*event*/)
         MarkTargetWithCircle(bot, doomguard);
         SetRtiTarget(botAI, "circle", doomguard);
 
-        if (bot->GetVictim() != doomguard)
+        if (AI_VALUE(Unit*, "current target") != doomguard)
             return Attack(doomguard);
 
         if (doomguard->GetVictim() == bot && bot->IsWithinMeleeRange(doomguard) &&
@@ -963,7 +963,7 @@ bool AzgalorRangedDpsPrioritizeDoomguardsAction::Execute(Event /*event*/)
         {
             SetRtiTarget(botAI, "circle", doomguard);
 
-            if (bot->GetTarget() != doomguard->GetGUID())
+            if (AI_VALUE(Unit*, "current target") != doomguard)
                 return Attack(doomguard);
         }
     }
@@ -971,7 +971,7 @@ bool AzgalorRangedDpsPrioritizeDoomguardsAction::Execute(Event /*event*/)
     {
         SetRtiTarget(botAI, "star", azgalor);
 
-        if (bot->GetTarget() != azgalor->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != azgalor)
             return Attack(azgalor);
     }
 
@@ -1007,7 +1007,7 @@ bool ArchimondeMoveBossToInitialPositionAction::Execute(Event /*event*/)
     if (!archimonde)
         return false;
 
-    if (bot->GetVictim() != archimonde)
+    if (AI_VALUE(Unit*, "current target") != archimonde)
         return Attack(archimonde);
 
     if (archimonde->GetVictim() == bot && bot->IsWithinMeleeRange(archimonde) &&

--- a/src/Ai/Raid/Karazhan/Action/RaidKarazhanActions.cpp
+++ b/src/Ai/Raid/Karazhan/Action/RaidKarazhanActions.cpp
@@ -50,11 +50,9 @@ bool AttumenTheHuntsmanMarkTargetAction::Execute(Event /*event*/)
 
         SetRtiTarget(botAI, "star", attumenMounted);
 
-        if (bot->GetTarget() != attumenMounted->GetGUID())
-        {
-            bot->SetTarget(attumenMounted->GetGUID());
+        if (AI_VALUE(Unit*, "current target") != attumenMounted)
             return Attack(attumenMounted);
-        }
+
     }
     else if (Unit* midnight = AI_VALUE2(Unit*, "find target", "midnight"))
     {
@@ -65,11 +63,8 @@ bool AttumenTheHuntsmanMarkTargetAction::Execute(Event /*event*/)
         {
             SetRtiTarget(botAI, "star", midnight);
 
-            if (bot->GetTarget() != midnight->GetGUID())
-            {
-                bot->SetTarget(midnight->GetGUID());
+            if (AI_VALUE(Unit*, "current target") != midnight)
                 return Attack(midnight);
-            }
         }
     }
 
@@ -90,7 +85,7 @@ bool AttumenTheHuntsmanSplitBossesAction::Execute(Event /*event*/)
     MarkTargetWithSquare(bot, attumen);
     SetRtiTarget(botAI, "square", attumen);
 
-    if (bot->GetVictim() != attumen)
+    if (AI_VALUE(Unit*, "current target") != attumen)
         return Attack(attumen);
 
     if (attumen->GetVictim() == bot && midnight->GetVictim() != bot)
@@ -162,7 +157,7 @@ bool MoroesMainTankAttackBossAction::Execute(Event /*event*/)
     MarkTargetWithCircle(bot, moroes);
     SetRtiTarget(botAI, "circle", moroes);
 
-    if (bot->GetVictim() != moroes)
+    if (AI_VALUE(Unit*, "current target") != moroes)
         return Attack(moroes);
 
     return false;
@@ -200,7 +195,7 @@ bool MaidenOfVirtueMoveBossToHealerAction::Execute(Event /*event*/)
     if (!maiden)
         return false;
 
-    if (bot->GetVictim() != maiden)
+    if (AI_VALUE(Unit*, "current target") != maiden)
         return Attack(maiden);
 
     Unit* healer = nullptr;
@@ -294,7 +289,7 @@ bool BigBadWolfPositionBossAction::Execute(Event /*event*/)
     if (!wolf)
         return false;
 
-    if (bot->GetVictim() != wolf)
+    if (AI_VALUE(Unit*, "current target") != wolf)
         return Attack(wolf);
 
     if (wolf->GetVictim() == bot)
@@ -425,7 +420,7 @@ bool TheCuratorPositionBossAction::Execute(Event /*event*/)
     MarkTargetWithCircle(bot, curator);
     SetRtiTarget(botAI, "circle", curator);
 
-    if (bot->GetVictim() != curator)
+    if (AI_VALUE(Unit*, "current target") != curator)
         return Attack(curator);
 
     if (curator->GetVictim() == bot)
@@ -1193,7 +1188,7 @@ bool PrinceMalchezaarMainTankMovementAction::Execute(Event /*event*/)
     if (!malchezaar)
         return false;
 
-    if (bot->GetVictim() != malchezaar)
+    if (AI_VALUE(Unit*, "current target") != malchezaar)
         return Attack(malchezaar);
 
     std::vector<Unit*> infernals = GetSpawnedInfernals(botAI);
@@ -1261,7 +1256,7 @@ bool NightbaneGroundPhasePositionBossAction::Execute(Event /*event*/)
 
     MarkTargetWithSkull(bot, nightbane);
 
-    if (bot->GetVictim() != nightbane)
+    if (AI_VALUE(Unit*, "current target") != nightbane)
         return Attack(nightbane);
 
     const ObjectGuid botGuid = bot->GetGUID();
@@ -1400,8 +1395,7 @@ bool NightbaneFlightPhaseMovementAction::Execute(Event /*event*/)
 
     MarkTargetWithMoon(bot, nightbane);
 
-    Unit* botTarget = botAI->GetUnit(bot->GetTarget());
-    if (botTarget && botTarget == nightbane)
+    if (AI_VALUE(Unit*, "current target") == nightbane)
     {
         bot->AttackStop();
         bot->InterruptNonMeleeSpells(true);

--- a/src/Ai/Raid/Magtheridon/Action/RaidMagtheridonActions.cpp
+++ b/src/Ai/Raid/Magtheridon/Action/RaidMagtheridonActions.cpp
@@ -61,7 +61,7 @@ bool MagtheridonMainTankAttackFirstThreeChannelersAction::Execute(Event /*event*
 
     SetRtiTarget(botAI, rtiName, currentTarget);
 
-    if (currentTarget && bot->GetVictim() != currentTarget)
+    if (currentTarget && AI_VALUE(Unit*, "current target") != currentTarget)
         return Attack(currentTarget);
 
     return false;
@@ -76,7 +76,7 @@ bool MagtheridonFirstAssistTankAttackNWChannelerAction::Execute(Event /*event*/)
     MarkTargetWithDiamond(bot, channelerDiamond);
     SetRtiTarget(botAI, "diamond", channelerDiamond);
 
-    if (bot->GetVictim() != channelerDiamond)
+    if (AI_VALUE(Unit*, "current target") != channelerDiamond)
         return Attack(channelerDiamond);
 
     if (channelerDiamond->GetVictim() == bot)
@@ -109,7 +109,7 @@ bool MagtheridonSecondAssistTankAttackNEChannelerAction::Execute(Event /*event*/
     MarkTargetWithTriangle(bot, channelerTriangle);
     SetRtiTarget(botAI, "triangle", channelerTriangle);
 
-    if (bot->GetVictim() != channelerTriangle)
+    if (AI_VALUE(Unit*, "current target") != channelerTriangle)
         return Attack(channelerTriangle);
 
     if (channelerTriangle->GetVictim() == bot)
@@ -219,7 +219,7 @@ bool MagtheridonAssignDPSPriorityAction::Execute(Event /*event*/)
     {
         SetRtiTarget(botAI, "square", channelerSquare);
 
-        if (bot->GetTarget() != channelerSquare->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != channelerSquare)
             return Attack(channelerSquare);
 
         return false;
@@ -230,7 +230,7 @@ bool MagtheridonAssignDPSPriorityAction::Execute(Event /*event*/)
     {
         SetRtiTarget(botAI, "star", channelerStar);
 
-        if (bot->GetTarget() != channelerStar->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != channelerStar)
             return Attack(channelerStar);
 
         return false;
@@ -241,7 +241,7 @@ bool MagtheridonAssignDPSPriorityAction::Execute(Event /*event*/)
     {
         SetRtiTarget(botAI, "circle", channelerCircle);
 
-        if (bot->GetTarget() != channelerCircle->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != channelerCircle)
             return Attack(channelerCircle);
 
         return false;
@@ -252,7 +252,7 @@ bool MagtheridonAssignDPSPriorityAction::Execute(Event /*event*/)
     {
         SetRtiTarget(botAI, "diamond", channelerDiamond);
 
-        if (bot->GetTarget() != channelerDiamond->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != channelerDiamond)
             return Attack(channelerDiamond);
 
         return false;
@@ -263,7 +263,7 @@ bool MagtheridonAssignDPSPriorityAction::Execute(Event /*event*/)
     {
         SetRtiTarget(botAI, "triangle", channelerTriangle);
 
-        if (bot->GetTarget() != channelerTriangle->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != channelerTriangle)
             return Attack(channelerTriangle);
 
         return false;
@@ -276,7 +276,7 @@ bool MagtheridonAssignDPSPriorityAction::Execute(Event /*event*/)
     {
         SetRtiTarget(botAI, "cross", magtheridon);
 
-        if (bot->GetTarget() != magtheridon->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != magtheridon)
             return Attack(magtheridon);
     }
 
@@ -347,7 +347,7 @@ bool MagtheridonMainTankPositionBossAction::Execute(Event /*event*/)
     MarkTargetWithCross(bot, magtheridon);
     SetRtiTarget(botAI, "cross", magtheridon);
 
-    if (bot->GetVictim() != magtheridon)
+    if (AI_VALUE(Unit*, "current target") != magtheridon)
         return Attack(magtheridon);
 
     if (magtheridon->GetVictim() == bot)

--- a/src/Ai/Raid/SerpentshrineCavern/Action/RaidSSCActions.cpp
+++ b/src/Ai/Raid/SerpentshrineCavern/Action/RaidSSCActions.cpp
@@ -153,7 +153,7 @@ bool HydrossTheUnstablePositionFrostTankAction::Execute(Event /*event*/)
         MarkTargetWithSquare(bot, hydross);
         SetRtiTarget(botAI, "square", hydross);
 
-        if (bot->GetTarget() != hydross->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != hydross)
             return Attack(hydross);
 
         if (hydross->GetVictim() == bot && bot->IsWithinMeleeRange(hydross))
@@ -233,7 +233,7 @@ bool HydrossTheUnstablePositionNatureTankAction::Execute(Event /*event*/)
         MarkTargetWithTriangle(bot, hydross);
         SetRtiTarget(botAI, "triangle", hydross);
 
-        if (bot->GetTarget() != hydross->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != hydross)
             return Attack(hydross);
 
         if (hydross->GetVictim() == bot && bot->IsWithinMeleeRange(hydross))
@@ -308,7 +308,7 @@ bool HydrossTheUnstablePrioritizeElementalAddsAction::Execute(Event /*event*/)
 
         SetRtiTarget(botAI, "skull", waterElemental);
 
-        if (bot->GetTarget() != waterElemental->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != waterElemental)
             return Attack(waterElemental);
     }
     else if (Unit* natureElemental = GetFirstAliveUnitByEntry(botAI, NPC_TAINTED_SPAWN_OF_HYDROSS))
@@ -318,7 +318,7 @@ bool HydrossTheUnstablePrioritizeElementalAddsAction::Execute(Event /*event*/)
 
         SetRtiTarget(botAI, "skull", natureElemental);
 
-        if (bot->GetTarget() != natureElemental->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != natureElemental)
             return Attack(natureElemental);
     }
 
@@ -518,7 +518,7 @@ bool TheLurkerBelowPositionMainTankAction::Execute(Event /*event*/)
     if (!lurker)
         return false;
 
-    if (bot->GetTarget() != lurker->GetGUID())
+    if (AI_VALUE(Unit*, "current target") != lurker)
         return Attack(lurker);
 
     const Position& position = LURKER_MAIN_TANK_POSITION;
@@ -639,7 +639,7 @@ bool TheLurkerBelowTanksPickUpAddsAction::Execute(Event /*event*/)
             MarkTargetWithIcon(bot, guardian, rtiIndices[i]);
             SetRtiTarget(botAI, rtiNames[i], guardian);
 
-            if (bot->GetVictim() != guardian)
+            if (AI_VALUE(Unit*, "current target") != guardian)
                 return Attack(guardian);
         }
     }
@@ -841,7 +841,7 @@ bool LeotherasTheBlindDestroyInnerDemonAction::Execute(Event /*event*/)
 
         // Roles without a strategy need to affirmatively attack their Inner Demons
         // Because DPS assist is disabled via multipliers
-        if (bot->GetTarget() != innerDemon->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != innerDemon)
             return Attack(innerDemon);
     }
 
@@ -978,7 +978,7 @@ bool LeotherasTheBlindFinalPhaseAssignDpsPriorityAction::Execute(Event /*event*/
     MarkTargetWithStar(bot, leotherasHuman);
     SetRtiTarget(botAI, "star", leotherasHuman);
 
-    if (bot->GetTarget() != leotherasHuman->GetGUID())
+    if (AI_VALUE(Unit*, "current target") != leotherasHuman)
         return Attack(leotherasHuman);
 
     Unit* leotherasDemon = GetPhase3LeotherasDemon(bot);
@@ -1092,7 +1092,7 @@ bool FathomLordKarathressMainTankPositionBossAction::Execute(Event /*event*/)
     MarkTargetWithTriangle(bot, karathress);
     SetRtiTarget(botAI, "triangle", karathress);
 
-    if (bot->GetTarget() != karathress->GetGUID())
+    if (AI_VALUE(Unit*, "current target") != karathress)
         return Attack(karathress);
 
     if (karathress->GetVictim() == bot && bot->IsWithinMeleeRange(karathress))
@@ -1128,7 +1128,7 @@ bool FathomLordKarathressFirstAssistTankPositionCaribdisAction::Execute(Event /*
     MarkTargetWithDiamond(bot, caribdis);
     SetRtiTarget(botAI, "diamond", caribdis);
 
-    if (bot->GetTarget() != caribdis->GetGUID())
+    if (AI_VALUE(Unit*, "current target") != caribdis)
         return Attack(caribdis);
 
     if (caribdis->GetVictim() == bot)
@@ -1163,7 +1163,7 @@ bool FathomLordKarathressSecondAssistTankPositionSharkkisAction::Execute(Event /
     MarkTargetWithStar(bot, sharkkis);
     SetRtiTarget(botAI, "star", sharkkis);
 
-    if (bot->GetTarget() != sharkkis->GetGUID())
+    if (AI_VALUE(Unit*, "current target") != sharkkis)
         return Attack(sharkkis);
 
     if (sharkkis->GetVictim() == bot && bot->IsWithinMeleeRange(sharkkis))
@@ -1198,7 +1198,7 @@ bool FathomLordKarathressThirdAssistTankPositionTidalvessAction::Execute(Event /
     MarkTargetWithCircle(bot, tidalvess);
     SetRtiTarget(botAI, "circle", tidalvess);
 
-    if (bot->GetTarget() != tidalvess->GetGUID())
+    if (AI_VALUE(Unit*, "current target") != tidalvess)
         return Attack(tidalvess);
 
     if (tidalvess->GetVictim() == bot && bot->IsWithinMeleeRange(tidalvess))
@@ -1322,7 +1322,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
         MarkTargetWithSkull(bot, totem);
         SetRtiTarget(botAI, "skull", totem);
 
-        if (bot->GetTarget() != totem->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != totem)
             return Attack(totem);
 
         // Direct movement order due to path between Sharkkis and totem sometimes being screwy
@@ -1343,7 +1343,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
         MarkTargetWithCircle(bot, tidalvess);
         SetRtiTarget(botAI, "circle", tidalvess);
 
-        if (bot->GetTarget() != tidalvess->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != tidalvess)
             return Attack(tidalvess);
 
         return false;
@@ -1363,7 +1363,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
                               position.GetPositionZ(), 8.0f, MovementPriority::MOVEMENT_COMBAT);
         }
 
-        if (bot->GetTarget() != caribdis->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != caribdis)
             return Attack(caribdis);
 
         return false;
@@ -1376,7 +1376,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
         MarkTargetWithStar(bot, sharkkis);
         SetRtiTarget(botAI, "star", sharkkis);
 
-        if (bot->GetTarget() != sharkkis->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != sharkkis)
             return Attack(sharkkis);
 
         return false;
@@ -1389,7 +1389,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
         MarkTargetWithCross(bot, fathomSporebat);
         SetRtiTarget(botAI, "cross", fathomSporebat);
 
-        if (bot->GetTarget() != fathomSporebat->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != fathomSporebat)
             return Attack(fathomSporebat);
 
         return false;
@@ -1401,7 +1401,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
         MarkTargetWithSquare(bot, fathomLurker);
         SetRtiTarget(botAI, "square", fathomLurker);
 
-        if (bot->GetTarget() != fathomLurker->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != fathomLurker)
             return Attack(fathomLurker);
 
         return false;
@@ -1414,7 +1414,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
         MarkTargetWithTriangle(bot, karathress);
         SetRtiTarget(botAI, "triangle", karathress);
 
-        if (bot->GetTarget() != karathress->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != karathress)
             return Attack(karathress);
     }
 
@@ -1460,7 +1460,7 @@ bool MorogrimTidewalkerMoveBossToTankPositionAction::Execute(Event /*event*/)
     if (!tidewalker)
         return false;
 
-    if (bot->GetTarget() != tidewalker->GetGUID())
+    if (AI_VALUE(Unit*, "current target") != tidewalker)
         return Attack(tidewalker);
 
     if (tidewalker->GetVictim() == bot && bot->IsWithinMeleeRange(tidewalker))
@@ -1610,7 +1610,7 @@ bool LadyVashjMainTankPositionBossAction::Execute(Event /*event*/)
     if (!vashj)
         return false;
 
-    if (bot->GetTarget() != vashj->GetGUID())
+    if (AI_VALUE(Unit*, "current target") != vashj)
         return Attack(vashj);
 
     if (vashj->GetVictim() == bot && bot->IsWithinMeleeRange(vashj))
@@ -1929,7 +1929,8 @@ bool LadyVashjAssignPhase2AndPhase3DpsPriorityAction::Execute(Event /*event*/)
         currentTarget = nullptr;
     }
 
-    if (target && currentTarget != target && bot->GetTarget() != target->GetGUID())
+    if (target && currentTarget != target &&
+        AI_VALUE(Unit*, "current target") != target)
         return Attack(target);
 
     // If bots have wandered too far from the center, move them back
@@ -1984,7 +1985,8 @@ bool LadyVashjTankAttackAndMoveAwayStriderAction::Execute(Event /*event*/)
         if (!bot->HasAura(SPELL_FEAR_WARD))
             bot->AddAura(SPELL_FEAR_WARD, bot);
 
-        if (botAI->IsAssistTankOfIndex(bot, 0, true) && bot->GetTarget() != strider->GetGUID())
+        if (botAI->IsAssistTankOfIndex(bot, 0, true) &&
+            AI_VALUE(Unit*, "current target") != strider)
             return Attack(strider);
 
         float currentDistance = bot->GetExactDist2d(vashj);
@@ -2040,7 +2042,7 @@ bool LadyVashjTeleportToTaintedElementalAction::Execute(Event /*event*/)
                         tainted->GetPositionZ(), tainted->GetOrientation());
     }
 
-    if (bot->GetTarget() != tainted->GetGUID())
+    if (AI_VALUE(Unit*, "current target") != tainted)
     {
         MarkTargetWithStar(bot, tainted);
         SetRtiTarget(botAI, "star", tainted);

--- a/src/Ai/Raid/SerpentshrineCavern/Multiplier/RaidSSCMultipliers.cpp
+++ b/src/Ai/Raid/SerpentshrineCavern/Multiplier/RaidSSCMultipliers.cpp
@@ -752,7 +752,7 @@ float LadyVashjDisableAutomaticTargetingAndMovementModifier::GetValue(Action *ac
             return 0.0f;
 
         Unit* enchanted = AI_VALUE2(Unit*, "find target", "enchanted elemental");
-        if (enchanted && bot->GetVictim() == enchanted &&
+        if (enchanted && AI_VALUE(Unit*, "current target") == enchanted &&
             dynamic_cast<CastDebuffSpellOnAttackerAction*>(action))
             return 0.0f;
     }
@@ -772,7 +772,7 @@ float LadyVashjDisableAutomaticTargetingAndMovementModifier::GetValue(Action *ac
                 dynamic_cast<FleeAction*>(action))
                 return 0.0f;
 
-            if (enchanted && bot->GetVictim() == enchanted &&
+            if (enchanted && AI_VALUE(Unit*, "current target") == enchanted &&
                 dynamic_cast<CastDebuffSpellOnAttackerAction*>(action))
                 return 0.0f;
         }

--- a/src/Ai/Raid/SerpentshrineCavern/Util/RaidSSCHelpers.cpp
+++ b/src/Ai/Raid/SerpentshrineCavern/Util/RaidSSCHelpers.cpp
@@ -209,35 +209,24 @@ namespace SerpentShrineCavernHelpers
     {
         Unit* vashj =
             botAI->GetAiObjectContext()->GetValue<Unit*>("find target", "lady vashj")->Get();
-        if (!vashj)
-            return false;
 
-        Creature* vashjCreature = vashj->ToCreature();
-        return vashjCreature && vashjCreature->GetHealthPct() > 70.0f &&
-               vashjCreature->GetReactState() != REACT_PASSIVE;
+        return vashj && vashj->GetHealthPct() > 70.0f;
     }
 
     bool IsLadyVashjInPhase2(PlayerbotAI* botAI)
     {
         Unit* vashj =
             botAI->GetAiObjectContext()->GetValue<Unit*>("find target", "lady vashj")->Get();
-        if (!vashj)
-            return false;
 
-        Creature* vashjCreature = vashj->ToCreature();
-        return vashjCreature && vashjCreature->GetReactState() == REACT_PASSIVE;
+        return vashj && vashj->GetHealthPct() <= 70.0f && vashj->HasAura(SPELL_MAGIC_BARRIER);
     }
 
     bool IsLadyVashjInPhase3(PlayerbotAI* botAI)
     {
         Unit* vashj =
             botAI->GetAiObjectContext()->GetValue<Unit*>("find target", "lady vashj")->Get();
-        if (!vashj)
-            return false;
 
-        Creature* vashjCreature = vashj->ToCreature();
-        return vashjCreature && vashjCreature->GetHealthPct() <= 50.0f &&
-               vashjCreature->GetReactState() != REACT_PASSIVE;
+        return vashj && vashj->GetHealthPct() <= 70.0f && !vashj->HasAura(SPELL_MAGIC_BARRIER);
     }
 
     bool IsValidLadyVashjCombatNpc(Unit* unit, PlayerbotAI* botAI)

--- a/src/Ai/Raid/SerpentshrineCavern/Util/RaidSSCHelpers.h
+++ b/src/Ai/Raid/SerpentshrineCavern/Util/RaidSSCHelpers.h
@@ -48,6 +48,7 @@ namespace SerpentShrineCavernHelpers
 
         // Lady Vashj <Coilfang Matron>
         SPELL_FEAR_WARD              =  6346,
+        SPELL_MAGIC_BARRIER          = 38112,
         SPELL_POISON_BOLT            = 38253,
         SPELL_STATIC_CHARGE          = 38280,
         SPELL_ENTANGLE               = 38316,

--- a/src/Ai/Raid/TempestKeep/Action/RaidTempestKeepActions.cpp
+++ b/src/Ai/Raid/TempestKeep/Action/RaidTempestKeepActions.cpp
@@ -93,7 +93,7 @@ bool AlarBossTanksMoveBetweenPlatformsAction::PositionMainTank(
                           MovementPriority::MOVEMENT_COMBAT, true, false);
         }
         else if ((locationIndex == PLATFORM_0_IDX || locationIndex == PLATFORM_2_IDX) &&
-                 bot->GetTarget() != alar->GetGUID())
+                 AI_VALUE(Unit*, "current target") != alar)
                  return Attack(alar);
     }
 
@@ -116,7 +116,7 @@ bool AlarBossTanksMoveBetweenPlatformsAction::PositionAssistTank(
                           MovementPriority::MOVEMENT_COMBAT, true, false);
         }
         else if ((locationIndex == PLATFORM_1_IDX || locationIndex == PLATFORM_3_IDX) &&
-                 bot->GetTarget() != alar->GetGUID())
+                 AI_VALUE(Unit*, "current target") != alar)
                  return Attack(alar);
     }
 
@@ -152,7 +152,7 @@ bool AlarMeleeDpsMoveBetweenPlatformsAction::Execute(Event /*event*/)
                           MovementPriority::MOVEMENT_COMBAT, true, false);
         }
 
-        if (bot->GetTarget() != alar->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != alar)
             return Attack(alar);
     }
 
@@ -227,7 +227,7 @@ bool AlarAssistTanksPickUpEmbersAction::HandlePhase1Embers(Unit* alar)
         MarkTargetWithSquare(bot, ember);
         SetRtiTarget(botAI, "square", ember);
 
-        if (bot->GetTarget() != ember->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != ember)
             return Attack(ember);
 
         if (ember->GetVictim() == bot)
@@ -286,7 +286,7 @@ bool AlarAssistTanksPickUpEmbersAction::HandlePhase2Embers()
 
         if (firstEmber->GetVictim() != bot)
         {
-            if (bot->GetTarget() != firstEmber->GetGUID())
+            if (AI_VALUE(Unit*, "current target") != firstEmber)
                 return Attack(firstEmber);
 
             return botAI->DoSpecificAction("taunt spell", Event(), true);
@@ -305,7 +305,7 @@ bool AlarAssistTanksPickUpEmbersAction::HandlePhase2Embers()
 
         if (secondEmber->GetVictim() != bot)
         {
-            if (bot->GetTarget() != secondEmber->GetGUID())
+            if (AI_VALUE(Unit*, "current target") != secondEmber)
                 return Attack(secondEmber);
 
             return botAI->DoSpecificAction("taunt spell", Event(), true);
@@ -336,7 +336,7 @@ bool AlarRangedDpsPrioritizeEmbersAction::Execute(Event /*event*/)
         }
 
         SetRtiTarget(botAI, "square", firstEmber);
-        if (bot->GetTarget() != firstEmber->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != firstEmber)
             return Attack(firstEmber);
     }
     else if (secondEmber)
@@ -349,13 +349,13 @@ bool AlarRangedDpsPrioritizeEmbersAction::Execute(Event /*event*/)
         }
 
         SetRtiTarget(botAI, "circle", secondEmber);
-        if (bot->GetTarget() != secondEmber->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != secondEmber)
             return Attack(secondEmber);
     }
     else if (Unit* alar = AI_VALUE2(Unit*, "find target", "al'ar"))
     {
         SetRtiTarget(botAI, "star", alar);
-        if (bot->GetTarget() != alar->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != alar)
             return Attack(alar);
     }
 
@@ -469,7 +469,7 @@ bool AlarSwapTanksOnBossAction::Execute(Event /*event*/)
     if (alar->GetHealth() == alar->GetMaxHealth())
     {
         SetRtiTarget(botAI, "star", alar);
-        if (bot->GetTarget() != alar->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != alar)
             return Attack(alar);
     }
 
@@ -477,7 +477,7 @@ bool AlarSwapTanksOnBossAction::Execute(Event /*event*/)
     if (secondEmberTank && secondEmberTank != bot)
     {
         SetRtiTarget(botAI, "star", alar);
-        if (bot->GetTarget() != alar->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != alar)
             return Attack(alar);
         else if (alar->GetVictim() != bot)
             return botAI->DoSpecificAction("taunt spell", Event(), true);
@@ -555,7 +555,7 @@ bool AlarReturnToRoomCenterAction::Execute(Event /*event*/)
 {
     constexpr float distFromCenter = 45.0f;
     const Position& center = ALAR_ROOM_CENTER;
-    if (bot->GetVictim() == nullptr &&
+    if (AI_VALUE(Unit*, "current target") == nullptr &&
         bot->GetExactDist2d(center.GetPositionX(), center.GetPositionY()) > distFromCenter)
     {
         return MoveInside(TEMPEST_KEEP_MAP_ID, center.GetPositionX(), center.GetPositionY(),
@@ -887,7 +887,7 @@ bool HighAstromancerSolarianTargetSolariumPriestsAction::Execute(Event /*event*/
         SetRtiTarget(botAI, "star", targetPriest);
     }
 
-    if (bot->GetTarget() != targetPriest->GetGUID())
+    if (AI_VALUE(Unit*, "current target") != targetPriest)
         return Attack(targetPriest);
 
     return false;
@@ -1047,7 +1047,7 @@ bool KaelthasSunstriderMainTankPositionSanguinarAction::Execute(Event /*event*/)
     MarkTargetWithStar(bot, sanguinar);
     SetRtiTarget(botAI, "star", sanguinar);
 
-    if (bot->GetTarget() != sanguinar->GetGUID())
+    if (AI_VALUE(Unit*, "current target") != sanguinar)
         return Attack(sanguinar);
 
     if (sanguinar->GetVictim() == bot && bot->IsWithinMeleeRange(sanguinar))
@@ -1090,7 +1090,7 @@ bool KaelthasSunstriderWarlockTankPositionCapernianAction::Execute(Event /*event
     MarkTargetWithCircle(bot, capernian);
     SetRtiTarget(botAI, "circle", capernian);
 
-    if (bot->GetTarget() != capernian->GetGUID() &&
+    if (AI_VALUE(Unit*, "current target") != capernian &&
         botAI->CanCastSpell("searing pain", capernian) &&
         botAI->CastSpell("searing pain", capernian))
         return true;
@@ -1251,7 +1251,7 @@ bool KaelthasSunstriderFirstAssistTankPositionTelonicusAction::Execute(Event /*e
     MarkTargetWithTriangle(bot, telonicus);
     SetRtiTarget(botAI, "triangle", telonicus);
 
-    if (bot->GetTarget() != telonicus->GetGUID())
+    if (AI_VALUE(Unit*, "current target") != telonicus)
         return Attack(telonicus);
 
     if (telonicus->GetVictim() == bot && bot->IsWithinMeleeRange(telonicus))
@@ -1331,7 +1331,7 @@ bool KaelthasSunstriderAssignAdvisorDpsPriorityAction::Execute(Event /*event*/)
         MarkTargetWithSquare(bot, thaladred);
         SetRtiTarget(botAI, "square", thaladred);
 
-        if (bot->GetTarget() != thaladred->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != thaladred)
             return Attack(thaladred);
 
         return false;
@@ -1346,7 +1346,7 @@ bool KaelthasSunstriderAssignAdvisorDpsPriorityAction::Execute(Event /*event*/)
     {
         SetRtiTarget(botAI, "circle", capernian);
 
-        if (bot->GetTarget() != capernian->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != capernian)
             return Attack(capernian);
 
         return false;
@@ -1360,7 +1360,7 @@ bool KaelthasSunstriderAssignAdvisorDpsPriorityAction::Execute(Event /*event*/)
     {
         SetRtiTarget(botAI, "star", sanguinar);
 
-        if (bot->GetTarget() != sanguinar->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != sanguinar)
             return Attack(sanguinar);
 
         return false;
@@ -1373,7 +1373,7 @@ bool KaelthasSunstriderAssignAdvisorDpsPriorityAction::Execute(Event /*event*/)
         !telonicus->HasAura(SPELL_PERMANENT_FEIGN_DEATH))
     {
         SetRtiTarget(botAI, "triangle", telonicus);
-        if (bot->GetTarget() != telonicus->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != telonicus)
             return Attack(telonicus);
 
         // Melee DPS need to stay at max-ish melee range behind Telonicus to avoid bombs
@@ -1461,7 +1461,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
             MarkTargetWithSkull(bot, staff);
             SetRtiTarget(botAI, "skull", staff);
 
-            if (bot->GetTarget() != staff->GetGUID())
+            if (AI_VALUE(Unit*, "current target") != staff)
                 return Attack(staff);
         }
         // Priority 2: Cosmic Infuser (Skull)
@@ -1470,7 +1470,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
             MarkTargetWithSkull(bot, mace);
             SetRtiTarget(botAI, "skull", mace);
 
-            if (bot->GetTarget() != mace->GetGUID())
+            if (AI_VALUE(Unit*, "current target") != mace)
                 return Attack(mace);
         }
         // Priority 3: Warp Slicer (Skull)
@@ -1479,7 +1479,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
             MarkTargetWithSkull(bot, sword);
             SetRtiTarget(botAI, "skull", sword);
 
-            if (bot->GetTarget() != sword->GetGUID())
+            if (AI_VALUE(Unit*, "current target") != sword)
                 return Attack(sword);
         }
         // Priority 4: Infinity Blades (Skull)
@@ -1488,7 +1488,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
             MarkTargetWithSkull(bot, dagger);
             SetRtiTarget(botAI, "skull", dagger);
 
-            if (bot->GetTarget() != dagger->GetGUID())
+            if (AI_VALUE(Unit*, "current target") != dagger)
                 return Attack(dagger);
         }
         // Priority 5: Devastation - ranged only (Diamond--marked in other method by main tank)
@@ -1496,7 +1496,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
         {
             SetRtiTarget(botAI, "diamond", axe);
 
-            if (bot->GetTarget() != axe->GetGUID())
+            if (AI_VALUE(Unit*, "current target") != axe)
                 return Attack(axe);
         }
         // Priority 6: Netherstrand Longbow (Skull)
@@ -1505,7 +1505,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
             MarkTargetWithSkull(bot, longbow);
             SetRtiTarget(botAI, "skull", longbow);
 
-            if (bot->GetTarget() != longbow->GetGUID())
+            if (AI_VALUE(Unit*, "current target") != longbow)
                 return Attack(longbow);
         }
         // Priority 7: Phaseshift Bulwark (Skull)
@@ -1514,7 +1514,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
             MarkTargetWithSkull(bot, shield);
             SetRtiTarget(botAI, "skull", shield);
 
-            if (bot->GetTarget() != shield->GetGUID())
+            if (AI_VALUE(Unit*, "current target") != shield)
                 return Attack(shield);
         }
     }
@@ -1531,7 +1531,7 @@ bool KaelthasSunstriderMoveDevastationAwayAction::Execute(Event /*event*/)
     MarkTargetWithDiamond(bot, axe);
     SetRtiTarget(botAI, "diamond", axe);
 
-    if (bot->GetTarget() != axe->GetGUID())
+    if (AI_VALUE(Unit*, "current target") != axe)
         return Attack(axe);
 
     constexpr float safeDistance = 13.0f;
@@ -1764,7 +1764,7 @@ bool KaelthasSunstriderMainTankPositionBossAction::Execute(Event /*event*/)
     MarkTargetWithStar(bot, kaelthas);
     SetRtiTarget(botAI, "star", kaelthas);
 
-    if (bot->GetTarget() != kaelthas->GetGUID())
+    if (AI_VALUE(Unit*, "current target") != kaelthas)
         return Attack(kaelthas);
 
     if (kaelthas->GetVictim() == bot && bot->IsWithinMeleeRange(kaelthas))
@@ -1862,7 +1862,7 @@ bool KaelthasSunstriderHandlePhoenixesAndEggsAction::AssistTanksPickUpPhoenixes(
     if (!targetPhoenix)
         return false;
 
-    if (bot->GetTarget() != targetPhoenix->GetGUID())
+    if (AI_VALUE(Unit*, "current target") != targetPhoenix)
         return Attack(targetPhoenix);
 
     constexpr float safeDistance = 12.0f;
@@ -1886,7 +1886,7 @@ bool KaelthasSunstriderHandlePhoenixesAndEggsAction::NonTanksDestroyEggsAndAvoid
             MarkTargetWithDiamond(bot, phoenixEgg);
             SetRtiTarget(botAI, "diamond", phoenixEgg);
 
-            if (bot->GetTarget() != phoenixEgg->GetGUID())
+            if (AI_VALUE(Unit*, "current target") != phoenixEgg)
                 return Attack(phoenixEgg);
         }
     }
@@ -1991,7 +1991,7 @@ bool KaelthasSunstriderBreakThroughShockBarrierAction::Execute(Event /*event*/)
                 return botAI->CastSpell(spell, kaelthas);
         }
     }
-    else if (bot->GetTarget() != kaelthas->GetGUID())
+    else if (AI_VALUE(Unit*, "current target") != kaelthas)
     {
         SetRtiTarget(botAI, "star", kaelthas);
         return Attack(kaelthas);

--- a/src/Ai/Raid/TempestKeep/Multiplier/RaidTempestKeepMultipliers.cpp
+++ b/src/Ai/Raid/TempestKeep/Multiplier/RaidTempestKeepMultipliers.cpp
@@ -100,7 +100,7 @@ float AlarPhase2NoTankingIfArmorMeltedMultiplier::GetValue(Action* action)
         return 1.0f;
 
     Unit* alar = AI_VALUE2(Unit*, "find target", "al'ar");
-    if (!alar || bot->GetTarget() != alar->GetGUID())
+    if (!alar || AI_VALUE(Unit*, "current target") != alar)
         return 1.0f;
 
     if (dynamic_cast<CastTauntAction*>(action) ||

--- a/src/Ai/Raid/ZulAman/Action/RaidZulAmanActions.cpp
+++ b/src/Ai/Raid/ZulAman/Action/RaidZulAmanActions.cpp
@@ -56,7 +56,7 @@ bool AkilzonTanksPositionBossAction::Execute(Event /*event*/)
     if (!akilzon)
         return false;
 
-    if (bot->GetVictim() != akilzon)
+    if (AI_VALUE(Unit*, "current target") != akilzon)
         return Attack(akilzon);
 
     if (akilzon->GetVictim() == bot)
@@ -168,7 +168,7 @@ bool NalorakkTanksPositionBossAction::MainTankPositionTrollForm(Unit* nalorakk)
 {
     if (!nalorakk->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_BEARFORM)))
     {
-        if (bot->GetVictim() != nalorakk)
+        if (AI_VALUE(Unit*, "current target") != nalorakk)
             return Attack(nalorakk);
 
         if (nalorakk->GetVictim() != bot)
@@ -198,7 +198,7 @@ bool NalorakkTanksPositionBossAction::FirstAssistTankPositionBearForm(Unit* nalo
 {
     if (nalorakk->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_BEARFORM)))
     {
-        if (bot->GetVictim() != nalorakk)
+        if (AI_VALUE(Unit*, "current target") != nalorakk)
             return Attack(nalorakk);
 
         if (nalorakk->GetVictim() != bot)
@@ -262,7 +262,7 @@ bool JanalaiTanksPositionBossAction::Execute(Event /*event*/)
     if (!janalai)
         return false;
 
-    if (bot->GetVictim() != janalai)
+    if (AI_VALUE(Unit*, "current target") != janalai)
         return Attack(janalai);
 
     if (janalai->GetVictim() == bot)
@@ -409,7 +409,7 @@ bool HalazziMainTankPositionBossAction::Execute(Event /*event*/)
     MarkTargetWithStar(bot, halazzi);
     SetRtiTarget(botAI, "star", halazzi);
 
-    if (bot->GetVictim() != halazzi)
+    if (AI_VALUE(Unit*, "current target") != halazzi)
         return Attack(halazzi);
 
     if (halazzi->GetVictim() == bot)
@@ -443,7 +443,7 @@ bool HalazziFirstAssistTankAttackSpiritLynxAction::Execute(Event /*event*/)
         MarkTargetWithCircle(bot, lynx);
         SetRtiTarget(botAI, "circle", lynx);
 
-        if (bot->GetVictim() != lynx)
+        if (AI_VALUE(Unit*, "current target") != lynx)
             return Attack(lynx);
 
         if (lynx->GetVictim() != bot)
@@ -455,7 +455,7 @@ bool HalazziFirstAssistTankAttackSpiritLynxAction::Execute(Event /*event*/)
     {
         SetRtiTarget(botAI, "star", halazzi);
 
-        if (bot->GetVictim() != halazzi)
+        if (AI_VALUE(Unit*, "current target") != halazzi)
             return Attack(halazzi);
 
         targetFound = true;
@@ -492,7 +492,7 @@ bool HalazziAssignDpsPriorityAction::Execute(Event /*event*/)
         MarkTargetWithSkull(bot, totem);
         SetRtiTarget(botAI, "skull", totem);
 
-        if (bot->GetTarget() != totem->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != totem)
             return Attack(totem);
 
         return false;
@@ -503,7 +503,7 @@ bool HalazziAssignDpsPriorityAction::Execute(Event /*event*/)
     {
         SetRtiTarget(botAI, "star", halazzi);
 
-        if (bot->GetTarget() != halazzi->GetGUID())
+        if (AI_VALUE(Unit*, "current target") != halazzi)
             return Attack(halazzi);
     }
 
@@ -602,7 +602,7 @@ bool HexLordMalacrassCastersStopAttackingAction::Execute(Event /*event*/)
         !malacrass->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_HEX_LORD_SPELL_REFLECTION)))
         return false;
 
-    if (bot->GetVictim() == malacrass)
+    if (AI_VALUE(Unit*, "current target") == malacrass)
     {
         bot->AttackStop();
         bot->InterruptNonMeleeSpells(true);
@@ -657,7 +657,7 @@ bool ZuljinTanksPositionBossAction::Execute(Event /*event*/)
     if (!zuljin)
         return false;
 
-    if (bot->GetVictim() != zuljin)
+    if (AI_VALUE(Unit*, "current target") != zuljin)
         return Attack(zuljin);
 
     if (zuljin->GetVictim() == bot)

--- a/src/Ai/Raid/ZulAman/Multiplier/RaidZulAmanMultipliers.cpp
+++ b/src/Ai/Raid/ZulAman/Multiplier/RaidZulAmanMultipliers.cpp
@@ -267,7 +267,7 @@ float HexLordMalacrassStopAttackingDuringSpellReflectionMultiplier::GetValue(Act
         return 1.0f;
 
     if (castSpellAction->getThreatType() == Action::ActionThreatType::Aoe ||
-        (bot->GetVictim() == malacrass &&
+        (AI_VALUE(Unit*, "current target") == malacrass &&
          castSpellAction->getThreatType() == Action::ActionThreatType::Single))
         return 0.0f;
 


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
Lady Vashj has been screwed up in Acore for a month or two. In Phase 2, only one generator activates (instead of four). As a result, disabling one generator brings Vashj into Phase 3. The strategy uses Vashj's HP + unit state to determine phase--with the Acore bug, Vashj enters Phase 3 at <65% HP (instead of the correct <50% HP, as deactivating a generator damages her by 5%) so under the current strategy, bots won't assume Phase 3 strategies at the right moment. I tried looking into the issue with Vashj in Acore and cannot figure it out, and I've had an issue open with Acore and don't know if/when it will be fixed. In the meantime, I'm modifying the strategy to use the shield barrier aura check on Vashj instead so it will work regardless of Vashj's HP at the time the generators are disabled. If/when Vashj is fixed, the strategy will still work.

I also changed bot-side targeting checks throughout the strategies I've written from GetVictim() and GetTarget() to using the AI's target state via "current target." This approach I believe is the best way to actually check for the target because a GetVictim() check can lock up Elemental Shamans and Balance Druids due to them not being able to start an attack to pass that check when outside of spell range, and a GetTarget() check can occasionally not align with the target that the bot is actually attacking.

- In effect, this should reduce cases where the bot AI thinks it is on the right raid target but encounter logic disagrees because the live victim or client selection is lagging or different.
- Exception: multipliers for blocking TankAssistAction still use a GetVictim() check. This is because "current target" processes before issuing an attack, and the targeting check for TankAssistAction is not to suppress it if the bot hasn't actually issued an attack.

There is a lot more than could be refactored with past strategies to make them better, but that's for another day. This PR is intended to be limited and simple to review.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.
Logic is described above. There should be no relevant impact on processing cost.


## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

Attempt Lady Vashj with the current bugged version. After disabling the lone generator, bots should enter Phase 3 strategies and the encounter should be completable.

Otherwise, generally run raids, and confirm there are no issues with bots switching targets or starting attacking.


## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [x] No
- - [ ] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


