### PR TITLE
Fix disenchant skill check causing bots to pass on usable loot

### DIFF
--- a/src/Ai/Base/Value/ItemUsageValue.cpp
+++ b/src/Ai/Base/Value/ItemUsageValue.cpp
@@ -109,12 +109,9 @@ ItemUsage ItemUsageValue::Calculate()
         // Retrieve the bot's Enchanting skill level
         uint32 enchantingSkill = bot->GetSkillValue(SKILL_ENCHANTING);
 
-        // Check if the bot has a high enough skill to disenchant this item
-        if (proto->RequiredDisenchantSkill > 0 && enchantingSkill < proto->RequiredDisenchantSkill)
-            return ITEM_USAGE_NONE; // Not skilled enough to disenchant
-
-        // BoE (Bind on Equip) items should NOT be disenchanted unless they are already bound
-        if (proto->Bonding == BIND_WHEN_PICKED_UP || (proto->Bonding == BIND_WHEN_EQUIPPED && isSoulbound))
+        // Only disenchant if skilled enough and binding allows it
+        if (enchantingSkill >= proto->RequiredDisenchantSkill &&
+            (proto->Bonding == BIND_WHEN_PICKED_UP || (proto->Bonding == BIND_WHEN_EQUIPPED && isSoulbound)))
             return ITEM_USAGE_DISENCHANT;
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

When a bot has the Enchanting skill but its level is insufficient to disenchant an item, the old code returned `ITEM_USAGE_NONE` immediately. This caused the bot to pass on loot rolls for items it could have used for other purposes (equip, quest turn-in, crafting reagents, guild tasks) because the function never reached those downstream checks.

The fix combines the skill check and binding check into a single positive condition: the bot only returns `ITEM_USAGE_DISENCHANT` when it is both skilled enough and the binding allows it. Otherwise, execution falls through to the remaining item usage evaluations as intended.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

- **Minimum logic:** Replace two separate guards (one early-return `NONE`, one positive `DISENCHANT`) with a single combined `if` that returns `DISENCHANT` only when both conditions are met. No new branches — one fewer than before.
- **Processing cost:** Identical. The same two comparisons execute once per disenchant-eligible item evaluation. No change to per-bot or per-tick cost.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify.
-->

1. Spawn a bot with Enchanting skill at a low level (e.g. 1/75).
2. Loot or roll on an armor/weapon item with `RequiredDisenchantSkill` higher than the bot's skill (e.g. a level 50 blue with required skill 225).
3. **Before:** The bot returns `ITEM_USAGE_NONE` and passes on the item, even if it could equip it or use it for a quest.
4. **After:** The bot correctly evaluates remaining usages (equip, quest, etc.) and rolls Need/Greed appropriately.

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

Same number of comparisons, one fewer early-return path.

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

Bots with insufficient enchanting skill will now correctly consider non-disenchant uses for items they previously passed on entirely.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)

Reduces branches from two `if` statements to one.

## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)

AI was used to refactor the two-condition guard into a single combined condition. The logic was reviewed and the behavioural difference (fall-through vs early return) was verified manually.

<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->

The root cause was that `return ITEM_USAGE_NONE` on the skill check short-circuited the entire `Calculate()` function, skipping all downstream item usage evaluations. The fix simply lets execution continue past the disenchant block when disenchanting isn't viable.