### PR TITLE
Fix: prot paladins get no blessing without Sanctuary; unify party-blessing path

### DIFF
--- a/src/Ai/Class/Paladin/Actions/PaladinActions.cpp
+++ b/src/Ai/Class/Paladin/Actions/PaladinActions.cpp
@@ -8,6 +8,7 @@
 #include "AiFactory.h"
 #include "Event.h"
 #include "GenericBuffUtils.h"
+#include "PaladinBlessingHelper.h"
 #include "PaladinGreaterBlessingAction.h"
 #include "PaladinHelper.h"
 #include "Playerbots.h"
@@ -24,18 +25,6 @@ static bool IsBlessingTargetCandidate(Player* bot, Player* player)
     return bot->GetDistance(player) < sPlayerbotAIConfig.spellDistance * 2 &&
            bot->IsWithinLOS(player->GetPositionX(), player->GetPositionY(),
                             player->GetPositionZ());
-}
-
-static bool HasBlessingAura(
-    PlayerbotAI* botAI, Unit* target, std::initializer_list<char const*> auraNames)
-{
-    for (char const* auraName : auraNames)
-    {
-        if (botAI->HasAura(auraName, target))
-            return true;
-    }
-
-    return false;
 }
 
 static bool IsGreaterBlessingMode(Player* bot)
@@ -90,48 +79,6 @@ static Unit* FindBlessingTarget(
     }
 
     return nullptr;
-}
-
-static inline bool IsTankRole(Player* player)
-{
-    if (!player)
-        return false;
-
-    if (player->HasTankSpec())
-        return true;
-
-    if (PlayerbotAI* otherAI = GET_PLAYERBOT_AI(player))
-    {
-        if (otherAI->HasStrategy("tank", BOT_STATE_NON_COMBAT) ||
-            otherAI->HasStrategy("tank", BOT_STATE_COMBAT)     ||
-            otherAI->HasStrategy("tank face", BOT_STATE_NON_COMBAT) ||
-            otherAI->HasStrategy("tank face", BOT_STATE_COMBAT)     ||
-            otherAI->HasStrategy("bear", BOT_STATE_NON_COMBAT) ||
-            otherAI->HasStrategy("bear", BOT_STATE_COMBAT))
-            return true;
-    }
-
-    return false;
-}
-
-static inline bool IsOnlyPaladinInGroup(Player* bot)
-{
-    if (!bot)
-        return false;
-
-    Group* group = bot->GetGroup();
-    if (!group)
-        return true;
-
-    uint32 paladins = 0u;
-    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
-    {
-        Player* player = ref->GetSource();
-        if (!player || !player->IsInWorld()) continue;
-        if (player->getClass() == CLASS_PALADIN) ++paladins;
-    }
-
-    return paladins == 1u;
 }
 
 inline std::string const GetActualBlessingOfMight(Unit* target)
@@ -195,70 +142,94 @@ inline std::string const GetActualBlessingOfWisdom(Unit* target)
     return "blessing of wisdom";
 }
 
-inline std::string const GetActualBlessingOfSanctuary(Unit* target, Player* bot)
+// A strategy only leads with its blessing on targets whose role it actually
+// suits; everyone else falls through to the role priority below.
+static bool PreferredLeadAppliesTo(
+    ai::gbless::BaseBlessingCategory preferred, ai::gbless::RoleProfile role)
 {
-    if (!bot->HasSpell(ai::paladin::SPELL_BLESSING_OF_SANCTUARY))
-        return "";
-
-    Player* targetPlayer = target->ToPlayer();
-    if (!targetPlayer)
-        return "";
-
-    if (auto* botAI = GET_PLAYERBOT_AI(bot))
+    using namespace ai::gbless;
+    switch (preferred)
     {
-        if (Unit* mainTank =
-            botAI->GetAiObjectContext()->GetValue<Unit*>("main tank")->Get())
-        {
-            if (mainTank == target)
-                return "blessing of sanctuary";
-        }
+        case BASE_KINGS:     return true;
+        case BASE_MIGHT:     return role == ROLE_PHYSICAL_DPS || role == ROLE_HYBRID_DPS;
+        case BASE_WISDOM:    return role == ROLE_CASTER || role == ROLE_HYBRID_DPS;
+        case BASE_SANCTUARY: return ai::blessing::IsTankRoleProfile(role);
+        default:             return false;
     }
-
-    if (targetPlayer->HasTankSpec())
-        return "blessing of sanctuary";
-
-    return "";
 }
 
-Unit* CastBlessingOfMightOnPartyAction::GetTarget()
+// Highest-priority blessing (for the target's role) that this bot can cast and
+// that another paladin isn't already providing, so we complement rather than
+// duplicate. The strategy's preferred blessing leads where it applies.
+// BASE_NONE means nothing to add.
+static ai::gbless::BaseBlessingCategory GetDesiredBlessingCategory(
+    Unit* target, PlayerbotAI* botAI, ai::gbless::BaseBlessingCategory preferred,
+    bool tanksWantSanctuary)
+{
+    using namespace ai::gbless;
+
+    Player* targetPlayer = target ? target->ToPlayer() : nullptr;
+    if (!targetPlayer)
+        return BASE_NONE;
+
+    RoleProfile role = ResolveRoleProfile(targetPlayer);
+
+    auto canProvide = [&](BaseBlessingCategory category)
+    {
+        return category != BASE_NONE &&
+               botAI->HasSpell(BlessingSpellName(ToSingleVariant(category))) &&
+               !ai::blessing::AnotherPaladinHasEqualOrStronger(botAI, target, category);
+    };
+
+    if (PreferredLeadAppliesTo(preferred, role) && canProvide(preferred))
+        return preferred;
+
+    bool promoteSanctuary = tanksWantSanctuary && ai::blessing::IsTankRoleProfile(role);
+    if (promoteSanctuary && canProvide(BASE_SANCTUARY))
+        return BASE_SANCTUARY;
+
+    for (BaseBlessingCategory category : BASE_BLESSING_PRIORITIES[role].priorities)
+    {
+        if (promoteSanctuary && category == BASE_SANCTUARY)
+            continue;
+        if (canProvide(category))
+            return category;
+    }
+
+    return BASE_NONE;
+}
+
+static std::string GetActualPaladinPartyBlessing(
+    Unit* target, PlayerbotAI* botAI, std::string const& preferred)
+{
+    bool tanksWantSanctuary = !ai::blessing::GroupHasRenewedHopePriest(botAI->GetBot());
+    ai::gbless::BaseBlessingCategory category = GetDesiredBlessingCategory(
+        target, botAI, ai::blessing::CategoryFromName(preferred), tanksWantSanctuary);
+    if (category == ai::gbless::BASE_NONE)
+        return "";
+
+    return ai::gbless::BlessingSpellName(ai::gbless::ToSingleVariant(category));
+}
+
+Unit* GetPaladinPartyBlessingTarget(
+    Player* bot, PlayerbotAI* botAI, std::string const& preferred)
 {
     if (IsGreaterBlessingMode(bot))
         return nullptr;
 
+    ai::gbless::BaseBlessingCategory preferredCategory = ai::blessing::CategoryFromName(preferred);
+    bool tanksWantSanctuary = !ai::blessing::GroupHasRenewedHopePriest(bot);
     return FindBlessingTarget(bot, botAI, [&](Player* player)
     {
-        return !HasBlessingAura(botAI, player,
-            { "blessing of might", "greater blessing of might",
-              "blessing of wisdom", "greater blessing of wisdom",
-              "blessing of sanctuary", "greater blessing of sanctuary" });
+        ai::gbless::BaseBlessingCategory category = GetDesiredBlessingCategory(
+            player, botAI, preferredCategory, tanksWantSanctuary);
+        return category != ai::gbless::BASE_NONE &&
+               !ai::blessing::HasOwnBlessingCategory(botAI, player, category);
     });
 }
 
 bool CastBlessingOfMightAction::Execute(Event /*event*/)
 {
-    Unit* target = GetTarget();
-    if (!target)
-        return false;
-
-    std::string castName = GetActualBlessingOfMight(target);
-    return botAI->CastSpell(castName, target);
-}
-
-Value<Unit*>* CastBlessingOfMightOnPartyAction::GetTargetValue()
-{
-    return context->GetValue<Unit*>(
-    "party member without aura",
-    "blessing of might,greater blessing of might,blessing of wisdom,"
-    "greater blessing of wisdom,blessing of sanctuary,"
-    "greater blessing of sanctuary"
-    );
-}
-
-bool CastBlessingOfMightOnPartyAction::Execute(Event /*event*/)
-{
-    if (IsGreaterBlessingMode(bot))
-        return false;
-
     Unit* target = GetTarget();
     if (!target)
         return false;
@@ -277,260 +248,53 @@ bool CastBlessingOfWisdomAction::Execute(Event /*event*/)
     return botAI->CastSpell(castName, target);
 }
 
