### PR TITLE
Fix re-entrant Engine::Init/Reset use-after-free on the bot AI tick

### DIFF
--- a/src/Bot/Engine/Engine.cpp
+++ b/src/Bot/Engine/Engine.cpp
@@ -114,8 +114,29 @@ void Engine::Reset()
     actionNodeFactories.creators.clear();
 }
 
+Engine::TickScope::TickScope(Engine* engine) : engine(engine) { ++engine->tickDepth; }
+
+Engine::TickScope::~TickScope()
+{
+    // When the outermost tick unwinds, apply any Init() that was deferred during it.
+    if (--engine->tickDepth == 0 && engine->initPending)
+    {
+        engine->initPending = false;
+        engine->Init();
+    }
+}
+
 void Engine::Init()
 {
+    // WL: never delete/rebuild the triggers/multipliers/queue while a tick is iterating them
+    // (a strategy change requested from inside an Action::Execute / Trigger::Check). Defer the
+    // rebuild to the TickScope at the bottom of the tick instead. See Engine.h for the rationale.
+    if (tickDepth > 0)
+    {
+        initPending = true;
+        return;
+    }
+
     Reset();
 
     for (std::map<std::string, Strategy*>::iterator i = strategies.begin(); i != strategies.end(); i++)
@@ -140,6 +161,8 @@ void Engine::Init()
 
 bool Engine::DoNextAction(Unit* /*unit*/, uint32 /*depth*/, bool minimal)
 {
+    TickScope tickScope(this);  // WL: defer any mid-tick Init() until this tick unwinds (re-entrancy UAF fix)
+
     LogAction("--- AI Tick ---");
 
     if (sPlayerbotAIConfig.logValuesPerTick)
@@ -304,6 +327,8 @@ bool Engine::MultiplyAndPush(
 
 ActionResult Engine::ExecuteAction(std::string const name, Event event, std::string const qualifier)
 {
+    TickScope tickScope(this);  // WL: defer any mid-tick Init() until this unwinds (re-entrancy UAF fix)
+
     bool result = false;
 
     ActionNode* actionNode = CreateActionNode(name);

--- a/src/Bot/Engine/Engine.h
+++ b/src/Bot/Engine/Engine.h
@@ -104,6 +104,24 @@ private:
     void LogAction(char const* format, ...);
     void LogValues();
 
+    // WL: re-entrancy guard (single-thread use-after-free fix).
+    // An Action::Execute() or Trigger::Check() can call ChangeStrategy / addStrategy /
+    // removeStrategy / removeAllStrategies / Init on THIS engine while DoNextAction /
+    // ProcessTriggers is still iterating triggers/multipliers/queue. Init() -> Reset()
+    // then deletes the very containers being iterated -> dangling pointers -> heap
+    // corruption (the recurring bot-AI crash; reproduced even single-threaded, proving
+    // it is re-entrancy, not a thread race). Fix: while a tick is on the stack
+    // (tickDepth > 0) Init() only flags initPending and returns; the rebuild runs once,
+    // after the outermost tick unwinds.
+    int tickDepth = 0;
+    bool initPending = false;
+    struct TickScope
+    {
+        explicit TickScope(Engine* engine);
+        ~TickScope();
+        Engine* engine;
+    };
+
     ActionExecutionListeners actionExecutionListeners;
 
 protected:


### PR DESCRIPTION
## Pull Request Description

Fixes the recurring playerbot use-after-free that takes the worldserver down on the map update threads. Root cause is a re-entrancy bug in the AI engine: `Engine::Reset()` deletes the `triggers` / `multipliers` / `queue` containers, and it is reached through `Engine::Init()` (addStrategy / removeStrategy / removeAllStrategies / ChangeStrategy / ResetStrategies). Some actions call `ChangeStrategy` on their own engine from inside `Execute()`, which runs while `DoNextAction` / `ProcessTriggers` is still iterating those same containers. When the changed strategy is the one currently ticking, `Reset()` frees the containers mid-iteration -> dangling `TriggerNode*` / `Multiplier*` -> heap corruption. It reproduces with `MapUpdate.Threads = 1`, so it is single-thread re-entrancy, not a thread race. Full write-up + a symbolicated crash dump are on #2474.

## Feature Evaluation

- Minimum logic: a depth counter. `DoNextAction` and `ExecuteAction` push a small RAII `TickScope` that increments `tickDepth`. While `tickDepth > 0`, `Init()` sets `initPending = true` and returns instead of running `Reset()`; the rebuild runs once when the outermost tick unwinds.
- Processing cost: negligible. One integer increment/decrement per engine tick, no allocation, no per-bot state. In the re-entrant case it does slightly less work, because a mid-tick rebuild becomes a single deferred one.

## How to Test the Changes

- High random-bot count with combat specs active (rogue and feral druid are the most reliable; idle fishing bots and arena exits also hit it).
- Optionally set `MapUpdate.Threads = 1` - it still crashes, which is what proves it is re-entrancy and not a race.
- Before: ACCESS_VIOLATION on a map worker thread in the AI engine (e.g. `Engine::ProcessTriggers`, `AiObjectContext::GetUntypedValue`, `Engine::MultiplyAndPush`); ~1 crash per several hours bots-only, minutes with a real player fighting among bots.
- After: no crash on those paths. Quick confirm without waiting for a crash: temporarily `LOG_ERROR` in `Engine::Init()` when `tickDepth > 0` - it lights up on any rogue/feral/fishing session, showing the re-entrant `Reset()` was firing.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

One int inc/dec per tick via RAII, no allocation, no per-bot data; if anything it reduces work in the re-entrant case.

- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)

Behavior is identical; a strategy change requested from inside a tick rebuilds one tick later instead of immediately, which is not observable in bot behavior.

- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [x] Yes (**explain below**)

Minimal: one `if (tickDepth > 0)` guard in `Init()` plus a small RAII `TickScope`. Two files (`Engine.cpp` / `Engine.h`), commented.

## AI Assistance

Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)

Yes. I run a private WotLK server and used an AI assistant for the crash-log analysis, root-causing this re-entrancy bug, and drafting the patch. I reproduced the crash myself (single-threaded, `MapUpdate.Threads = 1`, which is what proves it is re-entrancy and not a thread race), reviewed the change, and it is running live on my server now. It is small and self-contained - a depth counter that defers `Init()`'s rebuild while a tick is on the stack.

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated. (N/A - no new dialogue)
- - [x] Documentation updated if needed (Conf comments, WiKi commands). (N/A - no conf/command changes)

## Notes for Reviewers

The full root-cause analysis, the in-tick offenders found (`CheckStealthAction`, the `FishingAction` family, `ArenaTactics`), and a symbolicated crash dump are on #2474. The fix is running on my live server now.
