### PR TITLE
Fix: prot paladins get no blessing when Blessing of Sanctuary isn't learned

### DIFF
--- a/src/Ai/Class/Paladin/Actions/PaladinActions.cpp
+++ b/src/Ai/Class/Paladin/Actions/PaladinActions.cpp
@@ -114,6 +114,15 @@ static inline bool IsTankRole(Player* player)
     return false;
 }
 
+// Sanctuary is the top-priority blessing only for paladin tanks (its mana-regen
+// component); every other role prefers Kings or Might. In the single-blessing
+// path each member gets their top blessing, so Sanctuary is restricted to
+// paladin tanks here.
+static inline bool IsPaladinTank(Player* player)
+{
+    return player && player->getClass() == CLASS_PALADIN && IsTankRole(player);
+}
+
 static inline bool IsOnlyPaladinInGroup(Player* bot)
 {
     if (!bot)
@@ -204,17 +213,7 @@ inline std::string const GetActualBlessingOfSanctuary(Unit* target, Player* bot)
     if (!targetPlayer)
         return "";
 
-    if (auto* botAI = GET_PLAYERBOT_AI(bot))
-    {
-        if (Unit* mainTank =
-            botAI->GetAiObjectContext()->GetValue<Unit*>("main tank")->Get())
-        {
-            if (mainTank == target)
-                return "blessing of sanctuary";
-        }
-    }
-
-    if (targetPlayer->HasTankSpec())
+    if (IsPaladinTank(targetPlayer))
         return "blessing of sanctuary";
 
     return "";
@@ -372,7 +371,7 @@ bool CastBlessingOfSanctuaryOnPartyAction::Execute(Event /*event*/)
     if (Player* self = bot->ToPlayer())
     {
         bool selfHasSanct = HasSanctAura(self);
-        bool needSelf = IsTankRole(self) && !selfHasSanct;
+        bool needSelf = IsPaladinTank(self) && !selfHasSanct;
 
         if (needSelf)
         {
@@ -385,7 +384,7 @@ bool CastBlessingOfSanctuaryOnPartyAction::Execute(Event /*event*/)
     if (targetPlayer)
     {
         bool hasSanct = HasSanctAura(targetPlayer);
-        targetOk = IsTankRole(targetPlayer) && !hasSanct;
+        targetOk = IsPaladinTank(targetPlayer) && !hasSanct;
     }
 
     if (!targetOk)
@@ -397,7 +396,7 @@ bool CastBlessingOfSanctuaryOnPartyAction::Execute(Event /*event*/)
                 Player* player = ref->GetSource();
                 if (!player) continue;
                 if (!player->IsInWorld() || !player->IsAlive()) continue;
-                if (!IsTankRole(player)) continue;
+                if (!IsPaladinTank(player)) continue;
 
                 bool hasSanct = HasSanctAura(player);
                 if (!hasSanct)
@@ -411,18 +410,10 @@ bool CastBlessingOfSanctuaryOnPartyAction::Execute(Event /*event*/)
         }
     }
 
+    // With the HasSpell(Sanctuary) guard above, GetActualBlessingOfSanctuary is
+    // non-empty only for a paladin tank; anything else has no Sanctuary target.
     if (GetActualBlessingOfSanctuary(target, bot).empty())
-    {
-        if (targetPlayer)
-        {
-            if (IsTankRole(targetPlayer))
-                return botAI->CastSpell("blessing of sanctuary", target);
-            else
-                return false;
-        }
-        else
-            return false;
-    }
+        return false;
 
     return botAI->CastSpell("blessing of sanctuary", target);
 }
@@ -437,7 +428,7 @@ Unit* CastBlessingOfSanctuaryOnPartyAction::GetTarget()
 
     return FindBlessingTarget(bot, botAI, [&](Player* player)
     {
-        return IsTankRole(player) &&
+        return IsPaladinTank(player) &&
                !HasBlessingAura(botAI, player,
                    { "blessing of sanctuary", "greater blessing of sanctuary" });
     });