-Unit* CastBlessingOfWisdomOnPartyAction::GetTarget()
-{
-    if (IsGreaterBlessingMode(bot))
-        return nullptr;
-
-    return FindBlessingTarget(bot, botAI, [&](Player* player)
-    {
-        if (botAI->HasStrategy("bwisdom", BOT_STATE_NON_COMBAT) && IsTankRole(player))
-            return false;
-
-        return !HasBlessingAura(botAI, player,
-            { "blessing of might", "greater blessing of might",
-              "blessing of wisdom", "greater blessing of wisdom",
-              "blessing of sanctuary", "greater blessing of sanctuary" });
-    });
-}
-
-Value<Unit*>* CastBlessingOfWisdomOnPartyAction::GetTargetValue()
-{
-    return context->GetValue<Unit*>(
-    "party member without aura",
-    "blessing of wisdom,greater blessing of wisdom,blessing of might,greater blessing of might,"
-    "blessing of sanctuary,greater blessing of sanctuary"
-    );
-}
-
-bool CastBlessingOfWisdomOnPartyAction::Execute(Event /*event*/)
-{
-    if (IsGreaterBlessingMode(bot))
-        return false;
-
-    Unit* target = GetTarget();
-    if (!target)
-        return false;
-
-    Player* targetPlayer = target->ToPlayer();
-
-    if (Group* group = bot->GetGroup())
-        if (targetPlayer && !group->IsMember(targetPlayer->GetGUID()))
-            return false;
-
-    if (botAI->HasStrategy("bwisdom", BOT_STATE_NON_COMBAT) &&
-        targetPlayer && IsTankRole(targetPlayer))
-        return false;
-
-    std::string castName = GetActualBlessingOfWisdom(target);
-    if (castName.empty())
-        return false;
-
-    return botAI->CastSpell(castName, target);
-}
-
-Value<Unit*>* CastBlessingOfSanctuaryOnPartyAction::GetTargetValue()
+Value<Unit*>* CastBlessingOnPartyAction::GetTargetValue()
 {
     return context->GetValue<Unit*>(
         "party member without aura",
-        "blessing of sanctuary,greater blessing of sanctuary"
-    );
-}
-
-bool CastBlessingOfSanctuaryOnPartyAction::Execute(Event /*event*/)
-{
-    if (IsGreaterBlessingMode(bot))
-        return false;
-
-    if (!bot->HasSpell(ai::paladin::SPELL_BLESSING_OF_SANCTUARY))
-        return false;
-
-    Unit* target = GetTarget();
-    if (!target)
-        target = bot;
-
-    Player* targetPlayer = target ? target->ToPlayer() : nullptr;
-
-    const auto HasSanctAura = [&](Unit* unit) -> bool {
-        return botAI->HasAura("blessing of sanctuary", unit) ||
-               botAI->HasAura("greater blessing of sanctuary", unit);
-    };
-
-    if (Group* group = bot->GetGroup())
-    {
-        if (targetPlayer && !group->IsMember(targetPlayer->GetGUID()))
-        {
-            target = bot;
-            targetPlayer = bot->ToPlayer();
-        }
-    }
-
-    if (Player* self = bot->ToPlayer())
-    {
-        bool selfHasSanct = HasSanctAura(self);
-        bool needSelf = IsTankRole(self) && !selfHasSanct;
-
-        if (needSelf)
-        {
-            target = self;
-            targetPlayer = self;
-        }
-    }
-
-    bool targetOk = false;
-    if (targetPlayer)
-    {
-        bool hasSanct = HasSanctAura(targetPlayer);
-        targetOk = IsTankRole(targetPlayer) && !hasSanct;
-    }
-
-    if (!targetOk)
-    {
-        if (Group* group = bot->GetGroup())
-        {
-            for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
-            {
-                Player* player = ref->GetSource();
-                if (!player) continue;
-                if (!player->IsInWorld() || !player->IsAlive()) continue;
-                if (!IsTankRole(player)) continue;
-
-                bool hasSanct = HasSanctAura(player);
-                if (!hasSanct)
-                {
-                    target = player;
-                    targetPlayer = player;
-                    targetOk = true;
-                    break;
-                }
-            }
-        }
-    }
-
-    if (GetActualBlessingOfSanctuary(target, bot).empty())
-    {
-        if (targetPlayer)
-        {
-            if (IsTankRole(targetPlayer))
-                return botAI->CastSpell("blessing of sanctuary", target);
-            else
-                return false;
-        }
-        else
-            return false;
-    }
-
-    return botAI->CastSpell("blessing of sanctuary", target);
-}
-
-Unit* CastBlessingOfSanctuaryOnPartyAction::GetTarget()
-{
-    if (IsGreaterBlessingMode(bot))
-        return nullptr;
-
-    if (!bot->HasSpell(ai::paladin::SPELL_BLESSING_OF_SANCTUARY))
-        return nullptr;
-
-    return FindBlessingTarget(bot, botAI, [&](Player* player)
-    {
-        return IsTankRole(player) &&
-               !HasBlessingAura(botAI, player,
-                   { "blessing of sanctuary", "greater blessing of sanctuary" });
-    });
-}
-
-Value<Unit*>* CastBlessingOfKingsOnPartyAction::GetTargetValue()
-{
-    return context->GetValue<Unit*>(
-        "party member without aura",
+        "blessing of sanctuary,greater blessing of sanctuary,"
         "blessing of kings,greater blessing of kings,"
-        "blessing of sanctuary,greater blessing of sanctuary"
+        "blessing of might,greater blessing of might,"
+        "blessing of wisdom,greater blessing of wisdom"
     );
 }
 
