### PR TITLE
Remove nested loops from group tank functions

### DIFF
--- a/src/Ai/Raid/RaidBossHelpers.cpp
+++ b/src/Ai/Raid/RaidBossHelpers.cpp
@@ -108,13 +108,14 @@ Player* GetGroupMainTank(PlayerbotAI* botAI, Player* bot)
     if (!group)
         return nullptr;
 
+    ObjectGuid const mainTankGuid = botAI->GetMainTankGuid(group);
+    if (mainTankGuid.IsEmpty())
+        return nullptr;
+
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
         Player* member = ref->GetSource();
-        if (!member || !member->IsAlive())
-            continue;
-
-        if (botAI->IsMainTank(member))
+        if (member && member->IsAlive() && member->GetGUID() == mainTankGuid)
             return member;
     }
 
@@ -129,28 +130,32 @@ Player* GetGroupAssistTank(PlayerbotAI* botAI, Player* bot, uint8 index)
     if (!group)
         return nullptr;
 
+    ObjectGuid const mainTankGuid = botAI->GetMainTankGuid(group);
+    if (mainTankGuid.IsEmpty())
+        return nullptr;
+
     uint8 assistantCount = 0;
     std::vector<Player*> nonAssistantTanks;
 
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
         Player* member = ref->GetSource();
-        if (!member || !member->IsAlive())
-            continue;
-
-        if (botAI->IsAssistTank(member))
+        if (!member || !member->IsAlive() || !botAI->IsTank(member) ||
+            member->GetGUID() == mainTankGuid)
         {
-            if (group->IsAssistant(member->GetGUID()))
-            {
-                if (assistantCount == index)
-                    return member;
+            continue;
+        }
 
-                assistantCount++;
-            }
-            else
-            {
-                nonAssistantTanks.push_back(member);
-            }
+        if (group->IsAssistant(member->GetGUID()))
+        {
+            if (assistantCount == index)
+                return member;
+
+            assistantCount++;
+        }
+        else
+        {
+            nonAssistantTanks.push_back(member);
         }
     }
 

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -2369,47 +2369,38 @@ bool PlayerbotAI::IsDps(Player* player, bool bySpec)
     return false;
 }
 
-bool PlayerbotAI::IsMainTank(Player* player, bool ignoreMemberFlag)
+ObjectGuid PlayerbotAI::GetMainTankGuid(Group* group)
+{
+    if (!group)
+        return ObjectGuid::Empty;
+
+    // Check for main tank flag
+    Group::MemberSlotList const& slots = group->GetMemberSlots();
+    for (Group::member_citerator itr = slots.begin(); itr != slots.end(); ++itr)
+    {
+        if (itr->flags & MEMBER_FLAG_MAINTANK)
+            return itr->guid;
+    }
+
+    // Fallback if no flag is set: return the first alive tank
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (member && IsTank(member) && member->IsAlive())
+            return member->GetGUID();
+    }
+
+    return ObjectGuid::Empty;
+}
+
+bool PlayerbotAI::IsMainTank(Player* player)
 {
     Group* group = player->GetGroup();
     if (!group)
         return IsTank(player);
 
-    ObjectGuid mainTank = ObjectGuid();
-
-    // (1) Check for main tank flag (any class or spec)
-    if (!ignoreMemberFlag)
-    {
-        Group::MemberSlotList const& slots = group->GetMemberSlots();
-
-        for (Group::member_citerator itr = slots.begin(); itr != slots.end(); ++itr)
-        {
-            if (itr->flags & MEMBER_FLAG_MAINTANK)
-            {
-                mainTank = itr->guid;
-                break;
-            }
-        }
-
-        if (mainTank != ObjectGuid::Empty)
-            return player->GetGUID() == mainTank;
-    }
-
-    // (2) If no main tank flag, return the first tank
-    if (!IsTank(player) || !player->IsAlive())
-        return false;
-
-    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
-    {
-        Player* member = ref->GetSource();
-        if (!member)
-            continue;
-
-        if (IsTank(member) && member->IsAlive())
-            return player->GetGUID() == member->GetGUID();
-    }
-
-    return false;
+    ObjectGuid const mainTankGuid = GetMainTankGuid(group);
+    return !mainTankGuid.IsEmpty() && player->GetGUID() == mainTankGuid;
 }
 
 bool PlayerbotAI::IsBotMainTank(Player* player)
