### PR TITLE
Create framework for excluding targets (SWP staging)

### DIFF
--- a/src/Ai/Base/Value/AttackerWithoutAuraTargetValue.cpp
+++ b/src/Ai/Base/Value/AttackerWithoutAuraTargetValue.cpp
@@ -6,26 +6,27 @@
 #include "AttackerWithoutAuraTargetValue.h"
 
 #include "Playerbots.h"
+#include "Strategy.h"
+#include "TargetValue.h"
 
 Unit* AttackerWithoutAuraTargetValue::Calculate()
 {
     GuidVector attackers = botAI->GetAiObjectContext()->GetValue<GuidVector>("attackers")->Get();
+    GuidSet const dynamicExclusions = GatherStrategyTargetExclusions(botAI, TargetValueExclusionType::Attacker);
     // Unit* target = botAI->GetAiObjectContext()->GetValue<Unit*>("current target")->Get();
     uint32 max_health = 0;
     Unit* result = nullptr;
     for (ObjectGuid const guid : attackers)
     {
         Unit* unit = botAI->GetUnit(guid);
-        if (!unit || !unit->IsAlive())
+        if (!unit || !unit->IsAlive() || dynamicExclusions.find(guid) != dynamicExclusions.end())
             continue;
 
         if (!bot->IsWithinCombatRange(unit, botAI->GetRange(range)))
             continue;
 
         if (unit->GetHealth() < max_health)
-        {
             continue;
-        }
 
         if (!botAI->HasAura(qualifier, unit, false, true))
         {
@@ -40,13 +41,14 @@ Unit* AttackerWithoutAuraTargetValue::Calculate()
 Unit* MeleeAttackerWithoutAuraTargetValue::Calculate()
 {
     GuidVector attackers = botAI->GetAiObjectContext()->GetValue<GuidVector>("attackers")->Get();
+    GuidSet const dynamicExclusions = GatherStrategyTargetExclusions(botAI, TargetValueExclusionType::Attacker);
     // Unit* target = botAI->GetAiObjectContext()->GetValue<Unit*>("current target")->Get();
     uint32 max_health = 0;
     Unit* result = nullptr;
     for (ObjectGuid const guid : attackers)
     {
         Unit* unit = botAI->GetUnit(guid);
-        if (!unit || !unit->IsAlive())
+        if (!unit || !unit->IsAlive() || dynamicExclusions.find(guid) != dynamicExclusions.end())
             continue;
 
         if (!bot->IsWithinMeleeRange(unit))
@@ -56,9 +58,7 @@ Unit* MeleeAttackerWithoutAuraTargetValue::Calculate()
             continue;
 
         if (unit->GetHealth() < max_health)
-        {
             continue;
-        }
 
         if (!botAI->HasAura(qualifier, unit, false, true))
         {

--- a/src/Ai/Base/Value/DpsTargetValue.cpp
+++ b/src/Ai/Base/Value/DpsTargetValue.cpp
@@ -7,11 +7,20 @@
 
 #include "PlayerbotAIConfig.h"
 #include "Playerbots.h"
+#include "Strategy.h"
 
-class FindMaxThreatGapTargetStrategy : public FindTargetStrategy
+class DpsFindTargetStrategy : public FindTargetStrategy
 {
 public:
-    FindMaxThreatGapTargetStrategy(PlayerbotAI* botAI) : FindTargetStrategy(botAI), minThreat(0) {}
+    DpsFindTargetStrategy(PlayerbotAI* botAI) : FindTargetStrategy(botAI) {}
+
+    TargetValueExclusionType GetExclusionType() override { return TargetValueExclusionType::Dps; }
+};
+
+class FindMaxThreatGapTargetStrategy : public DpsFindTargetStrategy
+{
+public:
+    FindMaxThreatGapTargetStrategy(PlayerbotAI* botAI) : DpsFindTargetStrategy(botAI), minThreat(0) {}
 
     void CheckAttacker(Unit* attacker, ThreatManager* threatMgr) override
     {
@@ -41,11 +50,11 @@ protected:
 };
 
 // caster
-class CasterFindTargetSmartStrategy : public FindTargetStrategy
+class CasterFindTargetSmartStrategy : public DpsFindTargetStrategy
 {
 public:
     CasterFindTargetSmartStrategy(PlayerbotAI* botAI, float dps)
-        : FindTargetStrategy(botAI), dps_(dps), targetExpectedLifeTime(1000000)
+        : DpsFindTargetStrategy(botAI), dps_(dps), targetExpectedLifeTime(1000000)
     {
         result = nullptr;
     }
@@ -124,11 +133,11 @@ protected:
 };
 
 // General
-class GeneralFindTargetSmartStrategy : public FindTargetStrategy
+class GeneralFindTargetSmartStrategy : public DpsFindTargetStrategy
 {
 public:
     GeneralFindTargetSmartStrategy(PlayerbotAI* botAI, float dps)
-        : FindTargetStrategy(botAI), dps_(dps), targetExpectedLifeTime(1000000)
+        : DpsFindTargetStrategy(botAI), dps_(dps), targetExpectedLifeTime(1000000)
     {
     }
 
@@ -194,11 +203,11 @@ protected:
 };
 
 // combo
-class ComboFindTargetSmartStrategy : public FindTargetStrategy
+class ComboFindTargetSmartStrategy : public DpsFindTargetStrategy
 {
 public:
     ComboFindTargetSmartStrategy(PlayerbotAI* botAI, float dps)
-        : FindTargetStrategy(botAI), dps_(dps), targetExpectedLifeTime(1000000)
+        : DpsFindTargetStrategy(botAI), dps_(dps), targetExpectedLifeTime(1000000)
     {
     }
 
@@ -296,10 +305,10 @@ Unit* DpsTargetValue::Calculate()
     return TargetValue::FindTarget(&strategy);
 }
 
-class FindMaxHpTargetStrategy : public FindTargetStrategy
+class FindMaxHpTargetStrategy : public DpsFindTargetStrategy
 {
 public:
-    FindMaxHpTargetStrategy(PlayerbotAI* botAI) : FindTargetStrategy(botAI), maxHealth(0) {}
+    FindMaxHpTargetStrategy(PlayerbotAI* botAI) : DpsFindTargetStrategy(botAI), maxHealth(0) {}
 
     void CheckAttacker(Unit* attacker, ThreatManager*) override
     {

--- a/src/Ai/Base/Value/TankTargetValue.cpp
+++ b/src/Ai/Base/Value/TankTargetValue.cpp
@@ -9,6 +9,7 @@
 #include "AttackersValue.h"
 #include "Group.h"
 #include "PlayerbotAI.h"
+#include "Strategy.h"
 
 class FindTargetForTankStrategy : public FindNonCcTargetStrategy
 {
@@ -49,6 +50,8 @@ class FindTankTargetSmartStrategy : public FindTargetStrategy
 public:
     FindTankTargetSmartStrategy(PlayerbotAI* botAI) : FindTargetStrategy(botAI) {}
 
+    TargetValueExclusionType GetExclusionType() override { return TargetValueExclusionType::Tank; }
+
     void CheckAttacker(Unit* attacker, ThreatManager* /*threatMgr*/) override
     {
         if (Group* group = botAI->GetBot()->GetGroup())
@@ -57,6 +60,7 @@ public:
             if (guid && attacker->GetGUID() == guid)
                 return;
         }
+
         if (!attacker->IsAlive())
             return;
 

--- a/src/Ai/Base/Value/TargetValue.cpp
+++ b/src/Ai/Base/Value/TargetValue.cpp
@@ -11,17 +11,39 @@
 #include "Playerbots.h"
 #include "RtiTargetValue.h"
 #include "ScriptedCreature.h"
+#include "Strategy.h"
 #include "ThreatManager.h"
 
+GuidSet GatherStrategyTargetExclusions(PlayerbotAI* botAI, TargetValueExclusionType type)
+{
+    GuidSet exclusions;
+    if (!botAI || type == TargetValueExclusionType::None || !botAI->HasTargetExclusions())
+        return exclusions;
+
+    for (auto const& strategyName : botAI->GetStrategies(BOT_STATE_COMBAT))
+    {
+        Strategy* strategy = botAI->GetStrategy(strategyName, BOT_STATE_COMBAT);
+        if (!strategy)
+            continue;
+
+        strategy->AppendTargetExclusions(exclusions, type);
+    }
+
+    return exclusions;
+}
+
 Unit* FindTargetStrategy::GetResult() { return result; }
+
+TargetValueExclusionType FindTargetStrategy::GetExclusionType() { return TargetValueExclusionType::None; }
 
 Unit* TargetValue::FindTarget(FindTargetStrategy* strategy)
 {
     GuidVector attackers = botAI->GetAiObjectContext()->GetValue<GuidVector>("attackers")->Get();
+    GuidSet const dynamicExclusions = GatherStrategyTargetExclusions(botAI, strategy->GetExclusionType());
     for (ObjectGuid const guid : attackers)
     {
         Unit* unit = botAI->GetUnit(guid);
-        if (!unit)
+        if (!unit || dynamicExclusions.find(guid) != dynamicExclusions.end())
             continue;
 
         ThreatManager& threatMgr = unit->GetThreatMgr();

--- a/src/Ai/Base/Value/TargetValue.h
+++ b/src/Ai/Base/Value/TargetValue.h
@@ -13,6 +13,9 @@
 class PlayerbotAI;
 class ThreatManager;
 class Unit;
+enum class TargetValueExclusionType : uint8;
+
+GuidSet GatherStrategyTargetExclusions(PlayerbotAI* botAI, TargetValueExclusionType type);
 
 class FindTargetStrategy
 {
@@ -20,6 +23,7 @@ public:
     FindTargetStrategy(PlayerbotAI* botAI) : result(nullptr), botAI(botAI) {}
 
     Unit* GetResult();
+    virtual TargetValueExclusionType GetExclusionType();
     virtual void CheckAttacker(Unit* attacker, ThreatManager* threatMgr) = 0;
     void GetPlayerCount(Unit* creature, uint32* tankCount, uint32* dpsCount);
     bool IsHighPriority(Unit* attacker);
@@ -128,7 +132,7 @@ public:
 class FindTargetValue : public UnitCalculatedValue, public Qualified
 {
 public:
-    FindTargetValue(PlayerbotAI* ai) : UnitCalculatedValue(ai, "find target", /*2 * 1000*/ 1) {}
+    FindTargetValue(PlayerbotAI* botAI) : UnitCalculatedValue(botAI, "find target", /*2 * 1000*/ 1) {}
 
 public:
     Unit* Calculate();
@@ -137,14 +141,14 @@ public:
 class FindBossTargetStrategy : public FindTargetStrategy
 {
 public:
-    FindBossTargetStrategy(PlayerbotAI* ai) : FindTargetStrategy(ai) {}
+    FindBossTargetStrategy(PlayerbotAI* botAI) : FindTargetStrategy(botAI) {}
     virtual void CheckAttacker(Unit* attacker, ThreatManager* threatManager);
 };
 
 class BossTargetValue : public TargetValue, public Qualified
 {
 public:
-    BossTargetValue(PlayerbotAI* ai) : TargetValue(ai, "boss target", 2 * 1000) {}
+    BossTargetValue(PlayerbotAI* botAI) : TargetValue(botAI, "boss target", 2 * 1000) {}
 
 public:
     Unit* Calculate();

--- a/src/Bot/Engine/Engine.cpp
+++ b/src/Bot/Engine/Engine.cpp
@@ -118,10 +118,12 @@ void Engine::Init()
 {
     Reset();
 
+    hasTargetExclusions = false;
     for (std::map<std::string, Strategy*>::iterator i = strategies.begin(); i != strategies.end(); i++)
     {
         Strategy* strategy = i->second;
         strategyTypeMask |= strategy->GetType();
+        hasTargetExclusions |= strategy->HasTargetExclusions();
         strategy->InitMultipliers(multipliers);
         strategy->InitTriggers(triggers);
         for (auto &iter : strategy->actionNodeFactories.creators)

--- a/src/Bot/Engine/Engine.h
+++ b/src/Bot/Engine/Engine.h
@@ -86,6 +86,7 @@ public:
 
     void removeActionExecutionListener(ActionExecutionListener* listener) { actionExecutionListeners.Remove(listener); }
     bool HasStrategyType(StrategyType type) { return strategyTypeMask & type; }
+    bool HasTargetExclusions() const { return hasTargetExclusions; }
     virtual ~Engine(void);
 
     bool testMode;
@@ -115,6 +116,7 @@ protected:
     float lastRelevance;
     std::string lastAction;
     uint32 strategyTypeMask;
+    bool hasTargetExclusions = false;
     NamedObjectFactoryList<ActionNode> actionNodeFactories;
 };
 

--- a/src/Bot/Engine/Strategy/Strategy.h
+++ b/src/Bot/Engine/Strategy/Strategy.h
@@ -9,8 +9,17 @@
 #include "Action.h"
 #include "Multiplier.h"
 #include "NamedObjectContext.h"
+#include "ObjectGuid.h"
 #include "PlayerbotAIAware.h"
 #include "Trigger.h"
+
+enum class TargetValueExclusionType : uint8
+{
+    None = 0,
+    Tank,
+    Dps,
+    Attacker
+};
 
 enum StrategyType : uint32
 {
@@ -63,6 +72,9 @@ public:
     virtual std::vector<NextAction> getDefaultActions() { return {}; }
     virtual void InitTriggers([[maybe_unused]] std::vector<TriggerNode*>& triggers) {}
     virtual void InitMultipliers([[maybe_unused]] std::vector<Multiplier*>& multipliers) {}
+    virtual void AppendTargetExclusions([[maybe_unused]] GuidSet& exclusions,
+                                        [[maybe_unused]] TargetValueExclusionType type) {}
+    virtual bool HasTargetExclusions() const { return false; }
     virtual std::string const getName() = 0;
     virtual uint32 GetType() const { return STRATEGY_TYPE_GENERIC; }
     virtual ActionNode* GetAction(std::string const name);

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -1672,7 +1672,7 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
             strategyName = "tempestkeep";  // Tempest Keep: The Eye
             break;
         case 558:
-            strategyName = "tbc-ac"; // Auchindoun: Auchenai Crypts
+            strategyName = "tbc-ac";  // Auchindoun: Auchenai Crypts
             break;
         case 564:
             strategyName = "blacktemple";  // Black Temple
@@ -1762,6 +1762,11 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
         out << "Added " << strategyName << " instance strategy";
         TellMasterNoFacing(out.str());
     }
+}
+
+bool PlayerbotAI::HasTargetExclusions() const
+{
+    return engines[BOT_STATE_COMBAT] && engines[BOT_STATE_COMBAT]->HasTargetExclusions();
 }
 
 bool PlayerbotAI::DoSpecificAction(std::string const name, Event event, bool silent, std::string const qualifier)

--- a/src/Bot/PlayerbotAI.h
+++ b/src/Bot/PlayerbotAI.h
@@ -408,6 +408,7 @@ public:
     std::vector<std::string> GetStrategies(BotState type);
     Strategy* GetStrategy(std::string const name, BotState type);
     void ApplyInstanceStrategies(uint32 mapId, bool tellMaster = false);
+    bool HasTargetExclusions() const;
     void EvaluateHealerDpsStrategy();
     bool ContainsStrategy(StrategyType type);
     bool HasStrategy(std::string const name, BotState type);


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

**The tl;dr version**: This PR lets you make dungeon/raid strategies that allow tanks or dps to do what they normally do, except completely ignore [insert target] under [insert conditions].

**The longer version:**
This PR implements the ability for scripts to modify values used for bot target selection in order to exclude specified NPCs. Currently, doing this is possible only through assigning the moon icon, and even that doesn’t block actions that target through the “on attackers” path (i.e., actions relating to multi-dotting). Under this PR's approach, a bot evaluates its target, exclusions are gathered from all active combat strategies, and then they are applied before the strategy's own selection logic runs. This means excluded NPCs never enter the candidate pool in the first place. The bot simply acts as if they aren't there, rather than the strategy reacting after a bad target has already been chosen.

This capability is useful because it allows dungeon/raid scripts to command bots (or certain bots or types of bots) to ignore particular targets without completely suppressing their standard target selection behavior. Previously this could be done only with blanket overrides of TankAssistAction or DpsAssistAction and then creating an entirely new custom targeting scheme, which practically would have to be much simpler than the default targeting schemes, especially for tanks. 

I use this for SWP strategies, and therefore they cannot be implemented until this system (or a similar one) is in place. The system is very easy to use and can be done entirely in the strategy.cpp and strategy.h files for the dungeon/raid strategy you are working on. 

1. Declare a HasTargetExclusions member of the dungeon/raid strategy class (bool HasTargetExclusions() const override { return true; }).
2. Declare an AppendTargetExclusions member (void AppendTargetExclusions(GuidSet& exclusions, TargetValueExclusionType type) override)
3. Make a void function for each exclusion that contains the conditions for your exclusion and the target(s) being excluded.
4. In the definition of AppendTargetExclusions for the dungeon/raid strategy class, you can then select between any or all of tank, dps, and attackers value exclusions with a switch statement.

For example, the following sets up an exclusion that prevents tanks and melee dps from considering Shield Orbs as valid targets during Kil’jaeden:

```
void AppendKiljaedenShieldOrbExclusions(PlayerbotAI* botAI, GuidSet& exclusions)
{
    if (!botAI->IsMelee(botAI->GetBot()))
        return;

    if (!botAI->GetAiObjectContext()->GetValue<Unit*>("find target", "kil'jaeden")->Get())
        return;

    for (ObjectGuid const guid : botAI->GetAiObjectContext()->GetValue<GuidVector>("attackers")->Get())
    {
        Unit* attacker = botAI->GetUnit(guid);
        if (!attacker)
            continue;

        if (attacker->GetEntry() == static_cast<uint32>(SunwellNpcs::NPC_SHIELD_ORB))
            exclusions.insert(guid);
    }
}
```

The above is needed because I need tanks and (depending on positioning) melee dps to switch to Sinister Reflections when they spawn and back to KJ, but they should not go after the Orbs. There are four Sinister Reflections that spawn at a time so manually setting up a system for tanks and melee dps to decide between which to attack on every tick is far less effective and efficient than just telling them to ignore Shield Orbs and letting them pick between KJ and each Sinister Reflection.

Another example: I have another exclusion on KJ so that dps doesn’t attack Sinister Reflections unless a tank has aggro. If I used just a multiplier or action to implement such a block, it would result in dps rapidly swapping targets if their standard logic would want them to attack Sinister Reflections (they would attempt to attack the Sinister Reflection, then either be blocked (multiplier) or forced back to another target (action), and there would just be an ongoing fight between the raid implementation and standard strategy). But this way, dps simply does their own thing until a tank gets aggro, which is crucial because the Sinister Reflection mechanic is that they do not aggro immediately unless attacked first, and they will kill non-tanks almost immediately if aggroed onto them.

Conditions can basically be whatever you’d use for strategies anyway—presence of particular mob, role of bot, position of bot or mob, aura present on bot or mob, casting status, casting target, victim identity, distance comparisons, blah blah blah.


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

I think this is already pretty much covered by the description above and "Impact Assessment" below, but LMK if anything else is needed.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

Right now, just play with this merged and make sure there isn't some terrible performance impact.

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

When no strategy with target exclusions is active (i.e., right now), there is no performance impact. During Engine::Init(), the presence of a boolean flag is checked by scanning loaded strategies to see if any of them use target exclusions. Any strategy that doesn't call HasTargetExclusions gets ignored. This doesn't happen per-tick.

When a strategy with exclusions is active, there is a performance impact, but I think it is minimal. GatherStrategyTargetExclusions iterates each bot's combat strategies and calls AppendTargetExclusions on each. If there is no exclusion, the cost is just iterating the strategies. The real cost comes with implementing exclusions and the conditions on which the exclusion kicks in (but that's basically the same consideration as everything else with respect to dungeon/raid strategies).


- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)

I wouldn’t say so. There’s not much code added here, and it has no impact on anybody who isn’t seeking to utilize it for a specific purpose. 

## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

I had GPT-5.4 assist with analyzing the best sites in the target valuation paths to hook into and help with the overall implementation.

<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