-Unit* CastBlessingOfKingsOnPartyAction::GetTarget()
+Unit* CastBlessingOnPartyAction::GetTarget()
 {
-    if (IsGreaterBlessingMode(bot))
-        return nullptr;
-
-    const bool hasBwisdom = botAI->HasStrategy("bwisdom", BOT_STATE_NON_COMBAT);
-    const bool hasBkings = botAI->HasStrategy("bkings", BOT_STATE_NON_COMBAT);
-    const bool onlyPaladinInGroup = IsOnlyPaladinInGroup(bot);
-
-    return FindBlessingTarget(bot, botAI, [&](Player* player)
-    {
-        const bool isTank = IsTankRole(player);
-        const bool hasKingsOrSanct = HasBlessingAura(botAI, player,
-            { "blessing of kings", "greater blessing of kings",
-              "blessing of sanctuary", "greater blessing of sanctuary" });
-
-        if (hasKingsOrSanct)
-            return false;
-
-        if (hasBwisdom)
-            return isTank;
-
-        if (hasBkings)
-        {
-            if (isTank)
-                return false;
-
-            if (onlyPaladinInGroup && player == bot)
-                return false;
-        }
-
-        return true;
-    });
+    return GetPaladinPartyBlessingTarget(bot, botAI, spell);
 }
 
-bool CastBlessingOfKingsOnPartyAction::Execute(Event /*event*/)
+bool CastBlessingOnPartyAction::isUseful()
 {
-    if (IsGreaterBlessingMode(bot))
+    Unit* target = GetTarget();
+    if (!target || !target->IsInWorld() || target->GetMapId() != bot->GetMapId())
         return false;
 
+    std::string const blessing = GetActualPaladinPartyBlessing(target, botAI, spell);
+    return !blessing.empty() && AI_VALUE2(bool, "spell cast useful", blessing);
+}
+
+bool CastBlessingOnPartyAction::isPossible()
+{
     Unit* target = GetTarget();
     if (!target)
         return false;
 
-    Group* group = bot->GetGroup();
-    if (!group)
+    std::string const blessing = GetActualPaladinPartyBlessing(target, botAI, spell);
+    return !blessing.empty() && botAI->CanCastSpell(blessing, target);
+}
+
+bool CastBlessingOnPartyAction::Execute(Event /*event*/)
+{
+    Unit* target = GetTarget();
+    if (!target)
         return false;
 
-    if (botAI->HasStrategy("bkings", BOT_STATE_NON_COMBAT) &&
-        IsOnlyPaladinInGroup(bot))
-    {
-        if (target->GetGUID() == bot->GetGUID())
-            return false;
-    }
-
-    Player* targetPlayer = target->ToPlayer();
-    if (targetPlayer && !group->IsMember(targetPlayer->GetGUID()))
+    std::string const blessing = GetActualPaladinPartyBlessing(target, botAI, spell);
+    if (blessing.empty())
         return false;
 
-    const bool hasBwisdom = botAI->HasStrategy("bwisdom", BOT_STATE_NON_COMBAT);
-    const bool hasBkings = botAI->HasStrategy("bkings", BOT_STATE_NON_COMBAT);
-
-    if (hasBwisdom && (!targetPlayer || !IsTankRole(targetPlayer)))
-        return false;
-
-    if (targetPlayer)
-    {
-        const bool isTank = IsTankRole(targetPlayer);
-        const bool hasSanctFromMe =
-            target->HasAura(ai::paladin::SPELL_BLESSING_OF_SANCTUARY, bot->GetGUID()) ||
-            target->HasAura(ai::paladin::SPELL_GREATER_BLESSING_OF_SANCTUARY, bot->GetGUID());
-        const bool hasSanctAny =
-            botAI->HasAura("blessing of sanctuary", target) ||
-            botAI->HasAura("greater blessing of sanctuary", target);
-
-        if (isTank && hasSanctFromMe)
-            return false;
-
-        if (hasBkings && isTank && hasSanctAny)
-            return false;
-    }
-
-    return botAI->CastSpell("blessing of kings", target);
+    return botAI->CastSpell(blessing, target);
 }
 
 bool CastSealSpellAction::isUseful()

--- a/src/Ai/Class/Paladin/Actions/PaladinActions.cpp
+++ b/src/Ai/Class/Paladin/Actions/PaladinActions.cpp
@@ -11,20 +11,21 @@
 #include "PaladinBlessingHelper.h"
 #include "PaladinGreaterBlessingAction.h"
 #include "PaladinHelper.h"
+#include "Pet.h"
 #include "Playerbots.h"
 #include "SharedDefines.h"
 
-static bool IsBlessingTargetCandidate(Player* bot, Player* player)
+static bool IsBlessingTargetCandidate(Player* bot, Unit* unit)
 {
-    if (!player || !player->IsAlive() || player->GetMapId() != bot->GetMapId())
+    if (!unit || !unit->IsAlive() || unit->GetMapId() != bot->GetMapId())
         return false;
 
-    if (player->IsGameMaster())
+    if (unit->IsPlayer() && unit->ToPlayer()->IsGameMaster())
         return false;
 
-    return bot->GetDistance(player) < sPlayerbotAIConfig.spellDistance * 2 &&
-           bot->IsWithinLOS(player->GetPositionX(), player->GetPositionY(),
-                            player->GetPositionZ());
+    return bot->GetDistance(unit) < sPlayerbotAIConfig.spellDistance * 2 &&
+           bot->IsWithinLOS(unit->GetPositionX(), unit->GetPositionY(),
+                            unit->GetPositionZ());
 }
 
 static bool IsGreaterBlessingMode(Player* bot)
