### PR TITLE
fix(loot): two loot-pipeline deadlocks (quest-item nodes, stale loot target)

### DIFF
--- a/src/Ai/Base/Trigger/LootTriggers.cpp
+++ b/src/Ai/Base/Trigger/LootTriggers.cpp
@@ -11,6 +11,9 @@
 
 bool LootAvailableTrigger::IsActive()
 {
+    if (!AI_VALUE(bool, "has available loot"))
+        return false;
+
     bool distanceCheck = false;
     if (botAI->HasStrategy("stay", BOT_STATE_NON_COMBAT))
     {
@@ -23,9 +26,16 @@ bool LootAvailableTrigger::IsActive()
                                                                  INTERACTION_DISTANCE - 2.0f);
     }
 
-    // if loot target if empty, always pass distance check
-    return AI_VALUE(bool, "has available loot") &&
-        (distanceCheck || AI_VALUE(GuidVector, "all targets").empty());
+    // Loot target in range, or no hostile targets to deal with first.
+    if (distanceCheck || AI_VALUE(GuidVector, "all targets").empty())
+        return true;
+
+    // A target that became not loot-possible after being selected - the bot
+    // was pulled into combat while approaching it, or it despawned - never
+    // returns to range, so without this it stays selected forever and the
+    // loot action never gets to pick another. Report active so it can.
+    LootObject lootTarget = AI_VALUE(LootObject, "loot target");
+    return !lootTarget.IsEmpty() && !lootTarget.IsLootPossible(bot);
 }
 
 bool FarFromCurrentLootTrigger::IsActive()

--- a/src/Mgr/Item/LootObjectStack.cpp
+++ b/src/Mgr/Item/LootObjectStack.cpp
@@ -85,6 +85,7 @@ void LootObject::Refresh(Player* bot, ObjectGuid lootGUID)
     {
         bool onlyHasQuestItems = true;
         bool hasAnyQuestItems = false;
+        bool neededQuestItem = false;
 
         GameObjectQuestItemList const* items = sObjectMgr->GetGameObjectQuestItemList(go->GetEntry());
         for (size_t i = 0; i < MAX_GAMEOBJECT_QUEST_ITEMS; i++)
@@ -100,8 +101,12 @@ void LootObject::Refresh(Player* bot, ObjectGuid lootGUID)
 
             if (IsNeededForQuest(bot, itemId))
             {
+                // A gathering node can also drop a needed quest item (e.g.
+                // Root Sample off Barrens herbs); gathering yields both, so
+                // keep reading the lock below to set skillId rather than
+                // bailing here.
                 this->guid = lootGUID;
-                return;
+                neededQuestItem = true;
             }
 
             const ItemTemplate* proto = sObjectMgr->GetItemTemplate(itemId);
@@ -168,7 +173,7 @@ void LootObject::Refresh(Player* bot, ObjectGuid lootGUID)
         }
 
         // If gameobject has only quest items that bot doesn’t need, skip it.
-        if (hasAnyQuestItems && onlyHasQuestItems)
+        if (!neededQuestItem && hasAnyQuestItems && onlyHasQuestItems)
             return;
 
         // Otherwise, loot it.


### PR DESCRIPTION
## Pull Request Description

Two unrelated deadlocks in the shared loot pipeline. In both, a bot stops doing anything until something higher up resets it, and both hit any bot that loots or gathers. I ran into them while testing gathering, but neither is specific to it.

**1. Gathering a node that also drops a needed quest item.**
`LootObject::Refresh` bailed the moment it found a quest item the bot needs, before it read the gameobject's lock. So for a skill-locked node that also carries such an item (Barrens herbs drop a Root Sample for the *Root Samples* quest), `skillId` stayed `SKILL_NONE`. `OpenLootAction` then treated it as nothing it could gather and never cast the gather spell, so the bot just stood on the herb. It now finishes reading the lock and sets `skillId`. Gathering the node hands over both the herb and the quest item, so nothing is lost; a node is still skipped when its whole loot table is quest items the bot doesn't need.

**2. A stale loot target stops the bot looting.**
Once a target is picked, anything that makes it unreachable before the bot loots it (pulled into combat on the way, or the target despawns) leaves it set but no longer loot-possible. With that target out of range and other loot around, `LootAvailableTrigger` returned false, which gated off the one thing that would have replaced it. The bot kept the dead target and never looted again. The trigger now reports active in that case so the loot action can drop it.

## Feature Evaluation

- **Minimum logic.** Fix 1: when the needed quest item is found, set the guid but keep going to the lock read every other node already does (one extra bool). Fix 2: when out of range with other loot around, also report active if the current target isn't loot-possible (one `IsLootPossible` call).
- **Processing cost.** The only added work is that one `IsLootPossible` call, and only when loot is available, the target is out of range, and other targets exist. Every other path is unchanged, and the no-loot path now returns before it computes distance. Fix 1 adds nothing per tick.

## How to Test the Changes

1. Put a bot with Herbalism or Mining in a zone whose nodes drop a quest item, with that quest active (the Barrens, *Root Samples*). Before: it stands on the herb forever. After: it gathers it and receives the quest item.
2. Get a bot to pick a loot target and then lose access to it before looting, e.g. pull it into combat while it runs toward a corpse. Before: it keeps the dead target and stops looting. After: it drops the target and carries on.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] Minimal impact (**explain below**)

    The one added `IsLootPossible` call fires only in the out-of-range-with-other-loot case. Nothing else changes per tick.

- Does this change modify default bot behavior?
    - - [x] Yes (**explain why**)

    Bots that used to freeze (on a quest-item gather node, or on a stale loot target) now keep going. Bots that weren't stuck behave as before.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] Yes (**explain below**)

    One small branch each: a `neededQuestItem` flag in `Refresh`, and a stale-target check in the trigger. Both have an inline comment.

## AI Assistance

Was AI assistance used while working on this change?
- - [x] Yes (**explain below**)

Used to help diagnose the two deadlocks and draft the changes. I reviewed all of it and understand it.

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [ ] Any new bot dialogue lines are translated. <!-- N/A: no new dialogue -->
- - [x] Documentation updated if needed (Conf comments, WiKi commands). <!-- N/A: no config/command changes -->

## Notes for Reviewers
