### PR TITLE
Fix errors with greater blessing system PR (#2439)

### DIFF
--- a/src/Ai/Class/Paladin/Actions/PaladinGreaterBlessingAction.cpp
+++ b/src/Ai/Class/Paladin/Actions/PaladinGreaterBlessingAction.cpp
@@ -23,11 +23,19 @@ namespace ai::gbless
 namespace
 {
     constexpr uint32 GREATER_BLESSING_ASSIGNMENT_CACHE_MS = 4 * 1000;
-    constexpr uint32 GREATER_BLESSING_PENDING_ASSIGNMENT_CACHE_MS = 100;
+    constexpr uint32 GREATER_BLESSING_PENDING_ASSIGNMENT_CACHE_MS = 500;
     constexpr uint8 MAX_BLESSING_SLOTS = 4;
     constexpr uint8 MAX_CLASS_ID = 12;
 
     constexpr size_t BaseBlessingCategoryCount = MAX_BLESSING_SLOTS;
+
+    enum PaladinBlessingCapability : uint8
+    {
+        PALADIN_BLESSING_CAPABILITY_NONE            = 0,
+        PALADIN_BLESSING_CAPABILITY_IMPROVED_WISDOM = 1 << 0,
+        PALADIN_BLESSING_CAPABILITY_IMPROVED_MIGHT  = 1 << 1,
+        PALADIN_BLESSING_CAPABILITY_SANCTUARY       = 1 << 2
+    };
 
     constexpr size_t BaseBlessingIndex(BaseBlessingCategory category)
     {
@@ -58,22 +66,38 @@ namespace
                (!left.byRole || left.role == right.role);
     }
 
-    int TalentScore(Player* player)
+    uint8 GetPaladinBlessingCapabilities(Player* player)
     {
         if (!player)
-            return 0;
+            return PALADIN_BLESSING_CAPABILITY_NONE;
 
-        int score = 0;
+        uint8 capabilities = PALADIN_BLESSING_CAPABILITY_NONE;
         if (player->HasAura(SPELL_IMPROVED_MIGHT_R1) ||
             player->HasAura(SPELL_IMPROVED_MIGHT_R2))
         {
-            score += 2;
+            capabilities |= PALADIN_BLESSING_CAPABILITY_IMPROVED_MIGHT;
         }
         if (player->HasAura(SPELL_IMPROVED_WISDOM_R1) ||
             player->HasAura(SPELL_IMPROVED_WISDOM_R2))
         {
-            score += 1;
+            capabilities |= PALADIN_BLESSING_CAPABILITY_IMPROVED_WISDOM;
         }
+        if (player->HasSpell(ai::paladin::SPELL_BLESSING_OF_SANCTUARY))
+            capabilities |= PALADIN_BLESSING_CAPABILITY_SANCTUARY;
+
+        return capabilities;
+    }
+
+    int TalentScore(Player* player)
+    {
+        uint8 const capabilities = GetPaladinBlessingCapabilities(player);
+        int score = 0;
+
+        if (capabilities & PALADIN_BLESSING_CAPABILITY_IMPROVED_MIGHT)
+            score += 2;
+
+        if (capabilities & PALADIN_BLESSING_CAPABILITY_IMPROVED_WISDOM)
+            score += 1;
 
         return score;
     }
@@ -83,28 +107,72 @@ namespace
         if (!player)
             return std::numeric_limits<int>::min() / 4;
 
+        uint8 const capabilities = GetPaladinBlessingCapabilities(player);
+
         if (category == BASE_SANCTUARY)
         {
-            if (!player->HasSpell(ai::paladin::SPELL_BLESSING_OF_SANCTUARY))
+            if (!(capabilities & PALADIN_BLESSING_CAPABILITY_SANCTUARY))
                 return std::numeric_limits<int>::min() / 4;
 
             return 2;
         }
 
         if (category == BASE_MIGHT &&
-            (player->HasAura(SPELL_IMPROVED_MIGHT_R1) ||
-             player->HasAura(SPELL_IMPROVED_MIGHT_R2)))
+            (capabilities & PALADIN_BLESSING_CAPABILITY_IMPROVED_MIGHT))
         {
             return 1;
         }
         if (category == BASE_WISDOM &&
-            (player->HasAura(SPELL_IMPROVED_WISDOM_R1) ||
-             player->HasAura(SPELL_IMPROVED_WISDOM_R2)))
+            (capabilities & PALADIN_BLESSING_CAPABILITY_IMPROVED_WISDOM))
         {
             return 1;
         }
 
         return 0;
