### PR TITLE
fix: Strip any [BRACKET] prefix from chat commands

### DIFF
--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -976,6 +976,17 @@ void PlayerbotAI::HandleCommand(uint32 type, std::string const text, Player* fro
         filtered = filtered.substr(sPlayerbotAIConfig.commandPrefix.size());
     }
 
+    // Strip any [BRACKET] prefix (e.g., [VIP], [MOD], [ADMIN]) if present
+    if (filtered.find('[') == 0)
+    {
+        size_t const closeBracket = filtered.find(']');
+        if (closeBracket != std::string::npos)
+        {
+            filtered = filtered.substr(closeBracket + 1);
+            filtered = trim(filtered);
+        }
+    }
+
     if (chatMap.empty())
     {
         chatMap["#w "] = CHAT_MSG_WHISPER;


### PR DESCRIPTION
## Pull Request Description
Fixes an issue where chat commands prefixed with bracket-enclosed text (e.g., `[VIP]`, `[MOD]`, `[ADMIN]`) fail to parse and execute. Commands like `lfg 5`, `lfg 10`, `lfg 25`, and `lfg 40` now work correctly even when prefixed.

This is a generic solution that handles any future bracket-enclosed prefix without requiring code changes.

## Feature Evaluation

- **Minimum logic required:** Check if command text starts with `[`, find the matching `]`, and strip everything up to and including it. Then trim whitespace.
- **Processing cost:** Negligible. This logic executes once per chat command in the `HandleCommand()` method, using simple string operations (`find()` and `substr()`). No loops or complex processing. Cost is constant time O(n) where n is the length of the prefix (typically 3-6 characters).

## How to Test the Changes

1. Ensure a bot is configured to receive commands via VIP chat (or any bracket-prefixed channel).
2. Send commands like:
   - `[VIP] lfg 5`
   - `[VIP] lfg 10`
   - `[VIP] lfg 25`
   - `[VIP] lfg 40`
3. Expected behavior: Commands execute correctly and the bot joins the appropriate LFG queue.
4. Test with other bracket prefixes (e.g., `[MOD]`, `[ADMIN]`) to verify generic handling.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
  - ✅ **No, not at all** — The change adds only a single conditional check and string operations that execute once per chat command, not per tick.

- Does this change modify default bot behavior?
  - ✅ **No** — This only fixes command parsing; no behavioral changes.

- Does this change add new decision branches or increase maintenance complexity?
  - ✅ **No** — The fix is simple and handles all bracket prefixes generically.

## AI Assistance
- ✅ **No** — Manual implementation and testing.

## Final Checklist

- ✅ Stability is not compromised.
- ✅ Performance impact is understood, tested, and acceptable.
- ✅ Added logic complexity is justified and explained.
- ✅ No new bot dialogue lines added.
- ✅ No documentation changes needed.

## Notes for Reviewers

This fix addresses a real-world issue where VIP/MOD/ADMIN chat prefixes prevent command parsing. The solution is intentionally generic to future-proof against additional prefix types. The code follows AzerothCore style guidelines and passes all codestyle checks.