@@ -36,25 +37,33 @@ template <typename Predicate>
 static Unit* FindBlessingTarget(
     Player* bot, PlayerbotAI* botAI, Predicate&& predicate)
 {
-    std::vector<Player*> masters;
-    std::vector<Player*> healers;
-    std::vector<Player*> tanks;
-    std::vector<Player*> others;
+    std::vector<Unit*> masters;
+    std::vector<Unit*> healers;
+    std::vector<Unit*> tanks;
+    std::vector<Unit*> others;
+    std::vector<Unit*> pets;
 
     Player* master = botAI->GetMaster();
     auto addPlayer = [&](Player* player)
     {
-        if (!IsBlessingTargetCandidate(bot, player))
+        if (!player)
             return;
 
-        if (player == master)
-            masters.push_back(player);
-        else if (botAI->IsHeal(player))
-            healers.push_back(player);
-        else if (botAI->IsTank(player))
-            tanks.push_back(player);
-        else
-            others.push_back(player);
+        if (IsBlessingTargetCandidate(bot, player))
+        {
+            if (player == master)
+                masters.push_back(player);
+            else if (botAI->IsHeal(player))
+                healers.push_back(player);
+            else if (botAI->IsTank(player))
+                tanks.push_back(player);
+            else
+                others.push_back(player);
+        }
+
+        if (Pet* pet = player->GetPet())
+            if (IsBlessingTargetCandidate(bot, pet))
+                pets.push_back(pet);
     };
 
     if (Group* group = bot->GetGroup())
@@ -67,14 +76,14 @@ static Unit* FindBlessingTarget(
         addPlayer(bot);
     }
 
-    std::vector<std::vector<Player*>*> orderedLists = {
-        &masters, &healers, &tanks, &others };
-    for (std::vector<Player*>* players : orderedLists)
+    std::vector<std::vector<Unit*>*> orderedLists = {
+        &masters, &healers, &tanks, &others, &pets };
+    for (std::vector<Unit*>* units : orderedLists)
     {
-        for (Player* player : *players)
+        for (Unit* unit : *units)
         {
-            if (predicate(player))
-                return player;
+            if (predicate(unit))
+                return unit;
         }
     }
 
@@ -168,11 +177,11 @@ static ai::gbless::BaseBlessingCategory GetDesiredBlessingCategory(
 {
     using namespace ai::gbless;
 
-    Player* targetPlayer = target ? target->ToPlayer() : nullptr;
-    if (!targetPlayer)
+    if (!target)
         return BASE_NONE;
 
-    RoleProfile role = ResolveRoleProfile(targetPlayer);
+    Player* targetPlayer = target->ToPlayer();
+    RoleProfile role = targetPlayer ? ResolveRoleProfile(targetPlayer) : ROLE_PHYSICAL_DPS;
 
     auto canProvide = [&](BaseBlessingCategory category)
     {
@@ -219,12 +228,12 @@ Unit* GetPaladinPartyBlessingTarget(
 
     ai::gbless::BaseBlessingCategory preferredCategory = ai::blessing::CategoryFromName(preferred);
     bool tanksWantSanctuary = !ai::blessing::GroupHasRenewedHopePriest(bot);
-    return FindBlessingTarget(bot, botAI, [&](Player* player)
+    return FindBlessingTarget(bot, botAI, [&](Unit* unit)
     {
         ai::gbless::BaseBlessingCategory category = GetDesiredBlessingCategory(
-            player, botAI, preferredCategory, tanksWantSanctuary);
+            unit, botAI, preferredCategory, tanksWantSanctuary);
         return category != ai::gbless::BASE_NONE &&
-               !ai::blessing::HasOwnBlessingCategory(botAI, player, category);
+               !ai::blessing::HasOwnBlessingCategory(botAI, unit, category);
     });
 }
 

--- a/src/Ai/Class/Paladin/Actions/PaladinActions.h
+++ b/src/Ai/Class/Paladin/Actions/PaladinActions.h
@@ -84,15 +84,28 @@ public:
     bool Execute(Event event) override;
 };
 
-class CastBlessingOfMightOnPartyAction : public BuffOnPartyAction
+// Shared blessing-on-party dispatcher; the action's spell is the strategy's lead
+// blessing, with role-based fallbacks filled in by GetDesiredBlessingCategory.
+class CastBlessingOnPartyAction : public BuffOnPartyAction
 {
 public:
-    CastBlessingOfMightOnPartyAction(PlayerbotAI* botAI) : BuffOnPartyAction(botAI, "blessing of might") {}
+    CastBlessingOnPartyAction(PlayerbotAI* botAI, std::string const name)
+        : BuffOnPartyAction(botAI, name) {}
 
-    std::string const getName() override { return "blessing of might on party"; }
     Unit* GetTarget() override;
     Value<Unit*>* GetTargetValue() override;
+    bool isUseful() override;
+    bool isPossible() override;
     bool Execute(Event event) override;
+};
+
+class CastBlessingOfMightOnPartyAction : public CastBlessingOnPartyAction
+{
+public:
+    CastBlessingOfMightOnPartyAction(PlayerbotAI* botAI)
+        : CastBlessingOnPartyAction(botAI, "blessing of might") {}
+
+    std::string const getName() override { return "blessing of might on party"; }
 };
 
 class CastBlessingOfWisdomAction : public CastBuffSpellAction
@@ -103,15 +116,13 @@ public:
     bool Execute(Event event) override;
 };
 
-class CastBlessingOfWisdomOnPartyAction : public BuffOnPartyAction
+class CastBlessingOfWisdomOnPartyAction : public CastBlessingOnPartyAction
 {
 public:
-    CastBlessingOfWisdomOnPartyAction(PlayerbotAI* botAI) : BuffOnPartyAction(botAI, "blessing of wisdom") {}
+    CastBlessingOfWisdomOnPartyAction(PlayerbotAI* botAI)
+        : CastBlessingOnPartyAction(botAI, "blessing of wisdom") {}
 
     std::string const getName() override { return "blessing of wisdom on party"; }
-    Unit* GetTarget() override;
-    Value<Unit*>* GetTargetValue() override;
-    bool Execute(Event event) override;
 };
 
 class CastBlessingOfKingsAction : public CastBuffSpellAction
@@ -120,15 +131,13 @@ public:
     CastBlessingOfKingsAction(PlayerbotAI* botAI) : CastBuffSpellAction(botAI, "blessing of kings") {}
 };
 
-class CastBlessingOfKingsOnPartyAction : public BuffOnPartyAction
+class CastBlessingOfKingsOnPartyAction : public CastBlessingOnPartyAction
 {
 public:
-    CastBlessingOfKingsOnPartyAction(PlayerbotAI* botAI) : BuffOnPartyAction(botAI, "blessing of kings") {}
+    CastBlessingOfKingsOnPartyAction(PlayerbotAI* botAI)
+        : CastBlessingOnPartyAction(botAI, "blessing of kings") {}
 
     std::string const getName() override { return "blessing of kings on party"; }
-    Unit* GetTarget() override;
-    Value<Unit*>* GetTargetValue() override; // added for Sanctuary priority
-    bool Execute(Event event) override;      // added for 2 paladins logic
 };
 
 class CastBlessingOfSanctuaryAction : public CastBuffSpellAction
@@ -137,15 +146,15 @@ public:
     CastBlessingOfSanctuaryAction(PlayerbotAI* botAI) : CastBuffSpellAction(botAI, "blessing of sanctuary") {}
 };
 
-class CastBlessingOfSanctuaryOnPartyAction : public BuffOnPartyAction
+Unit* GetPaladinPartyBlessingTarget(Player* bot, PlayerbotAI* botAI, std::string const& preferred);
+
+class CastBlessingOfSanctuaryOnPartyAction : public CastBlessingOnPartyAction
 {
 public:
-    CastBlessingOfSanctuaryOnPartyAction(PlayerbotAI* botAI) : BuffOnPartyAction(botAI, "blessing of sanctuary") {}
+    CastBlessingOfSanctuaryOnPartyAction(PlayerbotAI* botAI)
+        : CastBlessingOnPartyAction(botAI, "blessing of sanctuary") {}
 
     std::string const getName() override { return "blessing of sanctuary on party"; }
-    Unit* GetTarget() override;
-    Value<Unit*>* GetTargetValue() override;
-    bool Execute(Event event) override;
 };
 
 class CastHolyLightAction : public CastHealingSpellAction