--- a/src/Ai/Class/Paladin/PaladinTriggers.cpp
+++ b/src/Ai/Class/Paladin/PaladinTriggers.cpp
@@ -34,6 +34,18 @@ bool BlessingTrigger::IsActive()
                                 "blessing of kings", "blessing of sanctuary", nullptr);
 }
 
+Value<Unit*>* BlessingOfKingsOnPartyTrigger::GetTargetValue()
+{
+    // A member already carrying Sanctuary counts as blessed for Kings purposes,
+    // matching CastBlessingOfKingsOnPartyAction's targeting. Without this the
+    // trigger would stay active for a Sanctuary-buffed paladin tank and spin a
+    // no-op cast every interval.
+    return context->GetValue<Unit*>(
+        "party member without aura",
+        ai::buff::MakeAuraQualifierForBuff("blessing of kings") + "," +
+        ai::buff::MakeAuraQualifierForBuff("blessing of sanctuary"));
+}
+
 bool DivineShieldLowHealthTrigger::IsActive()
 {
     return botAI->HasAura("divine shield", bot) && AI_VALUE2(uint8, "health", "self target") < 80;

--- a/src/Ai/Class/Paladin/PaladinTriggers.h
+++ b/src/Ai/Class/Paladin/PaladinTriggers.h
@@ -205,6 +205,12 @@ public:
     {
         spell = "blessing of kings";
     }
+
+    // Sanctuary satisfies Kings for targeting (the Kings action treats it the
+    // same), so a member already carrying Sanctuary should not keep this
+    // trigger active and spin a no-op cast. Keep the "blessing of kings" name;
+    // only widen the aura qualifier used to find a member still needing it.
+    Value<Unit*>* GetTargetValue() override;
 };
 
 class BlessingOfWisdomOnPartyTrigger : public BlessingOnPartyTrigger

--- a/src/Ai/Class/Paladin/Strategy/PaladinBuffStrategies.cpp
+++ b/src/Ai/Class/Paladin/Strategy/PaladinBuffStrategies.cpp
@@ -18,9 +18,15 @@ void PaladinBuffManaStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 
 void PaladinBuffHealthStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
+    // Sanctuary on paladin tanks (prio > Kings)
     triggers.push_back(
         new TriggerNode("blessing of sanctuary on party",
-                        { NextAction("blessing of sanctuary on party", 11.0f) }));
+                        { NextAction("blessing of sanctuary on party", 12.0f) }));
+
+    // Kings on everyone else; also covers a paladin tank lacking Sanctuary
+    triggers.push_back(
+        new TriggerNode("blessing of kings on party",
+                        { NextAction("blessing of kings on party", 11.0f) }));
 }
 
 void PaladinBuffDpsStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)

--- a/src/Bot/Factory/AiFactory.cpp
+++ b/src/Bot/Factory/AiFactory.cpp
@@ -33,6 +33,7 @@ constexpr uint32 SPELL_ICE_SHARDS = 15047;
 constexpr uint32 SPELL_WHIRLWIND = 1680;
 constexpr uint32 SPELL_CAT_FORM = 768;
 constexpr uint32 SPELL_DRUID_THICK_HIDE = 16931;
+constexpr uint32 SPELL_BLESSING_OF_KINGS = 20217;
 }
 
 AiObjectContext* AiFactory::createAiObjectContext(Player* player, PlayerbotAI* botAI)
