### PR TITLE
Fix: Dismount cleanup 

### DIFF
--- a/src/Ai/Base/Actions/CheckMountStateAction.cpp
+++ b/src/Ai/Base/Actions/CheckMountStateAction.cpp
@@ -17,6 +17,7 @@
 #include "SpellAuraEffects.h"
 
 static constexpr uint32 SPELL_COLD_WEATHER_FLYING = 54197;
+static constexpr float PARACHUTE_LAND_THRESHOLD = 15.0f;
 
 // Define the static map / init bool for caching bot preferred mount data globally
 std::unordered_map<uint32, PreferredMountCache> CheckMountStateAction::mountCache;
@@ -61,6 +62,21 @@ MountData CollectMountData(const Player* bot)
 
 bool CheckMountStateAction::Execute(Event /*event*/)
 {
+    // Forced flight dismount:
+    // Bots get stale flight movement flags after a forced dismount (e.g: Dalaran) because the post landing dismount cleanup
+    // needs MSG_MOVE_FALL_LAND (a client opcode) and client movement packets. The stale flags cause the bot to be stuck with
+    // the parachute, or even keep the bot hovering indefinitely and block MMAP routing.
+    // Note: Without MSG_MOVE_FALL_LAND, HandleFall doesn't trigger, meaning bots don't get fall damage in forced dismounts anyway,
+    // so the parachute usage here is more of an immersion feature.
+    if (bot->HasFeatherFallAura())
+    {
+        float floorZ = bot->GetMapHeight(bot->GetPositionX(), bot->GetPositionY(), bot->GetPositionZ());
+        if (floorZ != INVALID_HEIGHT && floorZ != VMAP_INVALID_HEIGHT_VALUE &&
+            bot->GetPositionZ() - floorZ <= PARACHUTE_LAND_THRESHOLD)
+            bot->RemoveAurasByType(SPELL_AURA_FEATHER_FALL);
+    }
+    ClearStaleFlightFlags();
+
     // Determine if there are no attackers
     bool noAttackers = !AI_VALUE2(bool, "combat", "self target") || !AI_VALUE(uint8, "attacker count");
     bool enemy = AI_VALUE(Unit*, "enemy player target");
@@ -204,7 +220,7 @@ bool CheckMountStateAction::Mount()
     // Get bot mount data
     MountData mountData = CollectMountData(bot);
     int32 masterMountType = GetMountType(master);
-    int32 masterSpeed = CalculateMasterMountSpeed(master, mountData);
+    int32 masterSpeed = CalculateMasterMountSpeed(master);
 
     // Try shapeshift
     if (TryForms(master, masterMountType, masterSpeed))
@@ -234,14 +250,17 @@ void CheckMountStateAction::Dismount()
     WorldPacket emptyPacket;
     bot->GetSession()->HandleCancelMountAuraOpcode(emptyPacket);
 
-    bool const wantsFly = bot->HasIncreaseMountedFlightSpeedAura() || bot->HasFlyAura();
-    bool const isWaterWalking = bot->HasUnitMovementFlag(MOVEMENTFLAG_WATERWALKING);
-    bool const isFlying = bot->HasUnitMovementFlag(MOVEMENTFLAG_FLYING);
-    bool const hasGravityDisabled = bot->HasUnitMovementFlag(MOVEMENTFLAG_DISABLE_GRAVITY);
-    if (!wantsFly && !isWaterWalking && (isFlying || hasGravityDisabled))
+    ClearStaleFlightFlags();
+}
+
+void CheckMountStateAction::ClearStaleFlightFlags()
+{
+    if (bot->HasIncreaseMountedFlightSpeedAura() || bot->HasFlyAura())
+        return;
+
+    if (bot->HasUnitMovementFlag(MOVEMENTFLAG_FLYING | MOVEMENTFLAG_DISABLE_GRAVITY))
     {
-        bot->RemoveUnitMovementFlag(
-            MOVEMENTFLAG_FLYING | MOVEMENTFLAG_CAN_FLY | MOVEMENTFLAG_DISABLE_GRAVITY);
+        bot->RemoveUnitMovementFlag(MOVEMENTFLAG_FLYING | MOVEMENTFLAG_DISABLE_GRAVITY | MOVEMENTFLAG_CAN_FLY);
         if (!bot->IsRooted())
             bot->SendMovementFlagUpdate();
     }
@@ -490,7 +509,7 @@ static bool BotCanUseFlyingMount(Player const* bot)
     return true;
 }
 
-int32 CheckMountStateAction::CalculateMasterMountSpeed(Player* master, const MountData& mountData) const
+int32 CheckMountStateAction::CalculateMasterMountSpeed(Player* master) const
 {
     // Check riding skill and level requirements
     int32 ridingSkill = bot->GetPureSkillValue(SKILL_RIDING);

--- a/src/Ai/Base/Actions/CheckMountStateAction.h
+++ b/src/Ai/Base/Actions/CheckMountStateAction.h
@@ -53,9 +53,10 @@ private:
     float CalculateDismountDistance() const;
     float CalculateMountDistance() const;
     void Dismount();
+    void ClearStaleFlightFlags();
     bool ShouldFollowMasterMountState(Player* master, bool noAttackers, bool shouldMount) const;
     bool ShouldDismountForMaster(Player* master) const;
-    int32 CalculateMasterMountSpeed(Player* master, const MountData& mountData) const;
+    int32 CalculateMasterMountSpeed(Player* master) const;
     bool CheckForSwiftMount() const;
     std::map<uint32, std::map<int32, std::vector<uint32>>> GetAllMountSpells() const;
     bool TryForms(Player* master, int32 masterMountType, int32 masterSpeed) const;


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
Cleans some stale flight flags, and gets rid of the parachute given in forced flight dismount. Refactors some dismount code, and get rid of the unused mountData parameter in CalculateMasterMountSpeed as well

`MOVEMENTFLAG_WATERWALKING` was removed because it might've been added to protect MOVEMENTFLAG_CAN_FLY, but if the bot remounts over water, MOVEMENTFLAG_CAN_FLY would be reapplied anyway. However if it has a function that I missed, we can re-add it.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.
Feature is currently at minimum cost.


## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

1. As GM hover high above Dalaran, but not high enough that you are outside the resting zone.
2. .summon some lvl +70  bots until you get some that are on a flying mount.
3. Watch as they lose their mount after 10 seconds, and be given a parachute as they fall.
4. When they reach the ground, they should be stuck with a parachute forever, and they shouldn't be stuck hovering just above the ground forever.


## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [x] Yes (**explain below**)
Checks if bot has `HasFeatherFallAura` to remove any stale flight flags.


## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [x] No
- - [ ] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->

Comment paragraph might be verbose, but worth it for whomever is looking at the code years from now trying to figure out why bots need special treatment with dismounting anyway.
