### PR TITLE
Fix: Prevent user error when using lower than needed value for RandomBotAccountCount

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -89,10 +89,20 @@ AiPlayerbot.MinRandomBots = 500
 AiPlayerbot.MaxRandomBots = 500
 
 # Randombot accounts
-# If you are not using any expansion at all, you may have to set this manually, in which case please
-# ensure that RandomBotAccountCount is at least greater than (MaxRandomBots / 10 + AddClassAccountPoolSize)
+# Set to 0 to automatically calculate needed accounts based on MaxRandomBots, EnablePeriodicOnlineOffline
+# and its ratio, and AddClassAccountPoolSize. Set manually if you want to create more accounts than needed.
+# If the manual value is less than the required, the system will override it with the required value.
 # Default: 0 (automatic)
 AiPlayerbot.RandomBotAccountCount = 0
+
+# Addclass accounts
+# Number of accounts created for bots reserved for the addclass command. As with randombots, each account has
+# 10 bots (or 9 if WotLK is disabled), one bot for each class.
+AiPlayerbot.AddClassAccountPoolSize = 50
+
+# Prefix for created bot accounts (of any type).
+# Do not change this prefix while there are existing bot accounts.
+AiPlayerbot.RandomBotAccountPrefix = "rndbot"
 
 # Delete all randombot accounts
 # To apply this, set the number to 1 and run the Worldserver. Once deletion is complete, if you would
@@ -127,9 +137,6 @@ AiPlayerbot.MaxAddedBots = 40
 # Enable/Disable creating bots by addclass command (0 = GM only, 1 = enabled)
 # Default: 1 (enabled)
 AiPlayerbot.AddClassCommand = 1
-
-# Set the addclass command account pool size
-AiPlayerbot.AddClassAccountPoolSize = 50
 
 # Bot group invitation permission level (0 = GM only, 1 = accept based on level, 2 = always accept)
 # Default: 1 (accept based on level)
@@ -679,9 +686,6 @@ AiPlayerbot.EndFishingWithMaster = 30.0
 
 # Enable/Disable randomly generated password for randombot accounts
 AiPlayerbot.RandomBotRandomPassword = 0
-
-# Prefix for account names to create for randombots
-AiPlayerbot.RandomBotAccountPrefix = "rndbot"
 
 # Minimum and maximum levels for randombots
 AiPlayerbot.RandomBotMinLevel = 1

--- a/src/Bot/Factory/RandomPlayerbotFactory.cpp
+++ b/src/Bot/Factory/RandomPlayerbotFactory.cpp
@@ -334,17 +334,11 @@ uint32 RandomPlayerbotFactory::CalculateTotalAccountCount()
                 sPlayerbotAIConfig.addClassAccountPoolSize == 0 ? 2 : -1);
 
             if (!res || res->Fetch()[0].Get<uint64>() == 0)
-            {
                 break;
-            }
 
             std::this_thread::sleep_for(std::chrono::milliseconds(50));     // Extra 50ms fixed delay for safety.
         }
     }
-
-    // Checks if randomBotAccountCount is set, otherwise calculate it dynamically.
-    if (sPlayerbotAIConfig.randomBotAccountCount > 0)
-        return sPlayerbotAIConfig.randomBotAccountCount;
 
     // Check existing account types
     uint32 existingRndBotAccounts = 0;
@@ -366,16 +360,14 @@ uint32 RandomPlayerbotFactory::CalculateTotalAccountCount()
         } while (typeCheck->NextRow());
     }
 
-    // Determine divisor based on Death Knight login eligibility and requested A&H faction ratio
+    // Determine divisor based on Death Knight availability and requested A&H faction ratio
     int divisor = CalculateAvailableCharsPerAccount();
 
     // Calculate max bots
     int maxBots = sPlayerbotAIConfig.maxRandomBots;
-    // Take periodic online - offline into account
+    // Take periodic online/offline into account
     if (sPlayerbotAIConfig.enablePeriodicOnlineOffline)
