### PR TITLE
fix bot leader handling

### DIFF
--- a/src/Ai/Base/Actions/ResetAiAction.cpp
+++ b/src/Ai/Base/Actions/ResetAiAction.cpp
@@ -44,6 +44,24 @@ bool ResetAiAction::Execute(Event event)
             }
         }
     }
+    if (sRandomPlayerbotMgr.IsRandomBot(bot) && !bot->InBattleground())
+    {
+        if (Group* group = bot->GetGroup())
+        {
+            if (!botAI->GetMaster() || GET_PLAYERBOT_AI(botAI->GetMaster()))
+            {
+                for (GroupReference* gref = group->GetFirstMember(); gref; gref = gref->next())
+                {
+                    Player* member = gref->GetSource();
+                    if (member && member != bot && !GET_PLAYERBOT_AI(member))
+                    {
+                        botAI->SetMaster(member);
+                        break;
+                    }
+                }
+            }
+        }
+    }
     PlayerbotRepository::instance().Reset(botAI);
     botAI->ResetStrategies(false);
     botAI->TellMaster("AI was reset to defaults");

--- a/src/Ai/Base/Actions/ResetAiAction.cpp
+++ b/src/Ai/Base/Actions/ResetAiAction.cpp
@@ -44,6 +44,15 @@ bool ResetAiAction::Execute(Event event)
             }
         }
     }
+    if (Player* master = botAI->GetMaster())
+    {
+        Group* botGroup = bot->GetGroup();
+        Group* masterGroup = master->GetGroup();
+        if (botGroup && (!masterGroup || masterGroup != botGroup))
+        {
+            botAI->SetMaster(nullptr);
+        }
+    }
     if (sRandomPlayerbotMgr.IsRandomBot(bot) && !bot->InBattleground())
     {
         if (Group* group = bot->GetGroup())

--- a/src/Ai/Base/Actions/ResetAiAction.cpp
+++ b/src/Ai/Base/Actions/ResetAiAction.cpp
@@ -49,26 +49,14 @@ bool ResetAiAction::Execute(Event event)
         Group* botGroup = bot->GetGroup();
         Group* masterGroup = master->GetGroup();
         if (botGroup && (!masterGroup || masterGroup != botGroup))
-        {
             botAI->SetMaster(nullptr);
-        }
     }
     if (sRandomPlayerbotMgr.IsRandomBot(bot) && !bot->InBattleground())
     {
-        if (Group* group = bot->GetGroup())
+        if (bot->GetGroup() && (!botAI->GetMaster() || GET_PLAYERBOT_AI(botAI->GetMaster())))
         {
-            if (!botAI->GetMaster() || GET_PLAYERBOT_AI(botAI->GetMaster()))
-            {
-                for (GroupReference* gref = group->GetFirstMember(); gref; gref = gref->next())
-                {
-                    Player* member = gref->GetSource();
-                    if (member && member != bot && !GET_PLAYERBOT_AI(member))
-                    {
-                        botAI->SetMaster(member);
-                        break;
-                    }
-                }
-            }
+            if (Player* newMaster = botAI->FindNewMaster())
+                botAI->SetMaster(newMaster);
         }
     }
     PlayerbotRepository::instance().Reset(botAI);

--- a/src/Ai/Base/Strategy/WorldPacketHandlerStrategy.cpp
+++ b/src/Ai/Base/Strategy/WorldPacketHandlerStrategy.cpp
@@ -16,7 +16,7 @@ void WorldPacketHandlerStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
     triggers.push_back(
         new TriggerNode("uninvite guid", { NextAction("uninvite", relevance) }));
     triggers.push_back(
-        new TriggerNode("group set leader", { /*NextAction("leader", relevance),*/ }));
+        new TriggerNode("group set leader", { NextAction("reset botAI", relevance) }));
     triggers.push_back(new TriggerNode(
         "not enough money", { NextAction("tell not enough money", relevance) }));
     triggers.push_back(

--- a/src/Bot/PlayerbotMgr.cpp
+++ b/src/Bot/PlayerbotMgr.cpp
@@ -481,14 +481,6 @@ void PlayerbotHolder::OnBotLogin(Player* const bot)
     }
 
     Player* master = botAI->GetMaster();
-    if (master && master->GetGroup() && !master->GetGroup()->IsLeader(master->GetGUID()))
-    {
-        Player* currentLeader = ObjectAccessor::FindConnectedPlayer(master->GetGroup()->GetLeaderGUID());
-        PlayerbotAI* currentLeaderAI = currentLeader ? GET_PLAYERBOT_AI(currentLeader) : nullptr;
-        bool currentLeaderIsRealPlayer = currentLeader && (!currentLeaderAI || currentLeaderAI->IsRealPlayer());
-        if (!currentLeaderIsRealPlayer)
-            master->GetGroup()->ChangeLeader(master->GetGUID());
-    }
 
     Group* group = bot->GetGroup();
     if (group)

--- a/src/Bot/PlayerbotMgr.cpp
+++ b/src/Bot/PlayerbotMgr.cpp
@@ -481,11 +481,13 @@ void PlayerbotHolder::OnBotLogin(Player* const bot)
     }
 
     Player* master = botAI->GetMaster();
-    if (master)
+    if (master && master->GetGroup() && !master->GetGroup()->IsLeader(master->GetGUID()))
     {
-        ObjectGuid masterGuid = master->GetGUID();
-        if (master->GetGroup() && !master->GetGroup()->IsLeader(masterGuid))
-            master->GetGroup()->ChangeLeader(masterGuid);
+        Player* currentLeader = ObjectAccessor::FindConnectedPlayer(master->GetGroup()->GetLeaderGUID());
+        PlayerbotAI* currentLeaderAI = currentLeader ? GET_PLAYERBOT_AI(currentLeader) : nullptr;
+        bool currentLeaderIsRealPlayer = currentLeader && (!currentLeaderAI || currentLeaderAI->IsRealPlayer());
+        if (!currentLeaderIsRealPlayer)
+            master->GetGroup()->ChangeLeader(master->GetGUID());
     }
 
     Group* group = bot->GetGroup();

--- a/src/Script/WorldThr/PlayerbotOperations.h
+++ b/src/Script/WorldThr/PlayerbotOperations.h
@@ -242,6 +242,7 @@ public:
         }
 
         group->ChangeLeader(newLeader->GetGUID());
+        group->SendUpdate();
         LOG_DEBUG("playerbots", "GroupSetLeaderOperation: Changed leader to {}", newLeader->GetName());
         return true;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
This pr fixes bots "freaking out" after leader change and bots will promote player to party leader after give leader command
closes #2420 #2424 

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.



## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
1. Join rdf or make group
2. Promote bot to leader (rnd or alt), if bot was not leader
3. Type /p give leader
4. Bot will promote you to leader and it will follow you instead of freaking out

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

1. Bots now reset their AI on every SMSG_GROUP_SET_LEADER packet, so old leader strategies get cleared after a leader change.
2. Random bots auto-bind their master to a real-player group member during reset botAI, so commands like give leader and follow logic that depend on HasActivePlayerMaster() start working for them.
3. On OnBotLogin, bots no longer steal leadership from a real player, they only force the leader change if the current leader is a bot or offline.

- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [x] Yes (**explain below**)

Adds two small guards: an "is current leader a real player" check on login, and a "find first real-player member" loop inside ResetAiAction. 
Both reuse existing patterns (IsRealPlayer(), the OnPlayerLogin master-assign loop).


## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [x] No
- - [ ] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->
