### PR TITLE
Add Death Talon Wyrmguard Strat to BWL

### DIFF
--- a/src/Ai/Raid/BWL/BWLActionContext.h
+++ b/src/Ai/Raid/BWL/BWLActionContext.h
@@ -14,6 +14,8 @@ public:
         creators["bwl turn off suppression device"] = &RaidBwlActionContext::bwl_turn_off_suppression_device;
         creators["bwl use hourglass sand"] = &RaidBwlActionContext::bwl_use_hourglass_sand;
         creators["bwl nefarian fear ward"] = &RaidBwlActionContext::bwl_nefarian_fear_ward;
+        creators["bwl death talon wyrmguard tank move away"] = &RaidBwlActionContext::bwl_death_talon_wyrmguard_tank_move_away;
+        creators["bwl death talon wyrmguard ranged move away"] = &RaidBwlActionContext::bwl_death_talon_wyrmguard_ranged_move_away;
     }
 
 private:
@@ -21,6 +23,8 @@ private:
     static Action* bwl_turn_off_suppression_device(PlayerbotAI* botAI) { return new BwlTurnOffSuppressionDeviceAction(botAI); }
     static Action* bwl_use_hourglass_sand(PlayerbotAI* botAI) { return new BwlUseHourglassSandAction(botAI); }
     static Action* bwl_nefarian_fear_ward(PlayerbotAI* botAI) { return new BwlNefarianFearWardAction(botAI); }
+    static Action* bwl_death_talon_wyrmguard_tank_move_away(PlayerbotAI* botAI) { return new BwlDeathTalonWyrmguardTankMoveAwayAction(botAI); }
+    static Action* bwl_death_talon_wyrmguard_ranged_move_away(PlayerbotAI* botAI) { return new BwlDeathTalonWyrmguardRangedMoveAwayAction(botAI); }
 };
 
 #endif

--- a/src/Ai/Raid/BWL/BWLActions.cpp
+++ b/src/Ai/Raid/BWL/BWLActions.cpp
@@ -51,3 +51,85 @@ bool BwlNefarianFearWardAction::Execute(Event /*event*/)
 
     return botAI->CastSpell("fear ward", victim);
 }
+
+// Trash
+
+static constexpr float WYRMGUARD_SAFE_DISTANCE = 16.0f;
+
+Unit* BwlDeathTalonWyrmguardTankMoveAwayAction::GetTarget()
+{
+    // Find a nearby wyrmguard within 16 yards being tanked by someone else
+    for (auto const& [guid, ref] : bot->GetThreatMgr().GetThreatenedByMeList())
+    {
+        Unit* unit = ref->GetOwner();
+        if (!unit || !unit->IsAlive() || unit->GetEntry() != NPC_DEATH_TALON_WYRMGUARD)
+            continue;
+        if (bot->GetDistance2d(unit) > WYRMGUARD_SAFE_DISTANCE)
+            continue;
+        Unit* victim = unit->GetVictim();
+        if (victim && victim != bot && victim->IsPlayer() && PlayerbotAI::IsTank(victim->ToPlayer()))
+            return unit;
+    }
+    return nullptr;
+}
+
+bool BwlDeathTalonWyrmguardTankMoveAwayAction::isUseful()
+{
+    if (!GetTarget())
+        return false;
+
+    // Must be actively tanking a wyrmguard before moving away from another tank's
+    for (auto const& [guid, ref] : bot->GetThreatMgr().GetThreatenedByMeList())
+    {
+        Unit* unit = ref->GetOwner();
+        if (unit && unit->IsAlive() && unit->GetEntry() == NPC_DEATH_TALON_WYRMGUARD && unit->GetVictim() == bot)
+            return true;
+    }
+    return false;
+}
+
+bool BwlDeathTalonWyrmguardTankMoveAwayAction::Execute(Event /*event*/)
+{
+    Unit* target = GetTarget();
+    if (!target)
+        return false;
+
+    float distToTravel = WYRMGUARD_SAFE_DISTANCE - bot->GetDistance2d(target);
+    if (distToTravel <= 0)
+        return false;
+
+    return MoveAway(target, distToTravel);
+}
+
+Unit* BwlDeathTalonWyrmguardRangedMoveAwayAction::GetTarget()
+{
+    // Find the closest wyrmguard within 16 yards
+    Unit* closest = nullptr;
+    float closestDist = WYRMGUARD_SAFE_DISTANCE;
+    for (auto const& [guid, ref] : bot->GetThreatMgr().GetThreatenedByMeList())
+    {
+        Unit* unit = ref->GetOwner();
+        if (!unit || !unit->IsAlive() || unit->GetEntry() != NPC_DEATH_TALON_WYRMGUARD)
+            continue;
+        float dist = bot->GetDistance2d(unit);
+        if (dist < closestDist)
+        {
+            closestDist = dist;
+            closest = unit;
+        }
+    }
+    return closest;
+}
+
+bool BwlDeathTalonWyrmguardRangedMoveAwayAction::Execute(Event /*event*/)
+{
+    Unit* target = GetTarget();
+    if (!target)
+        return false;
+
+    float distToTravel = WYRMGUARD_SAFE_DISTANCE - bot->GetDistance2d(target);
+    if (distToTravel <= 0)
+        return false;
+
+    return MoveAway(target, distToTravel);
+}