@@ -2478,19 +2469,31 @@ uint32 PlayerbotAI::GetGroupTankNum(Player* player)
 
 bool PlayerbotAI::IsAssistTank(Player* player)
 {
-    return IsTank(player) && !IsMainTank(player);
-}
-
-bool PlayerbotAI::IsAssistTankOfIndex(Player* player, uint8 index, bool ignoreDeadPlayers)
-{
-    if (!IsAssistTank(player))
-        return false;
-
-    if (ignoreDeadPlayers && !player->IsAlive())
+    if (!IsTank(player))
         return false;
 
     Group* group = player->GetGroup();
     if (!group)
+        return false;
+
+    return player->GetGUID() != GetMainTankGuid(group);
+}
+
+bool PlayerbotAI::IsAssistTankOfIndex(Player* player, uint8 index, bool ignoreDeadPlayers)
+{
+    if (!IsTank(player))
+        return false;
+
+    Group* group = player->GetGroup();
+    if (!group)
+        return false;
+
+    ObjectGuid const mainTankGuid = GetMainTankGuid(group);
+
+    if (player->GetGUID() == mainTankGuid)
+        return false;
+
+    if (ignoreDeadPlayers && !player->IsAlive())
         return false;
 
     uint8 totalAssistants = 0;
@@ -2501,8 +2504,11 @@ bool PlayerbotAI::IsAssistTankOfIndex(Player* player, uint8 index, bool ignoreDe
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
         Player* member = ref->GetSource();
-        if (!member || (ignoreDeadPlayers && !member->IsAlive()) || !IsAssistTank(member))
+        if (!member || (ignoreDeadPlayers && !member->IsAlive()) || !IsTank(member) ||
+            member->GetGUID() == mainTankGuid)
+        {
             continue;
+        }
 
         bool isAssistant = group->IsAssistant(member->GetGUID());
 

--- a/src/Bot/PlayerbotAI.h
+++ b/src/Bot/PlayerbotAI.h
@@ -28,6 +28,7 @@ class AiObjectContext;
 class Creature;
 class Engine;
 class ExternalEventHelper;
+class Group;
 class Gameobject;
 class Item;
 class ObjectGuid;
@@ -425,7 +426,8 @@ public:
     static bool IsRangedDps(Player* player, bool bySpec = false);
     static bool IsCombo(Player* player);
     static bool IsBotMainTank(Player* player);
-    static bool IsMainTank(Player* player, bool ignoreMemberFlag = false);
+    static bool IsMainTank(Player* player);
+    static ObjectGuid GetMainTankGuid(Group* group);
     static uint32 GetGroupTankNum(Player* player);
     static bool IsAssistTank(Player* player);
     static bool IsAssistTankOfIndex(Player* player, uint8 index, bool ignoreDeadPlayers = false);


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

Three functions, IsAssistTankOfIndex, GetGroupMainTank, and GetGroupAssistTank, check IsMainTank for every group member when iterating, thus creating a second layer of looping. This is bad for performance and is easily fixed by a per-call cache to get the main tank before iterating. I'm sure there are better ways of doing it, but this one is simple for a plebe like me to do and should be enough to improve the situation.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

I added a new helper, GetMainTankGuid, which is now used in the boolean tank role checks in PlayerbotAI.cpp and tank role getters in RaidBossHelpers.cpp.

The ignoreMemberFlag parameter was removed from IsMainTank. This is because I couldn't think of a simple way to keep it in a fashion that makes sense. Previously, IsMainTank would influence determination of assist tanks too, but now it doesn't, and so keeping the parameter there potentially creates an inconsistency between who the main tank is considered to be for purposes of being the main tank vs. purposes of being an assist tank. Moving the parameter to the new helper preserves the old pattern, but since nobody is actually going to directly call that helper, it's useless to exist there. Ultimately, the parameter has not been used a single time, and it's hard for me to imagine why anybody would want to use it, so it's safe to remove and it doesn't seem like anybody would be bothered by it.

I tested ingame by temporarily adding an IsAssistTankOfIndex call at the beginning of all 61 Black Temple triggers and sitting in the instance with 24 bots in a raid, though there were only 3 tanks so practically there were only 3 callers of relevance. Over 60s, pmon showed a reduction of 0.125s on triggers after the change (1.868s reduced to 1.743s). 

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

1. Run instances with strategies that rely on designated main tanks and assist tanks and confirm the strategies still work.
2. Check pmon before/after changes in the PR to evaluate performance differences.

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

I used DeepSeek v4 Pro, but it's terrible and might actually have caused me to spend more time on this than I otherwise would have. I ended up practically doing this all myself so please check carefully.

<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->