### PR TITLE
Clear ALL Compiler Warnings (must accompany core PR)

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -94,6 +94,7 @@ update, whose content are called within the codebase at src/strategy/actions/Fis
 - - [ ] Added logic complexity is justified and explained.
 - - [ ] Any new bot dialogue lines are translated.
 - - [ ] Documentation updated if needed (Conf comments, WiKi commands).
+- - [ ] New and modified files do not introduce new compiler warnings.
 
 ## Notes for Reviewers
 <!-- Anything else that's helpful to review or test your pull request. -->

--- a/src/Ai/Base/Actions/BattleGroundTactics.cpp
+++ b/src/Ai/Base/Actions/BattleGroundTactics.cpp
@@ -1368,7 +1368,7 @@ std::string const BGTactics::HandleConsoleCommandPrivate(WorldSession* session, 
         uint32 max = vPaths->size() - 1;
         if (num >= 0)  // num specified or found
         {
-            if (num > max)
+            if (uint32(num) > max)
                 return fmt::format("Path {} of range of 0 - {}", num, max);
             min = num;
             max = num;
@@ -2177,7 +2177,7 @@ bool BGTactics::selectObjective(bool reset)
 
             uint8 defendersProhab = 3;  // Default balanced
 
-            switch (strategy)
+            switch (static_cast<uint8>(strategy))
             {
                 case 0:
                 case 1:
@@ -3324,7 +3324,7 @@ bool BGTactics::selectObjectiveWp(std::vector<BattleBotPath*> const& vPaths)
 
         // don't pick path where bot is already closest to the paths closest point to target (it means path cant lead it
         // anywhere) don't pick path where closest point is too far away
-        if (closestPointIndex == (reverse ? 0 : path->size() - 1) || closestPointDistToBot > botDistanceLimit)
+        if (closestPointIndex == int(reverse ? 0 : path->size() - 1) || closestPointDistToBot > botDistanceLimit)
             continue;
 
         // creates a score based on dist-to-bot and dist-to-destination, where lower is better, and dist-to-bot is more

--- a/src/Ai/Base/Actions/ChatShortcutActions.cpp
+++ b/src/Ai/Base/Actions/ChatShortcutActions.cpp
@@ -73,7 +73,7 @@ bool FollowChatShortcutAction::Execute(Event /*event*/)
         else
         {
             WorldLocation loc = formation->GetLocation();
-            if (Formation::IsNullLocation(loc) || loc.GetMapId() == -1)
+            if (Formation::IsNullLocation(loc) || loc.GetMapId() == MAPID_INVALID)
                 return false;
 
             MovementPriority priority = botAI->GetState() == BOT_STATE_COMBAT ? MovementPriority::MOVEMENT_COMBAT : MovementPriority::MOVEMENT_NORMAL;

--- a/src/Ai/Base/Actions/ChooseRpgTargetAction.cpp
+++ b/src/Ai/Base/Actions/ChooseRpgTargetAction.cpp
@@ -116,9 +116,8 @@ bool ChooseRpgTargetAction::Execute(Event /*event*/)
     GuidPosition masterRpgTarget;
     if (master && master != bot && GET_PLAYERBOT_AI(master) && master->GetMapId() == bot->GetMapId() && !master->IsBeingTeleported())
     {
-        //TODO Implement
-        Player* player = botAI->GetMaster();
-        //GuidPosition masterRpgTarget = PAI_VALUE(GuidPosition, "rpg target"); //not used, line marked for removal.
+        Player* player = master;
+        masterRpgTarget = PAI_VALUE(GuidPosition, "rpg target");
     }
     else
         master = nullptr;
@@ -204,6 +203,7 @@ bool ChooseRpgTargetAction::Execute(Event /*event*/)
 
     SET_AI_VALUE(std::string, "next rpg action", "");
 
+    // Only fires when following a playerbot master.
     for (auto it = begin(targets); it != end(targets);)
     {
         //Remove empty targets.

--- a/src/Ai/Base/Actions/ChooseRpgTargetAction.cpp
+++ b/src/Ai/Base/Actions/ChooseRpgTargetAction.cpp
@@ -336,7 +336,7 @@ bool ChooseRpgTargetAction::isFollowValid(Player* bot, WorldPosition pos)
     if (!botAI->HasActivePlayerMaster() && distance < 50.0f)
     {
         Player* player = groupLeader;
-        if (groupLeader && !groupLeader->isMoving() ||
+        if ((groupLeader && !groupLeader->isMoving()) ||
             PAI_VALUE(WorldPosition, "last long move").distance(pos) < sPlayerbotAIConfig.reactDistance)
             return true;
     }

--- a/src/Ai/Base/Actions/ChooseTravelTargetAction.cpp
+++ b/src/Ai/Base/Actions/ChooseTravelTargetAction.cpp
@@ -469,7 +469,7 @@ bool ChooseTravelTargetAction::SetCurrentTarget(TravelTarget* target, TravelTarg
     return target->isActive();
 }
 
-bool ChooseTravelTargetAction::SetQuestTarget(TravelTarget* target, bool onlyCompleted, bool newQuests, bool activeQuests, bool completedQuests)
+bool ChooseTravelTargetAction::SetQuestTarget(TravelTarget* target, bool /*onlyCompleted*/, bool newQuests, bool activeQuests, bool completedQuests)
 {
     std::vector<TravelDestination*> activeDestinations;
     std::vector<WorldPosition*> activePoints;
@@ -928,7 +928,7 @@ bool ChooseTravelTargetAction::needForQuest(Unit* target)
                     int required = questTemplate->RequiredNpcOrGoCount[j];
                     int available = questStatus.CreatureOrGOCount[j];
 
-                    if (required && available < required && (target->GetEntry() == entry || justCheck))
+                    if (required && available < required && (target->GetEntry() == uint32(entry) || justCheck))
                         return true;
                 }
 

--- a/src/Ai/Base/Actions/FollowActions.cpp
+++ b/src/Ai/Base/Actions/FollowActions.cpp
@@ -218,7 +218,7 @@ bool FollowAction::Execute(Event /*event*/)
     else
     {
         WorldLocation loc = formation->GetLocation();
-        if (Formation::IsNullLocation(loc) || loc.GetMapId() == -1)
+        if (Formation::IsNullLocation(loc) || loc.GetMapId() == MAPID_INVALID)
             return false;
 
         MovementPriority priority = botAI->GetState() == BOT_STATE_COMBAT ? MovementPriority::MOVEMENT_COMBAT : MovementPriority::MOVEMENT_NORMAL;

--- a/src/Ai/Base/Actions/GenericSpellActions.cpp
+++ b/src/Ai/Base/Actions/GenericSpellActions.cpp
@@ -135,7 +135,7 @@ namespace
 }
 
 CastSpellAction::CastSpellAction(PlayerbotAI* botAI, std::string const spell)
-    : Action(botAI, spell), range(botAI->GetRange("spell")), spell(spell) {}
+    : Action(botAI, spell), spell(spell), range(botAI->GetRange("spell")) {}
 
 bool CastSpellAction::Execute(Event /*event*/)
 {
@@ -271,7 +271,7 @@ bool CastAuraSpellAction::isUseful()
         return false;
 
     Aura* aura = botAI->GetAura(spell, GetTarget(), isOwner, checkDuration);
-    if (!aura || (beforeDuration && aura->GetDuration() < beforeDuration))
+    if (!aura || (beforeDuration && uint32(aura->GetDuration()) < beforeDuration))
         return true;
 
     return false;
@@ -284,7 +284,7 @@ bool CastBuffSpellAction::isUseful()
         return false;
 
     Aura* aura = botAI->GetAura(spell, target, isOwner, checkDuration);
-    return !aura || (beforeDuration && aura->GetDuration() < beforeDuration);
+    return !aura || (beforeDuration && uint32(aura->GetDuration()) < beforeDuration);
 }
 
 bool CastBuffSpellAction::Execute(Event /*event*/)
@@ -306,7 +306,7 @@ bool GroupBuffSpellAction::isUseful()
     }
 
     Aura* aura = botAI->GetAura(spell, target, isOwner, checkDuration);
-    if (!aura || (beforeDuration && aura->GetDuration() < beforeDuration))
+    if (!aura || (beforeDuration && uint32(aura->GetDuration()) < beforeDuration))
         return true;
 
     return false;
@@ -363,7 +363,7 @@ bool CastEnchantItemOffHandAction::isPossible()
 
 CastHealingSpellAction::CastHealingSpellAction(PlayerbotAI* botAI, std::string const spell, uint8 estAmount,
                                                HealingManaEfficiency manaEfficiency, bool isOwner)
-    : CastAuraSpellAction(botAI, spell, isOwner), estAmount(estAmount), manaEfficiency(manaEfficiency)
+    : CastAuraSpellAction(botAI, spell, isOwner), manaEfficiency(manaEfficiency), estAmount(estAmount)
 {
     range = botAI->GetRange("heal");
 }

--- a/src/Ai/Base/Actions/InventoryAction.cpp
+++ b/src/Ai/Base/Actions/InventoryAction.cpp
@@ -400,7 +400,7 @@ ItemIds InventoryAction::FindOutfitItems(std::string const name)
 std::string const InventoryAction::parseOutfitName(std::string const outfit)
 {
     uint32 pos = outfit.find("=");
-    if (pos == -1)
+    if (pos == uint32(-1))
         return "";
 
     return outfit.substr(0, pos);
@@ -414,7 +414,7 @@ ItemIds InventoryAction::parseOutfitItems(std::string const text)
     while (pos < text.size())
     {
         uint32 endPos = text.find(',', pos);
-        if (endPos == -1)
+        if (endPos == uint32(-1))
             endPos = text.size();
 
         std::string const idC = text.substr(pos, endPos - pos);

--- a/src/Ai/Base/Actions/LfgActions.cpp
+++ b/src/Ai/Base/Actions/LfgActions.cpp
@@ -16,7 +16,7 @@
 
 using namespace lfg;
 
-bool LfgJoinAction::Execute(Event event) { return JoinLFG(); }
+bool LfgJoinAction::Execute(Event /*event*/) { return JoinLFG(); }
 
 uint32 LfgJoinAction::GetRoles()
 {
@@ -115,7 +115,7 @@ bool LfgJoinAction::JoinLFG()
         auto const& botLevel = bot->GetLevel();
 
         /*LFG_TYPE_RANDOM on classic is 15-58 so bot over level 25 will never queue*/
-        if (dungeon->MinLevel && (botLevel < dungeon->MinLevel || botLevel > dungeon->MaxLevel) ||
+        if ((dungeon->MinLevel && (botLevel < dungeon->MinLevel || botLevel > dungeon->MaxLevel)) ||
             (botLevel > dungeon->MinLevel + 10 && dungeon->TypeID == LFG_TYPE_DUNGEON))
             continue;
 

--- a/src/Ai/Base/Actions/LfgActions.cpp
+++ b/src/Ai/Base/Actions/LfgActions.cpp
@@ -174,7 +174,6 @@ bool LfgRoleCheckAction::Execute(Event /*event*/)
 {
     if (Group* group = bot->GetGroup())
     {
-        uint32 currentRoles = sLFGMgr->GetRoles(bot->GetGUID());
         uint32 newRoles = GetRoles();
         // if (currentRoles == newRoles)
         //     return false;

--- a/src/Ai/Base/Actions/MovementActions.cpp
+++ b/src/Ai/Base/Actions/MovementActions.cpp
@@ -167,7 +167,7 @@ bool MovementAction::MoveToLOS(WorldObject* target, bool ranged)
     return false;
 }
 
-bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool idle, bool react, bool normal_only,
+bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool /*idle*/, bool /*react*/, bool normal_only,
                             bool exact_waypoint, MovementPriority priority, bool lessDelay, bool backwards)
 {
     UpdateMovementState();
@@ -1854,7 +1854,7 @@ bool FleeWithPetAction::Execute(Event /*event*/)
 
 bool AvoidAoeAction::isUseful()
 {
-    if (getMSTime() - moveInterval < lastMoveTimer)
+    if (getMSTime() - moveInterval < uint32(lastMoveTimer))
         return false;
 
     GuidVector traps = AI_VALUE(GuidVector, "nearest trap with damage");
@@ -2285,7 +2285,7 @@ bool MovementAction::CheckLastFlee(float curAngle, std::list<FleeInfo>& infoList
 
 bool CombatFormationMoveAction::isUseful()
 {
-    if (getMSTime() - moveInterval < lastMoveTimer)
+    if (getMSTime() - moveInterval < uint32(lastMoveTimer))
         return false;
 
     if (bot->GetCurrentSpell(CURRENT_CHANNELED_SPELL) != nullptr)

--- a/src/Ai/Base/Actions/MovementActions.h
+++ b/src/Ai/Base/Actions/MovementActions.h
@@ -275,7 +275,7 @@ public:
         this->intervals = intervals;
         this->clockwise = clockwise;
         this->call_counters = 0;
-        for (int i = 0; i < intervals; i++)
+        for (uint32 i = 0; i < intervals; i++)
         {
             float angle = start_angle + 2 * M_PI * i / intervals;
             waypoints.push_back(std::make_pair(center_x + cos(angle) * radius, center_y + sin(angle) * radius));

--- a/src/Ai/Base/Actions/QuestAction.cpp
+++ b/src/Ai/Base/Actions/QuestAction.cpp
@@ -413,7 +413,7 @@ bool QuestItemPushResultAction::Execute(Event event)
                 continue;
 
             int32 previousCount = itemCount - count;
-            if (itemId == itemEntry && previousCount < quest->RequiredItemCount[i])
+            if (itemId == itemEntry && uint32(previousCount) < quest->RequiredItemCount[i])
             {
                 if (botAI->GetMaster())
                 {

--- a/src/Ai/Base/Actions/TradeAction.cpp
+++ b/src/Ai/Base/Actions/TradeAction.cpp
@@ -69,7 +69,7 @@ bool TradeAction::Execute(Event event)
             continue;
 
         int8 slot = item->CanBeTraded() ? -1 : TRADE_SLOT_NONTRADED;
-        if (TradeItem(item, slot) && slot != TRADE_SLOT_NONTRADED && ++traded >= count)
+        if (TradeItem(item, slot) && slot != TRADE_SLOT_NONTRADED && ++traded >= uint32(count))
             break;
     }
 

--- a/src/Ai/Base/Actions/TravelAction.cpp
+++ b/src/Ai/Base/Actions/TravelAction.cpp
@@ -37,7 +37,7 @@ bool TravelAction::Execute(Event /*event*/)
         if (!newTarget->IsAlive())
             continue;
 
-        if (newTarget->GetEntry() == target->getDestination()->getEntry())
+        if (newTarget->GetEntry() == uint32(target->getDestination()->getEntry()))
             continue;
 
         if (newTarget->IsInCombat())

--- a/src/Ai/Base/Trigger/GenericTriggers.cpp
+++ b/src/Ai/Base/Trigger/GenericTriggers.cpp
@@ -164,7 +164,7 @@ bool BuffTrigger::IsActive()
         return false;
 
     Aura* aura = botAI->GetAura(spell, target, checkIsOwner, checkDuration);
-    if (!aura || (beforeDuration && aura->GetDuration() < beforeDuration))
+    if (!aura || (beforeDuration && uint32(aura->GetDuration()) < beforeDuration))
         return true;
 
     return false;
@@ -418,7 +418,7 @@ bool HealerShouldAttackTrigger::IsActive()
     return true;
 }
 
-bool ItemCountTrigger::IsActive() { return AI_VALUE2(uint32, "item count", item) < count; }
+bool ItemCountTrigger::IsActive() { return AI_VALUE2(uint32, "item count", item) < uint32(count); }
 
 bool InterruptSpellTrigger::IsActive()
 {

--- a/src/Ai/Base/Trigger/RpgTriggers.cpp
+++ b/src/Ai/Base/Trigger/RpgTriggers.cpp
@@ -31,7 +31,7 @@ bool RpgTrigger::IsActive() { return true; }
 
 Event RpgTrigger::Check()
 {
-    if (!NoRpgTargetTrigger::IsActive() && (AI_VALUE(std::string, "next rpg action") == "choose rpg target") ||
+    if ((!NoRpgTargetTrigger::IsActive() && (AI_VALUE(std::string, "next rpg action") == "choose rpg target")) ||
         !FarFromRpgTargetTrigger::IsActive())
         return Trigger::Check();
 

--- a/src/Ai/Base/Value/Arrow.cpp
+++ b/src/Ai/Base/Value/Arrow.cpp
@@ -19,8 +19,8 @@ WorldLocation ArrowFormation::GetLocationInternal()
     uint32 tankLines = 1 + tanks.Size() / 6;
     uint32 meleeLines = 1 + melee.Size() / 6;
     uint32 rangedLines = 1 + ranged.Size() / 6;
-    //TODO Implement Healer Lines
-    uint32 healerLines = 1 + healers.Size() / 6;
+    //@TODO Implement Healer Lines
+    //uint32 healerLines = 1 + healers.Size() / 6;
     float offset = 0.f;
 
     Player* master = botAI->GetMaster();

--- a/src/Ai/Base/Value/Arrow.h
+++ b/src/Ai/Base/Value/Arrow.h
@@ -102,7 +102,7 @@ class ArrowFormation : public MoveAheadFormation
 {
 public:
     ArrowFormation(PlayerbotAI* botAI)
-        : MoveAheadFormation(botAI, "arrow"), built(false), masterUnit(nullptr), botUnit(nullptr)
+        : MoveAheadFormation(botAI, "arrow"), masterUnit(nullptr), botUnit(nullptr), built(false)
     {
     }
 

--- a/src/Ai/Base/Value/Arrow.h
+++ b/src/Ai/Base/Value/Arrow.h
@@ -16,11 +16,6 @@ class UnitPosition
 {
 public:
     UnitPosition(float x, float y) : x(x), y(y) {}
-    UnitPosition(UnitPosition const& other)
-    {
-        x = other.x;
-        y = other.y;
-    }
 
     float x, y;
 };

--- a/src/Ai/Base/Value/BudgetValues.cpp
+++ b/src/Ai/Base/Value/BudgetValues.cpp
@@ -25,7 +25,7 @@ uint32 MaxGearRepairCostValue::Calculate()
 
         uint32 curDurability = item->GetUInt32Value(ITEM_FIELD_DURABILITY);
 
-        if (i >= EQUIPMENT_SLOT_END && curDurability >= maxDurability)  // Only count items equiped or already damanged.
+        if (uint32(i) >= EQUIPMENT_SLOT_END && curDurability >= maxDurability)  // Only count items equiped or already damanged.
             continue;
 
         ItemTemplate const* ditemProto = item->GetTemplate();

--- a/src/Ai/Base/Value/CraftValue.h
+++ b/src/Ai/Base/Value/CraftValue.h
@@ -16,11 +16,6 @@ class CraftData
 {
 public:
     CraftData() : itemId(0) {}
-    CraftData(CraftData const& other) : itemId(other.itemId)
-    {
-        required.insert(other.required.begin(), other.required.end());
-        obtained.insert(other.obtained.begin(), other.obtained.end());
-    }
 
     uint32 itemId;
     std::map<uint32, uint32> required, obtained;

--- a/src/Ai/Base/Value/GrindTargetValue.cpp
+++ b/src/Ai/Base/Value/GrindTargetValue.cpp
@@ -182,7 +182,7 @@ bool GrindTargetValue::needForQuest(Unit* target)
                     int required = questTemplate->RequiredNpcOrGoCount[j];
                     int available = questStatus->CreatureOrGOCount[j];
 
-                    if (required && available < required && target->GetEntry() == entry)
+                    if (required && available < required && target->GetEntry() == uint32(entry))
                         return true;
                 }
             }

--- a/src/Ai/Base/Value/ItemUsageValue.cpp
+++ b/src/Ai/Base/Value/ItemUsageValue.cpp
@@ -708,7 +708,7 @@ bool ItemUsageValue::HasItemsNeededForSpell(uint32 spellId, ItemTemplate const* 
     for (uint8 i = 0; i < MAX_SPELL_REAGENTS; i++)
         if (spellInfo->ReagentCount[i] > 0 && spellInfo->Reagent[i])
         {
-            if (proto && proto->ItemId == spellInfo->Reagent[i] &&
+            if (proto && proto->ItemId == uint32(spellInfo->Reagent[i]) &&
                 spellInfo->ReagentCount[i] == 1)  // If we only need 1 item then current item does not need to be
                                                   // checked since we are looting/buying or already have it.
                 continue;
@@ -807,7 +807,7 @@ std::vector<uint32> ItemUsageValue::SpellsUsingItem(uint32 itemId, Player* bot)
             continue;
 
         for (uint8 i = 0; i < MAX_SPELL_REAGENTS; i++)
-            if (spellInfo->ReagentCount[i] > 0 && spellInfo->Reagent[i] == itemId)
+            if (spellInfo->ReagentCount[i] > 0 && uint32(spellInfo->Reagent[i]) == itemId)
                 retSpells.push_back(spellId);
     }
 

--- a/src/Ai/Base/Value/LastMovementValue.cpp
+++ b/src/Ai/Base/Value/LastMovementValue.cpp
@@ -14,11 +14,11 @@ LastMovement::LastMovement(LastMovement& other)
       taxiMaster(other.taxiMaster),
       lastFollow(other.lastFollow),
       lastAreaTrigger(other.lastAreaTrigger),
+      lastFlee(other.lastFlee),
       lastMoveToX(other.lastMoveToX),
       lastMoveToY(other.lastMoveToY),
       lastMoveToZ(other.lastMoveToZ),
-      lastMoveToOri(other.lastMoveToOri),
-      lastFlee(other.lastFlee)
+      lastMoveToOri(other.lastMoveToOri)
 {
     lastMoveShort = other.lastMoveShort;
     nextTeleport = other.nextTeleport;

--- a/src/Ai/Base/Value/NearestCorpsesValue.cpp
+++ b/src/Ai/Base/Value/NearestCorpsesValue.cpp
@@ -18,7 +18,6 @@ public:
 
 private:
     WorldObject const* i_obj;
-    float i_range;
 };
 
 void NearestCorpsesValue::FindUnits(std::list<Unit*>& targets)

--- a/src/Ai/Base/Value/NearestCorpsesValue.cpp
+++ b/src/Ai/Base/Value/NearestCorpsesValue.cpp
@@ -12,7 +12,7 @@
 class AnyDeadUnitInObjectRangeCheck
 {
 public:
-    AnyDeadUnitInObjectRangeCheck(WorldObject const* obj, float range) : i_obj(obj), i_range(range) {}
+    AnyDeadUnitInObjectRangeCheck(WorldObject const* obj, float /*range*/) : i_obj(obj) {}
     WorldObject const& GetFocusObject() const { return *i_obj; }
     bool operator()(Unit* u) { return !u->IsAlive(); }
 

--- a/src/Ai/Base/Value/PartyMemberToDispel.cpp
+++ b/src/Ai/Base/Value/PartyMemberToDispel.cpp
@@ -10,7 +10,7 @@ class PartyMemberToDispelPredicate : public FindPlayerPredicate, public Playerbo
 {
 public:
     PartyMemberToDispelPredicate(PlayerbotAI* botAI, uint32 dispelType)
-        : PlayerbotAIAware(botAI), FindPlayerPredicate(), dispelType(dispelType)
+        : FindPlayerPredicate(), PlayerbotAIAware(botAI), dispelType(dispelType)
     {
     }
 

--- a/src/Ai/Base/Value/PartyMemberWithoutAuraValue.cpp
+++ b/src/Ai/Base/Value/PartyMemberWithoutAuraValue.cpp
@@ -13,7 +13,7 @@ class PlayerWithoutAuraPredicate : public FindPlayerPredicate, public PlayerbotA
 {
 public:
     PlayerWithoutAuraPredicate(PlayerbotAI* botAI, std::string const aura)
-        : PlayerbotAIAware(botAI), FindPlayerPredicate(), auras(split(aura, ','))
+        : FindPlayerPredicate(), PlayerbotAIAware(botAI), auras(split(aura, ','))
     {
     }
 

--- a/src/Ai/Base/Value/PartyMemberWithoutItemValue.cpp
+++ b/src/Ai/Base/Value/PartyMemberWithoutItemValue.cpp
@@ -11,7 +11,7 @@ class PlayerWithoutItemPredicate : public FindPlayerPredicate, public PlayerbotA
 {
 public:
     PlayerWithoutItemPredicate(PlayerbotAI* botAI, std::string const item)
-        : PlayerbotAIAware(botAI), FindPlayerPredicate(), item(item)
+        : FindPlayerPredicate(), PlayerbotAIAware(botAI), item(item)
     {
     }
 

--- a/src/Ai/Base/Value/PositionValue.h
+++ b/src/Ai/Base/Value/PositionValue.h
@@ -20,10 +20,6 @@ public:
         : x(x), y(y), z(z), mapId(mapId), valueSet(valueSet)
     {
     }
-    PositionInfo(PositionInfo const& other)
-        : x(other.x), y(other.y), z(other.z), mapId(other.mapId), valueSet(other.valueSet)
-    {
-    }
 
     void Set(float newX, float newY, float newZ, uint32 newMapId)
     {

--- a/src/Ai/Base/Value/PossibleRpgTargetsValue.cpp
+++ b/src/Ai/Base/Value/PossibleRpgTargetsValue.cpp
@@ -75,7 +75,7 @@ bool PossibleRpgTargetsValue::AcceptUnit(Unit* unit)
 
     TravelTarget* travelTarget = context->GetValue<TravelTarget*>("travel target")->Get();
     if (travelTarget && travelTarget->getDestination() &&
-        travelTarget->getDestination()->getEntry() == unit->GetEntry())
+        static_cast<uint32>(travelTarget->getDestination()->getEntry()) == unit->GetEntry())
         return true;
 
     if (urand(1, 100) < 25 && unit->IsFriendlyTo(bot))

--- a/src/Ai/Base/Value/PvpValues.cpp
+++ b/src/Ai/Base/Value/PvpValues.cpp
@@ -24,11 +24,11 @@ Unit* FlagCarrierValue::Calculate()
             if (!bg)
                 return nullptr;
 
-            if ((!sameTeam && bot->GetTeamId() == TEAM_HORDE || (sameTeam && bot->GetTeamId() == TEAM_ALLIANCE)) &&
+            if (((!sameTeam && bot->GetTeamId() == TEAM_HORDE) || (sameTeam && bot->GetTeamId() == TEAM_ALLIANCE)) &&
                 !bg->GetFlagPickerGUID(TEAM_HORDE).IsEmpty())
                 carrier = ObjectAccessor::GetPlayer(bg->GetBgMap(), bg->GetFlagPickerGUID(TEAM_HORDE));
 
-            if ((!sameTeam && bot->GetTeamId() == TEAM_ALLIANCE || (sameTeam && bot->GetTeamId() == TEAM_HORDE)) &&
+            if (((!sameTeam && bot->GetTeamId() == TEAM_ALLIANCE) || (sameTeam && bot->GetTeamId() == TEAM_HORDE)) &&
                 !bg->GetFlagPickerGUID(TEAM_ALLIANCE).IsEmpty())
                 carrier = ObjectAccessor::GetPlayer(bg->GetBgMap(), bg->GetFlagPickerGUID(TEAM_ALLIANCE));
 

--- a/src/Ai/Base/Value/SpellIdValue.cpp
+++ b/src/Ai/Base/Value/SpellIdValue.cpp
@@ -30,7 +30,7 @@ uint32 SpellIdValue::Calculate()
 
     wstrToLower(wnamepart);
     char firstSymbol = tolower(namepart[0]);
-    int spellLength = wnamepart.length();
+    size_t spellLength = wnamepart.length();
 
     LocaleConstant loc = LOCALE_enUS;
 
@@ -133,13 +133,13 @@ uint32 SpellIdValue::Calculate()
                 continue;
             }
 
-            if (!highestRank || id > highestRank)
+            if (!highestRank || (uint32)id > highestRank)
             {
                 highestRank = id;
                 highestSpellId = spellId;
             }
 
-            if (!lowestRank || (lowestRank && id < lowestRank))
+            if (!lowestRank || (lowestRank && (uint32)id < lowestRank))
             {
                 lowestRank = id;
                 lowestSpellId = spellId;
@@ -153,7 +153,7 @@ uint32 SpellIdValue::Calculate()
             auto spellId = *it;
             if (!highestSpellId)
                 highestSpellId = spellId;
-            if (saveMana == rank)
+            if (saveMana == (int32)rank)
                 return spellId;
             lowestSpellId = spellId;
             rank++;
@@ -192,7 +192,7 @@ uint32 VehicleSpellIdValue::Calculate()
 
     wstrToLower(wnamepart);
     char firstSymbol = tolower(namepart[0]);
-    int spellLength = wnamepart.length();
+    size_t spellLength = wnamepart.length();
 
     const int loc = LocaleConstant::LOCALE_enUS;
 

--- a/src/Ai/Class/Paladin/Actions/PaladinActions.cpp
+++ b/src/Ai/Class/Paladin/Actions/PaladinActions.cpp
@@ -351,10 +351,6 @@ bool CastBlessingOfSanctuaryOnPartyAction::Execute(Event /*event*/)
 
     Player* targetPlayer = target ? target->ToPlayer() : nullptr;
 
-    const auto HasKingsAura = [&](Unit* unit) -> bool {
-        return botAI->HasAura("blessing of kings", unit) ||
-               botAI->HasAura("greater blessing of kings", unit);
-    };
     const auto HasSanctAura = [&](Unit* unit) -> bool {
         return botAI->HasAura("blessing of sanctuary", unit) ||
                botAI->HasAura("greater blessing of sanctuary", unit);

--- a/src/Ai/Dungeon/AC/ACMultipliers.cpp
+++ b/src/Ai/Dungeon/AC/ACMultipliers.cpp
@@ -15,8 +15,8 @@ float ShirrakFleeFocusFireMultiplier::GetValue(Action* action)
     if (!AI_VALUE2(Unit*, "find target", "shirrak the dead watcher"))
         return 1.0f;
 
-        std::list<Creature*> creatureList;
-            bot->GetCreatureListWithEntryInGrid(creatureList, static_cast<uint32>(AuchenaiCryptsIDs::NPC_FOCUS_FIRE), 20.0f);
+    std::list<Creature*> creatureList;
+    bot->GetCreatureListWithEntryInGrid(creatureList, static_cast<uint32>(AuchenaiCryptsIDs::NPC_FOCUS_FIRE), 20.0f);
 
     for (Creature* flare : creatureList)
     {

--- a/src/Ai/Dungeon/AC/ACTriggers.cpp
+++ b/src/Ai/Dungeon/AC/ACTriggers.cpp
@@ -16,8 +16,8 @@ bool ShirrakFleeFocusFireTrigger::IsActive()
     if (!AI_VALUE2(Unit*, "find target", "shirrak the dead watcher"))
         return false;
 
-        std::list<Creature*> creatureList;
-        bot->GetCreatureListWithEntryInGrid(creatureList, static_cast<uint32>(AuchenaiCryptsIDs::NPC_FOCUS_FIRE), 20.0f);
+    std::list<Creature*> creatureList;
+    bot->GetCreatureListWithEntryInGrid(creatureList, static_cast<uint32>(AuchenaiCryptsIDs::NPC_FOCUS_FIRE), 20.0f);
 
     for (Creature* flare : creatureList)
     {

--- a/src/Ai/Dungeon/OC/OCMultipliers.cpp
+++ b/src/Ai/Dungeon/OC/OCMultipliers.cpp
@@ -93,7 +93,7 @@ float EregosMultiplier::GetValue(Action* action)
     Unit* boss = AI_VALUE2(Unit*, "find target", "ley-guardian eregos");
     if (!boss) { return 1.0f; }
 
-    if (boss->HasAura(SPELL_PLANAR_SHIFT && dynamic_cast<OccDrakeAttackAction*>(action)))
+    if (boss->HasAura(SPELL_PLANAR_SHIFT) && dynamic_cast<OccDrakeAttackAction*>(action))
         return 0.0f;
 
     return 1.0f;

--- a/src/Ai/Dungeon/PoS/PoSActions.cpp
+++ b/src/Ai/Dungeon/PoS/PoSActions.cpp
@@ -24,7 +24,7 @@ bool IckAndKrickAction::Execute(Event /*event*/)
 
     bool pursuit = bot->HasAura(SPELL_PURSUIT) || (!botAI->IsTank(bot) && boss->HasUnitState(UNIT_STATE_CASTING) && boss->FindCurrentSpellBySpellId(SPELL_PURSUIT));
     bool poisonNova = boss->HasUnitState(UNIT_STATE_CASTING) && (boss->FindCurrentSpellBySpellId(SPELL_POISON_NOVA_POS) || boss->FindCurrentSpellBySpellId(SPELL_POISON_NOVA_POS_HC));
-    bool explosiveBarrage = orb || boss->HasUnitState(UNIT_STATE_CASTING) && (boss->FindCurrentSpellBySpellId(SPELL_EXPLOSIVE_BARRAGE_ICK) || boss->FindCurrentSpellBySpellId(SPELL_EXPLOSIVE_BARRAGE_KRICK));
+    bool explosiveBarrage = orb || (boss->HasUnitState(UNIT_STATE_CASTING) && (boss->FindCurrentSpellBySpellId(SPELL_EXPLOSIVE_BARRAGE_ICK) || boss->FindCurrentSpellBySpellId(SPELL_EXPLOSIVE_BARRAGE_KRICK)));
     bool isTank = botAI->IsTank(bot);
 
     if (pursuit && Pursuit(pursuit, boss))

--- a/src/Ai/Raid/BT/BTActions.cpp
+++ b/src/Ai/Raid/BT/BTActions.cpp
@@ -2373,14 +2373,26 @@ bool IllidanStormrageAssistTanksHandleFlamesOfAzzinothAction::RepositionToAvoidB
 
         if (distToNewPosition > 0.2f)
         {
-            return MoveTo(BLACK_TEMPLE_MAP_ID, newTarget.GetPositionX(), newTarget.GetPositionY(),
+            const float dX = newTarget.GetPositionX() - bot->GetPositionX();
+            const float dY = newTarget.GetPositionY() - bot->GetPositionY();
+            const float moveDist = std::min(5.0f, distToNewPosition);
+            const float moveX = bot->GetPositionX() + (dX / distToNewPosition) * moveDist;
+            const float moveY = bot->GetPositionY() + (dY / distToNewPosition) * moveDist;
+
+            return MoveTo(BLACK_TEMPLE_MAP_ID, moveX, moveY,
                           bot->GetPositionZ(), false, false, false, false,
                           MovementPriority::MOVEMENT_COMBAT, true, true);
         }
     }
     else if (distToPosition > 0.2f)
     {
-        return MoveTo(BLACK_TEMPLE_MAP_ID, target.GetPositionX(), target.GetPositionY(),
+        const float dX = target.GetPositionX() - bot->GetPositionX();
+        const float dY = target.GetPositionY() - bot->GetPositionY();
+        const float moveDist = std::min(3.0f, distToPosition);
+        const float moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
+        const float moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
+
+        return MoveTo(BLACK_TEMPLE_MAP_ID, moveX, moveY,
                       bot->GetPositionZ(), false, false, false, false,
                       MovementPriority::MOVEMENT_COMBAT, true, true);
     }

--- a/src/Ai/Raid/BT/BTActions.cpp
+++ b/src/Ai/Raid/BT/BTActions.cpp
@@ -2373,12 +2373,6 @@ bool IllidanStormrageAssistTanksHandleFlamesOfAzzinothAction::RepositionToAvoidB
 
         if (distToNewPosition > 0.2f)
         {
-            const float dX = newTarget.GetPositionX() - bot->GetPositionX();
-            const float dY = newTarget.GetPositionY() - bot->GetPositionY();
-            const float moveDist = std::min(5.0f, distToNewPosition);
-            const float moveX = bot->GetPositionX() + (dX / distToNewPosition) * moveDist;
-            const float moveY = bot->GetPositionY() + (dY / distToNewPosition) * moveDist;
-
             return MoveTo(BLACK_TEMPLE_MAP_ID, newTarget.GetPositionX(), newTarget.GetPositionY(),
                           bot->GetPositionZ(), false, false, false, false,
                           MovementPriority::MOVEMENT_COMBAT, true, true);
@@ -2386,12 +2380,6 @@ bool IllidanStormrageAssistTanksHandleFlamesOfAzzinothAction::RepositionToAvoidB
     }
     else if (distToPosition > 0.2f)
     {
-        const float dX = target.GetPositionX() - bot->GetPositionX();
-        const float dY = target.GetPositionY() - bot->GetPositionY();
-        const float moveDist = std::min(3.0f, distToPosition);
-        const float moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
-        const float moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
-
         return MoveTo(BLACK_TEMPLE_MAP_ID, target.GetPositionX(), target.GetPositionY(),
                       bot->GetPositionZ(), false, false, false, false,
                       MovementPriority::MOVEMENT_COMBAT, true, true);

--- a/src/Ai/Raid/BT/BTActions.cpp
+++ b/src/Ai/Raid/BT/BTActions.cpp
@@ -873,7 +873,7 @@ bool GurtoggBloodboilRotateRangedGroupsAction::Execute(Event /*event*/)
     int activeGroup = GetGurtoggActiveRotationGroup(gurtogg);
 
     bool inActiveGroup = false;
-    if (activeGroup >= 0 && activeGroup < groups.size())
+    if (activeGroup >= 0 && (size_t)activeGroup < groups.size())
     {
         auto const& group = groups[activeGroup];
         inActiveGroup = std::find(group.begin(), group.end(), bot) != group.end();
@@ -2105,7 +2105,7 @@ bool IllidanStormrageIsolateBotWithParasiteAction::Execute(Event /*event*/)
 }
 
 bool IllidanStormrageIsolateBotWithParasiteAction::InfectedBotMoveFromGroup(
-    Unit* illidan, const Position& target)
+    Unit* /*illidan*/, const Position& target)
 {
     if (bot->GetExactDist2d(target) < 1.0f)
         return false;
@@ -2116,7 +2116,7 @@ bool IllidanStormrageIsolateBotWithParasiteAction::InfectedBotMoveFromGroup(
 }
 
 bool IllidanStormrageIsolateBotWithParasiteAction::FreezeTrapShadowfiend(
-    Player* bot, Unit* illidan, const Position& target)
+    Player* bot, Unit* /*illidan*/, const Position& target)
 {
     if (bot->HasSpellCooldown(static_cast<uint32>(BlackTempleSpells::SPELL_FROST_TRAP)))
         return false;
@@ -2266,7 +2266,7 @@ bool IllidanStormrageAssistTanksHandleFlamesOfAzzinothAction::Execute(Event /*ev
 }
 
 bool IllidanStormrageAssistTanksHandleFlamesOfAzzinothAction::RepositionToAvoidEyeBlast(
-    Unit* illidan, const EyeBlastDangerArea& dangerArea)
+    Unit* /*illidan*/, const EyeBlastDangerArea& dangerArea)
 {
     if (!IsPositionInEyeBlastDangerArea(bot->GetPosition(), dangerArea))
         return false;

--- a/src/Ai/Raid/BT/BTActions.cpp
+++ b/src/Ai/Raid/BT/BTActions.cpp
@@ -2105,7 +2105,7 @@ bool IllidanStormrageIsolateBotWithParasiteAction::Execute(Event /*event*/)
 }
 
 bool IllidanStormrageIsolateBotWithParasiteAction::InfectedBotMoveFromGroup(
-    Unit* /*illidan*/, const Position& target)
+    Unit*, const Position& target)
 {
     if (bot->GetExactDist2d(target) < 1.0f)
         return false;
@@ -2116,7 +2116,7 @@ bool IllidanStormrageIsolateBotWithParasiteAction::InfectedBotMoveFromGroup(
 }
 
 bool IllidanStormrageIsolateBotWithParasiteAction::FreezeTrapShadowfiend(
-    Player* bot, Unit* /*illidan*/, const Position& target)
+    Player* bot, Unit*, const Position& target)
 {
     if (bot->HasSpellCooldown(static_cast<uint32>(BlackTempleSpells::SPELL_FROST_TRAP)))
         return false;
@@ -2266,7 +2266,7 @@ bool IllidanStormrageAssistTanksHandleFlamesOfAzzinothAction::Execute(Event /*ev
 }
 
 bool IllidanStormrageAssistTanksHandleFlamesOfAzzinothAction::RepositionToAvoidEyeBlast(
-    Unit* /*illidan*/, const EyeBlastDangerArea& dangerArea)
+    Unit*, const EyeBlastDangerArea& dangerArea)
 {
     if (!IsPositionInEyeBlastDangerArea(bot->GetPosition(), dangerArea))
         return false;

--- a/src/Ai/Raid/BT/BTHelpers.cpp
+++ b/src/Ai/Raid/BT/BTHelpers.cpp
@@ -16,7 +16,7 @@ namespace BlackTempleHelpers
     // Supremus
     std::unordered_map<uint32, time_t> supremusPhaseTimer;
 
-    bool HasSupremusVolcanoNearby(PlayerbotAI* botAI, Player* bot)
+    bool HasSupremusVolcanoNearby(PlayerbotAI* /*botAI*/, Player* bot)
     {
         constexpr float searchRadius = 20.0f;
         std::list<Creature*> creatureList;
@@ -446,7 +446,7 @@ namespace BlackTempleHelpers
         return distToLine < area.width;
     }
 
-    GameObject* FindNearestTrap(PlayerbotAI* botAI, Player* bot)
+    GameObject* FindNearestTrap(PlayerbotAI* botAI, Player* /*bot*/)
     {
         GuidVector const& gos =
             botAI->GetAiObjectContext()->GetValue<GuidVector>("nearest game objects")->Get();

--- a/src/Ai/Raid/BT/BTHelpers.cpp
+++ b/src/Ai/Raid/BT/BTHelpers.cpp
@@ -16,7 +16,7 @@ namespace BlackTempleHelpers
     // Supremus
     std::unordered_map<uint32, time_t> supremusPhaseTimer;
 
-    bool HasSupremusVolcanoNearby(PlayerbotAI* /*botAI*/, Player* bot)
+    bool HasSupremusVolcanoNearby(PlayerbotAI*, Player* bot)
     {
         constexpr float searchRadius = 20.0f;
         std::list<Creature*> creatureList;
@@ -446,7 +446,7 @@ namespace BlackTempleHelpers
         return distToLine < area.width;
     }
 
-    GameObject* FindNearestTrap(PlayerbotAI* botAI, Player* /*bot*/)
+    GameObject* FindNearestTrap(PlayerbotAI* botAI, Player*)
     {
         GuidVector const& gos =
             botAI->GetAiObjectContext()->GetValue<GuidVector>("nearest game objects")->Get();

--- a/src/Ai/Raid/ICC/Action/ICCActions_BPC.cpp
+++ b/src/Ai/Raid/ICC/Action/ICCActions_BPC.cpp
@@ -315,7 +315,6 @@ bool IccBpcEmpoweredVortexAction::MaintainRangedSpacing()
     static float const IDEAL_RADIUS = 25.0f;
     static float const RADIUS_TOLERANCE = 3.0f;
     static float const MOVE_INCREMENT = 3.0f;
-    static float const MIN_SPACING = 13.0f;
 
     bool const isRanged = botAI->IsRanged(bot) || botAI->IsHeal(bot);
     if (!isRanged)

--- a/src/Ai/Raid/ICC/Action/ICCActions_BQL.cpp
+++ b/src/Ai/Raid/ICC/Action/ICCActions_BQL.cpp
@@ -96,7 +96,7 @@ bool IccBqlGroupPositionAction::HandleShadowsMovement()
     constexpr int MAX_SHADOW_NPCS = 100;
     Unit* shadows[MAX_SHADOW_NPCS]{};  // Reasonable max estimate
     int shadowCount = 0;
-    for (int i = 0; i < npcs.size() && shadowCount < MAX_SHADOW_NPCS; i++)
+    for (uint32 i = 0; i < npcs.size() && shadowCount < MAX_SHADOW_NPCS; i++)
     {
         Unit* unit = botAI->GetUnit(npcs[i]);
         if (unit && unit->IsAlive() && unit->GetEntry() == NPC_SWARMING_SHADOWS)

--- a/src/Ai/Raid/ICC/Action/ICCActions_BQL.cpp
+++ b/src/Ai/Raid/ICC/Action/ICCActions_BQL.cpp
@@ -671,8 +671,6 @@ bool IccBqlGroupPositionAction::HandleGroupPosition(Unit* boss, Aura* frenzyAura
             {34.0f, 336.0f * D2R}, {34.0f, 348.0f * D2R},
         };
         int const totalSlots = sizeof(allSlots) / sizeof(allSlots[0]);
-        int const OUTER_RING_START = 8 + 15 + 20;  // first index of outer ring
-        int const MID_RING_START = 8 + 15;
 
         float const cx = ICC_BQL_CENTER_POSITION.GetPositionX();
         float const cy = ICC_BQL_CENTER_POSITION.GetPositionY();

--- a/src/Ai/Raid/ICC/Action/ICCActions_LK.cpp
+++ b/src/Ai/Raid/ICC/Action/ICCActions_LK.cpp
@@ -1395,7 +1395,7 @@ bool IccLichKingWinterAction::HandleRangedPositioning()
     return false;
 }
 
-bool IccLichKingWinterAction::HandleMainTankAddManagement(Unit* /*boss*/, Position const* frostPos)
+bool IccLichKingWinterAction::HandleMainTankAddManagement(Unit*, Position const* frostPos)
 {
     static constexpr float ENGAGE_RADIUS = 12.0f;
     static constexpr float TAUNT_RADIUS = 30.0f;
@@ -1579,7 +1579,7 @@ bool IccLichKingWinterAction::HandleMainTankAddManagement(Unit* /*boss*/, Positi
     return false;
 }
 
-bool IccLichKingWinterAction::HandleAssistTankAddManagement(Unit* /*boss*/, Position const* frostPos)
+bool IccLichKingWinterAction::HandleAssistTankAddManagement(Unit*, Position const* frostPos)
 {
     static constexpr float FROST_TOL = 3.0f;
     static constexpr float MELE_RANGE = 5.0f;
@@ -2186,7 +2186,7 @@ bool IccLichKingSpiritBombAction::IsBombThreatActive(PlayerbotAI* botAI, Player*
     return false;
 }
 
-bool IccLichKingSpiritBombAction::Execute(Event /*event*/)
+bool IccLichKingSpiritBombAction::Execute(Event)
 {
     Difficulty const diff = bot->GetMap() ? bot->GetMap()->GetDifficulty() : RAID_DIFFICULTY_10MAN_NORMAL;
     Unit* terenas = bot->FindNearestCreature(NPC_TERENAS_MENETHIL_HC, 55.0f);

--- a/src/Ai/Raid/ICC/Action/ICCActions_LK.cpp
+++ b/src/Ai/Raid/ICC/Action/ICCActions_LK.cpp
@@ -1400,7 +1400,7 @@ bool IccLichKingWinterAction::HandleRangedPositioning()
     return false;
 }
 
-bool IccLichKingWinterAction::HandleMainTankAddManagement(Unit* boss, Position const* frostPos)
+bool IccLichKingWinterAction::HandleMainTankAddManagement(Unit* /*boss*/, Position const* frostPos)
 {
     static constexpr float ENGAGE_RADIUS = 12.0f;
     static constexpr float TAUNT_RADIUS = 30.0f;
@@ -1584,7 +1584,7 @@ bool IccLichKingWinterAction::HandleMainTankAddManagement(Unit* boss, Position c
     return false;
 }
 
-bool IccLichKingWinterAction::HandleAssistTankAddManagement(Unit* boss, Position const* frostPos)
+bool IccLichKingWinterAction::HandleAssistTankAddManagement(Unit* /*boss*/, Position const* frostPos)
 {
     static constexpr float FROST_TOL = 3.0f;
     static constexpr float MELE_RANGE = 5.0f;
@@ -2191,7 +2191,7 @@ bool IccLichKingSpiritBombAction::IsBombThreatActive(PlayerbotAI* botAI, Player*
     return false;
 }
 
-bool IccLichKingSpiritBombAction::Execute(Event event)
+bool IccLichKingSpiritBombAction::Execute(Event /*event*/)
 {
     Difficulty const diff = bot->GetMap() ? bot->GetMap()->GetDifficulty() : RAID_DIFFICULTY_10MAN_NORMAL;
     Unit* terenas = bot->FindNearestCreature(NPC_TERENAS_MENETHIL_HC, 55.0f);

--- a/src/Ai/Raid/ICC/Action/ICCActions_LK.cpp
+++ b/src/Ai/Raid/ICC/Action/ICCActions_LK.cpp
@@ -65,11 +65,6 @@ static bool IsLkCollectibleAdd(Unit* unit)
            entry == NPC_DRUDGE_GHOUL3 || entry == NPC_DRUDGE_GHOUL4;
 }
 
-static bool HasFrontalAbility(uint32 entry)
-{
-    return IsLkShambling(entry) || IsLkRagingSpirit(entry);
-}
-
 static bool IsHeroicLk(Difficulty diff)
 {
     return diff == RAID_DIFFICULTY_10MAN_HEROIC || diff == RAID_DIFFICULTY_25MAN_HEROIC;

--- a/src/Ai/Raid/ICC/Action/ICCActions_PP.cpp
+++ b/src/Ai/Raid/ICC/Action/ICCActions_PP.cpp
@@ -1110,8 +1110,6 @@ bool IccPutricideGasCloudAction::HandleGroupAuraSituation(Unit* gasCloud)
         return false;
 
     constexpr float rangeMinSafeDistance = 15.0f;
-    constexpr float rangedMaxDistance = 25.0f;
-    constexpr float meleeRange = 5.0f;
     constexpr uint8 skullIconId = 7;
 
     Unit* volatileOoze = AI_VALUE2(Unit*, "find target", "volatile ooze");
@@ -1183,7 +1181,6 @@ bool IccPutricideAvoidMalleableGooAction::Execute(Event /*event*/)
         constexpr uint32 impactLifetimeMs = 6000;
         constexpr float gooDangerRadius = 8.0f;   // 5yd AoE + 3yd safety
         constexpr float puddleAvoidRadius = 6.0f;
-        constexpr float bombAvoidRadius = 6.0f;
 
         uint32 now = getMSTime();
         float botX = bot->GetPositionX();

--- a/src/Ai/Raid/ICC/Action/ICCActions_RF.cpp
+++ b/src/Ai/Raid/ICC/Action/ICCActions_RF.cpp
@@ -72,7 +72,7 @@ bool IccRotfaceTankPositionAction::MarkBossWithSkull(Unit* boss)
     return false;
 }
 
-bool IccRotfaceTankPositionAction::PositionMainTankAndMelee(Unit* boss, Unit* /*smallOoze*/)
+bool IccRotfaceTankPositionAction::PositionMainTankAndMelee(Unit* boss, Unit*)
 {
     bool isBossCasting = false;
     if (boss && boss->HasUnitState(UNIT_STATE_CASTING))
@@ -125,7 +125,7 @@ bool IccRotfaceTankPositionAction::PositionMainTankAndMelee(Unit* boss, Unit* /*
     return false;
 }
 
-bool IccRotfaceTankPositionAction::HandleAssistTankPositioning(Unit* /*boss*/)
+bool IccRotfaceTankPositionAction::HandleAssistTankPositioning(Unit*)
 {
     GuidVector bigOozes = AI_VALUE(GuidVector, "nearest hostile npcs");
     std::vector<Unit*> activeBigOozes;

--- a/src/Ai/Raid/ICC/Action/ICCActions_RF.cpp
+++ b/src/Ai/Raid/ICC/Action/ICCActions_RF.cpp
@@ -72,7 +72,7 @@ bool IccRotfaceTankPositionAction::MarkBossWithSkull(Unit* boss)
     return false;
 }
 
-bool IccRotfaceTankPositionAction::PositionMainTankAndMelee(Unit* boss, Unit* smallOoze)
+bool IccRotfaceTankPositionAction::PositionMainTankAndMelee(Unit* boss, Unit* /*smallOoze*/)
 {
     bool isBossCasting = false;
     if (boss && boss->HasUnitState(UNIT_STATE_CASTING))
@@ -125,7 +125,7 @@ bool IccRotfaceTankPositionAction::PositionMainTankAndMelee(Unit* boss, Unit* sm
     return false;
 }
 
-bool IccRotfaceTankPositionAction::HandleAssistTankPositioning(Unit* boss)
+bool IccRotfaceTankPositionAction::HandleAssistTankPositioning(Unit* /*boss*/)
 {
     GuidVector bigOozes = AI_VALUE(GuidVector, "nearest hostile npcs");
     std::vector<Unit*> activeBigOozes;

--- a/src/Ai/Raid/ICC/Action/ICCActions_SG.cpp
+++ b/src/Ai/Raid/ICC/Action/ICCActions_SG.cpp
@@ -1376,7 +1376,6 @@ std::vector<Unit*> IccSindragosaFrostBombAction::SelectTombs(std::vector<Unit*> 
         &ICC_SINDRAGOSA_THOMB3_POSITION
     };
     int const zoneIdx = (groupCount == 2) ? (groupIndex == 0 ? 0 : 2) : groupIndex;
-    Position const& zone = *tombZones[zoneIdx];
 
     static constexpr float MAX_ZONE_RADIUS = 3.0f;
     std::vector<Unit*> zoneTombs;

--- a/src/Ai/Raid/ICC/Action/ICCActions_VT.cpp
+++ b/src/Ai/Raid/ICC/Action/ICCActions_VT.cpp
@@ -114,7 +114,6 @@ bool IccValithriaGroupAction::Execute(Event /*event*/)
     Creature* portal = portalList.empty() ? nullptr : portalList.front();
 
     Creature* worm = bot->FindNearestCreature(NPC_ROT_WORM, 100.0f);
-    Creature* zombie = bot->FindNearestCreature(NPC_BLISTERING_ZOMBIE, 100.0f);
     Creature* manaVoid = bot->FindNearestCreature(NPC_MANA_VOID, 100.0f);
 
     // Column of Frost units - still hostile so the hostile list is fine here

--- a/src/Ai/Raid/ICC/ICCMultipliers.cpp
+++ b/src/Ai/Raid/ICC/ICCMultipliers.cpp
@@ -27,7 +27,6 @@ namespace
 {
 std::map<ObjectGuid, uint32> g_plagueTimes;
 std::map<ObjectGuid, bool> g_allowCure;
-std::mutex g_plagueMutex; // Lock before accessing shared variables
 }
 
 // Lady Deathwhisper
@@ -126,7 +125,8 @@ float IccGunshipMultiplier::GetValue(Action* action)
     // Bot in transit between ships: lock to rocket-jump action only so combat/movement
     // actions don't interfere with jump packet timing.
     bool const isHordeSide = muradin && muradin->IsAlive() && muradin->IsHostileTo(bot);
-    bool const isAllySide = saurfang && saurfang->IsAlive() && saurfang->IsHostileTo(bot);
+    //@TODO use isAllySide or remove.
+    //bool const isAllySide = saurfang && saurfang->IsAlive() && saurfang->IsHostileTo(bot);
     Position const friendlyPoint = isHordeSide ? ICC_GUNSHIP_ROCKET_JUMP_HORDE_FRIENDLY_POINT
                                                : ICC_GUNSHIP_ROCKET_JUMP_ALLY_FRIENDLY_POINT;
     Position const middlePoint = isHordeSide ? ICC_GUNSHIP_ROCKET_JUMP_HORDE_MIDDLE_POINT

--- a/src/Ai/Raid/Mag/MagActions.cpp
+++ b/src/Ai/Raid/Mag/MagActions.cpp
@@ -319,7 +319,7 @@ bool MagtheridonWarlockCCBurningAbyssalAction::Execute(Event /*event*/)
         }
     }
 
-    if (warlockIndex >= 0 && warlockIndex < abyssals.size())
+    if (warlockIndex >= 0 && (size_t)warlockIndex < abyssals.size())
     {
         Unit* assignedAbyssal = abyssals[warlockIndex];
         if (!botAI->HasAura("banish", assignedAbyssal) && botAI->CanCastSpell("banish", assignedAbyssal))
@@ -433,7 +433,7 @@ bool MagtheridonSpreadRangedAction::Execute(Event /*event*/)
         uint8 count = members.size();
 
         float angle = 2 * M_PI * botIndex / count;
-        float radius = static_cast<float>(rand()) / RAND_MAX * maxSpreadRadius;
+        float radius = static_cast<float>(rand()) / static_cast<float>(RAND_MAX) * maxSpreadRadius;
         float targetX = centerX + radius * cos(angle);
         float targetY = centerY + radius * sin(angle);
 
@@ -466,8 +466,8 @@ bool MagtheridonSpreadRangedAction::Execute(Event /*event*/)
 
     if (distToCenter > maxSpreadRadius + radiusBuffer)
     {
-        float angle = static_cast<float>(rand()) / RAND_MAX * 2.0f * M_PI;
-        float radius = static_cast<float>(rand()) / RAND_MAX * maxSpreadRadius;
+        float angle = static_cast<float>(rand()) / static_cast<float>(RAND_MAX) * 2.0f * M_PI;
+        float radius = static_cast<float>(rand()) / static_cast<float>(RAND_MAX) * maxSpreadRadius;
         float targetX = centerX + radius * cos(angle);
         float targetY = centerY + radius * sin(angle);
 
@@ -575,7 +575,7 @@ bool MagtheridonUseManticronCubeAction::HandleWaitingPhase(const CubeInfo& cubeI
             }
         }
 
-        float angle = static_cast<float>(rand()) / RAND_MAX * 2.0f * M_PI;
+        float angle = static_cast<float>(rand()) / static_cast<float>(RAND_MAX) * 2.0f * M_PI;
         float fallbackX = cubeInfo.x + cos(angle) * safeWaitDistance;
         float fallbackY = cubeInfo.y + sin(angle) * safeWaitDistance;
         float fallbackZ = bot->GetPositionZ();

--- a/src/Ai/Raid/Naxx/Action/NaxxActions_Razuvious.cpp
+++ b/src/Ai/Raid/Naxx/Action/NaxxActions_Razuvious.cpp
@@ -47,7 +47,7 @@ bool RazuviousUseObedienceCrystalAction::Execute(Event /*event*/)
         {
             // taunt
             bool tauntUseful = true;
-            if (forceObedience->GetDuration() <= (duration_time - 5000))
+            if (forceObedience->GetDuration() <= int32(duration_time - 5000))
             {
                 Unit* victim = target->GetVictim();
                 if (victim && victim->HasAura(SPELL_BONE_BARRIER))
@@ -57,7 +57,7 @@ bool RazuviousUseObedienceCrystalAction::Execute(Event /*event*/)
                     tauntUseful = false;
 
             }
-            if (forceObedience->GetDuration() >= (duration_time - 500))
+            if (forceObedience->GetDuration() >= int32(duration_time - 500))
                 tauntUseful = false;
 
             if (tauntUseful && !charm->HasSpellCooldown(29060))

--- a/src/Ai/Raid/Naxx/Action/NaxxActions_Shared.cpp
+++ b/src/Ai/Raid/Naxx/Action/NaxxActions_Shared.cpp
@@ -4,7 +4,7 @@ uint32 RotateAroundTheCenterPointAction::FindNearestWaypoint()
 {
     float minDistance = 0;
     int ret = -1;
-    for (int i = 0; i < intervals; i++)
+    for (uint32 i = 0; i < intervals; i++)
     {
         float w_x = waypoints[i].first, w_y = waypoints[i].second;
         float dis = bot->GetDistance2d(w_x, w_y);

--- a/src/Ai/Raid/SSC/SSCActions.cpp
+++ b/src/Ai/Raid/SSC/SSCActions.cpp
@@ -2339,7 +2339,7 @@ bool LadyVashjPassTheTaintedCoreAction::LineUpSecondCorePasser(
 }
 
 bool LadyVashjPassTheTaintedCoreAction::LineUpThirdCorePasser(
-    Player* designatedLooter, Player* firstCorePasser,
+    Player* /*designatedLooter*/, Player* firstCorePasser,
     Player* secondCorePasser, Unit* closestTrigger)
 {
     bool needThirdPasser =
@@ -2404,7 +2404,7 @@ bool LadyVashjPassTheTaintedCoreAction::LineUpThirdCorePasser(
 }
 
 bool LadyVashjPassTheTaintedCoreAction::LineUpFourthCorePasser(
-    Player* firstCorePasser, Player* secondCorePasser,
+    Player* /*firstCorePasser*/, Player* secondCorePasser,
     Player* thirdCorePasser, Unit* closestTrigger)
 {
     bool needFourthPasser =

--- a/src/Ai/Raid/SSC/SSCActions.cpp
+++ b/src/Ai/Raid/SSC/SSCActions.cpp
@@ -2339,7 +2339,7 @@ bool LadyVashjPassTheTaintedCoreAction::LineUpSecondCorePasser(
 }
 
 bool LadyVashjPassTheTaintedCoreAction::LineUpThirdCorePasser(
-    Player* /*designatedLooter*/, Player* firstCorePasser,
+    Player*, Player* firstCorePasser,
     Player* secondCorePasser, Unit* closestTrigger)
 {
     bool needThirdPasser =
@@ -2404,7 +2404,7 @@ bool LadyVashjPassTheTaintedCoreAction::LineUpThirdCorePasser(
 }
 
 bool LadyVashjPassTheTaintedCoreAction::LineUpFourthCorePasser(
-    Player* /*firstCorePasser*/, Player* secondCorePasser,
+    Player*, Player* secondCorePasser,
     Player* thirdCorePasser, Unit* closestTrigger)
 {
     bool needFourthPasser =

--- a/src/Ai/Raid/TK/TKActions.cpp
+++ b/src/Ai/Raid/TK/TKActions.cpp
@@ -1440,9 +1440,9 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
 
     if (axe)
     {
-        bool hasAggroFromWeapon = mace && mace->GetVictim() == bot ||
-                                  dagger && dagger->GetVictim() == bot ||
-                                  sword && sword->GetVictim() == bot;
+        bool hasAggroFromWeapon = (mace && mace->GetVictim() == bot) ||
+                                  (dagger && dagger->GetVictim() == bot) ||
+                                  (sword && sword->GetVictim() == bot);
         if (!botAI->IsTank(bot) ||
             (botAI->IsAssistTank(bot) && hasAggroFromWeapon))
         {
@@ -1608,7 +1608,7 @@ bool KaelthasSunstriderLootLegendaryWeaponsAction::ShouldBotLootWeapon(uint32 we
                    (bot->getClass() == CLASS_WARRIOR && tab != WARRIOR_TAB_ARMS);
 
         case NPC_WARP_SLICER:
-            return bot->getClass() == CLASS_ROGUE && tab != ROGUE_TAB_ASSASSINATION ||
+            return (bot->getClass() == CLASS_ROGUE && tab != ROGUE_TAB_ASSASSINATION) ||
                    (botAI->IsTank(bot) &&
                     (bot->getClass() == CLASS_DEATH_KNIGHT ||
                      bot->getClass() == CLASS_PALADIN));

--- a/src/Ai/Raid/Uld/UldActions.cpp
+++ b/src/Ai/Raid/Uld/UldActions.cpp
@@ -104,7 +104,7 @@ bool FlameLeviathanVehicleAction::MoveAvoidChasing(Unit* target)
         return false;
     if (avoidChaseIdx == -1)
     {
-        for (int i = 0; i < corners.size(); i++)
+        for (uint32 i = 0; i < corners.size(); i++)
         {
             if (bot->GetExactDist(corners[i]) > target->GetExactDist(corners[i]))
                 continue;
@@ -2633,7 +2633,7 @@ bool YoggSaronMarkTargetAction::Execute(Event /*event*/)
             if ((unit->GetEntry() == NPC_IMMORTAL_GUARDIAN || unit->GetEntry() == NPC_MARKED_IMMORTAL_GUARDIAN) &&
                 unit->GetHealthPct() > 10)
             {
-                if (unit->GetHealth() < lowestHealth)
+                if (unit->GetHealth() < uint32(lowestHealth))
                 {
                     lowestHealth = unit->GetHealth();
                     lowestHealthUnit = unit;

--- a/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp
@@ -225,7 +225,7 @@ bool NewRpgBaseAction::MoveWorldObjectTo(ObjectGuid guid, float distance)
     return MoveTo(mapId, x, y, z, false, false, false, true);
 }
 
-bool NewRpgBaseAction::MoveRandomNear(float moveStep, MovementPriority priority, WorldObject* center)
+bool NewRpgBaseAction::MoveRandomNear(float moveStep, MovementPriority priority, WorldObject* /*center*/)
 {
     if (IsWaitingForLastMove(priority))
         return false;
@@ -907,7 +907,7 @@ bool NewRpgBaseAction::GetQuestPOIPosAndObjectiveIdx(uint32 questId, std::vector
         bool inComplete = false;
         for (uint32 objective : incompleteObjectiveIdx)
         {
-            if (qPoi.ObjectiveIndex == objective)
+            if (qPoi.ObjectiveIndex == static_cast<int32>(objective))
             {
                 inComplete = true;
                 break;

--- a/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp
@@ -225,7 +225,7 @@ bool NewRpgBaseAction::MoveWorldObjectTo(ObjectGuid guid, float distance)
     return MoveTo(mapId, x, y, z, false, false, false, true);
 }
 
-bool NewRpgBaseAction::MoveRandomNear(float moveStep, MovementPriority priority, WorldObject* /*center*/)
+bool NewRpgBaseAction::MoveRandomNear(float moveStep, MovementPriority priority, WorldObject*)
 {
     if (IsWaitingForLastMove(priority))
         return false;

--- a/src/Ai/World/Rpg/Action/NewRpgOutdoorPvP.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgOutdoorPvP.cpp
@@ -2,7 +2,7 @@
 #include "OutdoorPvP.h"
 #include "OutdoorPvPMgr.h"
 
-bool NewRpgOutdoorPvpAction::Execute(Event /*event*/)
+bool NewRpgOutdoorPvpAction::Execute(Event)
 {
     if (!bot->IsPvP())
     {

--- a/src/Ai/World/Rpg/Action/NewRpgOutdoorPvP.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgOutdoorPvP.cpp
@@ -2,7 +2,7 @@
 #include "OutdoorPvP.h"
 #include "OutdoorPvPMgr.h"
 
-bool NewRpgOutdoorPvpAction::Execute(Event event)
+bool NewRpgOutdoorPvpAction::Execute(Event /*event*/)
 {
     if (!bot->IsPvP())
     {

--- a/src/Ai/World/Rpg/Action/RpgAction.cpp
+++ b/src/Ai/World/Rpg/Action/RpgAction.cpp
@@ -107,7 +107,7 @@ bool RpgAction::SetNextRpgAction()
     {
         std::vector<std::pair<Action*, uint32>> sortedActions;
 
-        for (int i = 0; i < actions.size(); i++)
+        for (uint32 i = 0; i < actions.size(); i++)
             sortedActions.push_back(std::make_pair(actions[i], relevances[i]));
 
         std::sort(sortedActions.begin(), sortedActions.end(), [](std::pair<Action*, uint32>i, std::pair<Action*, uint32> j) {return i.second > j.second; });

--- a/src/Bot/Cmd/PlayerbotCommandServer.cpp
+++ b/src/Bot/Cmd/PlayerbotCommandServer.cpp
@@ -26,7 +26,7 @@ bool ReadLine(socket_ptr sock, std::string* buffer, std::string* line)
         char buf[1025];
         boost::system::error_code error;
         size_t n = sock->read_some(boost::asio::buffer(buf), error);
-        if (n == -1 || error == boost::asio::error::eof)
+        if (n == static_cast<size_t>(-1) || error == boost::asio::error::eof)
             return false;
         else if (error)
             throw boost::system::system_error(error);  // Some other error.

--- a/src/Bot/Engine/Action/Action.h
+++ b/src/Bot/Engine/Action/Action.h
@@ -17,8 +17,7 @@ class NextAction
 {
 public:
     NextAction(std::string const name, float relevance = 0.0f)
-        : relevance(relevance), name(name) {}                                  // name after relevance - whipowill
-    NextAction(NextAction const& o) : relevance(o.relevance), name(o.name) {}  // name after relevance - whipowill
+        : relevance(relevance), name(name) {}  // name after relevance - whipowill
 
     std::string const getName() { return name; }
     float getRelevance() { return relevance; }

--- a/src/Bot/Engine/Strategy/CustomStrategy.cpp
+++ b/src/Bot/Engine/Strategy/CustomStrategy.cpp
@@ -35,7 +35,7 @@ std::vector<NextAction> toNextActionArray(const std::string actions)
     const std::vector<std::string> tokens = split(actions, ',');
     std::vector<NextAction> res = {};
 
-    for (const std::string token : tokens)
+    for (const std::string& token : tokens)
         res.push_back(toNextAction(token));
 
     return res;

--- a/src/Bot/Engine/Trigger/Trigger.cpp
+++ b/src/Bot/Engine/Trigger/Trigger.cpp
@@ -36,7 +36,7 @@ bool Trigger::needCheck(uint32 now)
     if (checkInterval < 2)
         return true;
 
-    if (!lastCheckTime || now - lastCheckTime >= checkInterval)
+    if (!lastCheckTime || now - lastCheckTime >= uint32(checkInterval))
     {
         lastCheckTime = now;
         return true;

--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -612,7 +612,7 @@ void PlayerbotFactory::Randomize(bool incremental)
     PerfMonitorOperation* pmo = sPerfMonitor.start(PERF_MON_RNDBOT, "PlayerbotFactory_Reset");
 
     if (!sPlayerbotAIConfig.equipAndSpecPersistence ||
-        level < sPlayerbotAIConfig.equipAndSpecPersistenceLevel)
+        level < uint32(sPlayerbotAIConfig.equipAndSpecPersistenceLevel))
     {
         bot->resetTalents(true);
     }
@@ -623,7 +623,7 @@ void PlayerbotFactory::Randomize(bool incremental)
         ClearSpells();
         ResetQuests();
         if (!sPlayerbotAIConfig.equipAndSpecPersistence ||
-            level < sPlayerbotAIConfig.equipAndSpecPersistenceLevel)
+            level < uint32(sPlayerbotAIConfig.equipAndSpecPersistenceLevel))
         {
             ClearAllItems();
         }
@@ -1189,7 +1189,7 @@ void PlayerbotFactory::InitPetTalents()
                 int index = urand(0, spells_row.size() - 1);
                 TalentEntry const* talentInfo = spells_row[index];
                 int maxRank = 0;
-                for (int rank = 0; rank < std::min((uint32)MAX_TALENT_RANK, (uint32)pet->GetFreeTalentPoints()); ++rank)
+                for (uint32 rank = 0; rank < std::min((uint32)MAX_TALENT_RANK, (uint32)pet->GetFreeTalentPoints()); ++rank)
                 {
                     uint32 spellId = talentInfo->RankID[rank];
                     if (!spellId)
@@ -2157,7 +2157,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
             ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
             if (!proto) continue;
             // Respect gear quality limit: trinket must not exceed itemQuality setting
-            if (static_cast<int32>(proto->Quality) > itemQuality) continue;
+            if (static_cast<int32>(proto->Quality) > static_cast<int32>(itemQuality)) continue;
             if (proto->RequiredLevel > level) continue;
             if (!CanEquipItem(proto)) continue;
             uint16 dest;
@@ -2227,7 +2227,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
 
         do
         {
-            for (uint32 requiredLevel = bot->GetLevel(); requiredLevel > std::max((int32)bot->GetLevel() - delta, 0);
+            for (uint32 requiredLevel = bot->GetLevel(); requiredLevel > uint32(std::max((int32)bot->GetLevel() - delta, 0));
                  requiredLevel--)
             {
                 for (InventoryType inventoryType : GetPossibleInventoryTypeListBySlot((EquipmentSlots)slot))
@@ -2262,7 +2262,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
                         if (proto->Class != ITEM_CLASS_WEAPON && proto->Class != ITEM_CLASS_ARMOR)
                             continue;
 
-                        if (proto->Quality != desiredQuality)
+                        if (proto->Quality != uint32(desiredQuality))
                             continue;
 
                         if (proto->Class == ITEM_CLASS_ARMOR &&
@@ -2298,7 +2298,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
         float bestScoreForSlot = -1;
         uint32 bestItemForSlot = 0;
         int32 bestRandomPropForSlot = 0;
-        for (int index = 0; index < ids.size(); index++)
+        for (size_t index = 0; index < ids.size(); index++)
         {
             uint32 newItemId = ids[index].first;
             int32 newItemProp = ids[index].second;
@@ -2419,7 +2419,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
             float bestScoreForSlot = -1;
             uint32 bestItemForSlot = 0;
             int32 bestRandomPropForSlot = 0;
-            for (int index = 0; index < ids.size(); index++)
+            for (size_t index = 0; index < ids.size(); index++)
             {
                 uint32 newItemId = ids[index].first;
                 int32 newItemProp = ids[index].second;
@@ -3391,7 +3391,7 @@ void PlayerbotFactory::InitTalents(uint32 specNo)
             int index = urand(0, spells_row.size() - 1);
             TalentEntry const* talentInfo = spells_row[index];
             int maxRank = 0;
-            for (int rank = 0; rank < std::min((uint32)MAX_TALENT_RANK, bot->GetFreeTalentPoints()); ++rank)
+            for (uint32 rank = 0; rank < std::min((uint32)MAX_TALENT_RANK, bot->GetFreeTalentPoints()); ++rank)
             {
                 uint32 spellId = talentInfo->RankID[rank];
                 if (!spellId)
@@ -3935,7 +3935,7 @@ void PlayerbotFactory::InitFood()
     }
 
     uint32 categories[] = {11, 59};
-    for (int i = 0; i < sizeof(categories) / sizeof(uint32); ++i)
+    for (size_t i = 0; i < sizeof(categories) / sizeof(uint32); ++i)
     {
         uint32 category = categories[i];
         std::vector<uint32>& ids = items[category];
@@ -5122,9 +5122,9 @@ void PlayerbotFactory::ApplyEnchantAndGemsNew(bool /*destroyOld*/)
                 if (curCount[0] != 0)
                 {
                     // Ensure meta gem activation
-                    for (int i = 1; i < curCount.size(); i++)
+                    for (size_t i = 1; i < curCount.size(); i++)
                     {
-                        if (curCount[i] < requiredActive && (gemProperties->color & (1 << i)))
+                        if (curCount[i] < (uint32)requiredActive && (gemProperties->color & (1 << i)))
                         {
                             score *= 2;
                             break;

--- a/src/Bot/Factory/RandomPlayerbotFactory.cpp
+++ b/src/Bot/Factory/RandomPlayerbotFactory.cpp
@@ -240,7 +240,7 @@ std::string const RandomPlayerbotFactory::CreateRandomBotName(NameRaceAndGender 
         botName += (botName.size() < 2) ? groupFormEnd[gender][rand() % 4] : "";
 
         // Replace Catagory value with random Letter from that Catagory's Letter string for a given bot gender
-        for (int i = 0; i < botName.size(); i++)
+        for (size_t i = 0; i < botName.size(); i++)
         {
             botName[i] = groupLetter[gender][groupCategory.find(botName[i])]
                                     [rand() % groupLetter[gender][groupCategory.find(botName[i])].size()];

--- a/src/Bot/PlayerbotMgr.cpp
+++ b/src/Bot/PlayerbotMgr.cpp
@@ -362,7 +362,7 @@ void PlayerbotHolder::LogoutPlayerBot(ObjectGuid guid)
         bot->SaveToDB(false, false);
 
         WorldSession* botWorldSessionPtr = bot->GetSession();
-        WorldSession* masterWorldSessionPtr = nullptr;
+        [[maybe_unused]] WorldSession* masterWorldSessionPtr = nullptr;     // Remove [[maybe_unused]] tag if timed logout implemented.
 
         if (botWorldSessionPtr->isLogingOut())
             return;

--- a/src/Bot/PlayerbotMgr.cpp
+++ b/src/Bot/PlayerbotMgr.cpp
@@ -130,7 +130,7 @@ void PlayerbotHolder::AddPlayerBot(ObjectGuid playerGuid, uint32 masterAccountId
                 ++loadingForMaster;
         }
         uint32 count = mgr->GetPlayerbotsCount() + loadingForMaster;
-        if (count >= PlayerbotAIConfig::instance().maxAddedBots)
+        if (count >= uint32(PlayerbotAIConfig::instance().maxAddedBots))
         {
             allowed = false;
             out << "Failure: You have added too many bots (more than " << sPlayerbotAIConfig.maxAddedBots << ")";

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -2022,7 +2022,7 @@ void RandomPlayerbotMgr::Clear(Player* bot)
     factory.ClearEverything();
 }
 
-uint32 RandomPlayerbotMgr::GetZoneLevel(uint16 mapId, float teleX, float teleY, float teleZ)
+uint32 RandomPlayerbotMgr::GetZoneLevel(uint16 mapId, float teleX, float teleY, float /*teleZ*/)
 {
     uint32 maxLevel = sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL);
 
@@ -2363,7 +2363,7 @@ void RandomPlayerbotMgr::SetValue(Player* bot, std::string const& type, uint32 v
     SetValue(bot->GetGUID().GetCounter(), type, value, data);
 }
 
-bool RandomPlayerbotMgr::HandlePlayerbotConsoleCommand(ChatHandler* handler, char const* args)
+bool RandomPlayerbotMgr::HandlePlayerbotConsoleCommand(ChatHandler* /*handler*/, char const* args)
 {
     if (!sPlayerbotAIConfig.enabled)
     {

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -1619,7 +1619,7 @@ void RandomPlayerbotMgr::RandomTeleport(Player* bot, std::vector<WorldLocation>&
         tlocs.push_back(WorldPosition(loc));
     // Do not teleport to maps disabled in config
     tlocs.erase(std::remove_if(tlocs.begin(), tlocs.end(),
-                               [bot](WorldPosition l)
+                               [](WorldPosition l)
                                {
                                    std::vector<uint32>::iterator i =
                                        find(sPlayerbotAIConfig.randomBotMaps.begin(),

--- a/src/Mgr/Item/RandomItemMgr.cpp
+++ b/src/Mgr/Item/RandomItemMgr.cpp
@@ -1630,7 +1630,7 @@ uint32 RandomItemMgr::CalculateStatWeight(uint8 playerclass, uint8 spec, ItemTem
     statWeight += attackPower;
 
     // handle negative stats
-    if (basicStatsWeight < 0 && (abs(basicStatsWeight) >= statWeight))
+    if (basicStatsWeight < 0 && (uint32(abs(basicStatsWeight)) >= statWeight))
         statWeight = 0;
     else
         statWeight += basicStatsWeight;
@@ -1816,7 +1816,7 @@ uint32 RandomItemMgr::GetUpgrade(Player* player, std::string spec, uint8 slot, u
         }
 
         // skip no stats trinkets
-        if (info.weights[specId] == 1 && info.slot == EQUIPMENT_SLOT_NECK || info.slot == EQUIPMENT_SLOT_TRINKET1 ||
+        if ((info.weights[specId] == 1 && info.slot == EQUIPMENT_SLOT_NECK) || info.slot == EQUIPMENT_SLOT_TRINKET1 ||
             info.slot == EQUIPMENT_SLOT_TRINKET2 || info.slot == EQUIPMENT_SLOT_FINGER1 ||
             info.slot == EQUIPMENT_SLOT_FINGER2)
             continue;
@@ -2250,7 +2250,7 @@ void RandomItemMgr::BuildEquipCacheNew()
         if (quest->GetRequiredClasses())
             continue;
 
-        for (int j = 0; j < quest->GetRewChoiceItemsCount(); j++)
+        for (uint32 j = 0; j < quest->GetRewChoiceItemsCount(); j++)
             if (uint32 itemId = quest->RewardChoiceItemId[j])
             {
                 ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
@@ -2261,7 +2261,7 @@ void RandomItemMgr::BuildEquipCacheNew()
                 questItemIds.insert(itemId);
             }
 
-        for (int j = 0; j < quest->GetRewItemsCount(); j++)
+        for (uint32 j = 0; j < quest->GetRewItemsCount(); j++)
             if (uint32 itemId = quest->RewardItemId[j])
             {
                 ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
@@ -2406,7 +2406,7 @@ void RandomItemMgr::BuildPotionCache()
                 if (proto->Duration & 0x80000000)
                     continue;
 
-                if (proto->AllowableClass != -1)
+                if (proto->AllowableClass != uint32(-1))
                     continue;
 
                 bool hybrid = false;
@@ -2799,7 +2799,7 @@ inline bool IsCraftedBySpellInfo(ItemTemplate const* proto, SpellInfo const* spe
             continue;
         }
 
-        if (proto->ItemId == spellInfo->Reagent[x])
+        if (proto->ItemId == uint32(spellInfo->Reagent[x]))
             return true;
 
     }

--- a/src/Mgr/Item/RandomItemMgr.h
+++ b/src/Mgr/Item/RandomItemMgr.h
@@ -12,14 +12,13 @@
 #include <unordered_set>
 #include <vector>
 
+#include "Player.h"
 #include "AiFactory.h"
 #include "ItemTemplate.h"
 
 class ChatHandler;
 
 struct ItemTemplate;
-
-enum EquipmentSlots : uint32;
 
 enum RandomItemType
 {

--- a/src/Mgr/Item/StatsCollector.cpp
+++ b/src/Mgr/Item/StatsCollector.cpp
@@ -34,7 +34,7 @@ void StatsCollector::CollectItemStats(ItemTemplate const* proto)
     }
     stats[STATS_TYPE_ARMOR] += proto->Armor;
     stats[STATS_TYPE_BLOCK_VALUE] += proto->Block;
-    for (int i = 0; i < proto->StatsCount; i++)
+    for (uint32 i = 0; i < proto->StatsCount; i++)
     {
         const _ItemStat& stat = proto->ItemStat[i];
         const int32& val = stat.ItemStatValue;

--- a/src/Mgr/Talent/Talentspec.cpp
+++ b/src/Mgr/Talent/Talentspec.cpp
@@ -316,7 +316,7 @@ std::vector<TalentSpec::TalentListEntry> TalentSpec::GetTalentTree(uint32 tabpag
     std::vector<TalentListEntry> retList;
 
     for (auto& entry : talents)
-        if (entry.tabPage() == tabpage)
+        if (entry.tabPage() == uint32(tabpage))
             retList.push_back(entry);
 
     return retList;
@@ -332,7 +332,7 @@ uint32 TalentSpec::GetTalentPoints(std::vector<TalentListEntry>& talents, int32 
 
     uint32 tPoints = 0;
     for (auto& entry : talents)
-        if (entry.tabPage() == tabpage)
+        if (entry.tabPage() == uint32(tabpage))
             tPoints = tPoints + entry.rank;
 
     return tPoints;
@@ -448,7 +448,7 @@ std::vector<TalentSpec::TalentListEntry> TalentSpec::SubTalentList(std::vector<T
             {
                 if (reverse == ABSOLUTE_DIST)
                     newentry.rank = std::abs(int32(newentry.rank - oldentry.rank));
-                else if (reverse == ADDED_POINTS || reverse == REMOVED_POINTS)
+                else if (reverse == ADDED_POINTS || reverse == uint32(REMOVED_POINTS))
                     newentry.rank = std::max(0u, (newentry.rank - oldentry.rank) * (reverse / 2));
                 else
                     newentry.rank = (newentry.rank - oldentry.rank) * reverse;

--- a/src/Mgr/Travel/TravelMgr.cpp
+++ b/src/Mgr/Travel/TravelMgr.cpp
@@ -540,7 +540,7 @@ std::string const WorldPosition::getAreaName(bool fullName, bool zoneName)
     return areaName;
 }
 
-std::set<Transport*> WorldPosition::getTransports(uint32 entry)
+std::set<Transport*> WorldPosition::getTransports(uint32 /*entry*/)
 {
     /*
     if (!entry)
@@ -1258,7 +1258,7 @@ bool QuestObjectiveTravelDestination::isActive(Player* bot)
         GuidVector targets = AI_VALUE(GuidVector, "possible targets");
 
         for (auto& target : targets)
-            if (target.GetEntry() == getEntry() && target.IsCreature() && botAI->GetCreature(target) &&
+            if (target.GetEntry() == uint32(getEntry()) && target.IsCreature() && botAI->GetCreature(target) &&
                 botAI->GetCreature(target)->IsAlive())
                 return true;
 
@@ -1310,7 +1310,7 @@ bool RpgTravelDestination::isActive(Player* bot)
 
     for (ObjectGuid const guid : ignoreList)
     {
-        if (guid.GetEntry() == getEntry())
+        if (guid.GetEntry() == uint32(getEntry()))
             return false;
 
     }
@@ -1455,7 +1455,7 @@ bool BossTravelDestination::isActive(Player* bot)
         GuidVector targets = AI_VALUE(GuidVector, "possible targets");
 
         for (auto& target : targets)
-            if (target.GetEntry() == getEntry() && target.IsCreature() && botAI->GetCreature(target) &&
+            if (target.GetEntry() == uint32(getEntry()) && target.IsCreature() && botAI->GetCreature(target) &&
                 botAI->GetCreature(target)->IsAlive())
                 return true;
 
@@ -3836,7 +3836,7 @@ uint32 TravelMgr::getDialogStatus(Player* pPlayer, int32 questgiver, Quest const
 
 // Selects a random WorldPosition from a list. Use a distance weighted distribution.
 std::vector<WorldPosition*> TravelMgr::getNextPoint(WorldPosition* center, std::vector<WorldPosition*> points,
-                                                    uint32 amount)
+                                                    uint32 /*amount*/)
 {
     std::vector<WorldPosition*> retVec;
 
@@ -4746,7 +4746,7 @@ void TravelMgr::PrepareDestinationCache()
                 {
                     LevelBracket bracket = zone2LevelBracket[areaId];
                     WorldPosition loc(mapId, x + cos(orient) * 5.0f, y + sin(orient) * 5.0f, z + 0.5f, orient + M_PI);
-                    for (int i = bracket.low; i <= bracket.high; i++)
+                    for (uint32 i = bracket.low; i <= bracket.high; i++)
                     {
                         if (forHorde)
                             hordeHubsPerLevelCache[i].push_back(loc);
@@ -4762,7 +4762,7 @@ void TravelMgr::PrepareDestinationCache()
 
                 LevelBracket bracket = zone2LevelBracket[areaId];
                 WorldPosition loc(mapId, x + cos(orient) * 5.0f, y + sin(orient) * 5.0f, z + 0.5f, orient + M_PI);
-                for (int i = bracket.low; i <= bracket.high; i++)
+                for (uint32 i = bracket.low; i <= bracket.high; i++)
                 {
                     if (forHorde)
                         hordeHubsPerLevelCache[i].push_back(loc);
@@ -4787,7 +4787,7 @@ void TravelMgr::PrepareDestinationCache()
             bLoc.loc = WorldLocation(mapId, x + cos(orient) * 6.0f, y + sin(orient) * 6.0f, z + 2.0f, orient + M_PI);
             bLoc.entry = templateEntry;
             uint32 level = (creatureTemplate->minlevel + creatureTemplate->maxlevel + 1) / 2;
-            for (int32 l = 1; l <= maxLevel; l++)
+            for (uint32 l = 1; l <= maxLevel; l++)
             {
                 // Bots 1-60 go to base game bankers (all have minlevel 30 or 45)
                 if (l <=60 && level > 45)
@@ -4818,13 +4818,13 @@ void TravelMgr::PrepareDestinationCache()
             for (int32 l = (int32)level - (int32)sPlayerbotAIConfig.randomBotTeleLowerLevel;
                  l <= (int32)level + (int32)sPlayerbotAIConfig.randomBotTeleHigherLevel; l++)
             {
-                if (l < 1 || l > maxLevel)
+                if (l < 1 || l > int32(maxLevel))
                     continue;
 
-                    locsPerLevelCache[(uint8)l].push_back(WorldLocation(std::get<0>(gridTuple),
-                        static_cast<float>(std::get<1>(gridTuple)) * 50.0f,
-                        static_cast<float>(std::get<2>(gridTuple)) * 50.0f,
-                        static_cast<float>(std::get<3>(gridTuple)) * 50.0f));
+                locsPerLevelCache[(uint8)l].push_back(WorldLocation(std::get<0>(gridTuple),
+                    static_cast<float>(std::get<1>(gridTuple)) * 50.0f,
+                    static_cast<float>(std::get<2>(gridTuple)) * 50.0f,
+                    static_cast<float>(std::get<3>(gridTuple)) * 50.0f));
             }
         }
     }

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -946,14 +946,14 @@ std::vector<std::vector<uint32>> PlayerbotAIConfig::ParseTempTalentsOrder(uint32
     }
     for (int tab = 0; tab < 3; tab++)
     {
-        if (tab_links.size() <= tab)
+        if (tab_links.size() <= (size_t)tab)
         {
             break;
         }
         std::sort(spells[tab].begin(), spells[tab].end(),
                   [&](TalentEntry const* lhs, TalentEntry const* rhs)
                   { return lhs->Row != rhs->Row ? lhs->Row < rhs->Row : lhs->Col < rhs->Col; });
-        for (int i = 0; i < tab_links[tab].size(); i++)
+        for (uint32 i = 0; i < tab_links[tab].size(); i++)
         {
             if (i >= spells[tab].size())
             {
@@ -1002,7 +1002,7 @@ std::vector<std::vector<uint32>> PlayerbotAIConfig::ParseTempPetTalentsOrder(uin
     std::sort(spells.begin(), spells.end(),
               [&](TalentEntry const* lhs, TalentEntry const* rhs)
               { return lhs->Row != rhs->Row ? lhs->Row < rhs->Row : lhs->Col < rhs->Col; });
-    for (int i = 0; i < tab_link.size(); i++)
+    for (uint32 i = 0; i < tab_link.size(); i++)
     {
         if (i >= spells.size())
         {

--- a/src/Script/PlayerbotCommandScript.cpp
+++ b/src/Script/PlayerbotCommandScript.cpp
@@ -72,7 +72,7 @@ public:
         return GuildTaskMgr::HandleConsoleCommand(handler, args);
     }
 
-    static bool HandlePerfMonCommand(ChatHandler* handler, char const* args)
+    static bool HandlePerfMonCommand(ChatHandler* /*handler*/, char const* args)
     {
         if (!strcmp(args, "reset"))
         {


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
Followup to several warnings cleanups done few months ago by @Celandriel. The hope is that we can live in a world where our children never see a compiler warning on the master branch. 

PR is in fourcommits. 

1. The first one is obvious incorrect casts, reordering of header signatures, incorrect brackets. 

2. The second deletes unused variables/code and redundant user-defined copy constructor. 

3. The third removes EquipmentSlots enum declaration, and it must be merged with this core commit https://github.com/mod-playerbots/azerothcore-wotlk/pull/222

Four years ago there was a crash happening in RandomItemMgr.h because of the declaration of EquipmentSlots. https://github.com/NoxMax/azerothcore-wotlk/commit/db71f4739cd2c3d3c5ffa8d17cc2aa5481c1650d
The correct fix was to include Player.h. Instead the enum was forward-declared in Playerbots, and changed in Player.h to uint32. That fixed the crash, but left a warning ever since. The third commit is a proper fix to the crash, that reverts the core changes, and doesn't create warnings.

4. Last one modifies the PR template to remind people not to add new warnings. I think we should eventually edit the .yml file for GH Action to treat warnings as errors, but for now, I am just adding this as an advice for the short term before we enforce it. I pasted the checkbox in this PR description too just as an immediate example.


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.



## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

Changes should compile without any errors and warnings, if you apply it to the current state of test-staging. There might be other errors introduced from accompanying new PRs.


## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->
Had Claude go through a long, long, list of warnings of all those int/uint comparisons.


<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->

Do not fear the 70 file diff. The 70 file diff should fear you. 
But seriously it's not as scary as it looks.