--- a/src/Ai/Raid/BWL/BWLActions.cpp
+++ b/src/Ai/Raid/BWL/BWLActions.cpp
@@ -95,7 +95,7 @@ bool BwlDeathTalonWyrmguardTankMoveAwayAction::Execute(Event /*event*/)
         return false;
 
     float distToTravel = WYRMGUARD_SAFE_DISTANCE - bot->GetDistance2d(target);
-    if (distToTravel <= 0)
+    if (distToTravel <= 0.0f)
         return false;
 
     return MoveAway(target, distToTravel);
@@ -128,7 +128,7 @@ bool BwlDeathTalonWyrmguardRangedMoveAwayAction::Execute(Event /*event*/)
         return false;
 
     float distToTravel = WYRMGUARD_SAFE_DISTANCE - bot->GetDistance2d(target);
-    if (distToTravel <= 0)
+    if (distToTravel <= 0.0f)
         return false;
 
     return MoveAway(target, distToTravel);

--- a/src/Ai/Raid/BWL/BWLActions.h
+++ b/src/Ai/Raid/BWL/BWLActions.h
@@ -2,6 +2,7 @@
 #define _PLAYERBOT_RAIDBWLACTIONS_H
 
 #include "Action.h"
+#include "MovementActions.h"
 
 // General
 
@@ -33,6 +34,25 @@ class BwlNefarianFearWardAction : public Action
 {
 public:
     BwlNefarianFearWardAction(PlayerbotAI* botAI) : Action(botAI, "bwl nefarian fear ward") {}
+    bool Execute(Event event) override;
+};
+
+// Trash
+
+class BwlDeathTalonWyrmguardTankMoveAwayAction : public MovementAction
+{
+public:
+    BwlDeathTalonWyrmguardTankMoveAwayAction(PlayerbotAI* botAI) : MovementAction(botAI, "bwl death talon wyrmguard tank move away") {}
+    Unit* GetTarget() override;
+    bool isUseful() override;
+    bool Execute(Event event) override;
+};
+
+class BwlDeathTalonWyrmguardRangedMoveAwayAction : public MovementAction
+{
+public:
+    BwlDeathTalonWyrmguardRangedMoveAwayAction(PlayerbotAI* botAI) : MovementAction(botAI, "bwl death talon wyrmguard ranged move away") {}
+    Unit* GetTarget() override;
     bool Execute(Event event) override;
 };
 

--- a/src/Ai/Raid/BWL/BWLHelpers.h
+++ b/src/Ai/Raid/BWL/BWLHelpers.h
@@ -24,6 +24,12 @@ namespace BlackwingLairHelpers
         GO_SUPPRESSION_DEVICE = 179784
     };
 
+    enum BlackwingLairNPCs
+    {
+        // Trash
+        NPC_DEATH_TALON_WYRMGUARD = 12460
+    };
+
     bool IsActiveSuppressionDeviceInRange(const GameObject* go, const Player* bot);
 }
 

--- a/src/Ai/Raid/BWL/BWLStrategy.cpp
+++ b/src/Ai/Raid/BWL/BWLStrategy.cpp
@@ -16,4 +16,10 @@ void RaidBwlStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 
     triggers.push_back(new TriggerNode("bwl nefarian fear ward", {
         NextAction("bwl nefarian fear ward", ACTION_RAID) }));
+
+    triggers.push_back(new TriggerNode("bwl death talon wyrmguard tank", {
+        NextAction("bwl death talon wyrmguard tank move away", ACTION_RAID) }));
+
+    triggers.push_back(new TriggerNode("bwl death talon wyrmguard ranged", {
+        NextAction("bwl death talon wyrmguard ranged move away", ACTION_RAID) }));
 }

