### PR TITLE
Add Nefarian Fear Ward action and trigger, along with Wild Magic trigger

### DIFF
--- a/src/Ai/Raid/BlackwingLair/Action/RaidBwlActions.cpp
+++ b/src/Ai/Raid/BlackwingLair/Action/RaidBwlActions.cpp
@@ -38,3 +38,16 @@ bool BwlUseHourglassSandAction::Execute(Event /*event*/)
 {
     return botAI->CastSpell(SPELL_HOURGLASS_SAND, bot);
 }
+
+bool BwlNefarianFearWardAction::Execute(Event /*event*/)
+{
+    Unit* nefarian = AI_VALUE2(Unit*, "find target", "nefarian");
+    if (!nefarian)
+        return false;
+
+    Unit* victim = nefarian->GetVictim();
+    if (!victim)
+        return false;
+
+    return botAI->CastSpell("fear ward", victim);
+}

--- a/src/Ai/Raid/BlackwingLair/Action/RaidBwlActions.h
+++ b/src/Ai/Raid/BlackwingLair/Action/RaidBwlActions.h
@@ -29,4 +29,11 @@ public:
     bool Execute(Event event) override;
 };
 
+class BwlNefarianFearWardAction : public Action
+{
+public:
+    BwlNefarianFearWardAction(PlayerbotAI* botAI) : Action(botAI, "bwl nefarian fear ward") {}
+    bool Execute(Event event) override;
+};
+
 #endif

--- a/src/Ai/Raid/BlackwingLair/RaidBwlActionContext.h
+++ b/src/Ai/Raid/BlackwingLair/RaidBwlActionContext.h
@@ -13,12 +13,14 @@ public:
         creators["bwl check onyxia scale cloak"] = &RaidBwlActionContext::bwl_check_onyxia_scale_cloak;
         creators["bwl turn off suppression device"] = &RaidBwlActionContext::bwl_turn_off_suppression_device;
         creators["bwl use hourglass sand"] = &RaidBwlActionContext::bwl_use_hourglass_sand;
+        creators["bwl nefarian fear ward"] = &RaidBwlActionContext::bwl_nefarian_fear_ward;
     }
 
 private:
     static Action* bwl_check_onyxia_scale_cloak(PlayerbotAI* botAI) { return new BwlOnyxiaScaleCloakAuraCheckAction(botAI); }
     static Action* bwl_turn_off_suppression_device(PlayerbotAI* botAI) { return new BwlTurnOffSuppressionDeviceAction(botAI); }
     static Action* bwl_use_hourglass_sand(PlayerbotAI* botAI) { return new BwlUseHourglassSandAction(botAI); }
+    static Action* bwl_nefarian_fear_ward(PlayerbotAI* botAI) { return new BwlNefarianFearWardAction(botAI); }
 };
 
 #endif

--- a/src/Ai/Raid/BlackwingLair/RaidBwlTriggerContext.h
+++ b/src/Ai/Raid/BlackwingLair/RaidBwlTriggerContext.h
@@ -11,11 +11,15 @@ public:
     {
         creators["bwl suppression device"] = &RaidBwlTriggerContext::bwl_suppression_device;
         creators["bwl affliction bronze"] = &RaidBwlTriggerContext::bwl_affliction_bronze;
+        creators["bwl wild magic"] = &RaidBwlTriggerContext::bwl_wild_magic;
+        creators["bwl nefarian fear ward"] = &RaidBwlTriggerContext::bwl_nefarian_fear_ward;
     }
 
 private:
     static Trigger* bwl_suppression_device(PlayerbotAI* ai) { return new BwlSuppressionDeviceTrigger(ai); }
     static Trigger* bwl_affliction_bronze(PlayerbotAI* ai) { return new BwlAfflictionBronzeTrigger(ai); }
+    static Trigger* bwl_wild_magic(PlayerbotAI* ai) { return new BwlWildMagicTrigger(ai); }
+    static Trigger* bwl_nefarian_fear_ward(PlayerbotAI* ai) { return new BwlNefarianFearWardTrigger(ai); }
 };
 
 #endif