-    {
         maxBots *= sPlayerbotAIConfig.periodicOnlineOfflineRatio;
-    }
 
     // Calculate number of accounts needed for RNDbots
     // Result is rounded up for maxBots not cleanly divisible by the divisor
@@ -416,11 +408,22 @@ uint32 RandomPlayerbotFactory::CalculateTotalAccountCount()
     }
 
     // Return existing total plus any additional accounts needed
-    return existingTotal + additionalAccountsNeeded;
+    uint32 calculatedTotal = existingTotal + additionalAccountsNeeded;
+
+    // Manually set randomBotAccountCount meets the requirements
+    if (sPlayerbotAIConfig.randomBotAccountCount >= calculatedTotal)
+        return sPlayerbotAIConfig.randomBotAccountCount;
+    // Manually set randomBotAccountCount doesn't meet the requirements. Using calculated value
+    if (sPlayerbotAIConfig.randomBotAccountCount > 0)
+        LOG_WARN("playerbots", "RandomBotAccountCount ({}) is lower than the required calculated value ({}). Using the calculated value instead.",
+            sPlayerbotAIConfig.randomBotAccountCount, calculatedTotal);
+
+    return calculatedTotal;
 }
 
 uint32 RandomPlayerbotFactory::CalculateAvailableCharsPerAccount()
 {
+    // Death Knight availability according to their login eligibility, and if WotLK is enabled at all.
     bool noDK = sPlayerbotAIConfig.disableDeathKnightLogin || sWorld->getIntConfig(CONFIG_EXPANSION) != EXPANSION_WRATH_OF_THE_LICH_KING;
 
     uint32 availableChars = noDK ? 9 : 10;
@@ -434,11 +437,9 @@ uint32 RandomPlayerbotFactory::CalculateAvailableCharsPerAccount()
     float unavailableRatio = static_cast<float>((std::max(hordeRatio, allianceRatio) - std::min(hordeRatio, allianceRatio))) /
         (std::max(hordeRatio, allianceRatio) * 2);
 
+    // Conservative floor to ensure enough characters (may result in more accounts than needed).
     if (unavailableRatio != 0)
-    {
-        // conservative floor to ensure enough chars (may result in more accounts than needed)
         availableChars = availableChars - availableChars * unavailableRatio;
-    }
 
     return availableChars;
 }


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
The required number of accounts is now always calculated on server start. The manual value of RandomBotAccountCount is only used when it's >= the calculated value. This prevents user error of using lower than needed value, during initial account creation or after.

Moved `AddClassAccountPoolSize` and `RandomBotAccountPrefix` up. They belong with the other account creation configs. 

Minor comment edits in `CalculateAvailableCharsPerAccount`; no code change there.


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.
Logic is at minimum to prevent this user error. Required number of accounts is now always calculated, but the calculation only happens on server start.


## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
- Make sure to have a snapshot of your server as this testing involves account deletions, so that it's easier to revert things.
- The functional change is only in RandomPlayerbotFactory.cpp, so you can quickly copy/paste the whole of `CalculateTotalAccountCount` to run this test
1. First delete your accounts `DeleteRandomBotAccounts = 1`
2. Then reboot with 
```
AiPlayerbot.MaxRandomBots = 500
RandomBotAccountCount = 0
DeleteRandomBotAccounts = 0
AddClassAccountPoolSize = 10
```
server should create the correct number of accounts needed: (500/10) +10 = 60
3. Reboot with a `RandomBotAccountCount` value equal to 100, server should create for you 50 new accounts, for a total of 110.
4. Delete your accounts again.
5. Reboot with a `RandomBotAccountCount = 30` (which is 20 less than required), server should give you a terminal warning and proceed to create 50+10 accounts. The 500 randombots should login and behave normally.


## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)
Account calculations will always be done on boot. No effect on the rest of the runtime.


- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [x] No
- - [ ] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


