### PR TITLE
Fix ".playerbots bot add" dropping the member that pushes a group past 5

### DIFF
--- a/src/Bot/PlayerbotMgr.cpp
+++ b/src/Bot/PlayerbotMgr.cpp
@@ -551,15 +551,14 @@ void PlayerbotHolder::OnBotLogin(Player* const bot)
         Group* mgroup = master->GetGroup();
         if (mgroup->GetMembersCount() >= 5)
         {
-            if (!mgroup->isRaidGroup() && !mgroup->isLFGGroup() && !mgroup->isBGGroup() && !mgroup->isBFGroup())
+            // A 5-member party is full, so only a raid can take a 6th member. GroupInviteOperation::
+            // Execute() self-converts a non-raid group with >= 5 members to a raid before adding, so a
+            // separate ConvertToRaid is unnecessary here. Queue the invite for a raid OR a plain
+            // (non-LFG/BG/battlefield) party; we deliberately skip LFG/BG/BFG groups so a bot login
+            // never force-converts a live dungeon-finder or battleground group into a raid.
+            if (mgroup->isRaidGroup() || (!mgroup->isLFGGroup() && !mgroup->isBGGroup() && !mgroup->isBFGroup()))
             {
-                // Queue ConvertToRaid operation
-                auto convertOp = std::make_unique<GroupConvertToRaidOperation>(master->GetGUID());
-                PlayerbotWorldThreadProcessor::instance().QueueOperation(std::move(convertOp));
-            }
-            if (mgroup->isRaidGroup())
-            {
-                // Queue AddMember operation
+                // Queue AddMember operation; Execute() converts the party to a raid before adding.
                 auto addOp = std::make_unique<GroupInviteOperation>(master->GetGUID(), bot->GetGUID());
                 PlayerbotWorldThreadProcessor::instance().QueueOperation(std::move(addOp));
             }


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

Fixes `.playerbots bot add` silently dropping the bot that becomes the **6th**
member of a group.

**Symptom:** when the master is already in a full 5-person, non-raid party and one
more bot is added, that bot is silently dropped and never joins. The party usually
still converts to a raid (the client shows *"You have joined a raid group"*) but the
new member is missing; in some timing paths the client instead shows *"You are not
in a raid group."* Same root cause either way.

**Root cause:** in `PlayerbotHolder::OnBotLogin()` (`src/Bot/PlayerbotMgr.cpp`), the
`>= 5 members` branch queues a `GroupConvertToRaidOperation` and then gates the
`GroupInviteOperation` behind `if (mgroup->isRaidGroup())`. The convert is only
**queued** (not applied) at that point, so `mgroup->isRaidGroup()` is still `false`
on the next line — the invite is never queued and the member is dropped, while the
queued convert still runs (leaving the party converted but without the new member).
This appears to have surfaced with the move to the queued
`PlayerbotWorldThreadProcessor` model; an earlier synchronous `ConvertToRaid()`
would have made the group a raid before the guard was evaluated.

**Fix** (in the `>= 5` branch):

1. **Remove the now-redundant queued `GroupConvertToRaidOperation`.**
   `GroupInviteOperation::Execute()` already self-converts a non-raid group with
   `>= 5` members to a raid before adding, so a separate convert op is unnecessary.
   (The `GroupConvertToRaidOperation` class is unchanged — it still has other callers
   in `src/Ai/Base/Actions/InviteToGroupAction.cpp`.)
2. **Widen the invite guard** so the invite is queued for a plain party too — the
   case the old code converted but never invited into:

```cpp
// before:
if (mgroup->isRaidGroup())
// after:
if (mgroup->isRaidGroup() || (!mgroup->isLFGGroup() && !mgroup->isBGGroup() && !mgroup->isBFGroup()))
```

The branch collapses to a single guarded invite; `Execute()` does the party→raid
conversion before adding. This deliberately does **not** simply remove the guard:
that would queue an invite for LFG/BG/battlefield groups and force-convert them.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

- **Minimum logic required:** delete the queued-convert block and change one boolean
  guard. No new operations, no new state, no new per-tick work.
- **Processing cost across many bots:** strictly **lower** than before — this path
  now queues **one fewer** operation (the redundant `GroupConvertToRaidOperation`)
  each time a bot logs into an already-full group. The guard itself is a cheap
  boolean evaluated only on bot login (not per tick).

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

Setup: a normal 3.3.5 realm with playerbots; a master account with several alt bots.

**Deterministic reproduction (before the fix):**
1. Log in as a player (the master), solo.
2. `.playerbots bot add` four bots and wait until they are actually in your party —
   you now have a full, non-raid party of 5.
3. `.playerbots bot add` one more bot.

- *Before:* the party converts to a raid, but the 6th bot is **not** in it (dropped).
- *After:* the 6th bot joins; the party becomes a raid containing all members.

> Note: adding all bots in a single command often "works" even unpatched, because
> the bots' logins can all be processed before the group fills (each takes the
> group-creation path). Adding the 6th to an **already-full** party reproduces it
> every time.