--- a/src/Ai/Raid/BWL/BWLTriggerContext.h
+++ b/src/Ai/Raid/BWL/BWLTriggerContext.h
@@ -13,6 +13,8 @@ public:
         creators["bwl affliction bronze"] = &RaidBwlTriggerContext::bwl_affliction_bronze;
         creators["bwl wild magic"] = &RaidBwlTriggerContext::bwl_wild_magic;
         creators["bwl nefarian fear ward"] = &RaidBwlTriggerContext::bwl_nefarian_fear_ward;
+        creators["bwl death talon wyrmguard tank"] = &RaidBwlTriggerContext::bwl_death_talon_wyrmguard_tank;
+        creators["bwl death talon wyrmguard ranged"] = &RaidBwlTriggerContext::bwl_death_talon_wyrmguard_ranged;
     }
 
 private:
@@ -20,6 +22,8 @@ private:
     static Trigger* bwl_affliction_bronze(PlayerbotAI* ai) { return new BwlAfflictionBronzeTrigger(ai); }
     static Trigger* bwl_wild_magic(PlayerbotAI* ai) { return new BwlWildMagicTrigger(ai); }
     static Trigger* bwl_nefarian_fear_ward(PlayerbotAI* ai) { return new BwlNefarianFearWardTrigger(ai); }
+    static Trigger* bwl_death_talon_wyrmguard_tank(PlayerbotAI* ai) { return new BwlDeathTalonWyrmguardTankTrigger(ai); }
+    static Trigger* bwl_death_talon_wyrmguard_ranged(PlayerbotAI* ai) { return new BwlDeathTalonWyrmguardRangedTrigger(ai); }
 };
 
 #endif

--- a/src/Ai/Raid/BWL/BWLTriggers.cpp
+++ b/src/Ai/Raid/BWL/BWLTriggers.cpp
@@ -28,6 +28,8 @@ bool BwlAfflictionBronzeTrigger::IsActive()
     return bot->HasAura(SPELL_BROOD_AFFLICTION_BRONZE);
 }
 
+// Nefarian
+
 bool BwlWildMagicTrigger::IsActive()
 {
     return bot->getClass() == CLASS_MAGE && bot->HasAura(SPELL_WILD_MAGIC);
@@ -47,4 +49,16 @@ bool BwlNefarianFearWardTrigger::IsActive()
         return false;
 
     return !botAI->HasAura("fear ward", victim);
+}
+
+// Trash
+
+bool BwlDeathTalonWyrmguardTankTrigger::IsActive()
+{
+    return PlayerbotAI::IsTank(bot) && AI_VALUE2(Unit*, "find target", "death talon wyrmguard");
+}
+
+bool BwlDeathTalonWyrmguardRangedTrigger::IsActive()
+{
+    return PlayerbotAI::IsRanged(bot) && AI_VALUE2(Unit*, "find target", "death talon wyrmguard");
 }

--- a/src/Ai/Raid/BWL/BWLTriggers.h
+++ b/src/Ai/Raid/BWL/BWLTriggers.h
@@ -37,4 +37,20 @@ public:
     bool IsActive() override;
 };
 
+// Trash
+
+class BwlDeathTalonWyrmguardTankTrigger : public Trigger
+{
+public:
+    BwlDeathTalonWyrmguardTankTrigger(PlayerbotAI* botAI) : Trigger(botAI, "bwl death talon wyrmguard tank") {}
+    bool IsActive() override;
+};
+
+class BwlDeathTalonWyrmguardRangedTrigger : public Trigger
+{
+public:
+    BwlDeathTalonWyrmguardRangedTrigger(PlayerbotAI* botAI) : Trigger(botAI, "bwl death talon wyrmguard ranged") {}
+    bool IsActive() override;
+};
+
 #endif


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
Adds strategy for ranged and tank bots when fighting Death Talon Wyrmguards.
Ranged will stay 16 yards away so as not to get hit by war stomp.
Tanks that are actively tanking at least one wyrmguard will move away from other wyrmguards not they are not tanking.

The main issue I'm still having is healer positioning, sometimes the tanks will outrange the healers in their attempt to stay away from eachother, but imo the fight is already alot smoother.


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.



## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
Go to BWL and pull the Wyrmguard 3 packs.
Ranged should stay away from all Wyrmguards, and tanks should attempt to spread out the wyrmguards.
I still split the pull between tanks using rti targets and pull back, since the tanks done actively pull mobs off of eachother.


## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->
Claude was used to generate the tank actions that checks for nearby untanked wyrmguards. I have reviewed and refined claude output afterwards.


<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


