### PR TITLE
Tanks use RTI targets

### DIFF
--- a/src/Ai/Base/Value/AttackerCountValues.cpp
+++ b/src/Ai/Base/Value/AttackerCountValues.cpp
@@ -22,7 +22,7 @@ bool HasAggroValue::Calculate()
     {
         return true;
     }
-    bool isMT = botAI->IsMainTank(bot);
+    bool isMT = botAI->IsExplicitMainTank(bot);
     if (victim &&
         (victim->GetGUID() == bot->GetGUID() || (!isMT && victim->ToPlayer() && botAI->IsTank(victim->ToPlayer()))))
     {

--- a/src/Ai/Base/Value/TankTargetValue.cpp
+++ b/src/Ai/Base/Value/TankTargetValue.cpp
@@ -104,6 +104,10 @@ public:
 
 Unit* TankTargetValue::Calculate()
 {
+    Unit* rtiTarget = RtiTargetValue::Calculate();
+    if (rtiTarget)
+        return rtiTarget;
+
     // FindTargetForTankStrategy strategy(botAI);
     FindTankTargetSmartStrategy strategy(botAI);
     return FindTarget(&strategy);

--- a/src/Ai/Base/Value/TankTargetValue.cpp
+++ b/src/Ai/Base/Value/TankTargetValue.cpp
@@ -9,6 +9,7 @@
 #include "AttackersValue.h"
 #include "Group.h"
 #include "PlayerbotAI.h"
+#include "Playerbots.h"
 
 class FindTargetForTankStrategy : public FindNonCcTargetStrategy
 {
@@ -104,9 +105,26 @@ public:
 
 Unit* TankTargetValue::Calculate()
 {
+    std::string const rti = botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Get();
     Unit* rtiTarget = RtiTargetValue::Calculate();
     if (rtiTarget)
-        return rtiTarget;
+    {
+        Unit* victim = rtiTarget->GetVictim();
+
+        if (victim && victim != bot)
+        {
+            if (Player* victimPlayer = victim->ToPlayer())
+            {
+                // rti target is attacking a non-tank player
+                if (!PlayerbotAI::IsTank(victimPlayer))
+                    return rtiTarget;
+                // rti target is attacking a tank player, check if the tank is a bot and has the same rti setting
+                PlayerbotAI* victimBotAI = GET_PLAYERBOT_AI(victimPlayer);
+                if (!victimBotAI || victimBotAI->GetAiObjectContext()->GetValue<std::string>("rti")->Get() != rti)
+                    return rtiTarget;
+            }
+        }
+    }
 
     // FindTargetForTankStrategy strategy(botAI);
     FindTankTargetSmartStrategy strategy(botAI);

--- a/src/Ai/Base/Value/TankTargetValue.cpp
+++ b/src/Ai/Base/Value/TankTargetValue.cpp
@@ -67,9 +67,9 @@ public:
     bool IsBetter(Unit* new_unit, Unit* old_unit)
     {
         Player* bot = botAI->GetBot();
-        // if group has multiple tanks, main tank just focus on the current target
+        // if group has multiple tanks, explicit main tank just focus on the current target
         Unit* currentTarget = botAI->GetAiObjectContext()->GetValue<Unit*>("current target")->Get();
-        if (currentTarget && botAI->IsMainTank(bot) && botAI->GetGroupTankNum(bot) > 1)
+        if (currentTarget && botAI->IsExplicitMainTank(bot) && botAI->GetGroupTankNum(bot) > 1)
         {
             if (old_unit == currentTarget)
                 return false;

--- a/src/Ai/Base/Value/TankTargetValue.h
+++ b/src/Ai/Base/Value/TankTargetValue.h
@@ -6,14 +6,14 @@
 #ifndef _PLAYERBOT_TANKTARGETVALUE_H
 #define _PLAYERBOT_TANKTARGETVALUE_H
 
-#include "TargetValue.h"
+#include "RtiTargetValue.h"
 
 class PlayerbotAI;
 
-class TankTargetValue : public TargetValue
+class TankTargetValue : public RtiTargetValue
 {
 public:
-    TankTargetValue(PlayerbotAI* botAI, std::string const name = "tank target") : TargetValue(botAI, name) {}
+    TankTargetValue(PlayerbotAI* botAI, std::string const name = "tank target") : RtiTargetValue(botAI, "rti", name) {}
 
     Unit* Calculate() override;
 };

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -2034,7 +2034,7 @@ bool PlayerbotAI::HasAggro(Unit* unit)
     if (!IsValidUnit(unit))
         return false;
 
-    bool isMT = IsMainTank(bot);
+    bool isMT = IsExplicitMainTank(bot);
     Unit* victim = unit->GetVictim();
     if (victim && (victim->GetGUID() == bot->GetGUID() || (!isMT && victim->ToPlayer() && IsTank(victim->ToPlayer()))))
     {
@@ -2365,6 +2365,20 @@ bool PlayerbotAI::IsDps(Player* player, bool bySpec)
                 return true;
             }
             break;
+    }
+    return false;
+}
+
+bool PlayerbotAI::IsExplicitMainTank(Player* player)
+{
+    Group* group = player->GetGroup();
+    if (!group)
+        return false;
+
+    for (Group::member_citerator itr = group->GetMemberSlots().begin(); itr != group->GetMemberSlots().end(); ++itr)
+    {
+        if (itr->flags & MEMBER_FLAG_MAINTANK)
+            return player->GetGUID() == itr->guid;
     }
     return false;
 }

--- a/src/Bot/PlayerbotAI.h
+++ b/src/Bot/PlayerbotAI.h
@@ -426,6 +426,7 @@ public:
     static bool IsCombo(Player* player);
     static bool IsBotMainTank(Player* player);
     static bool IsMainTank(Player* player, bool ignoreMemberFlag = false);
+    static bool IsExplicitMainTank(Player* player);
     static uint32 GetGroupTankNum(Player* player);
     static bool IsAssistTank(Player* player);
     static bool IsAssistTankOfIndex(Player* player, uint8 index, bool ignoreDeadPlayers = false);


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
There are two changes in this PR.
Tank RTI Targetting:
Right now tanks don't really care about their RTI target other than when using "pull rti target"
With this change a tank who is given an RTI target will make keeping the rti target aggrod to them priority 1, even from other tanks. Regular tank assist targetting follows after.

"Main tank" ambiguous behaviour:
When running with multiple tank bots where no tank has main tank assignment, the "default" main tank (whichever tank comes first in the lookup) will taunt off of other tanks.
Imo this is ambiguous behaviour, since the player never actually set any main tank they would expect the tanks to never be taunting off of eachother.


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.



## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
RTI targets:
Get two tank bots and assign one bot an rti mark like "rti cross".
Go to a pack of at least two enemies and mark one with the rti mark. (I used the first pull in MC)
Mark skull on a different enemy. Both tanks will go and attack the skull.

After the change the rti mark tank will go and attack the marked target instead of skull.

Main tank behaviour:
This one is difficult to test because its hard to tell which tank is considered the default main tank.
Get two tank bots and do not mark any as main tank. 
Tell one tank to attack something, keeping the other tank on passive or flee until the first tank gets aggro. 
Send the second tank to attack.
If the second tank was the default main tank it will taunt the mob off the first tank. Otherwise reset and reverse the tank attack order to see the behavior.

After the change neither tank should tank off eachother.


## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->
Claude generated IsExplicitMainTank function. It was thoroughly reviewed and tested.

<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