Full matrix verified in-client with the fix (all pass): party `<5` add; solo add
(creates group); existing-raid add; and a 5-man **LFG** group add (correctly left
untouched — no force-convert). Verified with a temporary instrumented build:

```
QUEUE invite (>=5): raid=false ...   <- plain party (the bug) -> now joins
QUEUE invite (>=5): raid=true  ...   <- existing raid -> joins
SKIP  invite (>=5, LFG/BG/BFG): raid=false lfg=true ...  <- LFG left untouched
```
`Errors.log` was empty across all scenarios.

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

  Runs only on bot login, and removes one queued operation — net less work, no
  per-tick cost.

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

  Only the broken case changes: adding a bot past 5 in a plain party now succeeds
  instead of dropping the bot. Behavior is bit-identical for raids and
  LFG/BG/battlefield groups (see the truth table in Notes for Reviewers).

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)

  It removes a branch (the queued-convert block); the `>= 5` case collapses to a
  single guarded invite.

## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)

AI (Claude) assisted with investigating the root cause, building a temporary
diagnostic logging harness to trace the exact code path on a live test realm, and
drafting this description. I reproduced the bug myself, deterministically, on a live
3.3.5 realm (adding a 6th bot to a full 5-person party), verified the fix in-client
across the group-type matrix above, and reviewed and understand the one-file logic
change. I own this change.

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated. (N/A — no new dialogue.)
- - [x] Documentation updated if needed (Conf comments, WiKi commands). (N/A — no config/command changes.)

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->

**Why LFG/BG/battlefield behavior is unchanged.** The only externally observable
change is whether the `GroupInviteOperation` is queued. Comparing the old guard `R`
against the new `R || (!L && !B && !F)` over every group kind (`R`=isRaid, `L`=isLFG,
`B`=isBG, `F`=isBFG):

| Group kind            | R | L | B | F | old `R` | new `R \|\| (!L&&!B&&!F)` | change |
|-----------------------|---|---|---|---|---------|---------------------------|--------|
| Raid (incl. BG raid)  | 1 | * | * | * | 1       | 1                         | none   |
| LFG party             | 0 | 1 | 0 | 0 | 0       | 0                         | none   |
| Battleground party    | 0 | 0 | 1 | 0 | 0       | 0                         | none   |
| Battlefield party     | 0 | 0 | 0 | 1 | 0       | 0                         | none   |
| Plain party (the bug) | 0 | 0 | 0 | 0 | 0       | **1**                     | **fix**|

The guards are bit-identical for every raid/LFG/BG/battlefield combination and
differ only for a plain non-raid party — the bug. Removing the redundant convert op
is likewise invisible for those kinds (it only ever fired for the plain-party case).

Scope: single C++ file, pure logic change — no schema, config, DB, or API impact.
