### PR TITLE
Refactoring of BWL strategy

### DIFF
--- a/src/Ai/Raid/BlackwingLair/Action/RaidBwlActions.cpp
+++ b/src/Ai/Raid/BlackwingLair/Action/RaidBwlActions.cpp
@@ -1,35 +1,40 @@
 #include "RaidBwlActions.h"
 
 #include "Playerbots.h"
+#include "RaidBwlHelpers.h"
+
+using namespace BlackwingLairHelpers;
+
+// General
 
 bool BwlOnyxiaScaleCloakAuraCheckAction::Execute(Event /*event*/)
 {
-    bot->AddAura(22683, bot);
+    bot->AddAura(SPELL_ONYXIA_SCALE_CLOAK, bot);
     return true;
 }
 
-bool BwlOnyxiaScaleCloakAuraCheckAction::isUseful() { return !bot->HasAura(22683); }
+bool BwlOnyxiaScaleCloakAuraCheckAction::isUseful()
+{
+    return !bot->HasAura(SPELL_ONYXIA_SCALE_CLOAK);
+}
 
 bool BwlTurnOffSuppressionDeviceAction::Execute(Event /*event*/)
 {
     GuidVector gos = AI_VALUE(GuidVector, "nearest game objects");
-    for (GuidVector::iterator i = gos.begin(); i != gos.end(); i++)
+    for (auto i = gos.begin(); i != gos.end(); ++i)
     {
         GameObject* go = botAI->GetGameObject(*i);
-        if (!go)
+        if (IsActiveSuppressionDeviceInRange(go, bot))
         {
-            continue;
+            go->SetGoState(GO_STATE_ACTIVE);
         }
-        if (go->GetEntry() != 179784 || go->GetDistance(bot) >= 15.0f || go->GetGoState() != GO_STATE_READY)
-        {
-            continue;
-        }
-        go->SetGoState(GO_STATE_ACTIVE);
     }
     return true;
 }
 
+// Chromaggus
+
 bool BwlUseHourglassSandAction::Execute(Event /*event*/)
 {
-    return botAI->CastSpell(23645, bot);
+    return botAI->CastSpell(SPELL_HOURGLASS_SAND, bot);
 }

--- a/src/Ai/Raid/BlackwingLair/Action/RaidBwlActions.h
+++ b/src/Ai/Raid/BlackwingLair/Action/RaidBwlActions.h
@@ -2,11 +2,8 @@
 #define _PLAYERBOT_RAIDBWLACTIONS_H
 
 #include "Action.h"
-#include "AttackAction.h"
-#include "GenericActions.h"
-#include "MovementActions.h"
-#include "PlayerbotAI.h"
-#include "Playerbots.h"
+
+// General
 
 class BwlOnyxiaScaleCloakAuraCheckAction : public Action
 {
@@ -22,6 +19,8 @@ public:
     BwlTurnOffSuppressionDeviceAction(PlayerbotAI* botAI) : Action(botAI, "bwl turn off suppression device") {}
     bool Execute(Event event) override;
 };
+
+// Chromaggus
 
 class BwlUseHourglassSandAction : public Action
 {

--- a/src/Ai/Raid/BlackwingLair/Strategy/RaidBwlStrategy.cpp
+++ b/src/Ai/Raid/BlackwingLair/Strategy/RaidBwlStrategy.cpp
@@ -1,15 +1,13 @@
 #include "RaidBwlStrategy.h"
 
-#include "Strategy.h"
-
 void RaidBwlStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
-    triggers.push_back(new TriggerNode("often",
-        { NextAction("bwl check onyxia scale cloak", ACTION_RAID) }));
+    triggers.push_back(new TriggerNode("often", {
+        NextAction("bwl check onyxia scale cloak", ACTION_RAID) }));
 
-    triggers.push_back(new TriggerNode("bwl suppression device",
-                        { NextAction("bwl turn off suppression device", ACTION_RAID) }));
+    triggers.push_back(new TriggerNode("bwl suppression device", {
+        NextAction("bwl turn off suppression device", ACTION_RAID) }));
 
-    triggers.push_back(new TriggerNode("bwl affliction bronze",
-        { NextAction("bwl use hourglass sand", ACTION_RAID) }));
+    triggers.push_back(new TriggerNode("bwl affliction bronze", {
+        NextAction("bwl use hourglass sand", ACTION_RAID) }));
 }

--- a/src/Ai/Raid/BlackwingLair/Strategy/RaidBwlStrategy.h
+++ b/src/Ai/Raid/BlackwingLair/Strategy/RaidBwlStrategy.h
@@ -8,9 +8,9 @@ class RaidBwlStrategy : public Strategy
 {
 public:
     RaidBwlStrategy(PlayerbotAI* ai) : Strategy(ai) {}
-    virtual std::string const getName() override { return "bwl"; }
-    virtual void InitTriggers(std::vector<TriggerNode*>& triggers) override;
-    // virtual void InitMultipliers(std::vector<Multiplier*> &multipliers) override;
+    std::string const getName() override { return "bwl"; }
+    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
+    // void InitMultipliers(std::vector<Multiplier*> &multipliers) override;
 };
 
 #endif

--- a/src/Ai/Raid/BlackwingLair/Trigger/RaidBwlTriggers.cpp
+++ b/src/Ai/Raid/BlackwingLair/Trigger/RaidBwlTriggers.cpp
@@ -1,24 +1,29 @@
 #include "RaidBwlTriggers.h"
 
