### PR TITLE
Druid Update Hotfix

### DIFF
--- a/src/Ai/Class/Druid/Strategy/GenericDruidNonCombatStrategy.cpp
+++ b/src/Ai/Class/Druid/Strategy/GenericDruidNonCombatStrategy.cpp
@@ -22,7 +22,6 @@ public:
         creators["remove curse on party"] = &remove_curse_on_party;
         creators["abolish poison on party"] = &abolish_poison_on_party;
         creators["revive"] = &revive;
-        creators["prowl"] = &prowl;
         creators["aquatic form"] = &aquatic_form;
     }
 
@@ -90,14 +89,6 @@ private:
     {
         return new ActionNode("revive",
                               /*P*/ { NextAction("caster form") },
-                              /*A*/ {},
-                              /*C*/ {});
-    }
-
-    static ActionNode* prowl([[maybe_unused]] PlayerbotAI* botAI)
-    {
-        return new ActionNode("prowl",
-                              /*P*/ { NextAction("cat form") },
                               /*A*/ {},
                               /*C*/ {});
     }
@@ -189,10 +180,7 @@ void GenericDruidNonCombatStrategy::InitTriggers(std::vector<TriggerNode*>& trig
     if (specTab == DRUID_TAB_BALANCE || specTab == DRUID_TAB_RESTORATION)
         triggers.push_back(new TriggerNode("often", { NextAction("apply oil", 1.0f) }));
     if (specTab == DRUID_TAB_FERAL)
-    {
         triggers.push_back(new TriggerNode("often", { NextAction("apply stone", 1.0f) }));
-        triggers.push_back(new TriggerNode("prowl", { NextAction("prowl", ACTION_INTERRUPT) }));
-    }
 
 }
 

--- a/src/Bot/Factory/AiFactory.cpp
+++ b/src/Bot/Factory/AiFactory.cpp
@@ -351,7 +351,7 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
                 engine->addStrategiesNoInit("balance", "cure", "aoe", "cc", "dps assist", nullptr);
             }
             else if (tab == DRUID_TAB_RESTORATION)
-                engine->addStrategiesNoInit("resto", "cure", "dps assist", "blanketing", "tranquility", nullptr);
+                engine->addStrategiesNoInit("resto", "cure", "dps assist", "tranquility", nullptr);
             else
             {
                 if (player->HasSpell(SPELL_CAT_FORM) && !player->HasAura(SPELL_DRUID_THICK_HIDE))

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -1624,7 +1624,7 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
 {
     static const std::vector<std::string> allInstanceStrategies =
     {
-        "aq20", "blacktemple", "bwl", "gruulslair", "hyjal", "icc", "karazhan",
+        "aq20", "blacktemple", "blanketing", "bwl", "gruulslair", "hyjal", "icc", "karazhan",
         "magtheridon", "moltencore", "naxx", "onyxia", "ssc", "tbc-ac", "tempestkeep",
         "ulduar", "voa", "wotlk-an", "wotlk-cos", "wotlk-dtk", "wotlk-eoe", "wotlk-fos",
         "wotlk-gd", "wotlk-hol", "wotlk-hor", "wotlk-hos", "wotlk-nex", "wotlk-occ",
@@ -1755,6 +1755,10 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
 
     engines[BOT_STATE_COMBAT]->addStrategy(strategyName);
     engines[BOT_STATE_NON_COMBAT]->addStrategy(strategyName);
+
+    // Resto Druids get blanketing (pre-HoT maintenance) in any recognized instance.
+    if (bot->getClass() == CLASS_DRUID && AiFactory::GetPlayerSpecTab(bot) == DRUID_TAB_RESTORATION)
+        engines[BOT_STATE_COMBAT]->addStrategy("blanketing");
 
     if (tellMaster && !strategyName.empty())
     {

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -1624,7 +1624,7 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
 {
     static const std::vector<std::string> allInstanceStrategies =
     {
-        "aq20", "blacktemple", "blanketing", "bwl", "gruulslair", "hyjal", "icc", "karazhan",
+        "aq20", "blacktemple", "bwl", "gruulslair", "hyjal", "icc", "karazhan",
         "magtheridon", "moltencore", "naxx", "onyxia", "ssc", "tbc-ac", "tempestkeep",
         "ulduar", "voa", "wotlk-an", "wotlk-cos", "wotlk-dtk", "wotlk-eoe", "wotlk-fos",
         "wotlk-gd", "wotlk-hol", "wotlk-hor", "wotlk-hos", "wotlk-nex", "wotlk-occ",
@@ -1755,10 +1755,6 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
 
     engines[BOT_STATE_COMBAT]->addStrategy(strategyName);
     engines[BOT_STATE_NON_COMBAT]->addStrategy(strategyName);
-
-    // Resto Druids get blanketing (pre-HoT maintenance) in any recognized instance.
-    if (bot->getClass() == CLASS_DRUID && AiFactory::GetPlayerSpecTab(bot) == DRUID_TAB_RESTORATION)
-        engines[BOT_STATE_COMBAT]->addStrategy("blanketing");
 
     if (tellMaster && !strategyName.empty())
     {


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

Hello playerbots community! Through testing and feedback, two issues have been brought to my attention with the druid update:

1. **The blanketing strategy is messing with the healer dps/healer should attack function**, as outlined in issue #2428 . It's also clunky in small groups/solo play. I have decided to remove the blanketing strategy from the list of default resto strategies. It is now an optional strategy only, enabled on resto druid by typing "co +blanketing" for those difficult healing fights.

2. **Prowl both existing in the combat strategy (catdruidstrategy) and noncombatstrategy has proven to be taxing/higher cpu usage than I would like** - @brighton-chi identified that prowl was high on the pmon output, and I confirmed locally that it was quite taxing. To fix this, I tested this by removing the prowl trigger/action from the non-combat strategy, and the numbers went down significantly. It's because it was constantly scanning for targets while not in combat, similar to how the pvp strategy does (not enabled by default, very taxing). Most rndbots aren't in combat, so this was scanning on all rndbots that were feral (cat) while out of combat. Now, it being only in the combat strategy is appropriate - the trigger returns early, and doesn't even scan if the bot is in combat. This is the prowl trigger:

Bot is not already prowling and not in combat
Bot has the Prowl spell and it's off cooldown
A valid target exists within engagement range (checks enemy player → grind target → dps target in priority order)
Distance check: 30y base, −10y if target has a victim, −10y more if target is also moving (floor 10y), +15y in BG or Arena

After I made this change locally, I tested it, and the only difference is that the cat will no longer go into prowl when outside of combat (walking around with master, unengaged to enemy target). It will still go into prowl when told to attack a target, or dps assist. We could potentially look at adding this back in, in a different way, when pvp becomes more of a focus. 

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

This reduces the processing cost of prowl and the blanketing strategy quite a bit, while still being functional in the situations that need those abilities/strategy.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->



## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

It reduces processing costs.

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

The cat druid will no longer preemptively go into prowl before the enemy is set to be attacked. It was cool to see the cat go into prowl when getting close to a mob, but there was a lot of processing cost with this outside of combat, so it's being shelved.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->


<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