--- a/src/Ai/Raid/BlackwingLair/Strategy/RaidBwlStrategy.cpp
+++ b/src/Ai/Raid/BlackwingLair/Strategy/RaidBwlStrategy.cpp
@@ -10,4 +10,10 @@ void RaidBwlStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 
     triggers.push_back(new TriggerNode("bwl affliction bronze", {
         NextAction("bwl use hourglass sand", ACTION_RAID) }));
+
+    triggers.push_back(new TriggerNode("bwl wild magic", {
+        NextAction("ice block", ACTION_RAID) }));
+
+    triggers.push_back(new TriggerNode("bwl nefarian fear ward", {
+        NextAction("bwl nefarian fear ward", ACTION_RAID) }));
 }

--- a/src/Ai/Raid/BlackwingLair/Trigger/RaidBwlTriggers.cpp
+++ b/src/Ai/Raid/BlackwingLair/Trigger/RaidBwlTriggers.cpp
@@ -27,3 +27,24 @@ bool BwlAfflictionBronzeTrigger::IsActive()
 {
     return bot->HasAura(SPELL_BROOD_AFFLICTION_BRONZE);
 }
+
+bool BwlWildMagicTrigger::IsActive()
+{
+    return bot->getClass() == CLASS_MAGE && bot->HasAura(SPELL_WILD_MAGIC);
+}
+
+bool BwlNefarianFearWardTrigger::IsActive()
+{
+    if (bot->getClass() != CLASS_PRIEST)
+        return false;
+
+    Unit* nefarian = AI_VALUE2(Unit*, "find target", "nefarian");
+    if (!nefarian || !nefarian->IsInCombat())
+        return false;
+
+    Unit* victim = nefarian->GetVictim();
+    if (!victim)
+        return false;
+
+    return !botAI->HasAura("fear ward", victim);
+}

--- a/src/Ai/Raid/BlackwingLair/Trigger/RaidBwlTriggers.h
+++ b/src/Ai/Raid/BlackwingLair/Trigger/RaidBwlTriggers.h
@@ -21,4 +21,20 @@ public:
     bool IsActive() override;
 };
 
+// Nefarian
+
+class BwlWildMagicTrigger : public Trigger
+{
+public:
+    BwlWildMagicTrigger(PlayerbotAI* botAI) : Trigger(botAI, "bwl wild magic") {}
+    bool IsActive() override;
+};
+
+class BwlNefarianFearWardTrigger : public Trigger
+{
+public:
+    BwlNefarianFearWardTrigger(PlayerbotAI* botAI) : Trigger(botAI, "bwl nefarian fear ward") {}
+    bool IsActive() override;
+};
+
 #endif

--- a/src/Ai/Raid/BlackwingLair/Util/RaidBwlHelpers.h
+++ b/src/Ai/Raid/BlackwingLair/Util/RaidBwlHelpers.h
@@ -12,7 +12,10 @@ namespace BlackwingLairHelpers
 
         // Chromaggus
         SPELL_BROOD_AFFLICTION_BRONZE = 23170,
-        SPELL_HOURGLASS_SAND = 23645
+        SPELL_HOURGLASS_SAND = 23645,
+
+        // Nefarian
+        SPELL_WILD_MAGIC = 23410
     };
 
     enum BlackwingLairGameObjects


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
For Nefarian in BWL, this does the following:
Mages - Ice block if the mage class call "Wild Magic" happens
Priests - Buff the current target of Nefarian with Fear Ward

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.



## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
Go to Nefarian (id 11583) or his phase 1 form (id 10162) in BWL with a mage and a priest bot.
During phase 2, the priest bot should cast fear ward on whoever nefarian is targeting.
Wait for a mage class call. Once it happens the mage bot should cast ice block (if its available) to remove the Wild Magic debuff.


## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->
AI assistance was used to explore how dungeon/raid strats are implemented and to explore examples.
All code has been reviewed


<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