+    }
+
+    void SelectActivePaladinPool(
+        std::vector<Player*>& botPaladins)
+    {
+        std::sort(botPaladins.begin(), botPaladins.end(),
+                  [](Player* left, Player* right)
+                  {
+                      return left->GetGUID() < right->GetGUID();
+                  });
+
+        std::vector<Player*> selectedPaladins;
+        selectedPaladins.reserve(botPaladins.size());
+        std::vector<bool> selected(botPaladins.size(), false);
+
+        auto const selectFirstWithCapability = [&](uint8 capability)
+        {
+            for (size_t index = 0; index < botPaladins.size(); ++index)
+            {
+                if (selected[index])
+                    continue;
+
+                if (!(GetPaladinBlessingCapabilities(botPaladins[index]) & capability))
+                    continue;
+
+                selected[index] = true;
+                selectedPaladins.push_back(botPaladins[index]);
+                return;
+            }
+        };
+
+        selectFirstWithCapability(PALADIN_BLESSING_CAPABILITY_SANCTUARY);
+        selectFirstWithCapability(PALADIN_BLESSING_CAPABILITY_IMPROVED_MIGHT);
+        selectFirstWithCapability(PALADIN_BLESSING_CAPABILITY_IMPROVED_WISDOM);
+
+        for (size_t index = 0; index < botPaladins.size(); ++index)
+        {
+            if (selected[index])
+                continue;
+
+            selectedPaladins.push_back(botPaladins[index]);
+        }
+
+        botPaladins = std::move(selectedPaladins);
     }
 
     struct DesiredBlessingSet
@@ -593,28 +661,21 @@ namespace
         if (botPaladins.empty())
             return false;
 
+        SelectActivePaladinPool(botPaladins);
+
+        uint8 activePaladinCount =
+            std::min<uint8>(static_cast<uint8>(botPaladins.size()), MAX_BLESSING_SLOTS);
+
         bool anySanctuaryAvailable = false;
-        for (Player* paladin : botPaladins)
+        for (uint8 paladinIndex = 0; paladinIndex < activePaladinCount; ++paladinIndex)
         {
-            if (paladin && paladin->HasSpell(ai::paladin::SPELL_BLESSING_OF_SANCTUARY))
+            if (GetPaladinBlessingCapabilities(botPaladins[paladinIndex]) &
+                PALADIN_BLESSING_CAPABILITY_SANCTUARY)
             {
                 anySanctuaryAvailable = true;
                 break;
             }
         }
-
-        std::sort(botPaladins.begin(), botPaladins.end(),
-                  [](Player* a, Player* b)
-                  {
-                      int sa = TalentScore(a);
-                      int sb = TalentScore(b);
-                      if (sa != sb)
-                          return sa > sb;
-                      return a->GetGUID() < b->GetGUID();
-                  });
-
-        uint8 activePaladinCount =
-            std::min<uint8>(static_cast<uint8>(botPaladins.size()), MAX_BLESSING_SLOTS);
 
         int mySlot = -1;
         for (size_t i = 0; i < botPaladins.size(); ++i)
@@ -695,7 +756,9 @@ namespace
                     classBuckets, botPaladins, allPaladins,
                     classWideOwners, exclusiveOwnersByBucket, classWideBases,
                     exclusiveBasesByBucket))
-                return false;
+            {
+                continue;
+            }
 
             for (size_t index = 0; index < classWideBases.size(); ++index)
             {


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

I decided to pick up some randombots and run Naxx40 at level 70, and good thing, because I realized the entire greater blessing system can collapse, especially with >4 Paladins.

Dumb shit:
- Failure of ComputeBestClassAssignments would cause ComputeGreaterBlessingAssignments to return false, meaning the entire Greater Blessing system would fail and nobody would receive any blessings of any kind. That should be a continue, lol.
- How ComputeBestClassAssignments would most likely fail would be if no Paladin was available to cast Sanctuary in a scenario where Sanctuary was expected (for example, if there were 3 Paladins in the raid, Rogues and Warriors expected that at least one would cast Sanctuary, and if none could, ComputeBestClassAssignments would fail).
- The priority system for improved talents was silly with the pure scoring (no reason that a Paladin with Improved Blessing of Might should get prioritized once one Paladin with Improved Blessing of Might was already assigned in the four, for example). This made the Sanctuary failure path more likely since basically if you had 4 Ret/Holy Paladins, they'd get picked to be your 4, and even if you had a Prot Paladin in your raid, they'd be excluded, and the whole Blessing system would fail

I also increased the pending assignment cache from 100 ms to 500 ms for performance improvement. No reason for it to be so short.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

There shouldn't be any impact here beyond the increased pending assignment cache, which is probably a (very minor) performance improvement.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

Try raiding with more than 4 Paladins and different configurations, including missing Sanctuary.

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

GPT-5.4 was used to diagnose the issue and propose fixes.

<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


