### PR TITLE
Expand PWS Usage by Disc Priests

### DIFF
--- a/src/Ai/Class/Priest/Strategy/HealPriestStrategy.cpp
+++ b/src/Ai/Class/Priest/Strategy/HealPriestStrategy.cpp
@@ -86,6 +86,7 @@ void HealPriestStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
         new TriggerNode(
             "party member almost full health",
             {
+                NextAction("power word: shield on party", ACTION_LIGHT_HEAL + 3),
                 NextAction("prayer of mending on party", ACTION_LIGHT_HEAL + 2),
                 NextAction("renew on party", ACTION_LIGHT_HEAL + 1)
             }


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
Disc Priests currently do not use Power Word: Shield until a party member is at "medium health" (configurable, default 65%). That is the second-level healing threshold; at the highest level, "almost full health" (configurable, default 85%), Disc Priests will use only Prayer of Mending and Renew. This PR adds PWS as the highest priority healing action starting at "almost full health."


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.
Added new action "power word: shield on party" to "party member almost full health" trigger in HealPriestStrategy.cpp (the "heal" strategy, which is the default strategy for Disc Priests, as Holy Priests use the "holy heal" strategy).


## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
Group up with a Disc Priest and take damage; confirm that PWS is cast when you drop below your configured almost full health threshold.


## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

PWS is the signature ability of Disc. Priests, and delaying it to 65% is significantly limiting their effectiveness in group content, particularly with raid bosses that deal raidwide damage and in heroic dungeons, where waiting until the tank hits 65% is a death wish. This single change makes an enormous difference in their effectiveness.

See below for before/after change for Eredar Twins (focus on the activity).

Before:

<img width="693" height="397" alt="Screenshot 2026-05-18 201949" src="https://github.com/user-attachments/assets/18ad84c7-9ad8-4c39-94e7-650c9bb5f36e" />

After:

<img width="746" height="409" alt="image" src="https://github.com/user-attachments/assets/6240f118-e12f-44c7-a1af-373e94985957" />


- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [x] No
- - [ ] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