--- a/src/Ai/Class/Paladin/Actions/PaladinGreaterBlessingAction.cpp
+++ b/src/Ai/Class/Paladin/Actions/PaladinGreaterBlessingAction.cpp
@@ -9,6 +9,7 @@
 #include "AiFactory.h"
 #include "Event.h"
 #include "GenericBuffUtils.h"
+#include "PaladinBlessingHelper.h"
 #include "PaladinHelper.h"
 #include "Playerbots.h"
 #include "SharedDefines.h"
@@ -848,126 +849,6 @@ bool IsEligibleGroupForAutoBlessings(Group const* group)
     }
 }
 
-static bool HasMyExactBlessing(PlayerbotAI* botAI, Unit* target, BlessingType type)
-{
-    std::string name = BlessingSpellName(type);
-    if (name.empty())
-        return false;
-
-    return botAI->HasAura(name.c_str(), target, false, true);
-}
-
-static int32 GetAuraStrength(Aura const* aura, AuraType auraType)
-{
-    if (!aura)
-        return 0;
-
-    int32 amount = 0;
-    for (uint8 effect = 0; effect < MAX_SPELL_EFFECTS; ++effect)
-    {
-        AuraEffect* auraEffect = aura->GetEffect(effect);
-        if (!auraEffect || auraEffect->GetAuraType() != auraType)
-            continue;
-
-        amount = std::max(amount, auraEffect->GetAmount());
-    }
-
-    return amount;
-}
-
-static int32 GetExistingBlessingStrength(
-    PlayerbotAI* botAI, Unit* target, BaseBlessingCategory category)
-{
-    if (category != BASE_MIGHT && category != BASE_WISDOM)
-        return 0;
-
-    AuraType auraType =
-        category == BASE_MIGHT ? SPELL_AURA_MOD_ATTACK_POWER : SPELL_AURA_MOD_POWER_REGEN;
-    int32 strongestAmount = 0;
-
-    for (BlessingType type : {ToSingleVariant(category), ToGreaterVariant(category)})
-    {
-        Aura* aura = botAI->GetAura(BlessingSpellName(type), target);
-        strongestAmount = std::max(strongestAmount, GetAuraStrength(aura, auraType));
-    }
-
-    return strongestAmount;
-}
-
-static bool HasSameFamilyBlessing(
-    PlayerbotAI* botAI, Unit* target, BaseBlessingCategory category)
-{
-    for (BlessingType type : {ToSingleVariant(category), ToGreaterVariant(category)})
-    {
-        if (botAI->HasAura(BlessingSpellName(type), target))
-            return true;
-    }
-
-    return false;
-}
-
-static int32 GetBlessingCastStrength(Player* caster, BlessingType type, uint32 spellId)
-{
-    if (!caster || !spellId)
-        return 0;
-
-    BaseBlessingCategory category = BaseBlessingOf(type);
-    if (category != BASE_MIGHT && category != BASE_WISDOM)
-        return 0;
-
-    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
-    if (!spellInfo)
-        return 0;
-
-    AuraType auraType =
-        category == BASE_MIGHT ? SPELL_AURA_MOD_ATTACK_POWER : SPELL_AURA_MOD_POWER_REGEN;
-    int32 amount = 0;
-    for (uint8 effect = 0; effect < MAX_SPELL_EFFECTS; ++effect)
-    {
-        if (spellInfo->Effects[effect].ApplyAuraName != auraType)
-            continue;
-
-        amount = std::max(amount, spellInfo->Effects[effect].BasePoints + 1);
-    }
-
-    if (amount <= 0)
-        return 0;
-
-    switch (category)
-    {
-        case BASE_MIGHT:
-            if (caster->HasAura(SPELL_IMPROVED_MIGHT_R2))
-                return amount * 125 / 100;
-            if (caster->HasAura(SPELL_IMPROVED_MIGHT_R1))
-                return amount * 112 / 100;
-            break;
-        case BASE_WISDOM:
-            if (caster->HasAura(SPELL_IMPROVED_WISDOM_R2))
-                return amount * 120 / 100;
-            if (caster->HasAura(SPELL_IMPROVED_WISDOM_R1))
-                return amount * 110 / 100;
-            break;
-        default:
-            break;
-    }
-
-    return amount;
-}
-
-static bool HasEquivalentOrStrongerSameFamilyBlessing(
-    PlayerbotAI* botAI, Unit* target, BlessingType castType, uint32 spellId)
-{
-    BaseBlessingCategory category = BaseBlessingOf(castType);
-    if (category != BASE_MIGHT && category != BASE_WISDOM)
-        return HasSameFamilyBlessing(botAI, target, category);
-
-    int32 castStrength = GetBlessingCastStrength(botAI->GetBot(), castType, spellId);
-    if (castStrength <= 0)
-        return false;
-
-    return GetExistingBlessingStrength(botAI, target, category) >= castStrength;
-}
-
 static bool MatchesBucket(Player* player, CachedBlessingBucketAssignment const& assignment)
 {
     if (!player || player->getClass() != assignment.classId)
@@ -995,8 +876,8 @@ static Player* FindMissingBlessingTarget(
             continue;
 
         if (!MatchesBucket(player, assignment) ||
-            HasMyExactBlessing(botAI, player, castType) ||
-            HasEquivalentOrStrongerSameFamilyBlessing(botAI, player, castType, spellId) ||
+            ai::blessing::HasMyExactBlessing(botAI, player, castType) ||
+            ai::blessing::HasEquivalentOrStrongerSameFamilyBlessing(botAI, player, castType, spellId) ||
             !botAI->CanCastSpell(spellName, player))
         {
             continue;

--- a/src/Ai/Class/Paladin/PaladinAiObjectContext.cpp
+++ b/src/Ai/Class/Paladin/PaladinAiObjectContext.cpp
@@ -338,10 +338,10 @@ private:
     static Action* seal_of_command(PlayerbotAI* botAI) { return new CastSealOfCommandAction(botAI); }
     static Action* seal_of_vengeance(PlayerbotAI* botAI) { return new CastSealOfVengeanceAction(botAI); }
     static Action* seal_of_corruption(PlayerbotAI* botAI) { return new CastSealOfCorruptionAction(botAI); }
-    static Action* blessing_of_sanctuary(PlayerbotAI* botAI) { return new CastBlessingOfSanctuaryAction(botAI); }
     static Action* blessing_of_might(PlayerbotAI* botAI) { return new CastBlessingOfMightAction(botAI); }
     static Action* blessing_of_wisdom(PlayerbotAI* botAI) { return new CastBlessingOfWisdomAction(botAI); }
     static Action* blessing_of_kings(PlayerbotAI* botAI) { return new CastBlessingOfKingsAction(botAI); }
+    static Action* blessing_of_sanctuary(PlayerbotAI* botAI) { return new CastBlessingOfSanctuaryAction(botAI); }
     static Action* divine_storm(PlayerbotAI* botAI) { return new CastDivineStormAction(botAI); }
     static Action* blessing_of_kings_on_party(PlayerbotAI* botAI)
     {

--- a/src/Ai/Class/Paladin/PaladinBlessingHelper.h
+++ b/src/Ai/Class/Paladin/PaladinBlessingHelper.h
@@ -35,8 +35,8 @@ namespace ai::blessing
         {
             Player* member = ref->GetSource();
             if (member && member->getClass() == CLASS_PRIEST &&
-                (member->HasSpell(SPELL_RENEWED_HOPE_R1) ||
-                 member->HasSpell(SPELL_RENEWED_HOPE_R2)))
+                (member->HasAura(SPELL_RENEWED_HOPE_R1) ||
+                 member->HasAura(SPELL_RENEWED_HOPE_R2)))
                 return true;
         }
 

--- a/src/Ai/Class/Paladin/PaladinBlessingHelper.h
+++ b/src/Ai/Class/Paladin/PaladinBlessingHelper.h
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license, you may redistribute it
+ * and/or modify it under version 3 of the License, or (at your option), any later version.
+ */
+
+#ifndef PLAYERBOTS_PALADINBLESSINGHELPER_H
+#define PLAYERBOTS_PALADINBLESSINGHELPER_H
+
+#include <algorithm>
+
+#include "PaladinGreaterBlessingAction.h"
+#include "Playerbots.h"
+#include "SpellAuraEffects.h"
+
+// Shared blessing utilities used by both the greater-blessing assignment and the
+// single-blessing dispatcher: blessing-category mapping, aura presence/strength
+// comparison (Improved Might/Wisdom aware), and role classification.
+namespace ai::blessing
+{
+    using namespace ai::gbless;
+
+    // Discipline priest Renewed Hope talent (ranks 1/2); its 3% raid damage
+    // reduction doesn't stack with Blessing of Sanctuary.
+    static constexpr uint32 SPELL_RENEWED_HOPE_R1 = 57470;
+    static constexpr uint32 SPELL_RENEWED_HOPE_R2 = 57472;
+
+    // True if any priest in the bot's group/raid has the Renewed Hope talent.
+    inline bool GroupHasRenewedHopePriest(Player* bot)
+    {
+        Group* group = bot ? bot->GetGroup() : nullptr;
+        if (!group)
+            return false;
+
+        for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+        {
+            Player* member = ref->GetSource();
+            if (member && member->getClass() == CLASS_PRIEST &&
+                (member->HasSpell(SPELL_RENEWED_HOPE_R1) ||
+                 member->HasSpell(SPELL_RENEWED_HOPE_R2)))
+                return true;
+        }
+
+        return false;
+    }
+
+    inline BaseBlessingCategory CategoryFromName(std::string const& name)
+    {
+        if (name == "blessing of kings")     return BASE_KINGS;
+        if (name == "blessing of might")     return BASE_MIGHT;
+        if (name == "blessing of wisdom")    return BASE_WISDOM;
+        if (name == "blessing of sanctuary") return BASE_SANCTUARY;
+        return BASE_NONE;
+    }
+
+    inline bool IsTankRoleProfile(RoleProfile role)
+    {
+        return role == ROLE_DRUID_TANK || role == ROLE_WARRIOR_DK_TANK ||
+               role == ROLE_PALADIN_TANK;
+    }
+
+    // Does the target already carry one of OUR (this bot's) blessings of this category?
+    inline bool HasOwnBlessingCategory(
+        PlayerbotAI* botAI, Unit* target, BaseBlessingCategory category)
+    {
+        for (BlessingType type : { ToSingleVariant(category), ToGreaterVariant(category) })
+            if (botAI->HasAura(BlessingSpellName(type), target, false, true))  // cast by us
+                return true;
+
+        return false;
+    }
+
+    inline bool HasMyExactBlessing(PlayerbotAI* botAI, Unit* target, BlessingType type)
+    {
+        std::string name = BlessingSpellName(type);
+        if (name.empty())
+            return false;
+
+        return botAI->HasAura(name, target, false, true);
+    }
+
+    inline int32 GetAuraStrength(Aura const* aura, AuraType auraType)
+    {
+        if (!aura)
+            return 0;
+
+        int32 amount = 0;
+        for (uint8 effect = 0; effect < MAX_SPELL_EFFECTS; ++effect)
+        {
+            AuraEffect* auraEffect = aura->GetEffect(effect);
+            if (!auraEffect || auraEffect->GetAuraType() != auraType)
+                continue;
+
+            amount = std::max(amount, auraEffect->GetAmount());
+        }
+
+        return amount;
+    }
+
+    inline int32 GetExistingBlessingStrength(
+        PlayerbotAI* botAI, Unit* target, BaseBlessingCategory category)
+    {
+        if (category != BASE_MIGHT && category != BASE_WISDOM)
+            return 0;
+
+        AuraType auraType =
+            category == BASE_MIGHT ? SPELL_AURA_MOD_ATTACK_POWER : SPELL_AURA_MOD_POWER_REGEN;
+        int32 strongestAmount = 0;
+
+        for (BlessingType type : { ToSingleVariant(category), ToGreaterVariant(category) })
+        {
+            Aura* aura = botAI->GetAura(BlessingSpellName(type), target);
+            strongestAmount = std::max(strongestAmount, GetAuraStrength(aura, auraType));
+        }
+
+        return strongestAmount;
+    }
+
+    inline bool HasSameFamilyBlessing(
+        PlayerbotAI* botAI, Unit* target, BaseBlessingCategory category)
+    {
+        for (BlessingType type : { ToSingleVariant(category), ToGreaterVariant(category) })
+        {
+            if (botAI->HasAura(BlessingSpellName(type), target))
+                return true;
+        }
+
+        return false;
+    }
+
+    inline int32 GetBlessingCastStrength(Player* caster, BlessingType type, uint32 spellId)
+    {
+        if (!caster || !spellId)
+            return 0;
+
+        BaseBlessingCategory category = BaseBlessingOf(type);
+        if (category != BASE_MIGHT && category != BASE_WISDOM)
+            return 0;
+
+        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+        if (!spellInfo)
+            return 0;
+
+        AuraType auraType =
+            category == BASE_MIGHT ? SPELL_AURA_MOD_ATTACK_POWER : SPELL_AURA_MOD_POWER_REGEN;
+        int32 amount = 0;
+        for (uint8 effect = 0; effect < MAX_SPELL_EFFECTS; ++effect)
+        {
+            if (spellInfo->Effects[effect].ApplyAuraName != auraType)
+                continue;
+
+            amount = std::max(amount, spellInfo->Effects[effect].BasePoints + 1);
+        }
+
+        if (amount <= 0)
+            return 0;
+
+        switch (category)
+        {
+            case BASE_MIGHT:
+                if (caster->HasAura(SPELL_IMPROVED_MIGHT_R2))
+                    return amount * 125 / 100;
+                if (caster->HasAura(SPELL_IMPROVED_MIGHT_R1))
+                    return amount * 112 / 100;
+                break;
+            case BASE_WISDOM:
+                if (caster->HasAura(SPELL_IMPROVED_WISDOM_R2))
+                    return amount * 120 / 100;
+                if (caster->HasAura(SPELL_IMPROVED_WISDOM_R1))
+                    return amount * 110 / 100;
+                break;
+            default:
+                break;
+        }
+
+        return amount;
+    }
+
+    // True if the target already has a same-family blessing at least as strong as
+    // what this bot would cast (Improved Might/Wisdom aware). Considers any caster.
+    inline bool HasEquivalentOrStrongerSameFamilyBlessing(
+        PlayerbotAI* botAI, Unit* target, BlessingType castType, uint32 spellId)
+    {
+        BaseBlessingCategory category = BaseBlessingOf(castType);
+        if (category != BASE_MIGHT && category != BASE_WISDOM)
+            return HasSameFamilyBlessing(botAI, target, category);
+
+        int32 castStrength = GetBlessingCastStrength(botAI->GetBot(), castType, spellId);
+        if (castStrength <= 0)
+            return false;
+
+        return GetExistingBlessingStrength(botAI, target, category) >= castStrength;
+    }
+
+    // True if another paladin already provides an equal-or-stronger same-family
+    // blessing of this category, so we complement instead of duplicating/downgrading.
+    inline bool AnotherPaladinHasEqualOrStronger(
+        PlayerbotAI* botAI, Unit* target, BaseBlessingCategory category)
+    {
+        BlessingType type = ToSingleVariant(category);
+        uint32 spellId = 0;
+        if (category == BASE_MIGHT || category == BASE_WISDOM)
+            spellId = botAI->GetAiObjectContext()->GetValue<uint32>(
+                "spell id", BlessingSpellName(type))->Get();
+
+        return HasEquivalentOrStrongerSameFamilyBlessing(botAI, target, type, spellId) &&
+               !HasOwnBlessingCategory(botAI, target, category);
+    }
+}
+
+#endif

--- a/src/Ai/Class/Paladin/PaladinTriggers.cpp
+++ b/src/Ai/Class/Paladin/PaladinTriggers.cpp
@@ -34,6 +34,15 @@ bool BlessingTrigger::IsActive()
                                 "blessing of kings", "blessing of sanctuary", nullptr);
 }
 
+bool BlessingOnPartyTrigger::IsActive()
+{
+    Unit* target = GetPaladinPartyBlessingTarget(bot, botAI, spell);
+    if (!target)
+        return false;
+
+    return !ai::buff::ShouldDeferPartyBuffEvaluationForRecentLogin(bot, target, spell);
+}
+
 bool DivineShieldLowHealthTrigger::IsActive()
 {
     return botAI->HasAura("divine shield", bot) && AI_VALUE2(uint8, "health", "self target") < 80;

--- a/src/Ai/Class/Paladin/PaladinTriggers.h
+++ b/src/Ai/Class/Paladin/PaladinTriggers.h
@@ -52,6 +52,8 @@ class BlessingOnPartyTrigger : public BuffOnPartyTrigger
 public:
     BlessingOnPartyTrigger(PlayerbotAI* botAI)
         : BuffOnPartyTrigger(botAI, "blessing of kings,blessing of might,blessing of wisdom", 2 * 2000) {}
+
+    bool IsActive() override;
 };
 
 class BlessingTrigger : public BuffTrigger
@@ -213,7 +215,7 @@ public:
     BlessingOfWisdomOnPartyTrigger(PlayerbotAI* botAI)
         : BlessingOnPartyTrigger(botAI)
     {
-        spell = "blessing of might,blessing of wisdom";
+        spell = "blessing of wisdom";
     }
 };
 