-#include "SharedDefines.h"
+#include "Playerbots.h"
+#include "RaidBwlHelpers.h"
+
+using namespace BlackwingLairHelpers;
+
+// General
 
 bool BwlSuppressionDeviceTrigger::IsActive()
 {
     GuidVector gos = AI_VALUE(GuidVector, "nearest game objects");
-    for (GuidVector::iterator i = gos.begin(); i != gos.end(); i++)
+    for (auto i = gos.begin(); i != gos.end(); ++i)
     {
-        GameObject* go = botAI->GetGameObject(*i);
-        if (!go)
+        const GameObject* go = botAI->GetGameObject(*i);
+        if (IsActiveSuppressionDeviceInRange(go, bot))
         {
-            continue;
+            return true;
         }
-        if (go->GetEntry() != 179784 || go->GetDistance(bot) >= 15.0f || go->GetGoState() != GO_STATE_READY)
-        {
-            continue;
-        }
-        return true;
     }
     return false;
 }
 
-bool BwlAfflictionBronzeTrigger::IsActive() { return bot->HasAura(23170); }
+// Chromaggus
+
+bool BwlAfflictionBronzeTrigger::IsActive()
+{
+    return bot->HasAura(SPELL_BROOD_AFFLICTION_BRONZE);
+}

--- a/src/Ai/Raid/BlackwingLair/Trigger/RaidBwlTriggers.h
+++ b/src/Ai/Raid/BlackwingLair/Trigger/RaidBwlTriggers.h
@@ -1,9 +1,9 @@
 #ifndef _PLAYERBOT_RAIDBWLTRIGGERS_H
 #define _PLAYERBOT_RAIDBWLTRIGGERS_H
 
-#include "PlayerbotAI.h"
-#include "Playerbots.h"
 #include "Trigger.h"
+
+// General
 
 class BwlSuppressionDeviceTrigger : public Trigger
 {
@@ -11,6 +11,8 @@ public:
     BwlSuppressionDeviceTrigger(PlayerbotAI* botAI) : Trigger(botAI, "bwl suppression device") {}
     bool IsActive() override;
 };
+
+// Chromaggus
 
 class BwlAfflictionBronzeTrigger : public Trigger
 {

--- a/src/Ai/Raid/BlackwingLair/Util/RaidBwlHelpers.cpp
+++ b/src/Ai/Raid/BlackwingLair/Util/RaidBwlHelpers.cpp
@@ -1,0 +1,12 @@
+#include "RaidBwlHelpers.h"
+
+namespace BlackwingLairHelpers
+{
+    bool IsActiveSuppressionDeviceInRange(const GameObject* go, const Player* bot)
+    {
+        return go &&
+               go->GetEntry() == GO_SUPPRESSION_DEVICE &&
+               go->GetDistance(bot) < 15.0f &&
+               go->GetGoState() == GO_STATE_READY;
+    }
+}

--- a/src/Ai/Raid/BlackwingLair/Util/RaidBwlHelpers.h
+++ b/src/Ai/Raid/BlackwingLair/Util/RaidBwlHelpers.h
@@ -1,0 +1,27 @@
+#ifndef _PLAYERBOT_RAIDBWLHELPERS_H
+#define _PLAYERBOT_RAIDBWLHELPERS_H
+
+#include "Player.h"
+
+namespace BlackwingLairHelpers
+{
+    enum BlackwingLairSpells
+    {
+        // General
+        SPELL_ONYXIA_SCALE_CLOAK = 22683,
+
+        // Chromaggus
+        SPELL_BROOD_AFFLICTION_BRONZE = 23170,
+        SPELL_HOURGLASS_SAND = 23645
+    };
+
+    enum BlackwingLairGameObjects
+    {
+        // General
+        GO_SUPPRESSION_DEVICE = 179784
+    };
+
+    bool IsActiveSuppressionDeviceInRange(const GameObject* go, const Player* bot);
+}
+
+#endif //_PLAYERBOT_RAIDBWLHELPERS_H


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
This PR refactors the Blackwing Lair strategy to align with newer raid strategy implementations.
It extracts repeated Blackwing Lair spell IDs, game object IDs, and suppression device checks into a shared helper, so the action and trigger code use the same centralized definitions instead of duplicating literals and condition chains.
No gameplay behavior changes are expected.

This PR is intended as a base for follow-up PRs that introduce additional boss-specific strategy logic.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
  - Move existing BWL-specific constants and the suppression device condition into a shared helper.
  - Keep all existing trigger names, action names, spell IDs, game object IDs, and condition checks unchanged.
  - Update the affected action/trigger implementations to call the helper instead of duplicating the same logic inline.
- Describe the **processing cost** when this logic executes across many bots.
  - No meaningful increase. The logic executed per bot remains effectively the same.
  - This refactor only replaces duplicated inline checks with a shared helper function and named constants.
  - There are no additional scans, branches, state tracking, or new decision loops.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
Run the Blackwing Lair raid and check if the already implemented features still work:
- _Onyxia Scale Cloak handling_: Confirm the bot still applies/checks the same aura as before.
- _Suppression device handling_: Confirm bots still detect nearby active suppression devices and turn them off under the same conditions as before.
- _Chromaggus bronze affliction handling_: Confirm bots still use Hourglass Sand if they have the bronze affliction.

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

A small helper call was introduced for the suppression device check, so there is technically a minor additional call overhead compared to the previous inline condition. In practice, the executed logic, iteration scope, and decision flow remain unchanged, so the impact is negligible and does not introduce meaningful scaling risk.

- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)

## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->
AI was used for review support and drafting the pull request text.
The refactoring itself was done manually.

<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->
This PR is intended to be behavior-preserving only.
The main change is consolidation of repeated Blackwing Lair constants and suppression device logic into a shared helper used by both actions and triggers. Review can focus on verifying that the extracted helper matches the previous conditions.