@@ -515,7 +516,12 @@ void AiFactory::AddDefaultNonCombatStrategies(Player* player, PlayerbotAI* const
             if (tab == PALADIN_TAB_PROTECTION)
             {
                 nonCombatEngine->addStrategiesNoInit("bthreat", "tank assist", "pull", "barmor", nullptr);
-                if (player->GetLevel() >= 20)
+                // Blessing of Kings is learned at level 20; below that fall
+                // back to Might. "bsanc" keeps Sanctuary on paladin tanks and
+                // Kings on everyone else, and Kings also covers the tank when
+                // the Sanctuary talent isn't trained -- so gating on Kings
+                // (which Sanctuary always implies) is enough.
+                if (player->HasSpell(SPELL_BLESSING_OF_KINGS))
                     nonCombatEngine->addStrategy("bsanc", false);
                 else
                     nonCombatEngine->addStrategy("bmight", false);


### PR DESCRIPTION
## Pull Request Description

Protection paladins were assigned the Sanctuary self/party blessing strategy gated **only on character level (`>= 20`)**, with no fallback when the Blessing of Sanctuary talent isn't trained. Since Sanctuary is a ~level-40 Protection talent, every prot paladin between level 20 and ~40 (and any prot build that skips the talent) ended up casting **no blessing at all**.

This change:
- **AiFactory** — gates the prot blessing strategy on `HasSpell(Blessing of Kings)` instead of level; below that, falls back to Blessing of Might (a low-level baseline blessing).
- **`bsanc` (`PaladinBuffHealthStrategy`)** — now casts Sanctuary on paladin tanks **and** Kings on everyone else, so Kings transparently covers the tank when Sanctuary isn't available.
- **Single-blessing Sanctuary** — restricted to paladin tanks via a new `IsPaladinTank()` helper, matching the blessing-priority table from #2358 where Sanctuary is the top-priority blessing only for paladin tanks (its mana-regen component); every other role prefers Kings/Might.
- Adds the `SPELL_BLESSING_OF_KINGS` constant.

Files: `AiFactory.cpp`, `PaladinActions.cpp`, `PaladinBuffStrategies.cpp`, `PaladinHelper.h`.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
  - A one-time `HasSpell` check at strategy-assignment time (when the non-combat engine is built, not per tick), one additional trigger node in an existing buff strategy, and a class comparison (`getClass() == CLASS_PALADIN`) added to the existing tank predicate used by the Sanctuary action.
- Describe the **processing cost** when this logic executes across many bots.
  - Negligible. The strategy gate runs once per engine build. The added Kings trigger reuses the existing Kings action and its existing "party member without aura" target value (cheap aura checks), and only resolves a cast when a blessing is actually missing. `IsPaladinTank` adds a single integer comparison to an already-running tank check. No new DB queries, allocations, or per-tick scans are introduced.

## How to Test the Changes

1. Spawn a Protection-spec paladin bot at **level 20–39** (no Sanctuary talent). Expected: bot maintains **Blessing of Kings** on itself and party members (previously: no blessing at all).
2. Spawn a Protection paladin **level 40+ with the Sanctuary talent**. Expected: **Sanctuary** on paladin tanks (incl. itself), **Kings** on everyone else.
3. Spawn a Protection paladin **below level 20**. Expected: **Blessing of Might** on the party.
4. Group the prot paladin with a **non-paladin tank** (druid/warrior/DK). Expected: that tank receives **Kings**, not Sanctuary.

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

  The only per-tick additions are (a) one extra trigger evaluation in the prot non-combat buff strategy, which reuses existing Kings aura/target logic and short-circuits once blessings are present, and (b) one class comparison inside the existing tank predicate. The strategy-selection gate itself runs once at engine build, not per tick.

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

  Prot paladin bots now reliably receive a blessing. Previously a prot paladin without the Sanctuary talent received none; they now receive Sanctuary (paladin tanks) / Kings (others) / Might (pre-20). Sanctuary recipients are also narrowed to paladin tanks to match the priority table in #2358.

- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [x] Yes (**explain below**)

  Minimal: a single spell-based gate branch replaces the previous level check, one small `IsPaladinTank()` helper is added, and one trigger node is added to an existing strategy.

## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

AI (Claude Code) was used for root-cause investigation, design discussion, and code generation across all four files. Every change was reviewed and is understood and owned by the contributor.

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated. (N/A — no new dialogue.)
- - [x] Documentation updated if needed (Conf comments, WiKi commands). (N/A — no conf/wiki changes.)

## Notes for Reviewers

- The fallback is handled entirely within the `bsanc` strategy: under `bsanc`, `hasBkings` is false in `CastBlessingOfKingsOnPartyAction::GetTarget`, so Kings has no tank-skip and naturally covers the paladin tank when Sanctuary can't be cast — while Sanctuary's higher priority (12.0 vs 11.0) wins when it can.
- The dormant `bkings` strategy and the greater-blessing priority system are intentionally left untouched; only the single-blessing Sanctuary path is narrowed to paladin tanks.