@@ -223,7 +225,7 @@ public:
     BlessingOfMightOnPartyTrigger(PlayerbotAI* botAI)
         : BlessingOnPartyTrigger(botAI)
     {
-        spell = "blessing of might,blessing of wisdom";
+        spell = "blessing of might";
     }
 };
 

--- a/src/Ai/Class/Paladin/Strategy/PaladinBuffStrategies.cpp
+++ b/src/Ai/Class/Paladin/Strategy/PaladinBuffStrategies.cpp
@@ -11,9 +11,6 @@ void PaladinBuffManaStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
     triggers.push_back(new TriggerNode("blessing of wisdom on party",
         { NextAction("blessing of wisdom on party", 11.0f) }));
-
-    triggers.push_back(new TriggerNode("blessing of kings on party",
-        { NextAction("blessing of kings on party", 10.5f) }));
 }
 
 void PaladinBuffHealthStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
@@ -82,12 +79,6 @@ void PaladinBuffThreatStrategy::InitTriggers(std::vector<TriggerNode*>& triggers
 
 void PaladinBuffStatsStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
-    // First Sanctuary (prio > Kings)
-    triggers.push_back(
-        new TriggerNode("blessing of sanctuary on party",
-                        { NextAction("blessing of sanctuary on party", 12.0f) }));
-
-    // After Kings
     triggers.push_back(
         new TriggerNode("blessing of kings on party",
                         { NextAction("blessing of kings on party", 11.0f) }));

--- a/src/Bot/Factory/AiFactory.cpp
+++ b/src/Bot/Factory/AiFactory.cpp
@@ -515,10 +515,7 @@ void AiFactory::AddDefaultNonCombatStrategies(Player* player, PlayerbotAI* const
             if (tab == PALADIN_TAB_PROTECTION)
             {
                 nonCombatEngine->addStrategiesNoInit("bthreat", "tank assist", "pull", "barmor", nullptr);
-                if (player->GetLevel() >= 20)
-                    nonCombatEngine->addStrategy("bsanc", false);
-                else
-                    nonCombatEngine->addStrategy("bmight", false);
+                nonCombatEngine->addStrategy("bsanc", false);
             }
             else if (tab == PALADIN_TAB_HOLY)
                 nonCombatEngine->addStrategiesNoInit("dps assist", "bwisdom", "bcast", nullptr);


### PR DESCRIPTION
## Pull Request Description

Fixes Protection paladins maintaining **no blessing at all** when the Blessing of Sanctuary talent isn't trained (guaranteed at level 20-39, and for any prot build that skips the talent), and reworks the paladin party-blessing path into a single, consistent dispatcher.

Previously the four blessing-on-party strategies (`bsanc`, `bmight`, `bwisdom`, `bkings`) each had their own bespoke action with divergent `hasBwisdom`/`hasBkings`/group logic, including a Kings action that bailed when the bot had no group (so solo bots got nothing). They're now one shared `CastBlessingOnPartyAction` that picks the best blessing per target from the role-priority table, leading with the strategy's blessing where it fits and complementing other paladins instead of duplicating.

### Base logic

Each blessing strategy keeps a single "lead" trigger; the shared action routes through `GetDesiredBlessingCategory(target, preferred)`:

1. **Lead**: if the strategy's preferred blessing suits the target's role, the bot can cast it, and no other paladin already provides it, use it.
2. **Renewed Hope rule**: with no Discipline priest carrying Renewed Hope in the raid, tanks promote Sanctuary to #1 (its 3% reduction doesn't stack with Renewed Hope).
3. **Fallback**: walk `BASE_BLESSING_PRIORITIES[role]` for the highest blessing the bot can cast that isn't already covered.

Target selection picks a party member (or self, when solo) that lacks that blessing **from us** (caster = bot), so we maintain our own blessing, can upgrade our own lower-priority blessing, and complement rather than duplicate. The "already covered" check reuses the greater-blessing system's strength-aware `HasEquivalentOrStrongerSameFamilyBlessing`, so we won't displace an equal-or-stronger blessing but will upgrade a weaker Might/Wisdom (Improved Might/Wisdom aware).

Party members' pets are included as targets too (second commit), scanned after all players so players are blessed first, matching how generic party buffs (Power Word: Fortitude, Mark of the Wild, ...) already walk pets. A pet isn't role-classifiable, so it's treated as physical DPS (Might → Kings).

**Role priority table** (`BASE_BLESSING_PRIORITIES`, reused from the greater-blessing system):

| Role | Priority order |
| --- | --- |
| Casters | Kings → Wisdom → Sanctuary → Might |
| Physical DPS (rogue/warrior/DK) | Might → Kings → Sanctuary |
| Hybrid DPS (enh/ret/hunter/cat) | Might → Kings → Wisdom → Sanctuary |
| Druid tank | Kings → Might → Sanctuary → Wisdom |
| Warrior/DK tank | Kings → Might → Sanctuary |
| Paladin tank | Sanctuary → Might → Wisdom → Kings |

**Strategy lead applicability** (`PreferredLeadAppliesTo`):

| Strategy (lead) | Leads on |
| --- | --- |
| `bkings` (Kings) | all roles |
| `bmight` (Might) | physical & hybrid DPS |
| `bwisdom` (Wisdom) | casters & hybrid DPS |
| `bsanc` (Sanctuary) | tanks |

### What changed vs. the old behavior

| Aspect | Old | New |
| --- | --- | --- |
| Strategy actions | 4 separate actions, bespoke `hasBwisdom`/`hasBkings`/group logic | 1 shared dispatcher keyed off the lead blessing |
| Prot paladin w/o Sanctuary talent | no blessing (esp. solo) | falls through to Might/Kings; self-buffs |
| Solo bot | Kings action bailed on "no group", no buff | self-targets and buffs |
| Multiple paladins | could duplicate / fight over blessings | complement via a strength-aware "another paladin has equal-or-stronger" check (won't duplicate; upgrades a weaker Might/Wisdom) |
| Re-cast / overwrite | could re-cast or be blocked by others' blessings | by-us check: never overwrites our own, upgrades our own lower-priority blessing |
| Sanctuary recipients | all tank specs equally | role-priority (paladin tanks lead; other tanks get it as fallback / when no Renewed Hope priest) |
| Disc-priest Renewed Hope | not considered | tanks promote Sanctuary when no Renewed Hope priest is present |
| Greater-blessing mode | per-action checks | single `IsGreaterBlessingMode` gate on trigger + target |
| Pets | never blessed (only players scanned) | party pets blessed too, after players, as physical DPS (Might → Kings) |

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
  - A per-target priority walk reusing the existing `ai::gbless` role table and `ResolveRoleProfile`, plus name-based `HasSpell` ("can I cast it") and the greater-blessing system's strength-aware `HasEquivalentOrStrongerSameFamilyBlessing` / by-us aura checks ("is it already covered"). One group scan for a Renewed Hope priest. Shared blessing utilities live in a new header-only `ai::blessing` namespace (`PaladinBlessingHelper.h`), consumed by both the dispatcher and the greater-blessing system. Strategy selection is unchanged (prot uses `bsanc`, holy uses `bwisdom`, ret uses `bmight`).
- Describe the **processing cost** when this logic executes across many bots.
  - The walk is a handful of `HasSpell`/`HasAura` calls over at most 4 categories, run during the blessing trigger's existing **4s** check interval, and only for the single-blessing fallback path; raids run the cached greater-blessing system instead, where these triggers are inert. Net code is a reduction (one path replaces four). No new DB queries or allocations.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

1. **Spell not available**: Prot paladin bot level 20-39 (no Sanctuary talent) receives Kings/Might (not nothing). Below 20: receives Might.
2. **Solo**: A lone paladin self-buffs its role blessing (prot gets Sanctuary if trained else Might; ret gets Might; holy gets Wisdom).
3. **Greater blessings active**: In a group/raid eligible for auto greater blessings, the single-blessing dispatcher does nothing (greater system owns blessings). Verify no double-casting.
4. **Multiple paladins**: Two+ paladins on the same group complement each other (e.g. casters end up with Kings from one and Wisdom from another) rather than both casting the same blessing.
5. **Multiple paladins, same strategy**: Two `bkings` paladins still diverge (one leads Kings, the other falls to the next role priority), no permanent fighting.
6. **Renewed Hope**: With a Disc priest carrying Renewed Hope in the raid, non-paladin tanks get Kings/Might; remove that priest and tanks shift to Sanctuary.
7. **Pets**: A hunter/warlock/DK in the group has their pet blessed (Might, or Kings under `bkings`) after the players are blessed; the pet's blessing isn't re-cast once present.

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

  The per-target walk and the Renewed Hope group scan run only on the blessing trigger's existing 4s interval, only in the non-greater (small-group/solo) path; raids use the cached greater-blessing system where these triggers are inactive. Overall this removes code paths rather than adding them.

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

  Paladin party-blessing selection is unified and corrected: prot paladins always get a blessing (the core bug), blessings are chosen by role priority, multiple paladins complement instead of duplicate, and Sanctuary is promoted for tanks when no Renewed Hope priest is present.

- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [x] Yes (**explain below**)

  It adds the role-priority walk and a Renewed Hope check, but **net** complexity drops: four bespoke blessing actions collapse into one shared dispatcher and several now-dead helpers are removed.

## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

AI (Claude Code) was used for investigation, design discussion, and code generation across the paladin blessing files. Every change was reviewed and is understood and owned by the contributor.

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated. (N/A, no new dialogue.)
- - [x] Documentation updated if needed (Conf comments, WiKi commands). (N/A, no conf/wiki changes.)

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->

- **Edge cases covered:** spell-not-known (falls through the priority walk), solo (self-target via `FindBlessingTarget`; never "greater mode" since `IsEligibleGroupForAutoBlessings(nullptr)` is false), greater-blessing mode (dispatcher gated off on both trigger and target), multiple paladins / same strategy (complement via the strategy-agnostic "from another paladin" aura check).
- **Known caveat (transient multi-paladin race):** in the uncoordinated single-blessing path, two paladins evaluating the same 4s tick before either casts can both pick a target's top blessing and briefly double-cast; it self-corrects within a cycle as the "from another" check kicks in. The greater-blessing system is what pre-assigns to avoid this.
- The `Renewed Hope` talent ids (`57470`/`57472`) are hardcoded (verified WotLK 3.3.5a talent ranks).
- The greater-blessing assignment logic and role table are unchanged; shared blessing utilities (aura/strength comparison, role/category mapping, Renewed Hope detection) were extracted into a new header-only `ai::blessing` namespace (`PaladinBlessingHelper.h`) consumed by both the greater path and the new dispatcher.
- Self-cast / combat blessing actions (`blessing of might/wisdom/kings` and their remaps) are intentionally left unchanged; only the on-party single-blessing path was reworked.
