### PR TITLE
Minors fixes relating to mounts and flight form

### DIFF
--- a/src/Ai/Base/Actions/CheckMountStateAction.cpp
+++ b/src/Ai/Base/Actions/CheckMountStateAction.cpp
@@ -296,7 +296,7 @@ bool CheckMountStateAction::TryForms(Player* master, int32 masterMountType, int3
     else if
         ((masterInShapeshiftForm == FORM_TRAVEL && botInShapeshiftForm == FORM_TRAVEL) ||
         ((masterInShapeshiftForm == FORM_FLIGHT || (masterMountType == 1 && masterSpeed == 149)) && botInShapeshiftForm == FORM_FLIGHT) ||
-        ((masterInShapeshiftForm == FORM_FLIGHT_EPIC || (masterMountType == 1 && masterSpeed == 279)) && botInShapeshiftForm == FORM_FLIGHT_EPIC))
+        ((masterInShapeshiftForm == FORM_FLIGHT_EPIC || (masterMountType == 1 && masterSpeed >= 279)) && botInShapeshiftForm == FORM_FLIGHT_EPIC))
         return true;
 
     // Check if master is in Travel Form and bot can do the same
@@ -322,7 +322,7 @@ bool CheckMountStateAction::TryForms(Player* master, int32 masterMountType, int3
     // Check if master is in Swift Flight Form or has an epic flying mount and bot can swift flight form
     if (botAI->CanCastSpell(SPELL_SWIFT_FLIGHT_FORM, bot, true) &&
         ((masterInShapeshiftForm == FORM_FLIGHT_EPIC && botInShapeshiftForm != FORM_FLIGHT_EPIC) ||
-        (masterMountType == 1 && masterSpeed == 279)))
+        (masterMountType == 1 && masterSpeed >= 279)))
     {
         botAI->CastSpell(SPELL_SWIFT_FLIGHT_FORM, bot);
 
@@ -427,18 +427,18 @@ bool CheckMountStateAction::TryPreferredMount(Player* master) const
 
 bool CheckMountStateAction::TryRandomMountFiltered(const std::map<int32, std::vector<uint32>>& spells, int32 masterSpeed) const
 {
-    for (auto const& pair : spells)
+    for (auto it = spells.rbegin(); it != spells.rend(); ++it)
     {
-        int32 currentSpeed = pair.first;
+        int32 currentSpeed = it->first;
 
         if ((masterSpeed > 59 && currentSpeed < 99) || (masterSpeed > 149 && currentSpeed < 279))
             continue;
 
         // Pick a random mount from the candidate group.
-        auto const& ids = pair.second;
+        auto const& ids = it->second;
         if (!ids.empty())
         {
-            // Required here as otherwise bots won't mount in BG's due to them constant moving
+            // Required here as otherwise bots won't mount in BGs due to them constant moving
             if (bot->isMoving())
                 bot->StopMoving();
 
@@ -479,15 +479,17 @@ bool CheckMountStateAction::ShouldFollowMasterMountState(Player* master, bool no
     bool isMasterMounted = master->IsMounted() || (masterInShapeshiftForm == FORM_FLIGHT ||
                                                     masterInShapeshiftForm == FORM_FLIGHT_EPIC ||
                                                     masterInShapeshiftForm == FORM_TRAVEL);
-    return isMasterMounted && !bot->IsMounted() && noAttackers &&
+    bool isBotMountedOrForm = bot->IsMounted() || botInShapeshiftForm == FORM_FLIGHT ||
+                              botInShapeshiftForm == FORM_FLIGHT_EPIC || botInShapeshiftForm == FORM_TRAVEL;
+    return isMasterMounted && !isBotMountedOrForm && noAttackers &&
         shouldMount && !bot->IsInCombat() && botAI->GetState() != BOT_STATE_COMBAT;
 }
 
 bool CheckMountStateAction::ShouldDismountForMaster(Player* master) const
 {
     bool isMasterMounted = master->IsMounted() || (masterInShapeshiftForm == FORM_FLIGHT ||
-                                                    masterInShapeshiftForm == FORM_FLIGHT_EPIC ||
-                                                    masterInShapeshiftForm == FORM_TRAVEL);
+                                                   masterInShapeshiftForm == FORM_FLIGHT_EPIC ||
+                                                   masterInShapeshiftForm == FORM_TRAVEL);
     return !isMasterMounted && bot->IsMounted();
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

Just another instance of me doing something stupid and thereby uncovering an issue that would probably affect nobody else ever. Plus some other stuff I noticed along the way.

I had set my Druids to Swift Flight Form in the preferred mounts table, which is totally unnecessary since they will prefer SFF (or regular Flight Form) anyway. But by using the preferred mounts table, I caused SFF (and would have happened with FF too) to move very slowly in short bursts. This is because ShouldFollowMasterMountState, which should return false if the bot is already mounted, didn't recognize Flight Forms as being mounted. So it would return true, call Mount, then call TryPreferredMount, and because I had SFF in the preferred mounts table, the bot was trying to recast SFF every tick while already in it. So I've added the Flight Forms (and Travel Form) to the checks in ShouldFollowMasterMountState to stop this.

I also noticed that TryForms required the master to have a 280% mount for a Druid bot to use SFF, meaning that the Druid wouldn't use it if the master has a 310% mount. It will still use a 280% mount, but not SFF. Druids should always be able to use SFF because if they obtain a 310% mount, SFF gets upgraded to 310%. So I just changed the masterSpeed check from == 279 to >= 279.

Finally, TryRandomMountFiltered was looping mounts from slowest to fastest, meaning that if a bot had 280% and 310% mounts, it would always pick a 280% mount. This makes no sense so I reversed the order, and now it will prioritize picking a 310% mount.


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

Minimum logic is described above. This should have no impact on processing cost.


## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

1. Make Flight Form or Swift Flight Form the preferred mount in the preferred mounts table for a Druid. Mount up and make sure the Druid transforms and follows properly.
2. Use a 310% mount with a bot Druid in your party that doesn't have a preferred mount. Make sure the Druid uses Swift Flight Form instead of picking a random mount.
3. Use a 310% mount with a bot in your party with at least one 310% mount and at least one 280% mount. Try this repeatedly and make sure the bot always picks a 310% mount.


## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

Bots will pick a 310% mount over a 280% mount if they have both; before it was always the opposite.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

Used DeepSeek v4 Pro to figure out the cause of the stuttering movement in Flight Form and to implement the fix for the TryRandomMountFiltered loop reversal.

<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


