### PR TITLE
Test staging

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -116,6 +116,7 @@ update, whose content are called within the codebase at src/strategy/actions/Fis
 - - [ ] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note).
 - - [ ] New source files use the GPLv2 header.
 - - [ ] Documentation updated if needed (Conf comments, WiKi commands).
+- - [ ] New and modified files do not introduce new compiler warnings.
 
 ## Notes for Reviewers
 <!-- Anything else that's helpful to review or test your pull request. -->

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -495,6 +495,15 @@ AiPlayerbot.AutoGreaterBlessings = 1
 # Default: 2 (all groups)
 AiPlayerbot.AutoPartyBuffs = 2
 
+# Bots tell the group when they attempt to use a reagent-based greater blessing or group buff
+# but have to fall back to the single-target version because they are out of reagents.
+# Default: 1 (enabled)
+AiPlayerbot.TellWhenMissingBuffReagents = 1
+
+# Cooldown for the missing buff reagent message, in seconds.
+# Default: 300 (5 minutes)
+AiPlayerbot.MissingBuffReagentMessageCooldown = 300
+
 # Bots can flee from enemies
 AiPlayerbot.FleeingEnabled = 1
 

--- a/data/sql/playerbots/updates/2026_06_13_00_ai_playerbot_missing_group_buff_reagent.sql
+++ b/data/sql/playerbots/updates/2026_06_13_00_ai_playerbot_missing_group_buff_reagent.sql
@@ -1,0 +1,29 @@
+DELETE FROM ai_playerbot_texts_chance
+WHERE name IN (
+  'rp_missing_reagent_greater_blessing',
+  'rp_missing_reagent_gift_of_the_wild',
+  'rp_missing_reagent_arcane_brilliance',
+  'rp_missing_reagent_generic',
+  'missing_group_buff_reagent'
+);
+
+DELETE FROM ai_playerbot_texts
+WHERE name IN (
+  'rp_missing_reagent_greater_blessing',
+  'rp_missing_reagent_gift_of_the_wild',
+  'rp_missing_reagent_arcane_brilliance',
+  'rp_missing_reagent_generic',
+  'missing_group_buff_reagent'
+);
+
+INSERT INTO ai_playerbot_texts
+  (id, name, text, say_type, reply_type, text_loc1, text_loc2, text_loc3, text_loc4, text_loc5, text_loc6, text_loc7, text_loc8)
+VALUES
+  (1900, 'missing_group_buff_reagent',
+   'I am out of reagents for %group_spell and am casting %base_spell instead.',
+   0, 0, '', '', '', '', '', '', '', '');
+
+INSERT INTO ai_playerbot_texts_chance
+  (name, probability)
+VALUES
+  ('missing_group_buff_reagent', 100);

--- a/data/sql/playerbots/updates/2026_06_19_00_ai_playerbot_cache_cleanup.sql
+++ b/data/sql/playerbots/updates/2026_06_19_00_ai_playerbot_cache_cleanup.sql
@@ -1,0 +1,5 @@
+-- Flush all caches after RandomItemMgr changes. Tables will be repopulated with
+-- the correct entries on the next start.
+TRUNCATE TABLE `playerbots_equip_cache`;
+TRUNCATE TABLE `playerbots_rnditem_cache`;
+TRUNCATE TABLE `playerbots_rarity_cache`;

--- a/src/Ai/Base/Actions/BattleGroundTactics.cpp
+++ b/src/Ai/Base/Actions/BattleGroundTactics.cpp
@@ -1368,7 +1368,7 @@ std::string const BGTactics::HandleConsoleCommandPrivate(WorldSession* session, 
         uint32 max = vPaths->size() - 1;
         if (num >= 0)  // num specified or found
         {
-            if (num > max)
+            if (uint32(num) > max)
                 return fmt::format("Path {} of range of 0 - {}", num, max);
             min = num;
             max = num;
@@ -2177,7 +2177,7 @@ bool BGTactics::selectObjective(bool reset)
 
             uint8 defendersProhab = 3;  // Default balanced
 
-            switch (strategy)
+            switch (static_cast<uint8>(strategy))
             {
                 case 0:
                 case 1:
@@ -3324,7 +3324,7 @@ bool BGTactics::selectObjectiveWp(std::vector<BattleBotPath*> const& vPaths)
 
         // don't pick path where bot is already closest to the paths closest point to target (it means path cant lead it
         // anywhere) don't pick path where closest point is too far away
-        if (closestPointIndex == (reverse ? 0 : path->size() - 1) || closestPointDistToBot > botDistanceLimit)
+        if (closestPointIndex == int(reverse ? 0 : path->size() - 1) || closestPointDistToBot > botDistanceLimit)
             continue;
 
         // creates a score based on dist-to-bot and dist-to-destination, where lower is better, and dist-to-bot is more

--- a/src/Ai/Base/Actions/BattleGroundTactics.cpp
+++ b/src/Ai/Base/Actions/BattleGroundTactics.cpp
@@ -4251,7 +4251,7 @@ bool ArenaTactics::Execute(Event /*event*/)
 {
     if (!bot->InBattleground())
     {
-        bool IsRandomBot = sRandomPlayerbotMgr.IsRandomBot(bot);
+        bool IsRandomBot = sRandomPlayerbotMgr.IsRandomBot(bot->GetGUID().GetCounter());
         botAI->ChangeStrategy("-arena", BOT_STATE_COMBAT);
         botAI->ChangeStrategy("-arena", BOT_STATE_NON_COMBAT);
         botAI->ResetStrategies(!IsRandomBot);

--- a/src/Ai/Base/Actions/BattleGroundTactics.cpp
+++ b/src/Ai/Base/Actions/BattleGroundTactics.cpp
@@ -4251,7 +4251,7 @@ bool ArenaTactics::Execute(Event /*event*/)
 {
     if (!bot->InBattleground())
     {
-        bool IsRandomBot = sRandomPlayerbotMgr.IsRandomBot(bot->GetGUID().GetCounter());
+        bool IsRandomBot = sRandomPlayerbotMgr.IsRandomBot(bot);
         botAI->ChangeStrategy("-arena", BOT_STATE_COMBAT);
         botAI->ChangeStrategy("-arena", BOT_STATE_NON_COMBAT);
         botAI->ResetStrategies(!IsRandomBot);

--- a/src/Ai/Base/Actions/ChangeStrategyAction.cpp
+++ b/src/Ai/Base/Actions/ChangeStrategyAction.cpp
@@ -51,9 +51,9 @@ bool ChangeNonCombatStrategyAction::Execute(Event event)
     if (sPlayerbotAIConfig.IsInRandomAccountList(account) && botAI->GetMaster() &&
         !botAI->GetMaster()->CanBeGameMaster())
     {
-        if (text.find("loot") != std::string::npos || text.find("gather") != std::string::npos)
+        if (text.find("loot") != std::string::npos)
         {
-            botAI->TellError("You can change any strategy except loot and gather");
+            botAI->TellError("You can change any strategy except loot");
             return false;
         }
     }

--- a/src/Ai/Base/Actions/ChatShortcutActions.cpp
+++ b/src/Ai/Base/Actions/ChatShortcutActions.cpp
@@ -73,7 +73,7 @@ bool FollowChatShortcutAction::Execute(Event /*event*/)
         else
         {
             WorldLocation loc = formation->GetLocation();
-            if (Formation::IsNullLocation(loc) || loc.GetMapId() == -1)
+            if (Formation::IsNullLocation(loc) || loc.GetMapId() == MAPID_INVALID)
                 return false;
 
             MovementPriority priority = botAI->GetState() == BOT_STATE_COMBAT ? MovementPriority::MOVEMENT_COMBAT : MovementPriority::MOVEMENT_NORMAL;

--- a/src/Ai/Base/Actions/CheckMountStateAction.cpp
+++ b/src/Ai/Base/Actions/CheckMountStateAction.cpp
@@ -296,7 +296,7 @@ bool CheckMountStateAction::TryForms(Player* master, int32 masterMountType, int3
     else if
         ((masterInShapeshiftForm == FORM_TRAVEL && botInShapeshiftForm == FORM_TRAVEL) ||
         ((masterInShapeshiftForm == FORM_FLIGHT || (masterMountType == 1 && masterSpeed == 149)) && botInShapeshiftForm == FORM_FLIGHT) ||
-        ((masterInShapeshiftForm == FORM_FLIGHT_EPIC || (masterMountType == 1 && masterSpeed == 279)) && botInShapeshiftForm == FORM_FLIGHT_EPIC))
+        ((masterInShapeshiftForm == FORM_FLIGHT_EPIC || (masterMountType == 1 && masterSpeed >= 279)) && botInShapeshiftForm == FORM_FLIGHT_EPIC))
         return true;
 
     // Check if master is in Travel Form and bot can do the same
@@ -322,7 +322,7 @@ bool CheckMountStateAction::TryForms(Player* master, int32 masterMountType, int3
     // Check if master is in Swift Flight Form or has an epic flying mount and bot can swift flight form
     if (botAI->CanCastSpell(SPELL_SWIFT_FLIGHT_FORM, bot, true) &&
         ((masterInShapeshiftForm == FORM_FLIGHT_EPIC && botInShapeshiftForm != FORM_FLIGHT_EPIC) ||
-        (masterMountType == 1 && masterSpeed == 279)))
+        (masterMountType == 1 && masterSpeed >= 279)))
     {
         botAI->CastSpell(SPELL_SWIFT_FLIGHT_FORM, bot);
 
@@ -427,18 +427,18 @@ bool CheckMountStateAction::TryPreferredMount(Player* master) const
 
 bool CheckMountStateAction::TryRandomMountFiltered(const std::map<int32, std::vector<uint32>>& spells, int32 masterSpeed) const
 {
-    for (auto const& pair : spells)
+    for (auto it = spells.rbegin(); it != spells.rend(); ++it)
     {
-        int32 currentSpeed = pair.first;
+        int32 currentSpeed = it->first;
 
         if ((masterSpeed > 59 && currentSpeed < 99) || (masterSpeed > 149 && currentSpeed < 279))
             continue;
 
         // Pick a random mount from the candidate group.
-        auto const& ids = pair.second;
+        auto const& ids = it->second;
         if (!ids.empty())
         {
-            // Required here as otherwise bots won't mount in BG's due to them constant moving
+            // Required here as otherwise bots won't mount in BGs due to them constant moving
             if (bot->isMoving())
                 bot->StopMoving();
 
@@ -479,15 +479,17 @@ bool CheckMountStateAction::ShouldFollowMasterMountState(Player* master, bool no
     bool isMasterMounted = master->IsMounted() || (masterInShapeshiftForm == FORM_FLIGHT ||
                                                     masterInShapeshiftForm == FORM_FLIGHT_EPIC ||
                                                     masterInShapeshiftForm == FORM_TRAVEL);
-    return isMasterMounted && !bot->IsMounted() && noAttackers &&
+    bool isBotMountedOrForm = bot->IsMounted() || botInShapeshiftForm == FORM_FLIGHT ||
+                              botInShapeshiftForm == FORM_FLIGHT_EPIC || botInShapeshiftForm == FORM_TRAVEL;
+    return isMasterMounted && !isBotMountedOrForm && noAttackers &&
         shouldMount && !bot->IsInCombat() && botAI->GetState() != BOT_STATE_COMBAT;
 }
 
 bool CheckMountStateAction::ShouldDismountForMaster(Player* master) const
 {
     bool isMasterMounted = master->IsMounted() || (masterInShapeshiftForm == FORM_FLIGHT ||
-                                                    masterInShapeshiftForm == FORM_FLIGHT_EPIC ||
-                                                    masterInShapeshiftForm == FORM_TRAVEL);
+                                                   masterInShapeshiftForm == FORM_FLIGHT_EPIC ||
+                                                   masterInShapeshiftForm == FORM_TRAVEL);
     return !isMasterMounted && bot->IsMounted();
 }
 

--- a/src/Ai/Base/Actions/ChooseRpgTargetAction.cpp
+++ b/src/Ai/Base/Actions/ChooseRpgTargetAction.cpp
@@ -116,9 +116,8 @@ bool ChooseRpgTargetAction::Execute(Event /*event*/)
     GuidPosition masterRpgTarget;
     if (master && master != bot && GET_PLAYERBOT_AI(master) && master->GetMapId() == bot->GetMapId() && !master->IsBeingTeleported())
     {
-        //TODO Implement
-        Player* player = botAI->GetMaster();
-        //GuidPosition masterRpgTarget = PAI_VALUE(GuidPosition, "rpg target"); //not used, line marked for removal.
+        Player* player = master;
+        masterRpgTarget = PAI_VALUE(GuidPosition, "rpg target");
     }
     else
         master = nullptr;
@@ -204,6 +203,7 @@ bool ChooseRpgTargetAction::Execute(Event /*event*/)
 
     SET_AI_VALUE(std::string, "next rpg action", "");
 
+    // Only fires when following a playerbot master.
     for (auto it = begin(targets); it != end(targets);)
     {
         //Remove empty targets.
@@ -336,7 +336,7 @@ bool ChooseRpgTargetAction::isFollowValid(Player* bot, WorldPosition pos)
     if (!botAI->HasActivePlayerMaster() && distance < 50.0f)
     {
         Player* player = groupLeader;
-        if (groupLeader && !groupLeader->isMoving() ||
+        if ((groupLeader && !groupLeader->isMoving()) ||
             PAI_VALUE(WorldPosition, "last long move").distance(pos) < sPlayerbotAIConfig.reactDistance)
             return true;
     }

--- a/src/Ai/Base/Actions/ChooseTravelTargetAction.cpp
+++ b/src/Ai/Base/Actions/ChooseTravelTargetAction.cpp
@@ -469,7 +469,7 @@ bool ChooseTravelTargetAction::SetCurrentTarget(TravelTarget* target, TravelTarg
     return target->isActive();
 }
 
-bool ChooseTravelTargetAction::SetQuestTarget(TravelTarget* target, bool onlyCompleted, bool newQuests, bool activeQuests, bool completedQuests)
+bool ChooseTravelTargetAction::SetQuestTarget(TravelTarget* target, bool /*onlyCompleted*/, bool newQuests, bool activeQuests, bool completedQuests)
 {
     std::vector<TravelDestination*> activeDestinations;
     std::vector<WorldPosition*> activePoints;
@@ -928,7 +928,7 @@ bool ChooseTravelTargetAction::needForQuest(Unit* target)
                     int required = questTemplate->RequiredNpcOrGoCount[j];
                     int available = questStatus.CreatureOrGOCount[j];
 
-                    if (required && available < required && (target->GetEntry() == entry || justCheck))
+                    if (required && available < required && (target->GetEntry() == uint32(entry) || justCheck))
                         return true;
                 }
 

--- a/src/Ai/Base/Actions/FollowActions.cpp
+++ b/src/Ai/Base/Actions/FollowActions.cpp
@@ -218,7 +218,7 @@ bool FollowAction::Execute(Event /*event*/)
     else
     {
         WorldLocation loc = formation->GetLocation();
-        if (Formation::IsNullLocation(loc) || loc.GetMapId() == -1)
+        if (Formation::IsNullLocation(loc) || loc.GetMapId() == MAPID_INVALID)
             return false;
 
         MovementPriority priority = botAI->GetState() == BOT_STATE_COMBAT ? MovementPriority::MOVEMENT_COMBAT : MovementPriority::MOVEMENT_NORMAL;

--- a/src/Ai/Base/Actions/GenericSpellActions.cpp
+++ b/src/Ai/Base/Actions/GenericSpellActions.cpp
@@ -314,8 +314,17 @@ bool GroupBuffSpellAction::isUseful()
 
 bool GroupBuffSpellAction::Execute(Event /*event*/)
 {
-    std::string const castName = ai::buff::UpgradeToGroupIfAppropriate(bot, botAI, spell);
-    return botAI->CastSpell(castName, GetTarget());
+    std::string missingReagentGroupName;
+    std::string const castName = ai::buff::UpgradeToGroupIfAppropriate(
+        bot, botAI, spell, &missingReagentGroupName);
+
+    if (!botAI->CastSpell(castName, GetTarget()))
+        return false;
+
+    if (!missingReagentGroupName.empty())
+        ai::buff::TryAnnounceMissingBuffReagents(botAI, spell, missingReagentGroupName);
+
+    return true;
 }
 
 CastEnchantItemMainHandAction::CastEnchantItemMainHandAction(

--- a/src/Ai/Base/Actions/GenericSpellActions.cpp
+++ b/src/Ai/Base/Actions/GenericSpellActions.cpp
@@ -135,7 +135,7 @@ namespace
 }
 
 CastSpellAction::CastSpellAction(PlayerbotAI* botAI, std::string const spell)
-    : Action(botAI, spell), range(botAI->GetRange("spell")), spell(spell) {}
+    : Action(botAI, spell), spell(spell), range(botAI->GetRange("spell")) {}
 
 bool CastSpellAction::Execute(Event /*event*/)
 {
@@ -271,7 +271,7 @@ bool CastAuraSpellAction::isUseful()
         return false;
 
     Aura* aura = botAI->GetAura(spell, GetTarget(), isOwner, checkDuration);
-    if (!aura || (beforeDuration && aura->GetDuration() < beforeDuration))
+    if (!aura || (beforeDuration && uint32(aura->GetDuration()) < beforeDuration))
         return true;
 
     return false;
@@ -284,7 +284,7 @@ bool CastBuffSpellAction::isUseful()
         return false;
 
     Aura* aura = botAI->GetAura(spell, target, isOwner, checkDuration);
-    return !aura || (beforeDuration && aura->GetDuration() < beforeDuration);
+    return !aura || (beforeDuration && uint32(aura->GetDuration()) < beforeDuration);
 }
 
 bool CastBuffSpellAction::Execute(Event /*event*/)
@@ -306,7 +306,7 @@ bool GroupBuffSpellAction::isUseful()
     }
 
     Aura* aura = botAI->GetAura(spell, target, isOwner, checkDuration);
-    if (!aura || (beforeDuration && aura->GetDuration() < beforeDuration))
+    if (!aura || (beforeDuration && uint32(aura->GetDuration()) < beforeDuration))
         return true;
 
     return false;
@@ -372,7 +372,7 @@ bool CastEnchantItemOffHandAction::isPossible()
 
 CastHealingSpellAction::CastHealingSpellAction(PlayerbotAI* botAI, std::string const spell, uint8 estAmount,
                                                HealingManaEfficiency manaEfficiency, bool isOwner)
-    : CastAuraSpellAction(botAI, spell, isOwner), estAmount(estAmount), manaEfficiency(manaEfficiency)
+    : CastAuraSpellAction(botAI, spell, isOwner), manaEfficiency(manaEfficiency), estAmount(estAmount)
 {
     range = botAI->GetRange("heal");
 }

--- a/src/Ai/Base/Actions/InventoryAction.cpp
+++ b/src/Ai/Base/Actions/InventoryAction.cpp
@@ -400,7 +400,7 @@ ItemIds InventoryAction::FindOutfitItems(std::string const name)
 std::string const InventoryAction::parseOutfitName(std::string const outfit)
 {
     uint32 pos = outfit.find("=");
-    if (pos == -1)
+    if (pos == uint32(-1))
         return "";
 
     return outfit.substr(0, pos);
@@ -414,7 +414,7 @@ ItemIds InventoryAction::parseOutfitItems(std::string const text)
     while (pos < text.size())
     {
         uint32 endPos = text.find(',', pos);
-        if (endPos == -1)
+        if (endPos == uint32(-1))
             endPos = text.size();
 
         std::string const idC = text.substr(pos, endPos - pos);

--- a/src/Ai/Base/Actions/LfgActions.cpp
+++ b/src/Ai/Base/Actions/LfgActions.cpp
@@ -16,7 +16,7 @@
 
 using namespace lfg;
 
-bool LfgJoinAction::Execute(Event event) { return JoinLFG(); }
+bool LfgJoinAction::Execute(Event /*event*/) { return JoinLFG(); }
 
 uint32 LfgJoinAction::GetRoles()
 {
@@ -115,7 +115,7 @@ bool LfgJoinAction::JoinLFG()
         auto const& botLevel = bot->GetLevel();
 
         /*LFG_TYPE_RANDOM on classic is 15-58 so bot over level 25 will never queue*/
-        if (dungeon->MinLevel && (botLevel < dungeon->MinLevel || botLevel > dungeon->MaxLevel) ||
+        if ((dungeon->MinLevel && (botLevel < dungeon->MinLevel || botLevel > dungeon->MaxLevel)) ||
             (botLevel > dungeon->MinLevel + 10 && dungeon->TypeID == LFG_TYPE_DUNGEON))
             continue;
 
@@ -174,7 +174,6 @@ bool LfgRoleCheckAction::Execute(Event /*event*/)
 {
     if (Group* group = bot->GetGroup())
     {
-        uint32 currentRoles = sLFGMgr->GetRoles(bot->GetGUID());
         uint32 newRoles = GetRoles();
         // if (currentRoles == newRoles)
         //     return false;

--- a/src/Ai/Base/Actions/MovementActions.cpp
+++ b/src/Ai/Base/Actions/MovementActions.cpp
@@ -167,7 +167,7 @@ bool MovementAction::MoveToLOS(WorldObject* target, bool ranged)
     return false;
 }
 
-bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool idle, bool react, bool normal_only,
+bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool /*idle*/, bool /*react*/, bool normal_only,
                             bool exact_waypoint, MovementPriority priority, bool lessDelay, bool backwards)
 {
     UpdateMovementState();
@@ -1854,7 +1854,7 @@ bool FleeWithPetAction::Execute(Event /*event*/)
 
 bool AvoidAoeAction::isUseful()
 {
-    if (getMSTime() - moveInterval < lastMoveTimer)
+    if (getMSTime() - moveInterval < uint32(lastMoveTimer))
         return false;
 
     GuidVector traps = AI_VALUE(GuidVector, "nearest trap with damage");
@@ -2285,7 +2285,7 @@ bool MovementAction::CheckLastFlee(float curAngle, std::list<FleeInfo>& infoList
 
 bool CombatFormationMoveAction::isUseful()
 {
-    if (getMSTime() - moveInterval < lastMoveTimer)
+    if (getMSTime() - moveInterval < uint32(lastMoveTimer))
         return false;
 
     if (bot->GetCurrentSpell(CURRENT_CHANNELED_SPELL) != nullptr)

--- a/src/Ai/Base/Actions/MovementActions.h
+++ b/src/Ai/Base/Actions/MovementActions.h
@@ -275,7 +275,7 @@ public:
         this->intervals = intervals;
         this->clockwise = clockwise;
         this->call_counters = 0;
-        for (int i = 0; i < intervals; i++)
+        for (uint32 i = 0; i < intervals; i++)
         {
             float angle = start_angle + 2 * M_PI * i / intervals;
             waypoints.push_back(std::make_pair(center_x + cos(angle) * radius, center_y + sin(angle) * radius));

--- a/src/Ai/Base/Actions/QuestAction.cpp
+++ b/src/Ai/Base/Actions/QuestAction.cpp
@@ -413,7 +413,7 @@ bool QuestItemPushResultAction::Execute(Event event)
                 continue;
 
             int32 previousCount = itemCount - count;
-            if (itemId == itemEntry && previousCount < quest->RequiredItemCount[i])
+            if (itemId == itemEntry && uint32(previousCount) < quest->RequiredItemCount[i])
             {
                 if (botAI->GetMaster())
                 {

--- a/src/Ai/Base/Actions/TaxiAction.cpp
+++ b/src/Ai/Base/Actions/TaxiAction.cpp
@@ -43,6 +43,7 @@ bool TaxiAction::Execute(Event event)
         if (bot->GetDistance(npc) > sPlayerbotAIConfig.farDistance)
             continue;
 
+        bot->GetSession()->SendLearnNewTaxiNode(npc);
         uint32 curloc = sObjectMgr->GetNearestTaxiNode(npc->GetPositionX(), npc->GetPositionY(), npc->GetPositionZ(),
                                                        npc->GetMapId(), bot->GetTeamId());
 

--- a/src/Ai/Base/Actions/TradeAction.cpp
+++ b/src/Ai/Base/Actions/TradeAction.cpp
@@ -69,7 +69,7 @@ bool TradeAction::Execute(Event event)
             continue;
 
         int8 slot = item->CanBeTraded() ? -1 : TRADE_SLOT_NONTRADED;
-        if (TradeItem(item, slot) && slot != TRADE_SLOT_NONTRADED && ++traded >= count)
+        if (TradeItem(item, slot) && slot != TRADE_SLOT_NONTRADED && ++traded >= uint32(count))
             break;
     }
 

--- a/src/Ai/Base/Actions/TravelAction.cpp
+++ b/src/Ai/Base/Actions/TravelAction.cpp
@@ -37,7 +37,7 @@ bool TravelAction::Execute(Event /*event*/)
         if (!newTarget->IsAlive())
             continue;
 
-        if (newTarget->GetEntry() == target->getDestination()->getEntry())
+        if (newTarget->GetEntry() == uint32(target->getDestination()->getEntry()))
             continue;
 
         if (newTarget->IsInCombat())

--- a/src/Ai/Base/Trigger/GenericTriggers.cpp
+++ b/src/Ai/Base/Trigger/GenericTriggers.cpp
@@ -164,7 +164,7 @@ bool BuffTrigger::IsActive()
         return false;
 
     Aura* aura = botAI->GetAura(spell, target, checkIsOwner, checkDuration);
-    if (!aura || (beforeDuration && aura->GetDuration() < beforeDuration))
+    if (!aura || (beforeDuration && uint32(aura->GetDuration()) < beforeDuration))
         return true;
 
     return false;
@@ -418,7 +418,7 @@ bool HealerShouldAttackTrigger::IsActive()
     return true;
 }
 
-bool ItemCountTrigger::IsActive() { return AI_VALUE2(uint32, "item count", item) < count; }
+bool ItemCountTrigger::IsActive() { return AI_VALUE2(uint32, "item count", item) < uint32(count); }
 
 bool InterruptSpellTrigger::IsActive()
 {

--- a/src/Ai/Base/Trigger/RpgTriggers.cpp
+++ b/src/Ai/Base/Trigger/RpgTriggers.cpp
@@ -31,7 +31,7 @@ bool RpgTrigger::IsActive() { return true; }
 
 Event RpgTrigger::Check()
 {
-    if (!NoRpgTargetTrigger::IsActive() && (AI_VALUE(std::string, "next rpg action") == "choose rpg target") ||
+    if ((!NoRpgTargetTrigger::IsActive() && (AI_VALUE(std::string, "next rpg action") == "choose rpg target")) ||
         !FarFromRpgTargetTrigger::IsActive())
         return Trigger::Check();
 

--- a/src/Ai/Base/Util/GenericBuffUtils.cpp
+++ b/src/Ai/Base/Util/GenericBuffUtils.cpp
@@ -205,9 +205,70 @@ namespace ai::buff
         return false;
     }
 
-    std::string UpgradeToGroupIfAppropriate(
-        Player* bot, PlayerbotAI* botAI, std::string const& baseName)
+    void ClearMissingBuffReagentNotice(PlayerbotAI* botAI, std::string const& groupName)
     {
+        if (!botAI || groupName.empty())
+            return;
+
+        botAI->GetAiObjectContext()
+            ->GetValue<MissingBuffReagentNoticeMap&>("missing buff reagent notice")->Get()
+            .erase(groupName);
+    }
+
+    bool TryAnnounceMissingBuffReagents(
+        PlayerbotAI* botAI, std::string const& baseName, std::string const& groupName)
+    {
+        if (!sPlayerbotAIConfig.tellWhenMissingBuffReagents)
+            return false;
+
+        Player* bot = botAI->GetBot();
+        if (bot->InBattleground())
+            return false;
+
+        auto const cooldownMs = sPlayerbotAIConfig.missingBuffReagentMessageCooldown * IN_MILLISECONDS;
+        auto const now = GameTime::GetGameTimeMS().count();
+        auto& noticeTimes = botAI->GetAiObjectContext()
+            ->GetValue<MissingBuffReagentNoticeMap&>("missing buff reagent notice")->Get();
+        auto const noticeIt = noticeTimes.find(groupName);
+
+        if (cooldownMs && noticeIt != noticeTimes.end() &&
+            getMSTimeDiff(noticeIt->second, now) < cooldownMs)
+        {
+            return false;
+        }
+
+        std::map<std::string, std::string> placeholders = {
+            {"%base_spell", baseName},
+            {"%group_spell", groupName}
+        };
+
+        std::string const message = PlayerbotTextMgr::instance().GetBotTextOrDefault(
+            "missing_group_buff_reagent",
+            "I am out of reagents for %group_spell and am casting %base_spell instead.",
+            placeholders);
+
+        Group* group = bot->GetGroup();
+        if (!group)
+            return false;
+
+        const bool announced =
+            group->isRaidGroup() ? botAI->SayToRaid(message) : botAI->SayToParty(message);
+
+        if (announced)
+            noticeTimes[groupName] = now;
+
+        return announced;
+    }
+
+    std::string UpgradeToGroupIfAppropriate(
+        Player* bot,
+        PlayerbotAI* botAI,
+        std::string const& baseName,
+        std::string* outMissingReagentGroupName)
+    {
+        if (outMissingReagentGroupName)
+            outMissingReagentGroupName->clear();
+
         if (!IsGroupVariantEnabled(bot, baseName))
             return baseName;
 
@@ -224,7 +285,13 @@ namespace ai::buff
             ->GetValue<uint32>("spell id", groupName)->Get();
 
         if (groupSpellId && HasRequiredReagents(bot, groupSpellId))
+        {
+            ClearMissingBuffReagentNotice(botAI, groupName);
             return groupName;
+        }
+
+        if (groupSpellId && outMissingReagentGroupName)
+            *outMissingReagentGroupName = groupName;
 
         return baseName;
     }

--- a/src/Ai/Base/Util/GenericBuffUtils.h
+++ b/src/Ai/Base/Util/GenericBuffUtils.h
@@ -7,6 +7,8 @@
 #define PLAYERBOTS_GENERICBUFFUTILS_H
 
 #include <string>
+#include <unordered_map>
+
 #include "Common.h"
 
 class Player;
@@ -15,6 +17,8 @@ class Unit;
 
 namespace ai::buff
 {
+
+typedef std::unordered_map<std::string, uint32> MissingBuffReagentNoticeMap;
 
 bool IsGroupVariantEnabled(Player* bot, std::string const& name);
 
@@ -33,10 +37,16 @@ bool ShouldDeferGreaterBlessingAssignmentForRecentLogin(Player* bot);
 
 bool HasRequiredReagents(Player* bot, uint32 spellId);
 
+void ClearMissingBuffReagentNotice(PlayerbotAI* botAI, std::string const& groupName);
+
+bool TryAnnounceMissingBuffReagents(
+    PlayerbotAI* botAI, std::string const& baseName, std::string const& groupName);
+
 std::string UpgradeToGroupIfAppropriate(
     Player* bot,
     PlayerbotAI* botAI,
-    std::string const& baseName);
+    std::string const& baseName,
+    std::string* outMissingReagentGroupName = nullptr);
 
 }
 

--- a/src/Ai/Base/Value/Arrow.cpp
+++ b/src/Ai/Base/Value/Arrow.cpp
@@ -19,8 +19,8 @@ WorldLocation ArrowFormation::GetLocationInternal()
     uint32 tankLines = 1 + tanks.Size() / 6;
     uint32 meleeLines = 1 + melee.Size() / 6;
     uint32 rangedLines = 1 + ranged.Size() / 6;
-    //TODO Implement Healer Lines
-    uint32 healerLines = 1 + healers.Size() / 6;
+    //@TODO Implement Healer Lines
+    //uint32 healerLines = 1 + healers.Size() / 6;
     float offset = 0.f;
 
     Player* master = botAI->GetMaster();

--- a/src/Ai/Base/Value/Arrow.h
+++ b/src/Ai/Base/Value/Arrow.h
@@ -16,11 +16,6 @@ class UnitPosition
 {
 public:
     UnitPosition(float x, float y) : x(x), y(y) {}
-    UnitPosition(UnitPosition const& other)
-    {
-        x = other.x;
-        y = other.y;
-    }
 
     float x, y;
 };
@@ -102,7 +97,7 @@ class ArrowFormation : public MoveAheadFormation
 {
 public:
     ArrowFormation(PlayerbotAI* botAI)
-        : MoveAheadFormation(botAI, "arrow"), built(false), masterUnit(nullptr), botUnit(nullptr)
+        : MoveAheadFormation(botAI, "arrow"), masterUnit(nullptr), botUnit(nullptr), built(false)
     {
     }
 

--- a/src/Ai/Base/Value/AttackerCountValues.cpp
+++ b/src/Ai/Base/Value/AttackerCountValues.cpp
@@ -22,7 +22,7 @@ bool HasAggroValue::Calculate()
     {
         return true;
     }
-    bool isMT = botAI->IsMainTank(bot);
+    bool isMT = botAI->IsExplicitMainTank(bot);
     if (victim &&
         (victim->GetGUID() == bot->GetGUID() || (!isMT && victim->ToPlayer() && botAI->IsTank(victim->ToPlayer()))))
     {

--- a/src/Ai/Base/Value/BudgetValues.cpp
+++ b/src/Ai/Base/Value/BudgetValues.cpp
@@ -25,7 +25,7 @@ uint32 MaxGearRepairCostValue::Calculate()
 
         uint32 curDurability = item->GetUInt32Value(ITEM_FIELD_DURABILITY);
 
-        if (i >= EQUIPMENT_SLOT_END && curDurability >= maxDurability)  // Only count items equiped or already damanged.
+        if (uint32(i) >= EQUIPMENT_SLOT_END && curDurability >= maxDurability)  // Only count items equiped or already damanged.
             continue;
 
         ItemTemplate const* ditemProto = item->GetTemplate();

--- a/src/Ai/Base/Value/CraftValue.h
+++ b/src/Ai/Base/Value/CraftValue.h
@@ -16,11 +16,6 @@ class CraftData
 {
 public:
     CraftData() : itemId(0) {}
-    CraftData(CraftData const& other) : itemId(other.itemId)
-    {
-        required.insert(other.required.begin(), other.required.end());
-        obtained.insert(other.obtained.begin(), other.obtained.end());
-    }
 
     uint32 itemId;
     std::map<uint32, uint32> required, obtained;

--- a/src/Ai/Base/Value/GrindTargetValue.cpp
+++ b/src/Ai/Base/Value/GrindTargetValue.cpp
@@ -182,7 +182,7 @@ bool GrindTargetValue::needForQuest(Unit* target)
                     int required = questTemplate->RequiredNpcOrGoCount[j];
                     int available = questStatus->CreatureOrGOCount[j];
 
-                    if (required && available < required && target->GetEntry() == entry)
+                    if (required && available < required && target->GetEntry() == uint32(entry))
                         return true;
                 }
             }

--- a/src/Ai/Base/Value/ItemUsageValue.cpp
+++ b/src/Ai/Base/Value/ItemUsageValue.cpp
@@ -708,7 +708,7 @@ bool ItemUsageValue::HasItemsNeededForSpell(uint32 spellId, ItemTemplate const* 
     for (uint8 i = 0; i < MAX_SPELL_REAGENTS; i++)
         if (spellInfo->ReagentCount[i] > 0 && spellInfo->Reagent[i])
         {
-            if (proto && proto->ItemId == spellInfo->Reagent[i] &&
+            if (proto && proto->ItemId == uint32(spellInfo->Reagent[i]) &&
                 spellInfo->ReagentCount[i] == 1)  // If we only need 1 item then current item does not need to be
                                                   // checked since we are looting/buying or already have it.
                 continue;
@@ -807,7 +807,7 @@ std::vector<uint32> ItemUsageValue::SpellsUsingItem(uint32 itemId, Player* bot)
             continue;
 
         for (uint8 i = 0; i < MAX_SPELL_REAGENTS; i++)
-            if (spellInfo->ReagentCount[i] > 0 && spellInfo->Reagent[i] == itemId)
+            if (spellInfo->ReagentCount[i] > 0 && uint32(spellInfo->Reagent[i]) == itemId)
                 retSpells.push_back(spellId);
     }
 

--- a/src/Ai/Base/Value/ItemUsageValue.cpp
+++ b/src/Ai/Base/Value/ItemUsageValue.cpp
@@ -232,10 +232,10 @@ ItemUsage ItemUsageValue::QueryItemUsageForEquip(ItemTemplate const* itemProto, 
     if (itemScore)
         shouldEquip = true;
 
-    if (itemProto->Class == ITEM_CLASS_WEAPON && !sRandomItemMgr.CanEquipWeapon(bot->getClass(), itemProto))
+    if (itemProto->Class == ITEM_CLASS_WEAPON && !sRandomItemMgr.CanEquipWeapon(itemProto, bot->getClass()))
         shouldEquip = false;
     if (itemProto->Class == ITEM_CLASS_ARMOR &&
-        !sRandomItemMgr.CanEquipArmor(bot->getClass(), bot->GetLevel(), itemProto))
+        !sRandomItemMgr.CanEquipArmor(itemProto, bot->getClass(), bot->GetLevel()))
         shouldEquip = false;
 
     uint8 possibleSlots = 1;
@@ -317,11 +317,11 @@ ItemUsage ItemUsageValue::QueryItemUsageForEquip(ItemTemplate const* itemProto, 
         }
 
         bool existingShouldEquip = true;
-        if (oldItemProto->Class == ITEM_CLASS_WEAPON && !sRandomItemMgr.CanEquipWeapon(bot->getClass(), oldItemProto))
+        if (oldItemProto->Class == ITEM_CLASS_WEAPON && !sRandomItemMgr.CanEquipWeapon(oldItemProto, bot->getClass()))
             existingShouldEquip = false;
 
         if (oldItemProto->Class == ITEM_CLASS_ARMOR &&
-            !sRandomItemMgr.CanEquipArmor(bot->getClass(), bot->GetLevel(), oldItemProto))
+            !sRandomItemMgr.CanEquipArmor(oldItemProto, bot->getClass(), bot->GetLevel()))
             existingShouldEquip = false;
 
         // uint32 oldItemPower = sRandomItemMgr.GetLiveStatWeight(bot, oldItemProto->ItemId);

--- a/src/Ai/Base/Value/LastMovementValue.cpp
+++ b/src/Ai/Base/Value/LastMovementValue.cpp
@@ -14,11 +14,11 @@ LastMovement::LastMovement(LastMovement& other)
       taxiMaster(other.taxiMaster),
       lastFollow(other.lastFollow),
       lastAreaTrigger(other.lastAreaTrigger),
+      lastFlee(other.lastFlee),
       lastMoveToX(other.lastMoveToX),
       lastMoveToY(other.lastMoveToY),
       lastMoveToZ(other.lastMoveToZ),
-      lastMoveToOri(other.lastMoveToOri),
-      lastFlee(other.lastFlee)
+      lastMoveToOri(other.lastMoveToOri)
 {
     lastMoveShort = other.lastMoveShort;
     nextTeleport = other.nextTeleport;

--- a/src/Ai/Base/Value/NearestCorpsesValue.cpp
+++ b/src/Ai/Base/Value/NearestCorpsesValue.cpp
@@ -12,13 +12,12 @@
 class AnyDeadUnitInObjectRangeCheck
 {
 public:
-    AnyDeadUnitInObjectRangeCheck(WorldObject const* obj, float range) : i_obj(obj), i_range(range) {}
+    AnyDeadUnitInObjectRangeCheck(WorldObject const* obj, float /*range*/) : i_obj(obj) {}
     WorldObject const& GetFocusObject() const { return *i_obj; }
     bool operator()(Unit* u) { return !u->IsAlive(); }
 
 private:
     WorldObject const* i_obj;
-    float i_range;
 };
 
 void NearestCorpsesValue::FindUnits(std::list<Unit*>& targets)

--- a/src/Ai/Base/Value/PartyMemberToDispel.cpp
+++ b/src/Ai/Base/Value/PartyMemberToDispel.cpp
@@ -10,7 +10,7 @@ class PartyMemberToDispelPredicate : public FindPlayerPredicate, public Playerbo
 {
 public:
     PartyMemberToDispelPredicate(PlayerbotAI* botAI, uint32 dispelType)
-        : PlayerbotAIAware(botAI), FindPlayerPredicate(), dispelType(dispelType)
+        : FindPlayerPredicate(), PlayerbotAIAware(botAI), dispelType(dispelType)
     {
     }
 

--- a/src/Ai/Base/Value/PartyMemberWithoutAuraValue.cpp
+++ b/src/Ai/Base/Value/PartyMemberWithoutAuraValue.cpp
@@ -13,7 +13,7 @@ class PlayerWithoutAuraPredicate : public FindPlayerPredicate, public PlayerbotA
 {
 public:
     PlayerWithoutAuraPredicate(PlayerbotAI* botAI, std::string const aura)
-        : PlayerbotAIAware(botAI), FindPlayerPredicate(), auras(split(aura, ','))
+        : FindPlayerPredicate(), PlayerbotAIAware(botAI), auras(split(aura, ','))
     {
     }
 

--- a/src/Ai/Base/Value/PartyMemberWithoutItemValue.cpp
+++ b/src/Ai/Base/Value/PartyMemberWithoutItemValue.cpp
@@ -11,7 +11,7 @@ class PlayerWithoutItemPredicate : public FindPlayerPredicate, public PlayerbotA
 {
 public:
     PlayerWithoutItemPredicate(PlayerbotAI* botAI, std::string const item)
-        : PlayerbotAIAware(botAI), FindPlayerPredicate(), item(item)
+        : FindPlayerPredicate(), PlayerbotAIAware(botAI), item(item)
     {
     }
 

--- a/src/Ai/Base/Value/PositionValue.h
+++ b/src/Ai/Base/Value/PositionValue.h
@@ -20,10 +20,6 @@ public:
         : x(x), y(y), z(z), mapId(mapId), valueSet(valueSet)
     {
     }
-    PositionInfo(PositionInfo const& other)
-        : x(other.x), y(other.y), z(other.z), mapId(other.mapId), valueSet(other.valueSet)
-    {
-    }
 
     void Set(float newX, float newY, float newZ, uint32 newMapId)
     {

--- a/src/Ai/Base/Value/PossibleRpgTargetsValue.cpp
+++ b/src/Ai/Base/Value/PossibleRpgTargetsValue.cpp
@@ -75,7 +75,7 @@ bool PossibleRpgTargetsValue::AcceptUnit(Unit* unit)
 
     TravelTarget* travelTarget = context->GetValue<TravelTarget*>("travel target")->Get();
     if (travelTarget && travelTarget->getDestination() &&
-        travelTarget->getDestination()->getEntry() == unit->GetEntry())
+        static_cast<uint32>(travelTarget->getDestination()->getEntry()) == unit->GetEntry())
         return true;
 
     if (urand(1, 100) < 25 && unit->IsFriendlyTo(bot))

--- a/src/Ai/Base/Value/PvpValues.cpp
+++ b/src/Ai/Base/Value/PvpValues.cpp
@@ -24,11 +24,11 @@ Unit* FlagCarrierValue::Calculate()
             if (!bg)
                 return nullptr;
 
-            if ((!sameTeam && bot->GetTeamId() == TEAM_HORDE || (sameTeam && bot->GetTeamId() == TEAM_ALLIANCE)) &&
+            if (((!sameTeam && bot->GetTeamId() == TEAM_HORDE) || (sameTeam && bot->GetTeamId() == TEAM_ALLIANCE)) &&
                 !bg->GetFlagPickerGUID(TEAM_HORDE).IsEmpty())
                 carrier = ObjectAccessor::GetPlayer(bg->GetBgMap(), bg->GetFlagPickerGUID(TEAM_HORDE));
 
-            if ((!sameTeam && bot->GetTeamId() == TEAM_ALLIANCE || (sameTeam && bot->GetTeamId() == TEAM_HORDE)) &&
+            if (((!sameTeam && bot->GetTeamId() == TEAM_ALLIANCE) || (sameTeam && bot->GetTeamId() == TEAM_HORDE)) &&
                 !bg->GetFlagPickerGUID(TEAM_ALLIANCE).IsEmpty())
                 carrier = ObjectAccessor::GetPlayer(bg->GetBgMap(), bg->GetFlagPickerGUID(TEAM_ALLIANCE));
 

--- a/src/Ai/Base/Value/SpellIdValue.cpp
+++ b/src/Ai/Base/Value/SpellIdValue.cpp
@@ -30,7 +30,7 @@ uint32 SpellIdValue::Calculate()
 
     wstrToLower(wnamepart);
     char firstSymbol = tolower(namepart[0]);
-    int spellLength = wnamepart.length();
+    size_t spellLength = wnamepart.length();
 
     LocaleConstant loc = LOCALE_enUS;
 
@@ -133,13 +133,13 @@ uint32 SpellIdValue::Calculate()
                 continue;
             }
 
-            if (!highestRank || id > highestRank)
+            if (!highestRank || (uint32)id > highestRank)
             {
                 highestRank = id;
                 highestSpellId = spellId;
             }
 
-            if (!lowestRank || (lowestRank && id < lowestRank))
+            if (!lowestRank || (lowestRank && (uint32)id < lowestRank))
             {
                 lowestRank = id;
                 lowestSpellId = spellId;
@@ -153,7 +153,7 @@ uint32 SpellIdValue::Calculate()
             auto spellId = *it;
             if (!highestSpellId)
                 highestSpellId = spellId;
-            if (saveMana == rank)
+            if (saveMana == (int32)rank)
                 return spellId;
             lowestSpellId = spellId;
             rank++;
@@ -192,7 +192,7 @@ uint32 VehicleSpellIdValue::Calculate()
 
     wstrToLower(wnamepart);
     char firstSymbol = tolower(namepart[0]);
-    int spellLength = wnamepart.length();
+    size_t spellLength = wnamepart.length();
 
     const int loc = LocaleConstant::LOCALE_enUS;
 

--- a/src/Ai/Base/Value/TankTargetValue.cpp
+++ b/src/Ai/Base/Value/TankTargetValue.cpp
@@ -9,6 +9,7 @@
 #include "AttackersValue.h"
 #include "Group.h"
 #include "PlayerbotAI.h"
+#include "Playerbots.h"
 
 class FindTargetForTankStrategy : public FindNonCcTargetStrategy
 {
@@ -66,9 +67,9 @@ public:
     bool IsBetter(Unit* new_unit, Unit* old_unit)
     {
         Player* bot = botAI->GetBot();
-        // if group has multiple tanks, main tank just focus on the current target
+        // if group has multiple tanks, explicit main tank just focus on the current target
         Unit* currentTarget = botAI->GetAiObjectContext()->GetValue<Unit*>("current target")->Get();
-        if (currentTarget && botAI->IsMainTank(bot) && botAI->GetGroupTankNum(bot) > 1)
+        if (currentTarget && botAI->IsExplicitMainTank(bot) && botAI->GetGroupTankNum(bot) > 1)
         {
             if (old_unit == currentTarget)
                 return false;
@@ -104,6 +105,27 @@ public:
 
 Unit* TankTargetValue::Calculate()
 {
+    std::string const rti = botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Get();
+    Unit* rtiTarget = RtiTargetValue::Calculate();
+    if (rtiTarget)
+    {
+        Unit* victim = rtiTarget->GetVictim();
+
+        if (victim && victim != bot)
+        {
+            if (Player* victimPlayer = victim->ToPlayer())
+            {
+                // rti target is attacking a non-tank player
+                if (!PlayerbotAI::IsTank(victimPlayer))
+                    return rtiTarget;
+                // rti target is attacking a tank player, check if the tank is a bot and has the same rti setting
+                PlayerbotAI* victimBotAI = GET_PLAYERBOT_AI(victimPlayer);
+                if (!victimBotAI || victimBotAI->GetAiObjectContext()->GetValue<std::string>("rti")->Get() != rti)
+                    return rtiTarget;
+            }
+        }
+    }
+
     // FindTargetForTankStrategy strategy(botAI);
     FindTankTargetSmartStrategy strategy(botAI);
     return FindTarget(&strategy);

--- a/src/Ai/Base/Value/TankTargetValue.h
+++ b/src/Ai/Base/Value/TankTargetValue.h
@@ -6,14 +6,14 @@
 #ifndef PLAYERBOTS_TANKTARGETVALUE_H
 #define PLAYERBOTS_TANKTARGETVALUE_H
 
-#include "TargetValue.h"
+#include "RtiTargetValue.h"
 
 class PlayerbotAI;
 
-class TankTargetValue : public TargetValue
+class TankTargetValue : public RtiTargetValue
 {
 public:
-    TankTargetValue(PlayerbotAI* botAI, std::string const name = "tank target") : TargetValue(botAI, name) {}
+    TankTargetValue(PlayerbotAI* botAI, std::string const name = "tank target") : RtiTargetValue(botAI, "rti", name) {}
 
     Unit* Calculate() override;
 };

--- a/src/Ai/Base/ValueContext.h
+++ b/src/Ai/Base/ValueContext.h
@@ -192,6 +192,7 @@ public:
         creators["spell id"] = &ValueContext::spell_id;
         creators["vehicle spell id"] = &ValueContext::vehicle_spell_id;
         creators["item for spell"] = &ValueContext::item_for_spell;
+        creators["missing buff reagent notice"] = &ValueContext::missing_buff_reagent_notice;
         creators["spell cast useful"] = &ValueContext::spell_cast_useful;
         creators["last spell cast"] = &ValueContext::last_spell_cast;
         creators["last spell cast time"] = &ValueContext::last_spell_cast_time;
@@ -363,7 +364,7 @@ private:
     static UntypedValue* attackers(PlayerbotAI* botAI) { return new AttackersValue(botAI); }
 
     static UntypedValue* position(PlayerbotAI* botAI) { return new PositionValue(botAI); }
-    static UntypedValue* pos(PlayerbotAI* ai) { return new SinglePositionValue(ai); }
+    static UntypedValue* pos(PlayerbotAI* botAI) { return new SinglePositionValue(botAI); }
     static UntypedValue* current_position(PlayerbotAI* botAI) { return new CurrentPositionValue(botAI); }
     static UntypedValue* rti(PlayerbotAI* botAI) { return new RtiValue(botAI); }
     static UntypedValue* rti_cc(PlayerbotAI* botAI) { return new RtiCcValue(botAI); }
@@ -375,6 +376,7 @@ private:
     static UntypedValue* last_spell_cast_time(PlayerbotAI* botAI) { return new LastSpellCastTimeValue(botAI); }
     static UntypedValue* spell_cast_useful(PlayerbotAI* botAI) { return new SpellCastUsefulValue(botAI); }
     static UntypedValue* item_for_spell(PlayerbotAI* botAI) { return new ItemForSpellValue(botAI); }
+    static UntypedValue* missing_buff_reagent_notice(PlayerbotAI* botAI) { return new MissingBuffReagentNoticeValue(botAI); }
     static UntypedValue* spell_id(PlayerbotAI* botAI) { return new SpellIdValue(botAI); }
     static UntypedValue* vehicle_spell_id(PlayerbotAI* botAI) { return new VehicleSpellIdValue(botAI); }
     static UntypedValue* inventory_item(PlayerbotAI* botAI) { return new InventoryItemValue(botAI); }
@@ -567,31 +569,28 @@ private:
 
     static UntypedValue* has_area_debuff(PlayerbotAI* botAI) { return new HasAreaDebuffValue(botAI); }
 
-    static UntypedValue* main_tank(PlayerbotAI* ai) { return new PartyMemberMainTankValue(ai); }
-    static UntypedValue* find_target(PlayerbotAI* ai) { return new FindTargetValue(ai); }
-    static UntypedValue* boss_target(PlayerbotAI* ai) { return new BossTargetValue(ai); }
-    static UntypedValue* nearest_triggers(PlayerbotAI* ai) { return new NearestTriggersValue(ai); }
-    static UntypedValue* neglect_threat(PlayerbotAI* ai) { return new NeglectThreatResetValue(ai); }
-    static UntypedValue* expected_lifetime(PlayerbotAI* ai) { return new EstimatedLifetimeValue(ai); }
-    static UntypedValue* expected_group_dps(PlayerbotAI* ai) { return new EstimatedGroupDpsValue(ai); }
-    static UntypedValue* area_debuff(PlayerbotAI* ai) { return new AreaDebuffValue(ai); }
-    static UntypedValue* nearest_trap_with_damange(PlayerbotAI* ai) { return new NearestTrapWithDamageValue(ai); }
-    static UntypedValue* disperse_distance(PlayerbotAI* ai) { return new DisperseDistanceValue(ai); }
-    static UntypedValue* last_flee_angle(PlayerbotAI* ai) { return new LastFleeAngleValue(ai); }
-    static UntypedValue* last_flee_timestamp(PlayerbotAI* ai) { return new LastFleeTimestampValue(ai); }
-    static UntypedValue* recently_flee_info(PlayerbotAI* ai) { return new RecentlyFleeInfo(ai); }
-    static UntypedValue* can_fish(PlayerbotAI* ai) { return new CanFishValue(ai); }
-    static UntypedValue* can_use_fishing_bobber(PlayerbotAI* ai) { return new CanUseFishingBobberValue(ai); }
-    static UntypedValue* fishing_spot(PlayerbotAI* ai) { return new FishingSpotValue(ai); }
-    // -------------------------------------------------------
-    // Flag for cutom glyphs : true when /w bot glyph equip
-    // -------------------------------------------------------
-    static UntypedValue* custom_glyphs(PlayerbotAI* ai)
+    static UntypedValue* main_tank(PlayerbotAI* botAI) { return new PartyMemberMainTankValue(botAI); }
+    static UntypedValue* find_target(PlayerbotAI* botAI) { return new FindTargetValue(botAI); }
+    static UntypedValue* boss_target(PlayerbotAI* botAI) { return new BossTargetValue(botAI); }
+    static UntypedValue* nearest_triggers(PlayerbotAI* botAI) { return new NearestTriggersValue(botAI); }
+    static UntypedValue* neglect_threat(PlayerbotAI* botAI) { return new NeglectThreatResetValue(botAI); }
+    static UntypedValue* expected_lifetime(PlayerbotAI* botAI) { return new EstimatedLifetimeValue(botAI); }
+    static UntypedValue* expected_group_dps(PlayerbotAI* botAI) { return new EstimatedGroupDpsValue(botAI); }
+    static UntypedValue* area_debuff(PlayerbotAI* botAI) { return new AreaDebuffValue(botAI); }
+    static UntypedValue* nearest_trap_with_damange(PlayerbotAI* botAI) { return new NearestTrapWithDamageValue(botAI); }
+    static UntypedValue* disperse_distance(PlayerbotAI* botAI) { return new DisperseDistanceValue(botAI); }
+    static UntypedValue* last_flee_angle(PlayerbotAI* botAI) { return new LastFleeAngleValue(botAI); }
+    static UntypedValue* last_flee_timestamp(PlayerbotAI* botAI) { return new LastFleeTimestampValue(botAI); }
+    static UntypedValue* recently_flee_info(PlayerbotAI* botAI) { return new RecentlyFleeInfo(botAI); }
+    static UntypedValue* can_fish(PlayerbotAI* botAI) { return new CanFishValue(botAI); }
+    static UntypedValue* can_use_fishing_bobber(PlayerbotAI* botAI) { return new CanUseFishingBobberValue(botAI); }
+    static UntypedValue* fishing_spot(PlayerbotAI* botAI) { return new FishingSpotValue(botAI); }
+    static UntypedValue* custom_glyphs(PlayerbotAI* botAI)
     {
-        return new ManualSetValue<bool>(ai, false, "custom_glyphs");
+        return new ManualSetValue<bool>(botAI, false, "custom_glyphs");
     }
-    static UntypedValue* wait_for_attack_time(PlayerbotAI* ai) { return new WaitForAttackTimeValue(ai); }
-    static UntypedValue* combat_start_time(PlayerbotAI* ai) { return new CombatStartTimeValue(ai); }
+    static UntypedValue* wait_for_attack_time(PlayerbotAI* botAI) { return new WaitForAttackTimeValue(botAI); }
+    static UntypedValue* combat_start_time(PlayerbotAI* botAI) { return new CombatStartTimeValue(botAI); }
 };
 
 #endif

--- a/src/Ai/Class/Paladin/Actions/PaladinActions.cpp
+++ b/src/Ai/Class/Paladin/Actions/PaladinActions.cpp
@@ -351,10 +351,6 @@ bool CastBlessingOfSanctuaryOnPartyAction::Execute(Event /*event*/)
 
     Player* targetPlayer = target ? target->ToPlayer() : nullptr;
 
-    const auto HasKingsAura = [&](Unit* unit) -> bool {
-        return botAI->HasAura("blessing of kings", unit) ||
-               botAI->HasAura("greater blessing of kings", unit);
-    };
     const auto HasSanctAura = [&](Unit* unit) -> bool {
         return botAI->HasAura("blessing of sanctuary", unit) ||
                botAI->HasAura("greater blessing of sanctuary", unit);

--- a/src/Ai/Class/Paladin/Actions/PaladinGreaterBlessingAction.cpp
+++ b/src/Ai/Class/Paladin/Actions/PaladinGreaterBlessingAction.cpp
@@ -1057,7 +1057,11 @@ static bool FindPendingAssignmentFromAssignments(
         if (IsGreaterVariant(castType))
         {
             uint32 spellId = aiContext->GetValue<uint32>("spell id", spellName)->Get();
-            if (!spellId || !ai::buff::HasRequiredReagents(bot, spellId))
+            if (spellId && ai::buff::HasRequiredReagents(bot, spellId))
+            {
+                ai::buff::ClearMissingBuffReagentNotice(botAI, spellName);
+            }
+            else
             {
                 castType = ToSingleVariant(castType);
                 spellName = BlessingSpellName(castType);
@@ -1145,10 +1149,29 @@ bool CastGreaterBlessingAssignmentAction::Execute(Event /*event*/)
     if (!FindPendingAssignment(assignment, spellName))
         return false;
 
+    AiObjectContext* aiContext = botAI->GetAiObjectContext();
+    if (!aiContext)
+        return false;
+
+    std::string missingReagentGroupName;
+    if (ai::gbless::IsGreaterVariant(assignment.blessing))
+    {
+        std::string const assignedSpellName = ai::gbless::BlessingSpellName(assignment.blessing);
+        uint32 const assignedSpellId = aiContext->GetValue<uint32>("spell id", assignedSpellName)->Get();
+        if (assignedSpellId && spellName != assignedSpellName && !ai::buff::HasRequiredReagents(bot, assignedSpellId))
+            missingReagentGroupName = assignedSpellName;
+    }
+
     if (!botAI->HasSpell(spellName))
         return false;
 
-    return botAI->CastSpell(spellName, assignment.player);
+    if (!botAI->CastSpell(spellName, assignment.player))
+        return false;
+
+    if (!missingReagentGroupName.empty())
+        ai::buff::TryAnnounceMissingBuffReagents(botAI, spellName, missingReagentGroupName);
+
+    return true;
 }
 
 bool CastGreaterBlessingAssignmentAction::FindPendingAssignment(

--- a/src/Ai/Dungeon/AC/ACMultipliers.cpp
+++ b/src/Ai/Dungeon/AC/ACMultipliers.cpp
@@ -15,8 +15,8 @@ float ShirrakFleeFocusFireMultiplier::GetValue(Action* action)
     if (!AI_VALUE2(Unit*, "find target", "shirrak the dead watcher"))
         return 1.0f;
 
-        std::list<Creature*> creatureList;
-            bot->GetCreatureListWithEntryInGrid(creatureList, static_cast<uint32>(AuchenaiCryptsIDs::NPC_FOCUS_FIRE), 20.0f);
+    std::list<Creature*> creatureList;
+    bot->GetCreatureListWithEntryInGrid(creatureList, static_cast<uint32>(AuchenaiCryptsIDs::NPC_FOCUS_FIRE), 20.0f);
 
     for (Creature* flare : creatureList)
     {

--- a/src/Ai/Dungeon/AC/ACTriggers.cpp
+++ b/src/Ai/Dungeon/AC/ACTriggers.cpp
@@ -16,8 +16,8 @@ bool ShirrakFleeFocusFireTrigger::IsActive()
     if (!AI_VALUE2(Unit*, "find target", "shirrak the dead watcher"))
         return false;
 
-        std::list<Creature*> creatureList;
-        bot->GetCreatureListWithEntryInGrid(creatureList, static_cast<uint32>(AuchenaiCryptsIDs::NPC_FOCUS_FIRE), 20.0f);
+    std::list<Creature*> creatureList;
+    bot->GetCreatureListWithEntryInGrid(creatureList, static_cast<uint32>(AuchenaiCryptsIDs::NPC_FOCUS_FIRE), 20.0f);
 
     for (Creature* flare : creatureList)
     {

--- a/src/Ai/Dungeon/OC/OCMultipliers.cpp
+++ b/src/Ai/Dungeon/OC/OCMultipliers.cpp
@@ -93,7 +93,7 @@ float EregosMultiplier::GetValue(Action* action)
     Unit* boss = AI_VALUE2(Unit*, "find target", "ley-guardian eregos");
     if (!boss) { return 1.0f; }
 
-    if (boss->HasAura(SPELL_PLANAR_SHIFT && dynamic_cast<OccDrakeAttackAction*>(action)))
+    if (boss->HasAura(SPELL_PLANAR_SHIFT) && dynamic_cast<OccDrakeAttackAction*>(action))
         return 0.0f;
 
     return 1.0f;

--- a/src/Ai/Dungeon/PoS/PoSActions.cpp
+++ b/src/Ai/Dungeon/PoS/PoSActions.cpp
@@ -24,7 +24,7 @@ bool IckAndKrickAction::Execute(Event /*event*/)
 
     bool pursuit = bot->HasAura(SPELL_PURSUIT) || (!botAI->IsTank(bot) && boss->HasUnitState(UNIT_STATE_CASTING) && boss->FindCurrentSpellBySpellId(SPELL_PURSUIT));
     bool poisonNova = boss->HasUnitState(UNIT_STATE_CASTING) && (boss->FindCurrentSpellBySpellId(SPELL_POISON_NOVA_POS) || boss->FindCurrentSpellBySpellId(SPELL_POISON_NOVA_POS_HC));
-    bool explosiveBarrage = orb || boss->HasUnitState(UNIT_STATE_CASTING) && (boss->FindCurrentSpellBySpellId(SPELL_EXPLOSIVE_BARRAGE_ICK) || boss->FindCurrentSpellBySpellId(SPELL_EXPLOSIVE_BARRAGE_KRICK));
+    bool explosiveBarrage = orb || (boss->HasUnitState(UNIT_STATE_CASTING) && (boss->FindCurrentSpellBySpellId(SPELL_EXPLOSIVE_BARRAGE_ICK) || boss->FindCurrentSpellBySpellId(SPELL_EXPLOSIVE_BARRAGE_KRICK)));
     bool isTank = botAI->IsTank(bot);
 
     if (pursuit && Pursuit(pursuit, boss))

--- a/src/Ai/Raid/BT/BTActions.cpp
+++ b/src/Ai/Raid/BT/BTActions.cpp
@@ -873,7 +873,7 @@ bool GurtoggBloodboilRotateRangedGroupsAction::Execute(Event /*event*/)
     int activeGroup = GetGurtoggActiveRotationGroup(gurtogg);
 
     bool inActiveGroup = false;
-    if (activeGroup >= 0 && activeGroup < groups.size())
+    if (activeGroup >= 0 && (size_t)activeGroup < groups.size())
     {
         auto const& group = groups[activeGroup];
         inActiveGroup = std::find(group.begin(), group.end(), bot) != group.end();
@@ -2105,7 +2105,7 @@ bool IllidanStormrageIsolateBotWithParasiteAction::Execute(Event /*event*/)
 }
 
 bool IllidanStormrageIsolateBotWithParasiteAction::InfectedBotMoveFromGroup(
-    Unit* illidan, const Position& target)
+    Unit*, const Position& target)
 {
     if (bot->GetExactDist2d(target) < 1.0f)
         return false;
@@ -2116,7 +2116,7 @@ bool IllidanStormrageIsolateBotWithParasiteAction::InfectedBotMoveFromGroup(
 }
 
 bool IllidanStormrageIsolateBotWithParasiteAction::FreezeTrapShadowfiend(
-    Player* bot, Unit* illidan, const Position& target)
+    Player* bot, Unit*, const Position& target)
 {
     if (bot->HasSpellCooldown(static_cast<uint32>(BlackTempleSpells::SPELL_FROST_TRAP)))
         return false;
@@ -2266,7 +2266,7 @@ bool IllidanStormrageAssistTanksHandleFlamesOfAzzinothAction::Execute(Event /*ev
 }
 
 bool IllidanStormrageAssistTanksHandleFlamesOfAzzinothAction::RepositionToAvoidEyeBlast(
-    Unit* illidan, const EyeBlastDangerArea& dangerArea)
+    Unit*, const EyeBlastDangerArea& dangerArea)
 {
     if (!IsPositionInEyeBlastDangerArea(bot->GetPosition(), dangerArea))
         return false;
@@ -2379,7 +2379,7 @@ bool IllidanStormrageAssistTanksHandleFlamesOfAzzinothAction::RepositionToAvoidB
             const float moveX = bot->GetPositionX() + (dX / distToNewPosition) * moveDist;
             const float moveY = bot->GetPositionY() + (dY / distToNewPosition) * moveDist;
 
-            return MoveTo(BLACK_TEMPLE_MAP_ID, newTarget.GetPositionX(), newTarget.GetPositionY(),
+            return MoveTo(BLACK_TEMPLE_MAP_ID, moveX, moveY,
                           bot->GetPositionZ(), false, false, false, false,
                           MovementPriority::MOVEMENT_COMBAT, true, true);
         }
@@ -2392,7 +2392,7 @@ bool IllidanStormrageAssistTanksHandleFlamesOfAzzinothAction::RepositionToAvoidB
         const float moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
         const float moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
 
-        return MoveTo(BLACK_TEMPLE_MAP_ID, target.GetPositionX(), target.GetPositionY(),
+        return MoveTo(BLACK_TEMPLE_MAP_ID, moveX, moveY,
                       bot->GetPositionZ(), false, false, false, false,
                       MovementPriority::MOVEMENT_COMBAT, true, true);
     }

--- a/src/Ai/Raid/BT/BTHelpers.cpp
+++ b/src/Ai/Raid/BT/BTHelpers.cpp
@@ -16,7 +16,7 @@ namespace BlackTempleHelpers
     // Supremus
     std::unordered_map<uint32, time_t> supremusPhaseTimer;
 
-    bool HasSupremusVolcanoNearby(PlayerbotAI* botAI, Player* bot)
+    bool HasSupremusVolcanoNearby(PlayerbotAI*, Player* bot)
     {
         constexpr float searchRadius = 20.0f;
         std::list<Creature*> creatureList;
@@ -446,7 +446,7 @@ namespace BlackTempleHelpers
         return distToLine < area.width;
     }
 
-    GameObject* FindNearestTrap(PlayerbotAI* botAI, Player* bot)
+    GameObject* FindNearestTrap(PlayerbotAI* botAI, Player*)
     {
         GuidVector const& gos =
             botAI->GetAiObjectContext()->GetValue<GuidVector>("nearest game objects")->Get();

--- a/src/Ai/Raid/ICC/Action/ICCActions_BPC.cpp
+++ b/src/Ai/Raid/ICC/Action/ICCActions_BPC.cpp
@@ -315,7 +315,6 @@ bool IccBpcEmpoweredVortexAction::MaintainRangedSpacing()
     static float const IDEAL_RADIUS = 25.0f;
     static float const RADIUS_TOLERANCE = 3.0f;
     static float const MOVE_INCREMENT = 3.0f;
-    static float const MIN_SPACING = 13.0f;
 
     bool const isRanged = botAI->IsRanged(bot) || botAI->IsHeal(bot);
     if (!isRanged)

--- a/src/Ai/Raid/ICC/Action/ICCActions_BQL.cpp
+++ b/src/Ai/Raid/ICC/Action/ICCActions_BQL.cpp
@@ -96,7 +96,7 @@ bool IccBqlGroupPositionAction::HandleShadowsMovement()
     constexpr int MAX_SHADOW_NPCS = 100;
     Unit* shadows[MAX_SHADOW_NPCS]{};  // Reasonable max estimate
     int shadowCount = 0;
-    for (int i = 0; i < npcs.size() && shadowCount < MAX_SHADOW_NPCS; i++)
+    for (uint32 i = 0; i < npcs.size() && shadowCount < MAX_SHADOW_NPCS; i++)
     {
         Unit* unit = botAI->GetUnit(npcs[i]);
         if (unit && unit->IsAlive() && unit->GetEntry() == NPC_SWARMING_SHADOWS)
@@ -671,8 +671,6 @@ bool IccBqlGroupPositionAction::HandleGroupPosition(Unit* boss, Aura* frenzyAura
             {34.0f, 336.0f * D2R}, {34.0f, 348.0f * D2R},
         };
         int const totalSlots = sizeof(allSlots) / sizeof(allSlots[0]);
-        int const OUTER_RING_START = 8 + 15 + 20;  // first index of outer ring
-        int const MID_RING_START = 8 + 15;
 
         float const cx = ICC_BQL_CENTER_POSITION.GetPositionX();
         float const cy = ICC_BQL_CENTER_POSITION.GetPositionY();

--- a/src/Ai/Raid/ICC/Action/ICCActions_LK.cpp
+++ b/src/Ai/Raid/ICC/Action/ICCActions_LK.cpp
@@ -65,11 +65,6 @@ static bool IsLkCollectibleAdd(Unit* unit)
            entry == NPC_DRUDGE_GHOUL3 || entry == NPC_DRUDGE_GHOUL4;
 }
 
-static bool HasFrontalAbility(uint32 entry)
-{
-    return IsLkShambling(entry) || IsLkRagingSpirit(entry);
-}
-
 static bool IsHeroicLk(Difficulty diff)
 {
     return diff == RAID_DIFFICULTY_10MAN_HEROIC || diff == RAID_DIFFICULTY_25MAN_HEROIC;
@@ -1400,7 +1395,7 @@ bool IccLichKingWinterAction::HandleRangedPositioning()
     return false;
 }
 
-bool IccLichKingWinterAction::HandleMainTankAddManagement(Unit* boss, Position const* frostPos)
+bool IccLichKingWinterAction::HandleMainTankAddManagement(Unit*, Position const* frostPos)
 {
     static constexpr float ENGAGE_RADIUS = 12.0f;
     static constexpr float TAUNT_RADIUS = 30.0f;
@@ -1584,7 +1579,7 @@ bool IccLichKingWinterAction::HandleMainTankAddManagement(Unit* boss, Position c
     return false;
 }
 
-bool IccLichKingWinterAction::HandleAssistTankAddManagement(Unit* boss, Position const* frostPos)
+bool IccLichKingWinterAction::HandleAssistTankAddManagement(Unit*, Position const* frostPos)
 {
     static constexpr float FROST_TOL = 3.0f;
     static constexpr float MELE_RANGE = 5.0f;
@@ -2191,7 +2186,7 @@ bool IccLichKingSpiritBombAction::IsBombThreatActive(PlayerbotAI* botAI, Player*
     return false;
 }
 
-bool IccLichKingSpiritBombAction::Execute(Event event)
+bool IccLichKingSpiritBombAction::Execute(Event)
 {
     Difficulty const diff = bot->GetMap() ? bot->GetMap()->GetDifficulty() : RAID_DIFFICULTY_10MAN_NORMAL;
     Unit* terenas = bot->FindNearestCreature(NPC_TERENAS_MENETHIL_HC, 55.0f);

--- a/src/Ai/Raid/ICC/Action/ICCActions_PP.cpp
+++ b/src/Ai/Raid/ICC/Action/ICCActions_PP.cpp
@@ -1110,8 +1110,6 @@ bool IccPutricideGasCloudAction::HandleGroupAuraSituation(Unit* gasCloud)
         return false;
 
     constexpr float rangeMinSafeDistance = 15.0f;
-    constexpr float rangedMaxDistance = 25.0f;
-    constexpr float meleeRange = 5.0f;
     constexpr uint8 skullIconId = 7;
 
     Unit* volatileOoze = AI_VALUE2(Unit*, "find target", "volatile ooze");
@@ -1183,7 +1181,6 @@ bool IccPutricideAvoidMalleableGooAction::Execute(Event /*event*/)
         constexpr uint32 impactLifetimeMs = 6000;
         constexpr float gooDangerRadius = 8.0f;   // 5yd AoE + 3yd safety
         constexpr float puddleAvoidRadius = 6.0f;
-        constexpr float bombAvoidRadius = 6.0f;
 
         uint32 now = getMSTime();
         float botX = bot->GetPositionX();

--- a/src/Ai/Raid/ICC/Action/ICCActions_RF.cpp
+++ b/src/Ai/Raid/ICC/Action/ICCActions_RF.cpp
@@ -72,7 +72,7 @@ bool IccRotfaceTankPositionAction::MarkBossWithSkull(Unit* boss)
     return false;
 }
 
-bool IccRotfaceTankPositionAction::PositionMainTankAndMelee(Unit* boss, Unit* smallOoze)
+bool IccRotfaceTankPositionAction::PositionMainTankAndMelee(Unit* boss, Unit*)
 {
     bool isBossCasting = false;
     if (boss && boss->HasUnitState(UNIT_STATE_CASTING))
@@ -125,7 +125,7 @@ bool IccRotfaceTankPositionAction::PositionMainTankAndMelee(Unit* boss, Unit* sm
     return false;
 }
 
-bool IccRotfaceTankPositionAction::HandleAssistTankPositioning(Unit* boss)
+bool IccRotfaceTankPositionAction::HandleAssistTankPositioning(Unit*)
 {
     GuidVector bigOozes = AI_VALUE(GuidVector, "nearest hostile npcs");
     std::vector<Unit*> activeBigOozes;

--- a/src/Ai/Raid/ICC/Action/ICCActions_SG.cpp
+++ b/src/Ai/Raid/ICC/Action/ICCActions_SG.cpp
@@ -1376,7 +1376,6 @@ std::vector<Unit*> IccSindragosaFrostBombAction::SelectTombs(std::vector<Unit*> 
         &ICC_SINDRAGOSA_THOMB3_POSITION
     };
     int const zoneIdx = (groupCount == 2) ? (groupIndex == 0 ? 0 : 2) : groupIndex;
-    Position const& zone = *tombZones[zoneIdx];
 
     static constexpr float MAX_ZONE_RADIUS = 3.0f;
     std::vector<Unit*> zoneTombs;

--- a/src/Ai/Raid/ICC/Action/ICCActions_VT.cpp
+++ b/src/Ai/Raid/ICC/Action/ICCActions_VT.cpp
@@ -114,7 +114,6 @@ bool IccValithriaGroupAction::Execute(Event /*event*/)
     Creature* portal = portalList.empty() ? nullptr : portalList.front();
 
     Creature* worm = bot->FindNearestCreature(NPC_ROT_WORM, 100.0f);
-    Creature* zombie = bot->FindNearestCreature(NPC_BLISTERING_ZOMBIE, 100.0f);
     Creature* manaVoid = bot->FindNearestCreature(NPC_MANA_VOID, 100.0f);
 
     // Column of Frost units - still hostile so the hostile list is fine here

--- a/src/Ai/Raid/ICC/ICCMultipliers.cpp
+++ b/src/Ai/Raid/ICC/ICCMultipliers.cpp
@@ -27,7 +27,6 @@ namespace
 {
 std::map<ObjectGuid, uint32> g_plagueTimes;
 std::map<ObjectGuid, bool> g_allowCure;
-std::mutex g_plagueMutex; // Lock before accessing shared variables
 }
 
 // Lady Deathwhisper
@@ -126,7 +125,8 @@ float IccGunshipMultiplier::GetValue(Action* action)
     // Bot in transit between ships: lock to rocket-jump action only so combat/movement
     // actions don't interfere with jump packet timing.
     bool const isHordeSide = muradin && muradin->IsAlive() && muradin->IsHostileTo(bot);
-    bool const isAllySide = saurfang && saurfang->IsAlive() && saurfang->IsHostileTo(bot);
+    //@TODO use isAllySide or remove.
+    //bool const isAllySide = saurfang && saurfang->IsAlive() && saurfang->IsHostileTo(bot);
     Position const friendlyPoint = isHordeSide ? ICC_GUNSHIP_ROCKET_JUMP_HORDE_FRIENDLY_POINT
                                                : ICC_GUNSHIP_ROCKET_JUMP_ALLY_FRIENDLY_POINT;
     Position const middlePoint = isHordeSide ? ICC_GUNSHIP_ROCKET_JUMP_HORDE_MIDDLE_POINT

--- a/src/Ai/Raid/Mag/MagActions.cpp
+++ b/src/Ai/Raid/Mag/MagActions.cpp
@@ -319,7 +319,7 @@ bool MagtheridonWarlockCCBurningAbyssalAction::Execute(Event /*event*/)
         }
     }
 
-    if (warlockIndex >= 0 && warlockIndex < abyssals.size())
+    if (warlockIndex >= 0 && (size_t)warlockIndex < abyssals.size())
     {
         Unit* assignedAbyssal = abyssals[warlockIndex];
         if (!botAI->HasAura("banish", assignedAbyssal) && botAI->CanCastSpell("banish", assignedAbyssal))
@@ -433,7 +433,7 @@ bool MagtheridonSpreadRangedAction::Execute(Event /*event*/)
         uint8 count = members.size();
 
         float angle = 2 * M_PI * botIndex / count;
-        float radius = static_cast<float>(rand()) / RAND_MAX * maxSpreadRadius;
+        float radius = static_cast<float>(rand()) / static_cast<float>(RAND_MAX) * maxSpreadRadius;
         float targetX = centerX + radius * cos(angle);
         float targetY = centerY + radius * sin(angle);
 
@@ -466,8 +466,8 @@ bool MagtheridonSpreadRangedAction::Execute(Event /*event*/)
 
     if (distToCenter > maxSpreadRadius + radiusBuffer)
     {
-        float angle = static_cast<float>(rand()) / RAND_MAX * 2.0f * M_PI;
-        float radius = static_cast<float>(rand()) / RAND_MAX * maxSpreadRadius;
+        float angle = static_cast<float>(rand()) / static_cast<float>(RAND_MAX) * 2.0f * M_PI;
+        float radius = static_cast<float>(rand()) / static_cast<float>(RAND_MAX) * maxSpreadRadius;
         float targetX = centerX + radius * cos(angle);
         float targetY = centerY + radius * sin(angle);
 
@@ -575,7 +575,7 @@ bool MagtheridonUseManticronCubeAction::HandleWaitingPhase(const CubeInfo& cubeI
             }
         }
 
-        float angle = static_cast<float>(rand()) / RAND_MAX * 2.0f * M_PI;
+        float angle = static_cast<float>(rand()) / static_cast<float>(RAND_MAX) * 2.0f * M_PI;
         float fallbackX = cubeInfo.x + cos(angle) * safeWaitDistance;
         float fallbackY = cubeInfo.y + sin(angle) * safeWaitDistance;
         float fallbackZ = bot->GetPositionZ();

--- a/src/Ai/Raid/Naxx/Action/NaxxActions_Razuvious.cpp
+++ b/src/Ai/Raid/Naxx/Action/NaxxActions_Razuvious.cpp
@@ -47,7 +47,7 @@ bool RazuviousUseObedienceCrystalAction::Execute(Event /*event*/)
         {
             // taunt
             bool tauntUseful = true;
-            if (forceObedience->GetDuration() <= (duration_time - 5000))
+            if (forceObedience->GetDuration() <= int32(duration_time - 5000))
             {
                 Unit* victim = target->GetVictim();
                 if (victim && victim->HasAura(SPELL_BONE_BARRIER))
@@ -57,7 +57,7 @@ bool RazuviousUseObedienceCrystalAction::Execute(Event /*event*/)
                     tauntUseful = false;
 
             }
-            if (forceObedience->GetDuration() >= (duration_time - 500))
+            if (forceObedience->GetDuration() >= int32(duration_time - 500))
                 tauntUseful = false;
 
             if (tauntUseful && !charm->HasSpellCooldown(29060))

--- a/src/Ai/Raid/Naxx/Action/NaxxActions_Shared.cpp
+++ b/src/Ai/Raid/Naxx/Action/NaxxActions_Shared.cpp
@@ -4,7 +4,7 @@ uint32 RotateAroundTheCenterPointAction::FindNearestWaypoint()
 {
     float minDistance = 0;
     int ret = -1;
-    for (int i = 0; i < intervals; i++)
+    for (uint32 i = 0; i < intervals; i++)
     {
         float w_x = waypoints[i].first, w_y = waypoints[i].second;
         float dis = bot->GetDistance2d(w_x, w_y);

--- a/src/Ai/Raid/RS/Action/RSActions.h
+++ b/src/Ai/Raid/RS/Action/RSActions.h
@@ -1,0 +1,1399 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef _PLAYERBOT_RSA_H
+#define _PLAYERBOT_RSA_H
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <list>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include "AttackAction.h"
+#include "MovementActions.h"
+#include "PlayerbotAI.h"
+#include "Playerbots.h"
+#include "RSScripts.h"
+#include "RSStrategy.h"
+#include "RSTriggers.h"
+#include "RtiTargetValue.h"
+#include "ThreatManager.h"
+#include "Timer.h"
+#include "Vehicle.h"
+
+inline const Position RS_SAVIANA_TANK_POSITION = Position(3152.36f, 619.4369f, 78.645874f);
+inline const Position RS_ZARITHRIAN_TANK_POSITION = Position(3049.7f, 528.125f, 89.5219f);
+inline const Position RS_BALTHARUS_TANK_POSITION = Position(3138.6873f, 381.2857f, 87.57249f);
+inline const Position RS_BALTHARUS_HEALER_POSITION = Position(3133.5005f, 414.67023f, 85.509735f);
+inline const Position RS_HALION_TANK_POSITION = Position(3141.0532f, 532.5485f, 72.88935f);
+inline const Position RS_HALION_CENTER_POSITION = Position(3156.0f, 533.811f, 72.9882f);
+inline const Position RS_HALION_TANK_METEOR_SPOT = Position(3170.5989f, 530.64606f, 72.887024f);
+inline const Position RS_HALION_COMBUSTION_SPOT_A = Position(3186.9033f, 497.85657f, 72.289635f);
+inline const Position RS_HALION_COMBUSTION_SPOT_B = Position(3164.8992f, 580.4305f, 72.873024f);
+inline const Position RS_HALION_METEOR_SPOT_A = Position(3167.8013f, 510.99084f, 72.85342f);
+inline const Position RS_HALION_METEOR_SPOT_B = Position(3160.1658f, 553.1889f, 72.88719f);
+inline const Position RS_HALION_METEOR_MID = Position(3158.5593f, 534.84015f, 72.88689f);
+
+inline float RsAngleDiff(float a, float b)
+{
+    float diff = a - b;
+    while (diff > static_cast<float>(M_PI))
+        diff -= 2.0f * static_cast<float>(M_PI);
+    while (diff < -static_cast<float>(M_PI))
+        diff += 2.0f * static_cast<float>(M_PI);
+    return diff;
+}
+
+inline bool RsSpotInFrontArc(Unit* caster, float x, float y, float range)
+{
+    if (!caster || !caster->IsAlive())
+        return false;
+
+    float const dx = x - caster->GetPositionX();
+    float const dy = y - caster->GetPositionY();
+    if (std::sqrt(dx * dx + dy * dy) > range)
+        return false;
+
+    float const diff = RsAngleDiff(std::atan2(dy, dx), caster->GetOrientation());
+    return std::fabs(diff) <= static_cast<float>(M_PI) / 2.0f;
+}
+
+inline bool RsCastClassTaunt(PlayerbotAI* botAI, Player* bot, Unit* target)
+{
+    if (!target || !target->IsAlive())
+        return false;
+
+    bool const threatReset = botAI->HasCheat(BotCheatMask::raid);
+
+    if (threatReset && target->GetVictim() != bot)
+    {
+        ThreatManager& mgr = target->GetThreatMgr();
+        mgr.AddThreat(bot, 1000000.0f, nullptr, true, true);
+        mgr.FixateTarget(bot);
+    }
+
+    switch (bot->getClass())
+    {
+        case CLASS_PALADIN:
+            if (threatReset)
+                bot->RemoveSpellCooldown(RS_SPELL_TAUNT_PALADIN, true);
+            if (botAI->CastSpell("hand of reckoning", target))
+                return true;
+            break;
+        case CLASS_DEATH_KNIGHT:
+            if (threatReset)
+                bot->RemoveSpellCooldown(RS_SPELL_TAUNT_DK, true);
+            if (botAI->CastSpell("dark command", target))
+                return true;
+            break;
+        case CLASS_DRUID:
+            if (threatReset)
+                bot->RemoveSpellCooldown(RS_SPELL_TAUNT_DRUID, true);
+            if (botAI->CastSpell("growl", target))
+                return true;
+            break;
+        case CLASS_WARRIOR:
+            if (threatReset)
+                bot->RemoveSpellCooldown(RS_SPELL_TAUNT_WARRIOR, true);
+            if (botAI->CastSpell("taunt", target))
+                return true;
+            break;
+        default:
+            break;
+    }
+
+    if (botAI->CastSpell("shoot", target) || botAI->CastSpell("throw", target))
+        return true;
+
+    return false;
+}
+
+inline float RsHalionBeamSignedDist(float px, float py, Unit* a, Unit* b)
+{
+    float const ax = a->GetPositionX();
+    float const ay = a->GetPositionY();
+    float const ex = b->GetPositionX() - ax;
+    float const ey = b->GetPositionY() - ay;
+    float const len = std::sqrt(ex * ex + ey * ey);
+    if (len < 0.01f)
+        return std::numeric_limits<float>::max();
+
+    return ((px - ax) * ey - (py - ay) * ex) / len;
+}
+
+inline bool RsHalionEngaged(PlayerbotAI* botAI)
+{
+    Unit* boss = botAI->GetAiObjectContext()->GetValue<Unit*>("find target", "halion")->Get();
+    return boss && boss->IsAlive() && boss->IsInCombat() &&
+           (boss->GetEntry() == NPC_HALION || boss->GetEntry() == NPC_TWILIGHT_HALION);
+}
+
+inline Unit* RsHalionPhase1Boss(PlayerbotAI* botAI)
+{
+    Unit* boss = botAI->GetAiObjectContext()->GetValue<Unit*>("find target", "halion")->Get();
+    if (!boss || !boss->IsAlive() || boss->GetEntry() != NPC_HALION)
+        return nullptr;
+
+    if (!boss->HealthAbovePct(75))
+        return nullptr;
+
+    if (boss->GetDisplayId() != boss->GetNativeDisplayId())
+        return nullptr;
+
+    return boss;
+}
+
+inline bool RsHalionInTwilight(Player* bot)
+{
+    return bot && bot->HasAura(SPELL_TWILIGHT_REALM);
+}
+
+inline Unit* RsHalionFindBoss(PlayerbotAI* botAI, std::string const& name, uint32 entry)
+{
+    Unit* boss = botAI->GetAiObjectContext()->GetValue<Unit*>("find target", name)->Get();
+    if (boss && boss->IsAlive() && boss->GetEntry() == entry)
+        return boss;
+
+    GuidVector const targets = botAI->GetAiObjectContext()->GetValue<GuidVector>("possible targets no los")->Get();
+    for (ObjectGuid const& guid : targets)
+    {
+        Unit* unit = botAI->GetUnit(guid);
+        if (unit && unit->IsAlive() && unit->GetEntry() == entry)
+            return unit;
+    }
+
+    return nullptr;
+}
+
+inline Unit* RsHalionTwilightBoss(PlayerbotAI* botAI)
+{
+    ObjectGuid guid;
+    {
+        std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+        auto const it = RubySanctumHelpers::cutterTiming.find(botAI->GetBot()->GetInstanceId());
+        if (it != RubySanctumHelpers::cutterTiming.end())
+            guid = it->second.bossGuid;
+    }
+
+    if (!guid.IsEmpty())
+        if (Unit* boss = botAI->GetUnit(guid); boss && boss->IsAlive() && boss->GetEntry() == NPC_TWILIGHT_HALION)
+            return boss;
+
+    return RsHalionFindBoss(botAI, "twilight halion", NPC_TWILIGHT_HALION);
+}
+
+inline Unit* RsHalionPhase2Boss(PlayerbotAI* botAI)
+{
+    Unit* boss = RsHalionTwilightBoss(botAI);
+    if (!boss || !boss->HealthAbovePct(50))
+        return nullptr;
+
+    return boss;
+}
+
+inline Unit* RsHalionAnyPhysicalBoss(PlayerbotAI* botAI)
+{
+    ObjectGuid guid;
+    {
+        std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+        auto const it = RubySanctumHelpers::halionCorporeality.find(botAI->GetBot()->GetInstanceId());
+        if (it != RubySanctumHelpers::halionCorporeality.end())
+            guid = it->second.physicalGuid;
+    }
+
+    if (!guid.IsEmpty())
+        if (Unit* boss = botAI->GetUnit(guid); boss && boss->IsAlive() && boss->GetEntry() == NPC_HALION)
+            return boss;
+
+    return RsHalionFindBoss(botAI, "halion", NPC_HALION);
+}
+
+inline bool RsHalionIsPhase3(PlayerbotAI* botAI)
+{
+    Unit* physical = RsHalionAnyPhysicalBoss(botAI);
+    if (!physical || physical->HealthAbovePct(50))
+        return false;
+    return RsHalionTwilightBoss(botAI) != nullptr;
+}
+
+inline constexpr uint8 RS_HALION_CORP_BALANCED = 5;
+inline constexpr uint8 RS_HALION_CORP_STOP_AT = 4;
+inline constexpr uint8 RS_HALION_CORP_STOP_ALL_AT = 2;
+inline constexpr uint32 RS_HALION_CORP_FRESH_MS = 3000;
+
+inline bool RsHalionOwnCorpIndex(PlayerbotAI* botAI, Player* bot, uint8& outIndex)
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    if (!RsHalionIsPhase3(botAI))
+        return false;
+
+    auto const it = RubySanctumHelpers::halionCorporeality.find(bot->GetInstanceId());
+    if (it == RubySanctumHelpers::halionCorporeality.end())
+        return false;
+
+    RubySanctumHelpers::HalionCorporeality const& corp = it->second;
+    bool const inTwilight = RsHalionInTwilight(bot);
+    uint32 const ownStamp = inTwilight ? corp.twilightStamp : corp.physicalStamp;
+    if (ownStamp == 0 || getMSTimeDiff(ownStamp, getMSTime()) > RS_HALION_CORP_FRESH_MS)
+        return false;
+
+    outIndex = inTwilight ? corp.twilightIndex : corp.physicalIndex;
+    return true;
+}
+
+inline bool RsHalionRealmThrottled(PlayerbotAI* botAI, Player* bot)
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    uint8 ownIndex = RS_HALION_CORP_BALANCED;
+    if (!RsHalionOwnCorpIndex(botAI, bot, ownIndex))
+        return false;
+
+    auto& throttled = RubySanctumHelpers::realmThrottled;
+    ObjectGuid const guid = bot->GetGUID();
+    bool& held = throttled[guid];
+
+    if (ownIndex <= RS_HALION_CORP_STOP_AT)
+        held = true;
+    else if (ownIndex >= RS_HALION_CORP_BALANCED)
+        held = false;
+
+    return held;
+}
+
+inline bool RsHalionLeadingTooMuch(PlayerbotAI* botAI, Player* bot)
+{
+    uint8 ownIndex = RS_HALION_CORP_BALANCED;
+    if (!RsHalionOwnCorpIndex(botAI, bot, ownIndex))
+        return false;
+
+    return ownIndex <= RS_HALION_CORP_STOP_ALL_AT;
+}
+
+inline bool RsHalionInThrottledHalf(PlayerbotAI* botAI, Player* bot)
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+        return true;
+
+    uint32 const instanceId = bot->GetInstanceId();
+    bool const inTwilight = RsHalionInTwilight(bot);
+    ObjectGuid const selfGuid = bot->GetGUID();
+
+    uint32 total = 0;
+    uint32 rank = 0;
+    for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
+    {
+        Player* member = itr->GetSource();
+        if (!member || !member->IsAlive() || member->GetInstanceId() != instanceId)
+            continue;
+        if (!GET_PLAYERBOT_AI(member))
+            continue;
+        if (PlayerbotAI::IsTank(member) || PlayerbotAI::IsHeal(member))
+            continue;
+        if (RsHalionInTwilight(member) != inTwilight)
+            continue;
+
+        ++total;
+        if (member->GetGUID() < selfGuid)
+            ++rank;
+    }
+
+    return rank < total / 2;
+}
+
+inline bool RsHalionP3TwilightAssigned(PlayerbotAI* botAI, Player* bot)
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    if (PlayerbotAI::IsMainTank(bot))
+        return false;
+    if (PlayerbotAI::IsTank(bot))
+        return true;
+
+    uint32 const instanceId = bot->GetInstanceId();
+    auto const key = std::make_pair(instanceId, bot->GetGUID());
+
+    auto it = RubySanctumHelpers::p3TwilightAssignment.find(key);
+    if (it != RubySanctumHelpers::p3TwilightAssignment.end())
+        return it->second;
+
+    Group* group = bot->GetGroup();
+    if (!group)
+    {
+        RubySanctumHelpers::p3TwilightAssignment[key] = false;
+        return false;
+    }
+
+    std::vector<ObjectGuid> melee, ranged, heals;
+    for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
+    {
+        Player* member = itr->GetSource();
+        if (!member || !member->IsAlive() || PlayerbotAI::IsTank(member))
+            continue;
+        ObjectGuid const guid = member->GetGUID();
+        if (PlayerbotAI::IsHeal(member))
+            heals.push_back(guid);
+        else if (PlayerbotAI::IsRanged(member))
+            ranged.push_back(guid);
+        else
+            melee.push_back(guid);
+    }
+
+    auto assignHalf = [&](std::vector<ObjectGuid>& guids)
+    {
+        std::sort(guids.begin(), guids.end());
+        int const half = static_cast<int>(guids.size()) / 2;
+        for (int i = 0; i < static_cast<int>(guids.size()); ++i)
+            RubySanctumHelpers::p3TwilightAssignment[{instanceId, guids[i]}] = (i >= half);
+    };
+
+    for (ObjectGuid const& guid : ranged)
+        RubySanctumHelpers::p3TwilightAssignment[{instanceId, guid}] = false;
+    for (ObjectGuid const& guid : melee)
+        RubySanctumHelpers::p3TwilightAssignment[{instanceId, guid}] = true;
+
+    assignHalf(heals);
+
+    it = RubySanctumHelpers::p3TwilightAssignment.find(key);
+    return it != RubySanctumHelpers::p3TwilightAssignment.end() && it->second;
+}
+
+inline GameObject* RsHalionFindPortal(PlayerbotAI* botAI)
+{
+    Player* bot = botAI->GetBot();
+    constexpr float SEARCH_RANGE = 200.0f;
+
+    if (RsHalionInTwilight(bot))
+        return bot->FindNearestGameObject(GO_HALION_PORTAL_4, SEARCH_RANGE, true);
+
+    if (GameObject* go = bot->FindNearestGameObject(GO_HALION_PORTAL_1, SEARCH_RANGE, true))
+        return go;
+    if (GameObject* go = bot->FindNearestGameObject(GO_HALION_PORTAL_2, SEARCH_RANGE, true))
+        return go;
+    if (GameObject* go = bot->FindNearestGameObject(GO_HALION_PORTAL_3, SEARCH_RANGE, true))
+        return go;
+    return bot->FindNearestGameObject(GO_HALION_PORTAL_4, SEARCH_RANGE, true);
+}
+
+inline constexpr uint32 RS_ZARITHRIAN_CLEAVE_SWAP_STACKS = 5;
+inline constexpr float RS_BALTHARUS_TANK_FACING = 0.0f;
+inline constexpr float RS_BALTHARUS_HEALER_REACH = 5.0f;
+inline constexpr float RS_BALTHARUS_BRAND_RANGE = 14.0f;
+
+class RsBaltharusBrandAction : public MoveAwayFromPlayerWithDebuffAction
+{
+public:
+    RsBaltharusBrandAction(PlayerbotAI* botAI)
+        : MoveAwayFromPlayerWithDebuffAction(botAI, "rs baltharus brand", SPELL_ENERVATING_BRAND,
+                                             RS_BALTHARUS_BRAND_RANGE) {}
+    bool Execute(Event event) override;
+};
+
+class RsBaltharusHealerPositionAction : public AttackAction
+{
+public:
+    RsBaltharusHealerPositionAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs baltharus healer position") {}
+    bool Execute(Event event) override;
+};
+
+class RsBaltharusAvoidFrontAction : public AttackAction
+{
+public:
+    RsBaltharusAvoidFrontAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs baltharus avoid front") {}
+    bool Execute(Event event) override;
+};
+
+class RsBaltharusTankPositionAction : public AttackAction
+{
+public:
+    RsBaltharusTankPositionAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs baltharus tank position") {}
+    bool Execute(Event event) override;
+
+private:
+    bool HoldAt(Position const& spot, Unit* faceAwayFrom);
+};
+
+class RsSavianaConflagrationAction : public MoveAwayFromPlayerWithDebuffAction
+{
+public:
+    RsSavianaConflagrationAction(PlayerbotAI* botAI)
+        : MoveAwayFromPlayerWithDebuffAction(botAI, "rs saviana conflagration", SPELL_FLAME_BEACON, 10.0f) {}
+    bool Execute(Event event) override;
+};
+
+class RsSavianaTankPositionAction : public AttackAction
+{
+public:
+    RsSavianaTankPositionAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs saviana tank position") {}
+    bool Execute(Event event) override;
+};
+
+class RsSavianaAvoidFrontAction : public AttackAction
+{
+public:
+    RsSavianaAvoidFrontAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs saviana avoid front") {}
+    bool Execute(Event event) override;
+};
+
+class RsSavianaMeleeSpreadAction : public AttackAction
+{
+public:
+    RsSavianaMeleeSpreadAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs saviana melee spread") {}
+    bool Execute(Event event) override;
+};
+
+class RsZarithrianAddsAction : public AttackAction
+{
+public:
+    RsZarithrianAddsAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs zarithrian adds") {}
+    bool Execute(Event event) override;
+
+private:
+    bool IsDesignatedMarker();
+    Unit* FindPriorityAdd();
+    void UpdateSkullMarker(Unit* priorityAdd);
+};
+
+class RsZarithrianTankAction : public AttackAction
+{
+public:
+    RsZarithrianTankAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs zarithrian tank") {}
+    bool Execute(Event event) override;
+
+private:
+    uint32 GetCleaveStacks(Unit* unit);
+    Unit* FindBoss();
+    void CollectAdds(std::vector<Unit*>& adds);
+    bool HoldBoss(Unit* boss);
+    bool RunAddsToBoss(Unit* boss, std::vector<Unit*> const& adds);
+};
+
+inline constexpr float RS_TRASH_TANK_SPREAD = 20.0f;
+inline constexpr float RS_TRASH_RANGED_DIST = 25.0f;
+inline constexpr float RS_TRASH_RANGED_TOL = 10.0f;
+inline constexpr float RS_TRASH_RANGED_STEP = 7.0f;
+inline constexpr float RS_TRASH_TANK_SPACE_TOL = 5.0f;
+inline constexpr float RS_TRASH_DETECT_RANGE = 40.0f;
+inline constexpr float RS_TRASH_TANK_GRAB_RANGE = 100.0f;
+
+inline bool RsTrashIsCommander(uint32 entry)
+{
+    return entry == NPC_CHARSCALE_COMMANDER || entry == NPC_CHARSCALE_COMMANDER_H;
+}
+
+inline bool RsTrashIsInvoker(uint32 entry)
+{
+    return entry == NPC_CHARSCALE_INVOKER || entry == NPC_CHARSCALE_INVOKER_H;
+}
+
+inline bool RsTrashIsCharscale(uint32 entry)
+{
+    switch (entry)
+    {
+        case NPC_CHARSCALE_INVOKER:
+        case NPC_CHARSCALE_INVOKER_H:
+        case NPC_CHARSCALE_ASSAULTER:
+        case NPC_CHARSCALE_ASSAULTER_H:
+        case NPC_CHARSCALE_ELITE:
+        case NPC_CHARSCALE_ELITE_H:
+        case NPC_CHARSCALE_COMMANDER:
+        case NPC_CHARSCALE_COMMANDER_H:
+            return true;
+        default:
+            return false;
+    }
+}
+
+inline bool RsTrashIsTrashEntry(uint32 entry)
+{
+    return RsTrashIsCharscale(entry) || entry == NPC_ONYX_FLAMECALLER;
+}
+
+inline int RsTrashPriorityRank(uint32 entry)
+{
+    switch (entry)
+    {
+        case NPC_CHARSCALE_COMMANDER:
+        case NPC_CHARSCALE_COMMANDER_H:
+            return 0;
+        case NPC_CHARSCALE_INVOKER:
+        case NPC_CHARSCALE_INVOKER_H:
+            return 1;
+        case NPC_ONYX_FLAMECALLER:
+            return 2;
+        case NPC_CHARSCALE_ASSAULTER:
+        case NPC_CHARSCALE_ASSAULTER_H:
+        case NPC_CHARSCALE_ELITE:
+        case NPC_CHARSCALE_ELITE_H:
+            return 3;
+        default:
+            return std::numeric_limits<int>::max();
+    }
+}
+
+inline void RsTrashCollect(PlayerbotAI* botAI, std::vector<Unit*>& out)
+{
+    GuidVector const targets = botAI->GetAiObjectContext()->GetValue<GuidVector>("possible targets no los")->Get();
+    for (ObjectGuid const& guid : targets)
+    {
+        Unit* unit = botAI->GetUnit(guid);
+        if (unit && unit->IsAlive() && RsTrashIsTrashEntry(unit->GetEntry()))
+            out.push_back(unit);
+    }
+}
+
+inline bool RsTrashActive(PlayerbotAI* botAI, Player* bot)
+{
+    if (!bot || !bot->IsInCombat())
+        return false;
+
+    GuidVector const targets = botAI->GetAiObjectContext()->GetValue<GuidVector>("possible targets no los")->Get();
+    for (ObjectGuid const& guid : targets)
+    {
+        Unit* unit = botAI->GetUnit(guid);
+        if (!unit || !unit->IsAlive())
+            continue;
+
+        if (!RsTrashIsCharscale(unit->GetEntry()))
+            continue;
+
+        if (bot->GetExactDist2d(unit) <= RS_TRASH_DETECT_RANGE)
+            return true;
+    }
+    return false;
+}
+
+class RsTrashAddsAction : public AttackAction
+{
+public:
+    RsTrashAddsAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs trash adds") {}
+    bool Execute(Event event) override;
+
+private:
+    bool IsDesignatedMarker();
+    Unit* FindPriorityAdd();
+    void UpdateSkullMarker(Unit* priorityAdd);
+};
+
+class RsTrashTankAction : public AttackAction
+{
+public:
+    RsTrashTankAction(PlayerbotAI* botAI, std::string const name) : AttackAction(botAI, name) {}
+
+protected:
+    bool HoldAt(std::vector<Unit*> const& assigned, float spotX, float spotY, float spotZ, bool moveToSpot,
+                bool hasAway, float awayOri);
+};
+
+class RsTrashMainTankAction : public RsTrashTankAction
+{
+public:
+    RsTrashMainTankAction(PlayerbotAI* botAI) : RsTrashTankAction(botAI, "rs trash main tank") {}
+    bool Execute(Event event) override;
+};
+
+class RsTrashAssistTankAction : public RsTrashTankAction
+{
+public:
+    RsTrashAssistTankAction(PlayerbotAI* botAI) : RsTrashTankAction(botAI, "rs trash assist tank") {}
+    bool Execute(Event event) override;
+};
+
+class RsTrashRangedAction : public AttackAction
+{
+public:
+    RsTrashRangedAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs trash ranged") {}
+    bool Execute(Event event) override;
+};
+
+inline float RsHalionTargetOrientation()
+{
+    float angle = std::atan2(RS_HALION_TANK_POSITION.GetPositionY() - RS_HALION_CENTER_POSITION.GetPositionY(),
+                             RS_HALION_TANK_POSITION.GetPositionX() - RS_HALION_CENTER_POSITION.GetPositionX());
+    if (angle < 0.0f)
+        angle += 2.0f * static_cast<float>(M_PI);
+    return angle;
+}
+
+inline constexpr float RS_HALION_COMBUSTION_REACH = 4.0f;
+
+inline constexpr float RS_HALION_COMBUSTION_RANGE = 10.0f;
+
+inline bool RsHalionHasCombustion(Unit* u)
+{
+    return u && (u->HasAura(SPELL_FIERY_COMBUSTION) || u->HasAura(SPELL_MARK_OF_COMBUSTION));
+}
+
+inline Position const& RsHalionCombustionSpot(uint32 instanceId)
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    auto const it = RubySanctumHelpers::meteorPingPong.find(instanceId);
+    uint32 const count = it != RubySanctumHelpers::meteorPingPong.end() ? it->second.count : 0;
+    return (count % 2u) == 0u ? RS_HALION_COMBUSTION_SPOT_A : RS_HALION_COMBUSTION_SPOT_B;
+}
+
+inline Position const& RsHalionCombustionSpot(Player* bot)
+{
+    return RsHalionCombustionSpot(bot->GetInstanceId());
+}
+
+inline bool RsHalionCombustionAtSpot(Unit* u)
+{
+    if (!u)
+        return false;
+
+    Player* p = u->ToPlayer();
+    if (!p)
+        return false;
+
+    Position const& spot = RsHalionCombustionSpot(p);
+    return p->GetExactDist2d(spot.GetPositionX(), spot.GetPositionY()) <= RS_HALION_COMBUSTION_REACH;
+}
+
+inline constexpr float RS_HALION_COMBUSTION_PLAYER_SAFE_DIST = 35.0f;
+
+inline bool RsHalionCombustionPlayerSafe(Player* p)
+{
+    if (!p)
+        return false;
+
+    return p->GetExactDist2d(RS_HALION_CENTER_POSITION.GetPositionX(),
+                             RS_HALION_CENTER_POSITION.GetPositionY()) >=
+           RS_HALION_COMBUSTION_PLAYER_SAFE_DIST;
+}
+
+inline bool RsHalionCombustionNotClear(Player* bot)
+{
+    Group* group = bot ? bot->GetGroup() : nullptr;
+    if (!group)
+        return false;
+
+    for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
+    {
+        Player* member = itr->GetSource();
+        if (member && member->IsAlive() && RsHalionHasCombustion(member) && !RsHalionCombustionAtSpot(member))
+            return true;
+    }
+    return false;
+}
+
+inline bool RsHalionIsCombustionDispeller(PlayerbotAI* botAI)
+{
+    return botAI->IsHeal(botAI->GetBot()) && RsHalionCombustionNotClear(botAI->GetBot());
+}
+
+inline constexpr float RS_HALION_CONSUMPTION_OUT_DIST = 46.0f;
+inline constexpr float RS_HALION_CONSUMPTION_OUT_REACH = 4.0f;
+inline constexpr float RS_HALION_CONSUMPTION_STEP = 10.0f;
+inline constexpr float RS_HALION_CONSUMPTION_POOL_CLEAR = 9.0f;
+
+inline bool RsHalionHasConsumption(Unit* u)
+{
+    return u && (u->HasAura(SPELL_MARK_OF_CONSUMPTION) || u->HasAura(SPELL_SOUL_CONSUMPTION));
+}
+
+inline void RsHalionCollectHazardPools(Unit* from, std::vector<Unit*>& pools)
+{
+    for (uint32 const entry : {NPC_CONSUMPTION, NPC_COMBUSTION})
+    {
+        std::list<Creature*> found;
+        from->GetCreatureListWithEntryInGrid(found, entry, 100.0f);
+        for (Creature* c : found)
+            if (c && c->IsAlive())
+                pools.push_back(c);
+    }
+}
+
+inline bool RsHalionSpotClearOfPools(std::vector<Unit*> const& pools, float px, float py)
+{
+    for (Unit* pool : pools)
+        if (pool->GetExactDist2d(px, py) <= RS_HALION_CONSUMPTION_POOL_CLEAR)
+            return false;
+    return true;
+}
+
+inline bool RsHalionPathClearOfPools(std::vector<Unit*> const& pools, float fromX, float fromY,
+                                     float toX, float toY)
+{
+    float const dx = toX - fromX;
+    float const dy = toY - fromY;
+    float const lenSq = dx * dx + dy * dy;
+
+    for (Unit* pool : pools)
+    {
+        float const px = pool->GetPositionX();
+        float const py = pool->GetPositionY();
+
+        float t = 0.0f;
+        if (lenSq > 0.0001f)
+            t = std::clamp(((px - fromX) * dx + (py - fromY) * dy) / lenSq, 0.0f, 1.0f);
+
+        float const nearX = px - (fromX + dx * t);
+        float const nearY = py - (fromY + dy * t);
+        if (std::sqrt(nearX * nearX + nearY * nearY) <= RS_HALION_CONSUMPTION_POOL_CLEAR)
+            return false;
+    }
+    return true;
+}
+
+inline bool RsHalionConsumptionAtSpot(PlayerbotAI* botAI, Player* member)
+{
+    Unit* boss = RsHalionTwilightBoss(botAI);
+    if (!boss || !member)
+        return false;
+
+    return member->GetExactDist2d(boss->GetPositionX(), boss->GetPositionY()) >=
+           RS_HALION_CONSUMPTION_OUT_DIST - RS_HALION_CONSUMPTION_OUT_REACH;
+}
+
+inline bool RsHalionConsumptionNotClear(PlayerbotAI* botAI)
+{
+    Group* group = botAI->GetBot()->GetGroup();
+    if (!group)
+        return false;
+
+    for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
+    {
+        Player* member = itr->GetSource();
+        if (member && member->IsAlive() && RsHalionHasConsumption(member) &&
+            !RsHalionConsumptionAtSpot(botAI, member))
+            return true;
+    }
+    return false;
+}
+
+inline constexpr uint32 RS_HALION_CONSUMPTION_HOLD_PCT = 75;
+inline constexpr float RS_HALION_CONSUMPTION_HEAL_PCT = 90.0f;
+
+inline Player* RsHalionConsumptionHealTarget(PlayerbotAI* botAI)
+{
+    Player* bot = botAI->GetBot();
+    Group* group = bot->GetGroup();
+    if (!group)
+        return nullptr;
+
+    Player* worst = nullptr;
+    for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
+    {
+        Player* member = itr->GetSource();
+        if (!member || !member->IsAlive() || !RsHalionHasConsumption(member))
+            continue;
+        if (RsHalionInTwilight(member) != RsHalionInTwilight(bot))
+            continue;
+        if (member->GetHealthPct() >= RS_HALION_CONSUMPTION_HEAL_PCT)
+            continue;
+        if (!worst || member->GetHealthPct() < worst->GetHealthPct())
+            worst = member;
+    }
+    return worst;
+}
+
+inline void RsHalionCollectAdds(PlayerbotAI* botAI, std::vector<Unit*>& adds)
+{
+    GuidVector const targets = botAI->GetAiObjectContext()->GetValue<GuidVector>("possible targets no los")->Get();
+    for (ObjectGuid const& guid : targets)
+    {
+        Unit* unit = botAI->GetUnit(guid);
+        if (unit && unit->IsAlive() &&
+            (unit->GetEntry() == NPC_LIVING_INFERNO || unit->GetEntry() == NPC_LIVING_EMBER))
+            adds.push_back(unit);
+    }
+}
+
+inline bool RsHalionAnyAddAlive(PlayerbotAI* botAI)
+{
+    GuidVector const targets = botAI->GetAiObjectContext()->GetValue<GuidVector>("possible targets no los")->Get();
+    for (ObjectGuid const& guid : targets)
+    {
+        Unit* unit = botAI->GetUnit(guid);
+        if (unit && unit->IsAlive() &&
+            (unit->GetEntry() == NPC_LIVING_INFERNO || unit->GetEntry() == NPC_LIVING_EMBER))
+            return true;
+    }
+    return false;
+}
+
+inline constexpr uint32 RS_HALION_PORTAL_ADD_CLEAR_MS = 5000;
+
+inline bool RsHalionPortalHeldForAdds(PlayerbotAI* botAI)
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    if (!RsHalionFindPortal(botAI))
+        return false;
+
+    uint32 const instanceId = botAI->GetBot()->GetInstanceId();
+
+    auto const hpIt = RubySanctumHelpers::bossHealth.find(instanceId);
+    bool const bossHigh = hpIt != RubySanctumHelpers::bossHealth.end() &&
+                          GetMSTimeDiffToNow(hpIt->second.stamp) <= RS_HALION_CORP_FRESH_MS &&
+                          hpIt->second.pct >= 65;
+    if (!bossHigh)
+        return false;
+
+    if (RsHalionAnyAddAlive(botAI))
+        return true;
+
+    RubySanctumHelpers::PortalAddGate& gate = RubySanctumHelpers::portalAddGate[instanceId];
+    uint32 const now = getMSTime();
+
+    if (gate.armTime == 0)
+        gate.armTime = now;
+
+    uint32 const since = std::max(gate.armTime, gate.lastAddAliveTime);
+    return getMSTimeDiff(since, now) < RS_HALION_PORTAL_ADD_CLEAR_MS;
+}
+
+inline uint32 RsHalionPortalAddHoldRemainingMs(PlayerbotAI* botAI)
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    if (RsHalionAnyAddAlive(botAI))
+        return RS_HALION_PORTAL_ADD_CLEAR_MS;
+
+    auto const it = RubySanctumHelpers::portalAddGate.find(botAI->GetBot()->GetInstanceId());
+    if (it == RubySanctumHelpers::portalAddGate.end())
+        return RS_HALION_PORTAL_ADD_CLEAR_MS;
+
+    uint32 const since = std::max(it->second.armTime, it->second.lastAddAliveTime);
+    uint32 const elapsed = getMSTimeDiff(since, getMSTime());
+    return elapsed >= RS_HALION_PORTAL_ADD_CLEAR_MS ? 0 : RS_HALION_PORTAL_ADD_CLEAR_MS - elapsed;
+}
+
+inline bool RsHalionCutterShouldMove(uint32 instanceId);
+
+inline bool RsHalionEnteringTwilight(PlayerbotAI* botAI, Player* bot)
+{
+    if (PlayerbotAI::IsMainTank(bot) || RsHalionInTwilight(bot))
+        return false;
+
+    Unit* physBoss = RsHalionAnyPhysicalBoss(botAI);
+    bool const phase3 = physBoss != nullptr && !physBoss->HealthAbovePct(50);
+    if (phase3 && !RsHalionP3TwilightAssigned(botAI, bot))
+        return false;
+
+    if (RsHalionPortalHeldForAdds(botAI))
+        return false;
+
+    if (RsHalionCutterShouldMove(bot->GetInstanceId()))
+        return false;
+
+    return RsHalionFindPortal(botAI) != nullptr;
+}
+
+template <typename Filter>
+inline Player* RsHalionPickTank(Group* group, Filter const& filter)
+{
+    Player* assist = nullptr;
+    Player* anyTank = nullptr;
+    for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
+    {
+        Player* member = itr->GetSource();
+        if (!member || !member->IsAlive() || !PlayerbotAI::IsTank(member) || !filter(member))
+            continue;
+
+        if (!anyTank || member->GetGUID() < anyTank->GetGUID())
+            anyTank = member;
+
+        if (PlayerbotAI::IsAssistTank(member) && (!assist || member->GetGUID() < assist->GetGUID()))
+            assist = member;
+    }
+
+    return assist ? assist : anyTank;
+}
+
+inline Player* RsHalionAddTank(PlayerbotAI* botAI)
+{
+    Group* group = botAI->GetBot()->GetGroup();
+    if (!group)
+        return nullptr;
+
+    return RsHalionPickTank(group, [](Player* member) { return !RsHalionInTwilight(member); });
+}
+
+inline Player* RsHalionTwilightTank(PlayerbotAI* botAI)
+{
+    Group* group = botAI->GetBot()->GetGroup();
+    if (!group)
+    {
+        Player* bot = botAI->GetBot();
+        return (PlayerbotAI::IsTank(bot) && bot->IsAlive() && RsHalionInTwilight(bot)) ? bot : nullptr;
+    }
+
+    return RsHalionPickTank(group, [](Player* member) { return RsHalionInTwilight(member); });
+}
+
+inline Player* RsHalionFirstCrosser(PlayerbotAI* botAI)
+{
+    Group* group = botAI->GetBot()->GetGroup();
+    if (!group)
+    {
+        Player* bot = botAI->GetBot();
+        return (PlayerbotAI::IsTank(bot) && bot->IsAlive() && !PlayerbotAI::IsMainTank(bot)) ? bot : nullptr;
+    }
+
+    return RsHalionPickTank(group, [](Player* member) { return !PlayerbotAI::IsMainTank(member); });
+}
+
+inline Player* RsHalionLiveMainTank(PlayerbotAI* botAI)
+{
+    Group* group = botAI->GetBot()->GetGroup();
+    if (!group)
+    {
+        Player* bot = botAI->GetBot();
+        return (PlayerbotAI::IsMainTank(bot) && bot->IsAlive()) ? bot : nullptr;
+    }
+
+    for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
+    {
+        Player* member = itr->GetSource();
+        if (member && member->IsAlive() && PlayerbotAI::IsMainTank(member))
+            return member;
+    }
+
+    return nullptr;
+}
+
+inline Player* RsHalionBossTank(PlayerbotAI* botAI)
+{
+    if (Player* mt = RsHalionLiveMainTank(botAI))
+        return mt;
+
+    Group* group = botAI->GetBot()->GetGroup();
+    if (!group)
+        return nullptr;
+
+    Player* anyTank = nullptr;
+    for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
+    {
+        Player* member = itr->GetSource();
+        if (!member || !member->IsAlive() || !PlayerbotAI::IsTank(member))
+            continue;
+
+        if (!anyTank || member->GetGUID() < anyTank->GetGUID())
+            anyTank = member;
+    }
+
+    return anyTank;
+}
+
+inline bool RsHalionTanksAdds(PlayerbotAI* botAI, Player* bot)
+{
+    return RsHalionAnyAddAlive(botAI) && RsHalionAddTank(botAI) == bot;
+}
+
+inline bool RsHalionAssistTankAsMelee(PlayerbotAI* botAI)
+{
+    Player* bot = botAI->GetBot();
+    if (!PlayerbotAI::IsTank(bot))
+        return false;
+
+    if (!RsHalionAnyPhysicalBoss(botAI))
+        return false;
+
+    if (RsHalionBossTank(botAI) == bot)
+        return false;
+
+    return !RsHalionTanksAdds(botAI, bot);
+}
+
+inline constexpr float RS_HALION_TANK_LEASH = 10.0f;
+inline constexpr float RS_HALION_METEOR_LEASH = 25.0f;
+inline constexpr float RS_HALION_METEOR_REACH = 4.0f;
+
+inline Position const& RsHalionMeteorSpot(uint32 instanceId)
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    auto const it = RubySanctumHelpers::meteorPingPong.find(instanceId);
+    uint32 const count = it != RubySanctumHelpers::meteorPingPong.end() ? it->second.count : 0;
+    return (count % 2u) == 0u ? RS_HALION_METEOR_SPOT_A : RS_HALION_METEOR_SPOT_B;
+}
+
+inline constexpr uint32 RS_HALION_METEOR_RECENT_MS = 5000;
+
+inline bool RsHalionMeteorCastRecently(uint32 instanceId)
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    auto const it = RubySanctumHelpers::meteorPingPong.find(instanceId);
+    uint32 const lastCast = it != RubySanctumHelpers::meteorPingPong.end() ? it->second.lastCastTime : 0;
+    return lastCast != 0 && GetMSTimeDiffToNow(lastCast) <= RS_HALION_METEOR_RECENT_MS;
+}
+
+inline bool RsHalionMeteorTargetedBossTank(PlayerbotAI* botAI)
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    Player* bot = botAI->GetBot();
+    if (RsHalionBossTank(botAI) != bot)
+        return false;
+
+    auto const it = RubySanctumHelpers::meteorPingPong.find(bot->GetInstanceId());
+    if (it == RubySanctumHelpers::meteorPingPong.end())
+        return false;
+
+    uint32 const t = it->second.tankMeteorTime;
+    return t != 0 && GetMSTimeDiffToNow(t) <= RS_HALION_METEOR_RECENT_MS;
+}
+
+inline bool RsHalionTankMeteorCommitted(PlayerbotAI* botAI)
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    Player* bot = botAI->GetBot();
+    auto& committed = RubySanctumHelpers::meteorCommitted;
+    ObjectGuid const guid = bot->GetGUID();
+
+    if (RsHalionBossTank(botAI) != bot)
+    {
+        committed.erase(guid);
+        return false;
+    }
+
+    auto const it = RubySanctumHelpers::meteorPingPong.find(bot->GetInstanceId());
+    uint32 const homeTime = it != RubySanctumHelpers::meteorPingPong.end() ? it->second.tankMeteorTime : 0;
+    uint32 const returnTime = it != RubySanctumHelpers::meteorPingPong.end() ? it->second.tankReturnTime : 0;
+
+    bool const homeRecent = homeTime != 0 && GetMSTimeDiffToNow(homeTime) <= RS_HALION_METEOR_RECENT_MS;
+    bool const returnRecent = returnTime != 0 && GetMSTimeDiffToNow(returnTime) <= RS_HALION_METEOR_RECENT_MS;
+
+    if (returnRecent && returnTime >= homeTime)
+    {
+        committed.erase(guid);
+        return false;
+    }
+
+    if (homeRecent)
+        committed.insert(guid);
+
+    return committed.count(guid) != 0;
+}
+
+inline bool RsHalionMeteorShouldRally(Player* bot)
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    auto& committed = RubySanctumHelpers::rallyCommitted;
+    ObjectGuid const guid = bot->GetGUID();
+
+    if (RsHalionInTwilight(bot))
+    {
+        committed.erase(guid);
+        return false;
+    }
+
+    float const dist = bot->GetExactDist2d(RsHalionMeteorSpot(bot->GetInstanceId()));
+
+    if (dist <= RS_HALION_METEOR_REACH)
+    {
+        committed.erase(guid);
+        return false;
+    }
+
+    if (dist > RS_HALION_METEOR_LEASH)
+        committed.insert(guid);
+
+    return committed.count(guid) != 0;
+}
+
+inline bool RsHalionCombustionReturning(Player* bot)
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    auto& returning = RubySanctumHelpers::combustionReturning;
+    ObjectGuid const guid = bot->GetGUID();
+
+    if (RsHalionHasCombustion(bot))
+    {
+        returning.insert(guid);
+        return false;
+    }
+
+    if (!returning.count(guid))
+        return false;
+
+    Position const& spot = RsHalionMeteorSpot(bot->GetInstanceId());
+    if (bot->GetExactDist2d(spot.GetPositionX(), spot.GetPositionY()) <= RS_HALION_METEOR_REACH)
+    {
+        returning.erase(guid);
+        return false;
+    }
+
+    return true;
+}
+
+inline constexpr float RS_HALION_LINE_MELEE_MIN = 5.0f;
+inline constexpr float RS_HALION_LINE_MELEE_MAX = 18.0f;
+inline constexpr float RS_HALION_LINE_RANGED_MIN = 20.0f;
+inline constexpr float RS_HALION_LINE_RANGED_MAX = 30.0f;
+inline constexpr float RS_HALION_LINE_OFFSET_OK = 4.0f;
+inline constexpr float RS_HALION_LINE_LEASH = 10.0f;
+
+inline constexpr float RS_HALION_CUTTER_HALF_WIDTH = 2.5f;
+inline constexpr float RS_HALION_CUTTER_MARGIN = 4.0f;
+inline constexpr float RS_HALION_CUTTER_BOT_CLEAR = 5.0f;
+inline constexpr float RS_HALION_CUTTER_FLANK_DIST = 15.0f;
+inline constexpr float RS_HALION_CUTTER_SAFE_DIST = 15.0f;
+inline constexpr float RS_HALION_CUTTER_TANK_SAFE_DIST = 15.0f;
+inline constexpr float RS_HALION_CUTTER_TANK_BEAM_GAP = 12.0f;
+inline constexpr float RS_HALION_CUTTER_TANK_TRAIL = 3.0f;
+inline constexpr float RS_HALION_CUTTER_TANK_TRAIL_TOL = 1.0f;
+inline constexpr float RS_HALION_CUTTER_TANK_TRAIL_NORMAL = 8.0f;
+inline constexpr float RS_HALION_CUTTER_LEADER_NEAR = 5.0f;
+inline constexpr float RS_HALION_CUTTER_LEADER_FAR = 8.0f;
+
+inline constexpr uint32 RS_HALION_CUTTER_CYCLE_MS = 29000;
+inline constexpr uint32 RS_HALION_CUTTER_LEAD_MS = 5000;
+inline constexpr uint32 RS_HALION_FIRST_SHOOT_MS = 21000;
+
+inline bool RsHalionCutterShouldMove(uint32 instanceId)
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    auto const it = RubySanctumHelpers::cutterTiming.find(instanceId);
+    if (it == RubySanctumHelpers::cutterTiming.end())
+        return false;
+
+    if (it->second.lastShootTime == 0)
+    {
+        if (it->second.active)
+            return true;
+        if (it->second.encounterStart == 0)
+            return false;
+
+        uint32 const sinceStart = GetMSTimeDiffToNow(it->second.encounterStart);
+        if (sinceStart < RS_HALION_FIRST_SHOOT_MS)
+            return sinceStart >= RS_HALION_FIRST_SHOOT_MS - RS_HALION_CUTTER_LEAD_MS;
+
+        uint32 const intoCycle = (sinceStart - RS_HALION_FIRST_SHOOT_MS) % RS_HALION_CUTTER_CYCLE_MS;
+        return intoCycle >= RS_HALION_CUTTER_CYCLE_MS - RS_HALION_CUTTER_LEAD_MS;
+    }
+
+    RubySanctumHelpers::CutterTiming const& state = it->second;
+    uint32 const since = GetMSTimeDiffToNow(state.lastShootTime);
+
+    if (state.active)
+        return true;
+
+    uint32 const intoCycle = since % RS_HALION_CUTTER_CYCLE_MS;
+    return intoCycle >= RS_HALION_CUTTER_CYCLE_MS - RS_HALION_CUTTER_LEAD_MS;
+}
+
+inline bool RsHalionCutterActive(uint32 instanceId)
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    auto const it = RubySanctumHelpers::cutterTiming.find(instanceId);
+    return it != RubySanctumHelpers::cutterTiming.end() && it->second.active;
+}
+
+inline uint32 RsHalionCutterMsUntilShoot(uint32 instanceId)
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    auto const it = RubySanctumHelpers::cutterTiming.find(instanceId);
+    if (it == RubySanctumHelpers::cutterTiming.end())
+        return RS_HALION_CUTTER_CYCLE_MS;
+
+    RubySanctumHelpers::CutterTiming const& state = it->second;
+    if (state.active)
+        return 0;
+
+    if (state.lastShootTime == 0)
+    {
+        if (state.encounterStart == 0)
+            return RS_HALION_CUTTER_CYCLE_MS;
+        uint32 const elapsed = GetMSTimeDiffToNow(state.encounterStart);
+        return elapsed >= RS_HALION_FIRST_SHOOT_MS ? 0 : RS_HALION_FIRST_SHOOT_MS - elapsed;
+    }
+
+    uint32 const since = GetMSTimeDiffToNow(state.lastShootTime);
+    uint32 const intoCycle = since % RS_HALION_CUTTER_CYCLE_MS;
+    return RS_HALION_CUTTER_CYCLE_MS - intoCycle;
+}
+
+inline bool RsHalionCollectOrbPairs(Unit* boss, std::vector<std::pair<Unit*, Unit*>>& pairs)
+{
+    Creature* carrier = boss->FindNearestCreature(NPC_ORB_CARRIER, 200.0f);
+    if (!carrier)
+        return false;
+
+    Vehicle* vehicle = carrier->GetVehicleKit();
+    if (!vehicle)
+        return false;
+
+    Unit* north = vehicle->GetPassenger(0);
+    Unit* south = vehicle->GetPassenger(1);
+    if (north && south)
+        pairs.emplace_back(north, south);
+
+    Unit* east = vehicle->GetPassenger(2);
+    Unit* west = vehicle->GetPassenger(3);
+    if (east && west)
+        pairs.emplace_back(east, west);
+
+    return !pairs.empty();
+}
+
+inline constexpr float RS_HALION_P2_MELEE_DIST = 18.0f;
+inline constexpr float RS_HALION_P2_RANGED_DIST = 25.0f;
+inline constexpr float RS_HALION_P2_STEP = 7.0f;
+inline constexpr float RS_HALION_CUTTER_DANGER = 7.0f;
+
+inline bool RsHalionCutterBeamDanger(PlayerbotAI* botAI, Player* bot)
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    if (!RsHalionInTwilight(bot) || !RsHalionCutterShouldMove(bot->GetInstanceId()))
+        return false;
+
+    auto& cache = RubySanctumHelpers::cutterDangerCache;
+    uint32 const now = getMSTime();
+    auto it = cache.find(bot->GetGUID());
+    if (it != cache.end() && getMSTimeDiff(it->second.first, now) < 250)
+        return it->second.second;
+
+    bool danger = false;
+    if (Unit* boss = RsHalionTwilightBoss(botAI))
+    {
+        std::vector<std::pair<Unit*, Unit*>> pairs;
+        if (RsHalionCollectOrbPairs(boss, pairs))
+        {
+            for (auto const& pair : pairs)
+            {
+                if (std::fabs(RsHalionBeamSignedDist(bot->GetPositionX(), bot->GetPositionY(),
+                                                     pair.first, pair.second)) <= RS_HALION_CUTTER_DANGER)
+                {
+                    danger = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    cache[bot->GetGUID()] = {now, danger};
+    return danger;
+}
+
+inline constexpr float RS_HALION_PORTAL_FINISH_DIST = 15.0f;
+inline constexpr uint32 RS_HALION_PORTAL_COMMIT_MARGIN_MS = 1200;
+
+inline bool RsHalionPortalCommit(PlayerbotAI* botAI, Player* bot)
+{
+    if (!RsHalionInTwilight(bot))
+        return false;
+
+    Unit* twilightBoss = RsHalionTwilightBoss(botAI);
+    if (!twilightBoss || twilightBoss->HealthAbovePct(50))
+        return false;
+    if (RsHalionP3TwilightAssigned(botAI, bot))
+        return false;
+    if (RsHalionHasConsumption(bot))
+        return false;
+
+    GameObject* portal = RsHalionFindPortal(botAI);
+    if (!portal)
+        return false;
+
+    float const dist = bot->GetExactDist2d(portal->GetPositionX(), portal->GetPositionY());
+    if (dist <= RS_HALION_PORTAL_FINISH_DIST)
+        return true;
+
+    if (RsHalionCutterActive(bot->GetInstanceId()))
+        return false;
+
+    float speed = bot->GetSpeed(MOVE_RUN);
+    if (speed < 1.0f)
+        speed = 7.0f;
+    uint32 const reachMs = static_cast<uint32>((dist / speed) * 1000.0f);
+    return reachMs + RS_HALION_PORTAL_COMMIT_MARGIN_MS <= RsHalionCutterMsUntilShoot(bot->GetInstanceId());
+}
+
+class RsHalionTankPositionAction : public AttackAction
+{
+public:
+    RsHalionTankPositionAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs halion tank position") {}
+    bool Execute(Event event) override;
+};
+
+class RsHalionAvoidConesAction : public AttackAction
+{
+public:
+    RsHalionAvoidConesAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs halion avoid cones") {}
+    bool Execute(Event event) override;
+};
+
+class RsHalionCombustionAction : public MoveAwayFromPlayerWithDebuffAction
+{
+public:
+    RsHalionCombustionAction(PlayerbotAI* botAI)
+        : MoveAwayFromPlayerWithDebuffAction(botAI, "rs halion combustion", SPELL_MARK_OF_COMBUSTION,
+                                             RS_HALION_COMBUSTION_RANGE) {}
+    bool Execute(Event event) override;
+};
+
+class RsHalionMeteorAction : public AttackAction
+{
+public:
+    RsHalionMeteorAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs halion meteor") {}
+    bool Execute(Event event) override;
+};
+
+class RsHalionAddsAction : public AttackAction
+{
+public:
+    RsHalionAddsAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs halion adds") {}
+    bool Execute(Event event) override;
+};
+
+class RsHalionAddTankAction : public AttackAction
+{
+public:
+    RsHalionAddTankAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs halion add tank") {}
+    bool Execute(Event event) override;
+};
+
+class RsHalionStartPositionAction : public AttackAction
+{
+public:
+    RsHalionStartPositionAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs halion start position") {}
+    bool Execute(Event event) override;
+};
+
+class RsHalionEnterPortalAction : public AttackAction
+{
+public:
+    RsHalionEnterPortalAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs halion enter portal") {}
+    bool Execute(Event event) override;
+};
+
+class RsHalionP2TankPositionAction : public AttackAction
+{
+public:
+    RsHalionP2TankPositionAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs halion p2 tank position") {}
+    bool Execute(Event event) override;
+};
+
+class RsHalionP2AvoidConesAction : public AttackAction
+{
+public:
+    RsHalionP2AvoidConesAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs halion p2 avoid cones") {}
+    bool Execute(Event event) override;
+};
+
+class RsHalionConsumptionAction : public AttackAction
+{
+public:
+    RsHalionConsumptionAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs halion consumption") {}
+    bool Execute(Event event) override;
+};
+
+class RsHalionCutterAction : public AttackAction
+{
+public:
+    RsHalionCutterAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs halion cutter") {}
+    bool Execute(Event event) override;
+};
+
+class RsHalionHealConsumptionAction : public AttackAction
+{
+public:
+    RsHalionHealConsumptionAction(PlayerbotAI* botAI) : AttackAction(botAI, "rs halion heal consumption") {}
+    bool Execute(Event event) override;
+};
+
+#endif

--- a/src/Ai/Raid/RS/Action/RSActions_ADD.cpp
+++ b/src/Ai/Raid/RS/Action/RSActions_ADD.cpp
@@ -1,0 +1,474 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "NearestNpcsValue.h"
+#include "Playerbots.h"
+#include "RSActions.h"
+
+namespace
+{
+    void ResolveTanks(PlayerbotAI* botAI, Player*& mainTank, Player*& assistTank)
+    {
+        mainTank = nullptr;
+        assistTank = nullptr;
+
+        Group* group = botAI->GetBot()->GetGroup();
+        if (!group)
+            return;
+
+        for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
+        {
+            Player* member = itr->GetSource();
+            if (!member || !member->IsAlive())
+                continue;
+
+            if (!mainTank && botAI->IsMainTank(member))
+                mainTank = member;
+
+            if (!assistTank && botAI->IsAssistTank(member))
+                assistTank = member;
+
+            if (mainTank && assistTank)
+                break;
+        }
+    }
+
+    void CollectTrashForTank(Player* bot, std::vector<Unit*>& out)
+    {
+        for (uint32 const entry : {NPC_CHARSCALE_INVOKER, NPC_CHARSCALE_INVOKER_H,
+                                   NPC_CHARSCALE_ASSAULTER, NPC_CHARSCALE_ASSAULTER_H,
+                                   NPC_CHARSCALE_ELITE, NPC_CHARSCALE_ELITE_H,
+                                   NPC_CHARSCALE_COMMANDER, NPC_CHARSCALE_COMMANDER_H,
+                                   NPC_ONYX_FLAMECALLER})
+        {
+            std::list<Creature*> found;
+            bot->GetCreatureListWithEntryInGrid(found, entry, RS_TRASH_TANK_GRAB_RANGE);
+            for (Creature* c : found)
+                if (c && c->IsAlive() && c->IsInCombat())
+                    out.push_back(c);
+        }
+    }
+
+    void PartitionMobs(std::vector<Unit*> const& mobs, std::vector<Unit*>& assistSet, std::vector<Unit*>& mainSet)
+    {
+        Unit* assistInvoker = nullptr;
+        for (Unit* mob : mobs)
+        {
+            if (mob && mob->IsAlive() && RsTrashIsInvoker(mob->GetEntry()))
+                if (!assistInvoker || mob->GetGUID() < assistInvoker->GetGUID())
+                    assistInvoker = mob;
+        }
+
+        for (Unit* mob : mobs)
+        {
+            if (!mob || !mob->IsAlive())
+                continue;
+
+            if (RsTrashIsCommander(mob->GetEntry()) || mob == assistInvoker)
+                assistSet.push_back(mob);
+            else
+                mainSet.push_back(mob);
+        }
+    }
+
+    bool FrontReference(PlayerbotAI* botAI, Player* bot, float& rx, float& ry)
+    {
+        Group* group = bot->GetGroup();
+        if (group)
+        {
+            float sx = 0.0f;
+            float sy = 0.0f;
+            int count = 0;
+            for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
+            {
+                Player* member = itr->GetSource();
+                if (!member || !member->IsAlive())
+                    continue;
+
+                if (member->GetMapId() != bot->GetMapId() || member->GetInstanceId() != bot->GetInstanceId())
+                    continue;
+
+                if (botAI->IsTank(member) || !botAI->IsRanged(member))
+                    continue;
+
+                sx += member->GetPositionX();
+                sy += member->GetPositionY();
+                ++count;
+            }
+
+            if (count > 0)
+            {
+                rx = sx / count;
+                ry = sy / count;
+                return true;
+            }
+        }
+
+        Player* master = botAI->GetMaster();
+        if (master && master->IsInWorld() && master->GetMapId() == bot->GetMapId() &&
+            master->GetInstanceId() == bot->GetInstanceId() && !botAI->IsTank(master))
+        {
+            rx = master->GetPositionX();
+            ry = master->GetPositionY();
+            return true;
+        }
+
+        return false;
+    }
+
+    bool AwayFromRanged(PlayerbotAI* botAI, Player* bot, float& awayOri)
+    {
+        float rx = 0.0f;
+        float ry = 0.0f;
+        if (!FrontReference(botAI, bot, rx, ry))
+            return false;
+
+        float const dx = bot->GetPositionX() - rx;
+        float const dy = bot->GetPositionY() - ry;
+        if (dx * dx + dy * dy < 0.01f)
+            return false;
+
+        awayOri = std::atan2(dy, dx);
+        return true;
+    }
+
+    bool MarkableAdd(PlayerbotAI* botAI, Unit* mob)
+    {
+        if (!mob || !mob->IsAlive())
+            return false;
+
+        if (mob->IsInCombat())
+            return true;
+
+        Unit* victim = mob->GetVictim();
+        return victim && victim->IsPlayer() && botAI->IsTank(victim->ToPlayer());
+    }
+}
+
+bool RsTrashAddsAction::Execute(Event )
+{
+    context->GetValue<std::string>("rti")->Set("skull");
+
+    if (!IsDesignatedMarker())
+        return false;
+
+    UpdateSkullMarker(FindPriorityAdd());
+    return false;
+}
+
+bool RsTrashAddsAction::IsDesignatedMarker()
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+        return true;
+
+    ObjectGuid lowest = bot->GetGUID();
+    for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
+    {
+        Player* member = itr->GetSource();
+        if (!member || !member->IsAlive())
+            continue;
+
+        PlayerbotAI* memberAI = sPlayerbotsMgr.GetPlayerbotAI(member);
+        if (!memberAI)
+            continue;
+
+        if (memberAI->IsTank(member) || memberAI->IsHeal(member))
+            continue;
+
+        if (member->GetMapId() != bot->GetMapId() || member->GetInstanceId() != bot->GetInstanceId())
+            continue;
+
+        if (member->GetGUID() < lowest)
+            lowest = member->GetGUID();
+    }
+
+    return bot->GetGUID() == lowest;
+}
+
+Unit* RsTrashAddsAction::FindPriorityAdd()
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+        return nullptr;
+
+    std::vector<Unit*> mobs;
+    RsTrashCollect(botAI, mobs);
+
+    std::vector<Unit*> markable;
+    for (Unit* mob : mobs)
+        if (MarkableAdd(botAI, mob))
+            markable.push_back(mob);
+
+    if (markable.empty())
+        return nullptr;
+
+    int bestRank = std::numeric_limits<int>::max();
+    for (Unit* mob : markable)
+        bestRank = std::min(bestRank, RsTrashPriorityRank(mob->GetEntry()));
+
+    Unit* current = botAI->GetUnit(group->GetTargetIcon(RtiTargetValue::skullIndex));
+    if (current && MarkableAdd(botAI, current) && RsTrashIsTrashEntry(current->GetEntry()) &&
+        RsTrashPriorityRank(current->GetEntry()) == bestRank)
+        return current;
+
+    Unit* best = nullptr;
+    for (Unit* mob : markable)
+    {
+        if (RsTrashPriorityRank(mob->GetEntry()) != bestRank)
+            continue;
+
+        if (!best || mob->GetGUID() < best->GetGUID())
+            best = mob;
+    }
+
+    return best;
+}
+
+void RsTrashAddsAction::UpdateSkullMarker(Unit* priorityAdd)
+{
+    if (!priorityAdd)
+        return;
+
+    Group* group = bot->GetGroup();
+    if (!group)
+        return;
+
+    if (group->GetTargetIcon(RtiTargetValue::skullIndex) != priorityAdd->GetGUID())
+        group->SetTargetIcon(RtiTargetValue::skullIndex, bot->GetGUID(), priorityAdd->GetGUID());
+}
+
+bool RsTrashTankAction::HoldAt(std::vector<Unit*> const& assigned, float spotX, float spotY, float spotZ,
+                               bool moveToSpot, bool hasAway, float awayOri)
+{
+    Unit* nearest = nullptr;
+    float best = std::numeric_limits<float>::max();
+    for (Unit* mob : assigned)
+    {
+        if (!mob || !mob->IsAlive())
+            continue;
+
+        if (botAI->HasCheat(BotCheatMask::raid) && mob->IsInCombat() && mob->GetVictim() != bot)
+        {
+            ThreatManager& mgr = mob->GetThreatMgr();
+            mgr.AddThreat(bot, 1000000.0f, nullptr, true, true);
+            mgr.FixateTarget(bot);
+        }
+
+        if (hasAway)
+            mob->SetFacingTo(awayOri);
+
+        float const d = bot->GetExactDist2d(mob);
+        if (d < best)
+        {
+            best = d;
+            nearest = mob;
+        }
+    }
+
+    if (nearest)
+        bot->SetTarget(nearest->GetGUID());
+
+    if (moveToSpot && bot->GetExactDist2d(spotX, spotY) > RS_TRASH_TANK_SPACE_TOL)
+        return MoveTo(bot->GetMapId(), spotX, spotY, spotZ, false, false, false, true,
+                      MovementPriority::MOVEMENT_COMBAT);
+
+    if (nearest)
+        bot->SetFacingToObject(nearest);
+
+    return false;
+}
+
+bool RsTrashMainTankAction::Execute(Event )
+{
+    if (!botAI->IsTank(bot))
+        return false;
+
+    if (bot->GetMotionMaster()->GetCurrentMovementGeneratorType() == FOLLOW_MOTION_TYPE)
+    {
+        bot->AttackStop();
+        bot->InterruptNonMeleeSpells(true);
+        if (bot->GetTarget())
+            bot->SetTarget(ObjectGuid::Empty);
+        return false;
+    }
+
+    std::vector<Unit*> mobs;
+    CollectTrashForTank(bot, mobs);
+    if (mobs.empty())
+        return false;
+
+    float awayOri = 0.0f;
+    bool const hasAway = AwayFromRanged(botAI, bot, awayOri);
+
+    Player* mainTank = nullptr;
+    Player* assistTank = nullptr;
+    ResolveTanks(botAI, mainTank, assistTank);
+
+    if (!assistTank || assistTank == bot)
+        return HoldAt(mobs, 0.0f, 0.0f, 0.0f, false, hasAway, awayOri);
+
+    std::vector<Unit*> assistSet;
+    std::vector<Unit*> mainSet;
+    PartitionMobs(mobs, assistSet, mainSet);
+
+    bool hasCommander = false;
+    for (Unit* mob : mobs)
+        if (mob && mob->IsAlive() && RsTrashIsCommander(mob->GetEntry()))
+        {
+            hasCommander = true;
+            break;
+        }
+
+    if (!hasCommander)
+        return HoldAt(mainSet, 0.0f, 0.0f, 0.0f, false, hasAway, awayOri);
+
+    float dirX = bot->GetPositionX() - assistTank->GetPositionX();
+    float dirY = bot->GetPositionY() - assistTank->GetPositionY();
+
+    float rx = 0.0f;
+    float ry = 0.0f;
+    if (FrontReference(botAI, bot, rx, ry))
+    {
+        float ux = rx - assistTank->GetPositionX();
+        float uy = ry - assistTank->GetPositionY();
+        float const ulen = std::sqrt(ux * ux + uy * uy);
+        if (ulen > 0.01f)
+        {
+            ux /= ulen;
+            uy /= ulen;
+            float px = -uy;
+            float py = ux;
+            if (dirX * px + dirY * py < 0.0f)
+            {
+                px = -px;
+                py = -py;
+            }
+            dirX = px;
+            dirY = py;
+        }
+    }
+
+    float len = std::sqrt(dirX * dirX + dirY * dirY);
+    if (len < 0.01f)
+    {
+        dirX = std::cos(bot->GetOrientation());
+        dirY = std::sin(bot->GetOrientation());
+        len = 1.0f;
+    }
+
+    float const spotX = assistTank->GetPositionX() + (dirX / len) * RS_TRASH_TANK_SPREAD;
+    float const spotY = assistTank->GetPositionY() + (dirY / len) * RS_TRASH_TANK_SPREAD;
+
+    return HoldAt(mainSet, spotX, spotY, bot->GetPositionZ(), true, hasAway, awayOri);
+}
+
+bool RsTrashAssistTankAction::Execute(Event )
+{
+    if (!botAI->IsTank(bot))
+        return false;
+
+    if (bot->GetMotionMaster()->GetCurrentMovementGeneratorType() == FOLLOW_MOTION_TYPE)
+    {
+        bot->AttackStop();
+        bot->InterruptNonMeleeSpells(true);
+        if (bot->GetTarget())
+            bot->SetTarget(ObjectGuid::Empty);
+        return false;
+    }
+
+    std::vector<Unit*> mobs;
+    CollectTrashForTank(bot, mobs);
+    if (mobs.empty())
+        return false;
+
+    float awayOri = 0.0f;
+    bool const hasAway = AwayFromRanged(botAI, bot, awayOri);
+
+    Player* mainTank = nullptr;
+    Player* assistTank = nullptr;
+    ResolveTanks(botAI, mainTank, assistTank);
+
+    if (!mainTank || mainTank == bot)
+        return HoldAt(mobs, 0.0f, 0.0f, 0.0f, false, hasAway, awayOri);
+
+    std::vector<Unit*> assistSet;
+    std::vector<Unit*> mainSet;
+    PartitionMobs(mobs, assistSet, mainSet);
+
+    return HoldAt(assistSet, 0.0f, 0.0f, 0.0f, false, hasAway, awayOri);
+}
+
+bool RsTrashRangedAction::Execute(Event )
+{
+    if (botAI->IsTank(bot))
+        return false;
+
+    Group* group = bot->GetGroup();
+    if (!group)
+        return false;
+
+    Player* nearestTank = nullptr;
+    float nd = std::numeric_limits<float>::max();
+    for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
+    {
+        Player* member = itr->GetSource();
+        if (!member || !member->IsAlive() || member == bot)
+            continue;
+
+        if (!botAI->IsTank(member))
+            continue;
+
+        if (member->GetMapId() != bot->GetMapId() || member->GetInstanceId() != bot->GetInstanceId())
+            continue;
+
+        float const d = bot->GetExactDist2d(member);
+        if (d < nd)
+        {
+            nd = d;
+            nearestTank = member;
+        }
+    }
+
+    if (!nearestTank)
+        return false;
+
+    float ax = bot->GetPositionX() - nearestTank->GetPositionX();
+    float ay = bot->GetPositionY() - nearestTank->GetPositionY();
+    float alen = std::sqrt(ax * ax + ay * ay);
+    if (alen < 0.01f)
+    {
+        ax = std::cos(bot->GetOrientation());
+        ay = std::sin(bot->GetOrientation());
+        alen = 1.0f;
+    }
+
+    float const desiredX = nearestTank->GetPositionX() + (ax / alen) * RS_TRASH_RANGED_DIST;
+    float const desiredY = nearestTank->GetPositionY() + (ay / alen) * RS_TRASH_RANGED_DIST;
+
+    float const dx = desiredX - bot->GetPositionX();
+    float const dy = desiredY - bot->GetPositionY();
+    float const dist = std::sqrt(dx * dx + dy * dy);
+    if (dist <= RS_TRASH_RANGED_TOL)
+        return false;
+
+    float const stepLen = std::min(RS_TRASH_RANGED_STEP, dist);
+    float const moveX = bot->GetPositionX() + (dx / dist) * stepLen;
+    float const moveY = bot->GetPositionY() + (dy / dist) * stepLen;
+    float const moveZ = bot->GetPositionZ();
+
+    if (!bot->IsWithinLOS(moveX, moveY, moveZ))
+        return false;
+
+    return MoveTo(bot->GetMapId(), moveX, moveY, moveZ, false, false, false, false,
+                  MovementPriority::MOVEMENT_COMBAT, true);
+}

--- a/src/Ai/Raid/RS/Action/RSActions_BAL.cpp
+++ b/src/Ai/Raid/RS/Action/RSActions_BAL.cpp
@@ -1,0 +1,661 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <map>
+#include <utility>
+#include <vector>
+
+#include "NearestNpcsValue.h"
+#include "ObjectAccessor.h"
+#include "Playerbots.h"
+#include "RSActions.h"
+
+namespace
+{
+    constexpr float RS_BALTHARUS_FRONT_RANGE = 16.0f;
+
+    std::vector<Unit*> RsBaltharusCasters(PlayerbotAI* botAI)
+    {
+        std::vector<Unit*> casters;
+
+        if (Unit* boss = botAI->GetAiObjectContext()->GetValue<Unit*>("find target", "baltharus the warborn")->Get())
+            casters.push_back(boss);
+
+        GuidVector const targets = botAI->GetAiObjectContext()->GetValue<GuidVector>("possible targets no los")->Get();
+        for (ObjectGuid const& guid : targets)
+        {
+            Unit* unit = botAI->GetUnit(guid);
+            if (unit && unit->IsAlive() && unit->GetEntry() == NPC_BALTHARUS_THE_WARBORN_CLONE)
+                casters.push_back(unit);
+        }
+
+        return casters;
+    }
+
+    bool RsBaltharusSpotInFrontOfAny(std::vector<Unit*> const& casters, float x, float y)
+    {
+        for (Unit* caster : casters)
+            if (RsSpotInFrontArc(caster, x, y, RS_BALTHARUS_FRONT_RANGE))
+                return true;
+        return false;
+    }
+
+    struct MarkInfo
+    {
+        float x = 0.0f;
+        float y = 0.0f;
+        float z = 0.0f;
+        bool hasDest = false;
+        bool reached = false;
+    };
+
+    std::map<std::pair<uint32, ObjectGuid>, MarkInfo> gMarkedAnchors;
+
+    MarkInfo* GetMarkInfo(uint32 instanceId, ObjectGuid guid)
+    {
+        auto it = gMarkedAnchors.find(std::make_pair(instanceId, guid));
+        return it != gMarkedAnchors.end() ? &it->second : nullptr;
+    }
+
+    void EnsureMarkedAnchor(uint32 instanceId, ObjectGuid guid)
+    {
+        gMarkedAnchors.emplace(std::make_pair(instanceId, guid), MarkInfo{});
+    }
+}
+
+bool RsBaltharusBrandAction::Execute(Event )
+{
+    if (botAI->IsTank(bot))
+        return false;
+
+    uint32 const instanceId = bot->GetInstanceId();
+
+    for (auto it = gMarkedAnchors.begin(); it != gMarkedAnchors.end();)
+    {
+        if (it->first.first == instanceId)
+        {
+            Player* owner = ObjectAccessor::FindPlayer(it->first.second);
+            if (!owner || !owner->HasAura(SPELL_ENERVATING_BRAND))
+            {
+                it = gMarkedAnchors.erase(it);
+                continue;
+            }
+        }
+        ++it;
+    }
+
+    if (bot->HasAura(SPELL_ENERVATING_BRAND))
+        EnsureMarkedAnchor(instanceId, bot->GetGUID());
+
+    Group* const group = bot->GetGroup();
+    if (!group)
+        return false;
+
+    std::vector<Player*> others;
+    for (GroupReference* gref = group->GetFirstMember(); gref; gref = gref->next())
+    {
+        Player* member = gref->GetSource();
+        if (member && member != bot && member->IsAlive())
+            others.push_back(member);
+    }
+
+    if (others.empty())
+        return false;
+
+    MarkInfo* myMark = GetMarkInfo(instanceId, bot->GetGUID());
+
+    if (myMark && myMark->hasDest)
+    {
+
+        constexpr float settleDist = 1.5f;
+
+        float const distToDest = bot->GetExactDist2d(myMark->x, myMark->y);
+        if (distToDest <= settleDist)
+        {
+            myMark->reached = true;
+
+            return false;
+        }
+
+        return MoveTo(bot->GetMapId(), myMark->x, myMark->y, myMark->z, false, false, false, false,
+                      MovementPriority::MOVEMENT_COMBAT, true);
+    }
+
+    constexpr float MAX_NON_MARKED_RANGED_DISTANCE = 35.0f;
+    bool const isNonMarkedRanged = (myMark == nullptr) && (!botAI->IsMelee(bot));
+
+    auto minDistFrom = [&](float x, float y) -> float
+    {
+        float best = std::numeric_limits<float>::max();
+        for (Player* member : others)
+        {
+            MarkInfo* memberMark = GetMarkInfo(instanceId, member->GetGUID());
+
+            if (myMark)
+            {
+                if (memberMark)
+                    continue;
+            }
+            else
+            {
+
+                if (memberMark && !memberMark->reached)
+                    continue;
+            }
+
+            best = std::min(best, member->GetExactDist2d(x, y));
+        }
+        return best;
+    };
+
+    bool const hereClear = minDistFrom(bot->GetPositionX(), bot->GetPositionY()) >= RS_BALTHARUS_BRAND_RANGE;
+    std::vector<Unit*> const casters = RsBaltharusCasters(botAI);
+    bool const hereInFront = RsBaltharusSpotInFrontOfAny(casters, bot->GetPositionX(), bot->GetPositionY());
+
+    float const tankX = RS_BALTHARUS_TANK_POSITION.GetPositionX();
+    float const tankY = RS_BALTHARUS_TANK_POSITION.GetPositionY();
+    float const distToTank = bot->GetExactDist2d(tankX, tankY);
+    bool effectiveHereClear = hereClear;
+    if (isNonMarkedRanged && distToTank > MAX_NON_MARKED_RANGED_DISTANCE)
+        effectiveHereClear = false;
+
+    if (effectiveHereClear && !hereInFront)
+        return false;
+
+    int const directions = 8;
+    float const increment = 3.0f;
+    float const searchRadius = 30.0f;
+    float bestX = bot->GetPositionX();
+    float bestY = bot->GetPositionY();
+    float bestZ = bot->GetPositionZ();
+    float bestScore = -1.0f;
+
+    for (int i = 0; i < directions; ++i)
+    {
+        float const angle = (i * 2.0f * static_cast<float>(M_PI)) / directions;
+        for (float distance = increment; distance <= searchRadius; distance += increment)
+        {
+            float const moveX = bot->GetPositionX() + distance * std::cos(angle);
+            float const moveY = bot->GetPositionY() + distance * std::sin(angle);
+            float const moveZ = bot->GetPositionZ();
+
+            if (isNonMarkedRanged)
+            {
+                float const dxTank = moveX - tankX;
+                float const dyTank = moveY - tankY;
+                float const dTank = std::sqrt(dxTank * dxTank + dyTank * dyTank);
+                if (dTank > MAX_NON_MARKED_RANGED_DISTANCE)
+                    continue;
+            }
+
+            float const clearance = minDistFrom(moveX, moveY);
+            if (clearance < RS_BALTHARUS_BRAND_RANGE)
+                continue;
+
+            if (RsBaltharusSpotInFrontOfAny(casters, moveX, moveY))
+                continue;
+
+            if (!bot->IsWithinLOS(moveX, moveY, moveZ))
+                continue;
+
+            if (myMark)
+            {
+                bool tooCloseToOtherMarked = false;
+                for (auto const& entry : gMarkedAnchors)
+                {
+
+                    if (entry.first.first != instanceId || entry.first.second == bot->GetGUID())
+                        continue;
+                    MarkInfo const& other = entry.second;
+                    if (!other.hasDest)
+                        continue;
+                    float const dx = moveX - other.x;
+                    float const dy = moveY - other.y;
+                    float const dd = std::sqrt(dx * dx + dy * dy);
+                    if (dd < RS_BALTHARUS_BRAND_RANGE)
+                    {
+                        tooCloseToOtherMarked = true;
+                        break;
+                    }
+                }
+                if (tooCloseToOtherMarked)
+                    continue;
+            }
+
+            if (clearance > bestScore)
+            {
+                bestScore = clearance;
+                bestX = moveX;
+                bestY = moveY;
+                bestZ = moveZ;
+            }
+        }
+    }
+
+    if (bestScore > 0.0f)
+    {
+
+        if (myMark)
+        {
+            myMark->x = bestX;
+            myMark->y = bestY;
+            myMark->z = bestZ;
+            myMark->hasDest = true;
+            myMark->reached = false;
+        }
+
+        return MoveTo(bot->GetMapId(), bestX, bestY, bestZ, false, false, false, false, MovementPriority::MOVEMENT_COMBAT, true);
+    }
+
+    if (myMark)
+    {
+        Player* nearest = nullptr;
+        float nearestDist = std::numeric_limits<float>::max();
+        for (Player* member : others)
+        {
+            float const d = member->GetExactDist2d(bot->GetPositionX(), bot->GetPositionY());
+            if (d < nearestDist)
+            {
+                nearestDist = d;
+                nearest = member;
+            }
+        }
+
+        if (nearest)
+        {
+            float dx = bot->GetPositionX() - nearest->GetPositionX();
+            float dy = bot->GetPositionY() - nearest->GetPositionY();
+            float const len = std::sqrt(dx * dx + dy * dy);
+            if (len < 0.01f)
+            {
+                dx = 1.0f;
+                dy = 0.0f;
+            }
+            else
+            {
+                dx /= len;
+                dy /= len;
+            }
+
+            float const stepOut = (RS_BALTHARUS_BRAND_RANGE - nearestDist) + 2.0f;
+            float fbX = bot->GetPositionX() + dx * stepOut;
+            float fbY = bot->GetPositionY() + dy * stepOut;
+            float fbZ = bot->GetPositionZ();
+
+            if (!RsBaltharusSpotInFrontOfAny(casters, fbX, fbY) && bot->IsWithinLOS(fbX, fbY, fbZ))
+            {
+                myMark->x = fbX;
+                myMark->y = fbY;
+                myMark->z = fbZ;
+                myMark->hasDest = true;
+                myMark->reached = false;
+
+                return MoveTo(bot->GetMapId(), fbX, fbY, fbZ, false, false, false, false,
+                              MovementPriority::MOVEMENT_COMBAT, true);
+            }
+        }
+    }
+
+    if (isNonMarkedRanged && distToTank > MAX_NON_MARKED_RANGED_DISTANCE)
+    {
+        float const dx = bot->GetPositionX() - tankX;
+        float const dy = bot->GetPositionY() - tankY;
+        float len = std::sqrt(dx * dx + dy * dy);
+        float tx, ty, tz = bot->GetPositionZ();
+        if (len > 0.0001f)
+        {
+            tx = tankX + (dx / len) * MAX_NON_MARKED_RANGED_DISTANCE;
+            ty = tankY + (dy / len) * MAX_NON_MARKED_RANGED_DISTANCE;
+        }
+        else
+        {
+
+            tx = tankX + MAX_NON_MARKED_RANGED_DISTANCE;
+            ty = tankY;
+        }
+
+        if (!RsBaltharusSpotInFrontOfAny(casters, tx, ty) && bot->IsWithinLOS(tx, ty, tz))
+            return MoveTo(bot->GetMapId(), tx, ty, tz, false, false, false, false, MovementPriority::MOVEMENT_COMBAT, true);
+    }
+
+    return false;
+}
+
+bool RsBaltharusHealerPositionAction::Execute(Event )
+{
+    if (!botAI->IsHeal(bot) || botAI->IsTank(bot))
+        return false;
+
+    if (bot->HasAura(SPELL_ENERVATING_BRAND))
+        return false;
+
+    float const distToHealSpot = bot->GetExactDist2d(RS_BALTHARUS_HEALER_POSITION.GetPositionX(),
+                                                     RS_BALTHARUS_HEALER_POSITION.GetPositionY());
+    if (distToHealSpot <= RS_BALTHARUS_HEALER_REACH)
+        return false;
+
+    return MoveTo(bot->GetMapId(), RS_BALTHARUS_HEALER_POSITION.GetPositionX(),
+                  RS_BALTHARUS_HEALER_POSITION.GetPositionY(),
+                  RS_BALTHARUS_HEALER_POSITION.GetPositionZ(),
+                  false, false, false, true, MovementPriority::MOVEMENT_COMBAT);
+}
+
+bool RsBaltharusAvoidFrontAction::Execute(Event )
+{
+    if (botAI->IsTank(bot))
+        return false;
+
+    std::vector<Unit*> const casters = RsBaltharusCasters(botAI);
+    if (casters.empty())
+        return false;
+
+    Unit* anchor = nullptr;
+    if (Unit* victim = bot->GetVictim())
+        for (Unit* caster : casters)
+            if (caster == victim)
+                anchor = caster;
+    if (!anchor)
+    {
+        float nearestDist = std::numeric_limits<float>::max();
+        for (Unit* caster : casters)
+        {
+            float const d = bot->GetExactDist2d(caster);
+            if (d < nearestDist)
+            {
+                nearestDist = d;
+                anchor = caster;
+            }
+        }
+    }
+    if (!anchor)
+        return false;
+
+    float nearestCaster = std::numeric_limits<float>::max();
+    for (Unit* caster : casters)
+        nearestCaster = std::min(nearestCaster, bot->GetExactDist2d(caster));
+    if (nearestCaster > 20.0f)
+        return false;
+
+    if (botAI->IsMelee(bot))
+    {
+        float const flankDist = 4.0f;
+        float const settleDist = 2.0f;
+
+        static float const flankOffsets[] = {
+            static_cast<float>(M_PI),
+            static_cast<float>(M_PI) * 0.75f,
+            static_cast<float>(M_PI) * 1.25f,
+            static_cast<float>(M_PI) * 0.5f,
+            static_cast<float>(M_PI) * 1.5f
+        };
+
+        for (float const offset : flankOffsets)
+        {
+            float const angle = anchor->GetOrientation() + offset;
+            float const targetX = anchor->GetPositionX() + flankDist * std::cos(angle);
+            float const targetY = anchor->GetPositionY() + flankDist * std::sin(angle);
+            float const targetZ = anchor->GetPositionZ();
+
+            if (RsBaltharusSpotInFrontOfAny(casters, targetX, targetY))
+                continue;
+
+            if (!bot->IsWithinLOS(targetX, targetY, targetZ))
+                continue;
+
+            if (bot->GetExactDist2d(targetX, targetY) < settleDist)
+                return false;
+
+            return MoveTo(bot->GetMapId(), targetX, targetY, targetZ, false, false, false, false, MovementPriority::MOVEMENT_COMBAT, true);
+        }
+    }
+
+    if (!RsBaltharusSpotInFrontOfAny(casters, bot->GetPositionX(), bot->GetPositionY()))
+        return false;
+
+    float const step = 7.0f;
+    int const directions = 12;
+
+    for (int i = 0; i < directions; ++i)
+    {
+        float const angle = (i * 2.0f * static_cast<float>(M_PI)) / directions;
+        float const moveX = bot->GetPositionX() + step * std::cos(angle);
+        float const moveY = bot->GetPositionY() + step * std::sin(angle);
+        float const moveZ = bot->GetPositionZ();
+
+        if (RsBaltharusSpotInFrontOfAny(casters, moveX, moveY))
+            continue;
+
+        if (!bot->IsWithinLOS(moveX, moveY, moveZ))
+            continue;
+
+        return MoveTo(bot->GetMapId(), moveX, moveY, moveZ, false, false, false, false, MovementPriority::MOVEMENT_COMBAT, true);
+    }
+
+    return false;
+}
+
+bool RsBaltharusTankPositionAction::HoldAt(Position const& spot, Unit* faceAwayFrom)
+{
+    bool const onSpot = bot->GetExactDist2d(spot.GetPositionX(), spot.GetPositionY()) <= 3.0f;
+    bool const inMelee = faceAwayFrom && bot->IsWithinMeleeRange(faceAwayFrom);
+
+    if (faceAwayFrom && !inMelee && !onSpot)
+        return MoveTo(bot->GetMapId(), faceAwayFrom->GetPositionX(), faceAwayFrom->GetPositionY(),
+                      faceAwayFrom->GetPositionZ(), false, false, false, true,
+                      MovementPriority::MOVEMENT_COMBAT);
+
+    if (!onSpot)
+        return MoveTo(bot->GetMapId(), spot.GetPositionX(), spot.GetPositionY(), spot.GetPositionZ(),
+                      false, false, false, true, MovementPriority::MOVEMENT_COMBAT);
+
+    if (faceAwayFrom && std::fabs(bot->GetOrientation() - RS_BALTHARUS_TANK_FACING) > 0.1f)
+        bot->SetFacingTo(RS_BALTHARUS_TANK_FACING);
+
+    return false;
+}
+
+bool RsBaltharusTankPositionAction::Execute(Event )
+{
+    if (!botAI->IsTank(bot))
+        return false;
+
+    if (!(bot->HasAura(RS_SPELL_PAIN_SUPPRESION)))
+        bot->AddAura(RS_SPELL_PAIN_SUPPRESION, bot);
+
+    Unit* boss = nullptr;
+    GuidVector const targets = AI_VALUE(GuidVector, "possible targets no los");
+    for (ObjectGuid const& guid : targets)
+    {
+        Unit* unit = botAI->GetUnit(guid);
+        if (unit && unit->IsAlive() && unit->GetEntry() == NPC_BALTHARUS_THE_WARBORN)
+        {
+            boss = unit;
+            break;
+        }
+    }
+    if (!boss)
+        return false;
+
+    bool const isMainTank = botAI->IsMainTank(bot);
+
+    Player* assistTankPlayer = nullptr;
+    Player* mainTankPlayer = nullptr;
+    bool assistTankAlive = false;
+
+    if (Group* group = bot->GetGroup())
+    {
+        for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
+        {
+            Player* member = itr->GetSource();
+            if (!member || !member->IsAlive())
+                continue;
+
+            if (!assistTankPlayer && botAI->IsAssistTank(member))
+            {
+                assistTankPlayer = member;
+                assistTankAlive = true;
+            }
+
+            if (!mainTankPlayer && botAI->IsMainTank(member))
+            {
+                mainTankPlayer = member;
+            }
+
+            if (assistTankPlayer && mainTankPlayer)
+                break;
+        }
+    }
+
+    auto IsPlayerMarked = [&](Player* player) -> bool
+    {
+        if (!player)
+            return false;
+        if (Group* grp = player->GetGroup())
+        {
+            for (uint8 icon = 0; icon < 8; ++icon)
+            {
+                if (grp->GetTargetIcon(icon) == player->GetGUID())
+                    return true;
+            }
+        }
+        return false;
+    };
+
+    std::vector<Unit*> clones;
+    for (ObjectGuid const& guid : targets)
+    {
+        Unit* unit = botAI->GetUnit(guid);
+        if (unit && unit->IsAlive() && unit->GetEntry() == NPC_BALTHARUS_THE_WARBORN_CLONE)
+            clones.push_back(unit);
+    }
+
+    if (isMainTank)
+    {
+        bot->SetTarget(boss->GetGUID());
+
+        if (Group* group = bot->GetGroup())
+        {
+            if (group->GetTargetIcon(RtiTargetValue::skullIndex) != boss->GetGUID())
+                group->SetTargetIcon(RtiTargetValue::skullIndex, bot->GetGUID(), boss->GetGUID());
+        }
+
+        if (boss->GetVictim() != bot)
+            RsCastClassTaunt(botAI, bot, boss);
+
+        if (!assistTankAlive)
+        {
+            for (Unit* clone : clones)
+            {
+                if (!clone)
+                    continue;
+
+                if (clone->GetVictim() != bot)
+                    RsCastClassTaunt(botAI, bot, clone);
+            }
+        }
+
+        boss->SetFacingTo(RS_BALTHARUS_TANK_FACING);
+        for (Unit* clone : clones)
+        {
+            if (clone && clone->IsAlive())
+                clone->SetFacingTo(RS_BALTHARUS_TANK_FACING);
+        }
+
+        if (IsPlayerMarked(bot))
+            return false;
+
+        return HoldAt(RS_BALTHARUS_TANK_POSITION, boss);
+    }
+
+    if (botAI->IsAssistTank(bot))
+    {
+        if (clones.empty())
+            return false;
+
+        std::vector<Unit*> myClones;
+        for (Unit* clone : clones)
+        {
+            if (!clone)
+                continue;
+
+            if (mainTankPlayer)
+            {
+                float const dAssist = bot->GetExactDist2d(clone);
+                float const dMain = mainTankPlayer->GetExactDist2d(clone);
+                if (dAssist < dMain)
+                    myClones.push_back(clone);
+            }
+            else
+            {
+
+                myClones.push_back(clone);
+            }
+        }
+
+        if (myClones.empty())
+        {
+            Unit* nearest = nullptr;
+            float best = std::numeric_limits<float>::max();
+            for (Unit* clone : clones)
+            {
+                if (!clone)
+                    continue;
+                float const d = bot->GetExactDist2d(clone);
+                if (d < best)
+                {
+                    best = d;
+                    nearest = clone;
+                }
+            }
+            if (nearest)
+                myClones.push_back(nearest);
+        }
+
+        for (Unit* clone : myClones)
+        {
+            if (!clone)
+                continue;
+
+            if (clone->GetVictim() != bot)
+                RsCastClassTaunt(botAI, bot, clone);
+
+            if (clone->IsAlive())
+                clone->SetFacingTo(RS_BALTHARUS_TANK_FACING);
+        }
+
+        Unit* myClone = myClones.front();
+        if (myClone)
+            bot->SetTarget(myClone->GetGUID());
+
+        boss->SetFacingTo(RS_BALTHARUS_TANK_FACING);
+
+        if (IsPlayerMarked(bot))
+            return false;
+
+        float const assistX = RS_BALTHARUS_TANK_POSITION.GetPositionX() - 25.0f;
+        float const assistY = RS_BALTHARUS_TANK_POSITION.GetPositionY();
+        float const assistZ = RS_BALTHARUS_TANK_POSITION.GetPositionZ();
+
+        bool const onAssistSpot = bot->GetExactDist2d(assistX, assistY) <= 3.0f;
+        bool const cloneInMelee = myClone && bot->IsWithinMeleeRange(myClone);
+
+        if (myClone && !cloneInMelee && !onAssistSpot)
+            return MoveTo(bot->GetMapId(), myClone->GetPositionX(), myClone->GetPositionY(),
+                          myClone->GetPositionZ(), false, false, false, true, MovementPriority::MOVEMENT_COMBAT);
+
+        if (!onAssistSpot)
+            return MoveTo(bot->GetMapId(), assistX, assistY, assistZ, false, false, false, true, MovementPriority::MOVEMENT_COMBAT);
+
+        if (std::fabs(bot->GetOrientation() - RS_BALTHARUS_TANK_FACING) > 0.1f)
+            bot->SetFacingTo(RS_BALTHARUS_TANK_FACING);
+        return false;
+    }
+
+    return false;
+}

--- a/src/Ai/Raid/RS/Action/RSActions_HAL.cpp
+++ b/src/Ai/Raid/RS/Action/RSActions_HAL.cpp
@@ -1,0 +1,949 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <map>
+#include <utility>
+#include <vector>
+
+#include "ObjectAccessor.h"
+#include "Pet.h"
+#include "Playerbots.h"
+#include "RSActions.h"
+#include "RSScripts.h"
+#include "ThreatManager.h"
+#include "Timer.h"
+#include "Vehicle.h"
+
+bool RsHalionTankPositionAction::Execute(Event )
+{
+    if (RsHalionBossTank(botAI) != bot)
+        return false;
+
+    Unit* boss = RsHalionAnyPhysicalBoss(botAI);
+    if (!boss || !boss->IsInCombat())
+        return false;
+
+    context->GetValue<std::string>("rti")->Set("skull");
+
+    if (bot->GetTarget() != boss->GetGUID())
+        bot->SetTarget(boss->GetGUID());
+
+    std::vector<Unit*> adds;
+    RsHalionCollectAdds(botAI, adds);
+
+    if (botAI->HasCheat(BotCheatMask::raid))
+    {
+        for (Unit* add : adds)
+        {
+            if (add->GetVictim() == bot)
+                continue;
+            ThreatManager& mgr = add->GetThreatMgr();
+            mgr.AddThreat(bot, 1000000.0f, nullptr, true, true);
+            mgr.FixateTarget(bot);
+        }
+    }
+
+    if (Group* group = bot->GetGroup())
+    {
+        Unit* skullTarget = nullptr;
+
+        Unit* current = ObjectAccessor::GetUnit(*bot, group->GetTargetIcon(RtiTargetValue::skullIndex));
+        bool const currentIsAliveAdd = current && current->IsAlive() &&
+            std::find(adds.begin(), adds.end(), current) != adds.end();
+
+        if (currentIsAliveAdd)
+        {
+            skullTarget = current;
+        }
+        else if (!adds.empty())
+        {
+            for (Unit* add : adds)
+            {
+                if (add->GetEntry() == NPC_LIVING_INFERNO)
+                {
+                    skullTarget = add;
+                    break;
+                }
+            }
+            if (!skullTarget)
+            {
+                float best = std::numeric_limits<float>::max();
+                for (Unit* add : adds)
+                {
+                    float const d = bot->GetExactDist2d(add);
+                    if (d < best)
+                    {
+                        best = d;
+                        skullTarget = add;
+                    }
+                }
+            }
+        }
+        else
+        {
+            skullTarget = boss;
+        }
+
+        if (skullTarget && group->GetTargetIcon(RtiTargetValue::skullIndex) != skullTarget->GetGUID())
+            group->SetTargetIcon(RtiTargetValue::skullIndex, bot->GetGUID(), skullTarget->GetGUID());
+
+        if (!adds.empty())
+        {
+            if (group->GetTargetIcon(RtiTargetValue::starIndex) != boss->GetGUID())
+                group->SetTargetIcon(RtiTargetValue::starIndex, bot->GetGUID(), boss->GetGUID());
+        }
+        else if (!group->GetTargetIcon(RtiTargetValue::starIndex).IsEmpty())
+        {
+            group->SetTargetIcon(RtiTargetValue::starIndex, bot->GetGUID(), ObjectGuid::Empty);
+        }
+    }
+
+    if (botAI->HasCheat(BotCheatMask::raid) && boss->GetVictim() != bot)
+    {
+        ThreatManager& mgr = boss->GetThreatMgr();
+        mgr.AddThreat(bot, 1000000.0f, nullptr, true, true);
+    }
+
+    bool const committed = RsHalionTankMeteorCommitted(botAI);
+    Position const& home = committed ? RS_HALION_TANK_METEOR_SPOT : RS_HALION_TANK_POSITION;
+
+    if (bot->GetExactDist2d(home) > 1.0f)
+    {
+        if (committed && bot->IsNonMeleeSpellCast(false))
+            bot->InterruptNonMeleeSpells(false);
+
+        if (committed && !bot->HasAura(RS_SPELL_NITRO_BOOSTS))
+            bot->AddAura(RS_SPELL_NITRO_BOOSTS, bot);
+
+        return MoveTo(bot->GetMapId(), home.GetPositionX(), home.GetPositionY(), home.GetPositionZ(),
+                      false, false, false, true, MovementPriority::MOVEMENT_FORCED, true, false);
+    }
+
+    bot->SetFacingToObject(boss);
+
+    return false;
+}
+
+bool RsHalionAvoidConesAction::Execute(Event )
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    if (PlayerbotAI::IsMainTank(bot))
+        return false;
+
+    if (botAI->IsTank(bot) && !RsHalionAssistTankAsMelee(botAI))
+        return false;
+
+    Unit* boss = RsHalionAnyPhysicalBoss(botAI);
+    if (!boss)
+        return false;
+
+    if (!botAI->IsTank(bot) && RsHalionRealmThrottled(botAI, bot))
+    {
+        if (bot->GetVictim())
+            bot->AttackStop();
+        if (Pet* pet = bot->GetPet())
+            if (pet->GetVictim())
+                pet->AttackStop();
+    }
+
+    bool const melee = botAI->IsMelee(bot);
+    bool const addsUp = RsHalionAnyAddAlive(botAI);
+
+    if (melee && addsUp)
+        context->GetValue<std::string>("rti")->Set("star");
+    else
+        context->GetValue<std::string>("rti")->Set("skull");
+
+    if (melee && bot->GetTarget() != boss->GetGUID())
+        bot->SetTarget(boss->GetGUID());
+
+    float const bossX = boss->GetPositionX();
+    float const bossY = boss->GetPositionY();
+
+    float const dA = bot->GetExactDist2d(RS_HALION_METEOR_SPOT_A.GetPositionX(), RS_HALION_METEOR_SPOT_A.GetPositionY());
+    float const dB = bot->GetExactDist2d(RS_HALION_METEOR_SPOT_B.GetPositionX(), RS_HALION_METEOR_SPOT_B.GetPositionY());
+
+    auto& botUsesSpotA = RubySanctumHelpers::meteorSpotUsesA;
+    ObjectGuid const botGuid = bot->GetGUID();
+    auto memIt = botUsesSpotA.find(botGuid);
+    bool usesA = memIt != botUsesSpotA.end() ? memIt->second : dA <= dB;
+    if (usesA && dB + 8.0f < dA)
+        usesA = false;
+    else if (!usesA && dA + 8.0f < dB)
+        usesA = true;
+    botUsesSpotA[botGuid] = usesA;
+
+    Position const& spot = usesA ? RS_HALION_METEOR_SPOT_A : RS_HALION_METEOR_SPOT_B;
+
+    if (bot->GetExactDist2d(spot.GetPositionX(), spot.GetPositionY()) <= RS_HALION_LINE_LEASH)
+        return false;
+
+    float const lineX = spot.GetPositionX() - bossX;
+    float const lineY = spot.GetPositionY() - bossY;
+    float const lineLen = std::sqrt(lineX * lineX + lineY * lineY);
+    if (lineLen < 0.01f)
+        return false;
+
+    float const ux = lineX / lineLen;
+    float const uy = lineY / lineLen;
+
+    float const minDist = melee ? RS_HALION_LINE_MELEE_MIN : RS_HALION_LINE_RANGED_MIN;
+    float const maxDist = melee ? RS_HALION_LINE_MELEE_MAX : RS_HALION_LINE_RANGED_MAX;
+
+    float const distToBoss = bot->GetExactDist2d(bossX, bossY);
+
+    float const botDX = bot->GetPositionX() - bossX;
+    float const botDY = bot->GetPositionY() - bossY;
+    float const along = botDX * ux + botDY * uy;
+    float const offset = std::fabs(botDX * uy - botDY * ux);
+
+    bool const onLine = along > 0.0f && offset <= RS_HALION_LINE_OFFSET_OK;
+    bool const inBand = distToBoss >= minDist && distToBoss <= maxDist;
+
+    if (onLine && inBand)
+        return false;
+
+    float desired = distToBoss;
+    if (desired < minDist)
+        desired = minDist;
+    else if (desired > maxDist)
+        desired = maxDist;
+
+    float const moveX = bossX + ux * desired;
+    float const moveY = bossY + uy * desired;
+
+    if (!bot->IsWithinLOS(moveX, moveY, bot->GetPositionZ()))
+        return false;
+
+    return MoveTo(bot->GetMapId(), moveX, moveY, bot->GetPositionZ(), false, false, false, false,
+                  MovementPriority::MOVEMENT_COMBAT, true);
+}
+
+bool RsHalionCombustionAction::Execute(Event )
+{
+    if (RsHalionHasCombustion(bot) && RsHalionCombustionAtSpot(bot))
+    {
+        bot->RemoveAurasDueToSpell(SPELL_FIERY_COMBUSTION, ObjectGuid::Empty, 0, AURA_REMOVE_BY_EXPIRE);
+        bot->RemoveAurasDueToSpell(SPELL_MARK_OF_COMBUSTION, ObjectGuid::Empty, 0, AURA_REMOVE_BY_EXPIRE);
+        return false;
+    }
+
+    if (RsHalionBossTank(botAI) == bot)
+        return false;
+
+    if (!RsHalionHasCombustion(bot))
+    {
+        if (RsHalionCombustionReturning(bot))
+        {
+            Position const& rally = RsHalionMeteorSpot(bot->GetInstanceId());
+            return MoveTo(bot->GetMapId(), rally.GetPositionX(), rally.GetPositionY(), rally.GetPositionZ(),
+                          false, false, false, true, MovementPriority::MOVEMENT_FORCED);
+        }
+        return false;
+    }
+
+    if (!bot->HasAura(RS_SPELL_NITRO_BOOSTS))
+        bot->AddAura(RS_SPELL_NITRO_BOOSTS, bot);
+
+    Position const& spot = RsHalionCombustionSpot(bot);
+
+    if (bot->GetExactDist2d(spot.GetPositionX(), spot.GetPositionY()) <= RS_HALION_COMBUSTION_REACH)
+        return false;
+
+    return MoveTo(bot->GetMapId(), spot.GetPositionX(), spot.GetPositionY(), spot.GetPositionZ(),
+                  false, false, false, true, MovementPriority::MOVEMENT_FORCED);
+}
+
+bool RsHalionMeteorAction::Execute(Event )
+{
+    if (botAI->IsTank(bot) && !RsHalionAssistTankAsMelee(botAI))
+        return false;
+
+    if (!RsHalionAnyPhysicalBoss(botAI))
+        return false;
+
+    if (!RsHalionMeteorShouldRally(bot))
+        return false;
+
+    if (bot->IsNonMeleeSpellCast(false))
+        bot->InterruptNonMeleeSpells(false);
+    botAI->Reset();
+
+    Position const& target = RsHalionMeteorSpot(bot->GetInstanceId());
+    Position const& mid = RS_HALION_METEOR_MID;
+
+    float const distToTarget = bot->GetExactDist2d(target.GetPositionX(), target.GetPositionY());
+    float const midToTarget = mid.GetExactDist2d(target.GetPositionX(), target.GetPositionY());
+    float const distToMid = bot->GetExactDist2d(mid.GetPositionX(), mid.GetPositionY());
+
+    Position const& leg = (distToMid > RS_HALION_METEOR_REACH && distToTarget > midToTarget) ? mid : target;
+
+    return MoveTo(bot->GetMapId(), leg.GetPositionX(), leg.GetPositionY(), leg.GetPositionZ(),
+                  false, false, false, true, MovementPriority::MOVEMENT_FORCED, true);
+}
+
+bool RsHalionStartPositionAction::Execute(Event )
+{
+    if (RsHalionBossTank(botAI) == bot)
+        return false;
+
+    Unit* boss = RsHalionPhase1Boss(botAI);
+    if (!boss || !boss->HealthAbovePct(99))
+        return false;
+
+    if (bot->GetExactDist2d(RS_HALION_METEOR_SPOT_A.GetPositionX(), RS_HALION_METEOR_SPOT_A.GetPositionY()) <=
+        RS_HALION_METEOR_REACH)
+        return false;
+
+    return MoveTo(bot->GetMapId(), RS_HALION_METEOR_SPOT_A.GetPositionX(), RS_HALION_METEOR_SPOT_A.GetPositionY(),
+                  RS_HALION_METEOR_SPOT_A.GetPositionZ(), false, false, false, true,
+                  MovementPriority::MOVEMENT_COMBAT);
+}
+
+bool RsHalionAddsAction::Execute(Event )
+{
+    return false;
+}
+
+bool RsHalionAddTankAction::Execute(Event )
+{
+    return false;
+}
+
+bool RsHalionEnterPortalAction::Execute(Event )
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    if (PlayerbotAI::IsMainTank(bot))
+        return false;
+
+    Unit* physBoss = RsHalionAnyPhysicalBoss(botAI);
+    bool const phase3 = physBoss != nullptr && !physBoss->HealthAbovePct(50);
+
+    bool p3TwilightExit = false;
+    if (RsHalionInTwilight(bot))
+    {
+        Unit* twilightBoss = RsHalionTwilightBoss(botAI);
+        bool const tBossLow = twilightBoss != nullptr && !twilightBoss->HealthAbovePct(50);
+        if (!tBossLow || RsHalionP3TwilightAssigned(botAI, bot))
+            return false;
+
+        if (RsHalionHasConsumption(bot))
+            return false;
+
+        if (!RsHalionPortalCommit(botAI, bot))
+            return false;
+
+        p3TwilightExit = true;
+    }
+    else if (RsHalionPortalHeldForAdds(botAI))
+    {
+        if (RsHalionFirstCrosser(botAI) == bot)
+        {
+            uint32 const remaining = RsHalionPortalAddHoldRemainingMs(botAI);
+            uint32 const shown = (remaining + 999) / 1000 + 2;
+
+            auto& lastShown = RubySanctumHelpers::portalCountdownLastShown;
+            uint32& last = lastShown[bot->GetInstanceId()];
+            if (last != shown)
+            {
+                last = shown;
+                botAI->Yell(std::to_string(shown));
+            }
+        }
+        return false;
+    }
+
+    auto& botPortalTarget = RubySanctumHelpers::botPortalTarget;
+    ObjectGuid const botGuid = bot->GetGUID();
+
+    GameObject* portal = nullptr;
+    auto cachedIt = botPortalTarget.find(botGuid);
+    if (cachedIt != botPortalTarget.end())
+    {
+        portal = ObjectAccessor::GetGameObject(*bot, cachedIt->second);
+        if (!portal)
+            botPortalTarget.erase(cachedIt);
+    }
+
+    if (!portal)
+    {
+        portal = RsHalionFindPortal(botAI);
+        if (!portal)
+            return false;
+        botPortalTarget[botGuid] = portal->GetGUID();
+    }
+
+    bool const isFirstCrosser = (p3TwilightExit || phase3) ? false : (RsHalionFirstCrosser(botAI) == bot);
+    if (!isFirstCrosser && !p3TwilightExit && !phase3)
+    {
+        Player* firstCrosser = RsHalionFirstCrosser(botAI);
+        if (!firstCrosser || !RsHalionInTwilight(firstCrosser))
+            return false;
+
+        auto& portalSeen = RubySanctumHelpers::portalSeen;
+        uint32& seen = portalSeen[bot->GetInstanceId()][bot->GetGUID()];
+        if (seen == 0)
+            seen = getMSTime();
+
+        if (GetMSTimeDiffToNow(seen) < 1000)
+            return false;
+    }
+
+    float const distToPortal = bot->GetExactDist2d(portal->GetPositionX(), portal->GetPositionY());
+
+    if (distToPortal > INTERACTION_DISTANCE - 0.5f)
+    {
+        float goalX = portal->GetPositionX();
+        float goalY = portal->GetPositionY();
+
+        std::vector<Unit*> pools;
+        RsHalionCollectHazardPools(bot, pools);
+        if (!pools.empty())
+        {
+            float const dx = goalX - bot->GetPositionX();
+            float const dy = goalY - bot->GetPositionY();
+            float const len = std::sqrt(dx * dx + dy * dy);
+            if (len > 0.01f)
+            {
+                float const ux = dx / len;
+                float const uy = dy / len;
+                float const probe = std::min(len, RS_HALION_CONSUMPTION_STEP);
+                float const aheadX = bot->GetPositionX() + ux * probe;
+                float const aheadY = bot->GetPositionY() + uy * probe;
+
+                if (!RsHalionSpotClearOfPools(pools, aheadX, aheadY))
+                {
+                    bool routed = false;
+                    for (float const deg : {35.0f, -35.0f, 60.0f, -60.0f, 90.0f, -90.0f})
+                    {
+                        float const a = std::atan2(uy, ux) + deg * static_cast<float>(M_PI) / 180.0f;
+                        float const sideX = bot->GetPositionX() + std::cos(a) * probe;
+                        float const sideY = bot->GetPositionY() + std::sin(a) * probe;
+                        if (RsHalionSpotClearOfPools(pools, sideX, sideY) &&
+                            bot->IsWithinLOS(sideX, sideY, bot->GetPositionZ()))
+                        {
+                            goalX = sideX;
+                            goalY = sideY;
+                            routed = true;
+                            break;
+                        }
+                    }
+                    if (!routed)
+                        return false;
+                }
+            }
+        }
+
+        if (p3TwilightExit && RsHalionCutterShouldMove(bot->GetInstanceId()) &&
+            !bot->HasAura(RS_SPELL_MAGIC_BARRIER))
+        {
+            bot->AddAura(RS_SPELL_MAGIC_BARRIER, bot);
+            ObjectGuid const barrierGuid = bot->GetGUID();
+            botAI->AddTimedEvent([barrierGuid]()
+            {
+                if (Player* p = ObjectAccessor::FindPlayer(barrierGuid))
+                    p->RemoveAura(RS_SPELL_MAGIC_BARRIER);
+            }, 5000);
+        }
+
+        return MoveTo(bot->GetMapId(), goalX, goalY, portal->GetPositionZ(),
+                      false, false, false, false, MovementPriority::MOVEMENT_FORCED);
+    }
+
+    botPortalTarget.erase(botGuid);
+    botAI->RemoveShapeshift();
+    bot->GetMotionMaster()->Clear();
+    bot->StopMoving();
+    bot->SetFacingToObject(portal);
+
+    portal->Use(bot);
+
+    if (p3TwilightExit)
+        bot->RemoveAura(SPELL_TWILIGHT_REALM);
+
+    if (!p3TwilightExit && !phase3)
+    {
+        bot->AddAura(RS_SPELL_MAGIC_BARRIER, bot);
+
+        ObjectGuid const guid = bot->GetGUID();
+        botAI->AddTimedEvent([guid]()
+        {
+            if (Player* p = ObjectAccessor::FindPlayer(guid))
+                p->RemoveAura(RS_SPELL_MAGIC_BARRIER);
+        }, 5000);
+    }
+
+    return true;
+}
+
+bool RsHalionP2TankPositionAction::Execute(Event )
+{
+    if (RsHalionTwilightTank(botAI) != bot || !RsHalionInTwilight(bot))
+        return false;
+
+    Unit* boss = RsHalionTwilightBoss(botAI);
+    if (!boss)
+        return false;
+
+    if (bot->GetTarget() != boss->GetGUID())
+        bot->SetTarget(boss->GetGUID());
+
+    if (Group* group = bot->GetGroup())
+    {
+        if (group->GetTargetIcon(RtiTargetValue::crossIndex) != boss->GetGUID())
+            group->SetTargetIcon(RtiTargetValue::crossIndex, bot->GetGUID(), boss->GetGUID());
+    }
+
+    if (botAI->HasCheat(BotCheatMask::raid))
+    {
+        ThreatManager& mgr = boss->GetThreatMgr();
+        if (boss->GetVictim() != bot)
+            mgr.AddThreat(bot, 1000000.0f, nullptr, true, true);
+        mgr.FixateTarget(bot);
+    }
+
+    context->GetValue<std::string>("rti")->Set("cross");
+
+    float const distToBoss = bot->GetExactDist2d(boss->GetPositionX(), boss->GetPositionY());
+    if (std::fabs(distToBoss - RS_HALION_CUTTER_FLANK_DIST) > 2.0f)
+    {
+        float const tankAngle = std::atan2(bot->GetPositionY() - boss->GetPositionY(),
+                                           bot->GetPositionX() - boss->GetPositionX());
+        float const rx = boss->GetPositionX() + std::cos(tankAngle) * RS_HALION_CUTTER_FLANK_DIST;
+        float const ry = boss->GetPositionY() + std::sin(tankAngle) * RS_HALION_CUTTER_FLANK_DIST;
+        if (bot->IsWithinLOS(rx, ry, bot->GetPositionZ()))
+            return MoveTo(bot->GetMapId(), rx, ry, bot->GetPositionZ(), false, false, false, false,
+                          MovementPriority::MOVEMENT_COMBAT, true, false);
+    }
+
+    return false;
+}
+
+bool RsHalionP2AvoidConesAction::Execute(Event )
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    if (RsHalionTwilightTank(botAI) == bot)
+        return false;
+
+    Unit* boss = RsHalionTwilightBoss(botAI);
+    if (!boss)
+        return false;
+
+    if (RsHalionPortalCommit(botAI, bot))
+        return false;
+
+    if (RsHalionCutterShouldMove(bot->GetInstanceId()))
+    {
+        auto& botPortalTarget = RubySanctumHelpers::botPortalTarget;
+        auto portalIt = botPortalTarget.find(bot->GetGUID());
+        if (portalIt != botPortalTarget.end())
+        {
+            botPortalTarget.erase(portalIt);
+            if (bot->GetMotionMaster()->GetCurrentMovementGeneratorType() == POINT_MOTION_TYPE)
+            {
+                bot->GetMotionMaster()->Clear();
+                bot->StopMoving();
+            }
+        }
+    }
+
+    if (!PlayerbotAI::IsTank(bot) && RsHalionRealmThrottled(botAI, bot))
+    {
+        if (bot->GetVictim())
+            bot->AttackStop();
+        if (Pet* pet = bot->GetPet())
+            if (pet->GetVictim())
+                pet->AttackStop();
+    }
+
+    if (PlayerbotAI::IsTank(bot))
+    {
+        Player* twilightTank = RsHalionTwilightTank(botAI);
+        if (!twilightTank)
+            return false;
+        if (bot->GetExactDist2d(twilightTank) <= 2.0f)
+            return false;
+        return MoveTo(bot->GetMapId(), twilightTank->GetPositionX(), twilightTank->GetPositionY(),
+                      twilightTank->GetPositionZ(), false, false, false, false,
+                      MovementPriority::MOVEMENT_COMBAT);
+    }
+
+    context->GetValue<std::string>("rti")->Set("cross");
+
+    Player* tank = RsHalionTwilightTank(botAI);
+    if (!tank)
+        return false;
+
+    std::vector<std::pair<Unit*, Unit*>> pairs;
+    bool const singleCutter = RsHalionCollectOrbPairs(boss, pairs) && pairs.size() == 1;
+    bool const cutterFiring = RsHalionCutterActive(bot->GetInstanceId());
+
+    if (RsHalionCutterBeamDanger(botAI, bot) && singleCutter && cutterFiring)
+    {
+        if (bot->IsNonMeleeSpellCast(false))
+            bot->InterruptNonMeleeSpells(false);
+
+        Unit* na = pairs[0].first;
+        Unit* nb = pairs[0].second;
+        float const nearestSigned = RsHalionBeamSignedDist(bot->GetPositionX(), bot->GetPositionY(), na, nb);
+        float const nearest = std::fabs(nearestSigned);
+        float const ex = nb->GetPositionX() - na->GetPositionX();
+        float const ey = nb->GetPositionY() - na->GetPositionY();
+        float const elen = std::sqrt(ex * ex + ey * ey);
+        if (elen > 0.01f)
+        {
+            float const side = nearestSigned >= 0.0f ? 1.0f : -1.0f;
+            float const nx = side * ey / elen;
+            float const ny = side * -ex / elen;
+            float const clear = RS_HALION_CUTTER_DANGER + RS_HALION_CUTTER_MARGIN;
+            float const stepLen = std::max(clear - nearest, RS_HALION_P2_STEP);
+            float const moveX = bot->GetPositionX() + nx * stepLen;
+            float const moveY = bot->GetPositionY() + ny * stepLen;
+            if (bot->IsWithinLOS(moveX, moveY, bot->GetPositionZ()))
+                return MoveTo(bot->GetMapId(), moveX, moveY, bot->GetPositionZ(), false, false, false,
+                              true, MovementPriority::MOVEMENT_FORCED, true);
+        }
+    }
+
+    bool const lockedClass = bot->getClass() == CLASS_ROGUE || bot->getClass() == CLASS_WARRIOR;
+    bool const loose = RsHalionCutterShouldMove(bot->GetInstanceId()) &&
+        !lockedClass &&
+        !RsHalionCutterBeamDanger(botAI, bot);
+
+    if (loose && bot->IsNonMeleeSpellCast(false, false, true))
+        return false;
+
+    if (RsHalionCutterBeamDanger(botAI, bot) && cutterFiring && bot->IsNonMeleeSpellCast(false))
+        bot->InterruptNonMeleeSpells(false);
+
+    float const bossX = boss->GetPositionX();
+    float const bossY = boss->GetPositionY();
+    float const bossToTank = std::atan2(tank->GetPositionY() - bossY, tank->GetPositionX() - bossX);
+    float const radius = botAI->IsMelee(bot) ? RS_HALION_P2_MELEE_DIST : RS_HALION_P2_RANGED_DIST;
+    float slotAngle = bossToTank + static_cast<float>(M_PI) * 95.0f / 180.0f;
+
+    if (singleCutter && cutterFiring)
+    {
+        float const clear = RS_HALION_CUTTER_DANGER + RS_HALION_CUTTER_MARGIN;
+        auto slotClear = [&](float ang) -> bool
+        {
+            float const sx = bossX + std::cos(ang) * radius;
+            float const sy = bossY + std::sin(ang) * radius;
+            return std::fabs(RsHalionBeamSignedDist(sx, sy, pairs[0].first, pairs[0].second)) > clear;
+        };
+
+        if (!slotClear(slotAngle))
+        {
+            float const stepArc = static_cast<float>(M_PI) / 18.0f;
+            for (int i = 1; i <= 18; ++i)
+            {
+                if (slotClear(slotAngle + stepArc * static_cast<float>(i)))
+                {
+                    slotAngle += stepArc * static_cast<float>(i);
+                    break;
+                }
+                if (slotClear(slotAngle - stepArc * static_cast<float>(i)))
+                {
+                    slotAngle -= stepArc * static_cast<float>(i);
+                    break;
+                }
+            }
+        }
+    }
+
+    float const targetX = bossX + std::cos(slotAngle) * radius;
+    float const targetY = bossY + std::sin(slotAngle) * radius;
+
+    float const dx = targetX - bot->GetPositionX();
+    float const dy = targetY - bot->GetPositionY();
+    float const dist = std::sqrt(dx * dx + dy * dy);
+    if (dist <= (loose ? RS_HALION_P2_STEP : 1.0f))
+        return false;
+
+    float const botZ = bot->GetPositionZ();
+    auto losOk = [&](float x, float y) -> bool
+    {
+        return bot->IsWithinLOS(x, y, botZ) || bot->IsWithinLOS(x, y, botZ + 2.0f) ||
+               bot->IsWithinLOS(x, y, botZ - 2.0f);
+    };
+
+    float const stepLen = std::min(dist, RS_HALION_P2_STEP);
+    float const moveX = bot->GetPositionX() + (dx / dist) * stepLen;
+    float const moveY = bot->GetPositionY() + (dy / dist) * stepLen;
+
+    if (losOk(moveX, moveY))
+        return MoveTo(bot->GetMapId(), moveX, moveY, botZ, false, false, false, false,
+                      MovementPriority::MOVEMENT_FORCED, true);
+
+    float const toBossX = bossX - bot->GetPositionX();
+    float const toBossY = bossY - bot->GetPositionY();
+    float const toBossLen = std::sqrt(toBossX * toBossX + toBossY * toBossY);
+    if (toBossLen < 0.01f)
+        return false;
+
+    float const radialStep = std::min(toBossLen, RS_HALION_P2_STEP);
+    float const radialX = bot->GetPositionX() + (toBossX / toBossLen) * radialStep;
+    float const radialY = bot->GetPositionY() + (toBossY / toBossLen) * radialStep;
+    if (!losOk(radialX, radialY))
+        return false;
+
+    return MoveTo(bot->GetMapId(), radialX, radialY, botZ, false, false, false, false,
+                  MovementPriority::MOVEMENT_FORCED, true);
+}
+
+bool RsHalionConsumptionAction::Execute(Event )
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    auto& clearedForConsumption = RubySanctumHelpers::clearedForConsumption;
+    ObjectGuid const botGuid = bot->GetGUID();
+
+    if (!bot->HasAura(SPELL_MARK_OF_CONSUMPTION) && !bot->HasAura(SPELL_SOUL_CONSUMPTION))
+    {
+        clearedForConsumption.erase(botGuid);
+        return false;
+    }
+
+    if (RsHalionIsPhase3(botAI) && bot->HealthBelowPct(RS_HALION_CONSUMPTION_HOLD_PCT))
+    {
+        if (bot->GetMotionMaster()->GetCurrentMovementGeneratorType() == POINT_MOTION_TYPE)
+        {
+            bot->GetMotionMaster()->Clear();
+            bot->StopMoving();
+        }
+        return false;
+    }
+
+    Unit* boss = RsHalionTwilightBoss(botAI);
+    if (!boss)
+        return false;
+
+    if (!clearedForConsumption.count(botGuid))
+    {
+        if (bot->GetMotionMaster()->GetCurrentMovementGeneratorType() == POINT_MOTION_TYPE)
+        {
+            bot->GetMotionMaster()->Clear();
+            bot->StopMoving();
+        }
+        clearedForConsumption.insert(botGuid);
+    }
+
+    if (!bot->HasAura(RS_SPELL_NITRO_BOOSTS))
+        bot->AddAura(RS_SPELL_NITRO_BOOSTS, bot);
+
+    float const bossX = boss->GetPositionX();
+    float const bossY = boss->GetPositionY();
+    float const distToBoss = bot->GetExactDist2d(bossX, bossY);
+
+    if (distToBoss >= RS_HALION_CONSUMPTION_OUT_DIST - RS_HALION_CONSUMPTION_OUT_REACH)
+    {
+        bot->RemoveAurasDueToSpell(SPELL_SOUL_CONSUMPTION, ObjectGuid::Empty, 0, AURA_REMOVE_BY_EXPIRE);
+        bot->RemoveAurasDueToSpell(SPELL_MARK_OF_CONSUMPTION, ObjectGuid::Empty, 0, AURA_REMOVE_BY_EXPIRE);
+        return false;
+    }
+
+    std::vector<std::pair<Unit*, Unit*>> pairs;
+    RsHalionCollectOrbPairs(boss, pairs);
+
+    std::vector<Unit*> pools;
+    RsHalionCollectHazardPools(bot, pools);
+
+    auto beamClear = [&](float px, float py) -> bool
+    {
+        for (auto const& pair : pairs)
+            if (std::fabs(RsHalionBeamSignedDist(px, py, pair.first, pair.second)) <= RS_HALION_CUTTER_BOT_CLEAR)
+                return false;
+        return true;
+    };
+
+    bool const startInPool = !RsHalionSpotClearOfPools(pools, bot->GetPositionX(), bot->GetPositionY());
+
+    float const radAngle = distToBoss > 0.01f
+        ? std::atan2(bot->GetPositionY() - bossY, bot->GetPositionX() - bossX)
+        : 0.0f;
+    float const stepArc = static_cast<float>(M_PI) / 36.0f;
+
+    bool moveResult = false;
+    auto tryReachOut = [&](bool needBeamClear, bool needPoolClear, bool needPathClear) -> bool
+    {
+        for (int i = 0; i <= 24; ++i)
+        {
+            for (float const sign : {1.0f, -1.0f})
+            {
+                float const a = radAngle + sign * stepArc * static_cast<float>(i);
+                float const goalX = bossX + std::cos(a) * RS_HALION_CONSUMPTION_OUT_DIST;
+                float const goalY = bossY + std::sin(a) * RS_HALION_CONSUMPTION_OUT_DIST;
+
+                if (needBeamClear && !beamClear(goalX, goalY))
+                    continue;
+                if (needPoolClear && !RsHalionSpotClearOfPools(pools, goalX, goalY))
+                    continue;
+
+                float const dx = goalX - bot->GetPositionX();
+                float const dy = goalY - bot->GetPositionY();
+                float const dist = std::sqrt(dx * dx + dy * dy);
+                float const stepLen = std::min(RS_HALION_CONSUMPTION_STEP, dist);
+                float const moveX = dist < 0.01f ? goalX : bot->GetPositionX() + (dx / dist) * stepLen;
+                float const moveY = dist < 0.01f ? goalY : bot->GetPositionY() + (dy / dist) * stepLen;
+
+                if (needBeamClear && !beamClear(moveX, moveY))
+                    continue;
+                if (needPoolClear && !RsHalionSpotClearOfPools(pools, moveX, moveY))
+                    continue;
+                if (needPathClear && !startInPool &&
+                    !RsHalionPathClearOfPools(pools, bot->GetPositionX(), bot->GetPositionY(), moveX, moveY))
+                    continue;
+                if (!bot->IsWithinLOS(moveX, moveY, bot->GetPositionZ()))
+                    continue;
+
+                moveResult = MoveTo(bot->GetMapId(), moveX, moveY, bot->GetPositionZ(), false, false, false,
+                                    true, MovementPriority::MOVEMENT_FORCED);
+                return true;
+            }
+        }
+        return false;
+    };
+
+    if (tryReachOut(true, true, true) || tryReachOut(true, true, false) ||
+        tryReachOut(true, false, false) || tryReachOut(false, false, false))
+        return moveResult;
+
+    return false;
+}
+
+bool RsHalionHealConsumptionAction::Execute(Event )
+{
+    Player* target = RsHalionConsumptionHealTarget(botAI);
+    if (!target)
+        return false;
+
+    if (bot->GetExactDist2d(target) > 36.0f)
+        return MoveTo(bot->GetMapId(), target->GetPositionX(), target->GetPositionY(), target->GetPositionZ(),
+                      false, false, false, false, MovementPriority::MOVEMENT_COMBAT);
+
+    switch (bot->getClass())
+    {
+        case CLASS_PRIEST:
+            return botAI->CastSpell("flash heal", target) || botAI->CastSpell("greater heal", target) ||
+                   botAI->CastSpell("renew", target);
+        case CLASS_DRUID:
+            return botAI->CastSpell("regrowth", target) || botAI->CastSpell("nourish", target) ||
+                   botAI->CastSpell("rejuvenation", target);
+        case CLASS_SHAMAN:
+            return botAI->CastSpell("lesser healing wave", target) || botAI->CastSpell("healing wave", target) ||
+                   botAI->CastSpell("riptide", target);
+        case CLASS_PALADIN:
+            return botAI->CastSpell("flash of light", target) || botAI->CastSpell("holy light", target);
+        default:
+            break;
+    }
+
+    return false;
+}
+
+bool RsHalionCutterAction::Execute(Event )
+{
+    std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+    if (bot->HasAura(SPELL_MARK_OF_CONSUMPTION) || bot->HasAura(SPELL_SOUL_CONSUMPTION))
+        return false;
+
+    Unit* boss = RsHalionTwilightBoss(botAI);
+    if (!boss)
+        return false;
+
+    std::vector<std::pair<Unit*, Unit*>> pairs;
+    if (!RsHalionCollectOrbPairs(boss, pairs))
+        return false;
+
+    if (!RsHalionCutterShouldMove(bot->GetInstanceId()))
+        return false;
+
+    if (RsHalionPortalCommit(botAI, bot))
+        return false;
+
+    float const bossX = boss->GetPositionX();
+    float const bossY = boss->GetPositionY();
+
+    auto nearestBeamDist = [&](float px, float py) -> float
+    {
+        float best = std::numeric_limits<float>::max();
+        for (auto const& pair : pairs)
+            best = std::min(best, std::fabs(RsHalionBeamSignedDist(px, py, pair.first, pair.second)));
+        return best;
+    };
+
+    Player* twilightTank = RsHalionTwilightTank(botAI);
+
+    RubySanctumHelpers::CutterTiming& timing = RubySanctumHelpers::cutterTiming[bot->GetInstanceId()];
+    float const spinSign = timing.spinSign != 0.0f ? timing.spinSign : 1.0f;
+
+    if (twilightTank == bot)
+    {
+        if (boss->GetVictim() != bot)
+            return false;
+
+        float const radius = RS_HALION_CUTTER_FLANK_DIST;
+        float const distToBoss = bot->GetExactDist2d(bossX, bossY);
+        float const tankAngle = std::atan2(bot->GetPositionY() - bossY, bot->GetPositionX() - bossX);
+
+        if (std::fabs(distToBoss - radius) > 2.0f)
+        {
+            float const rx = bossX + std::cos(tankAngle) * radius;
+            float const ry = bossY + std::sin(tankAngle) * radius;
+            if (bot->IsWithinLOS(rx, ry, bot->GetPositionZ()))
+                return MoveTo(bot->GetMapId(), rx, ry, bot->GetPositionZ(), false, false, false, true,
+                              MovementPriority::MOVEMENT_FORCED, true, false);
+        }
+
+        float const trailAngle = RS_HALION_CUTTER_TANK_TRAIL / radius;
+        float const tolAngle = RS_HALION_CUTTER_TANK_TRAIL_TOL / radius;
+
+        float bestDist = std::numeric_limits<float>::max();
+        float follow = 0.0f;
+        for (auto const& pair : pairs)
+        {
+            float const phi = std::atan2(pair.second->GetPositionY() - pair.first->GetPositionY(),
+                                         pair.second->GetPositionX() - pair.first->GetPositionX());
+            for (float const c : {phi, phi + static_cast<float>(M_PI)})
+            {
+                float const targetAngle = c - spinSign * trailAngle;
+                float f = spinSign * (targetAngle - tankAngle);
+                while (f > static_cast<float>(M_PI))
+                    f -= 2.0f * static_cast<float>(M_PI);
+                while (f < -static_cast<float>(M_PI))
+                    f += 2.0f * static_cast<float>(M_PI);
+                if (std::fabs(f) < bestDist)
+                {
+                    bestDist = std::fabs(f);
+                    follow = f;
+                }
+            }
+        }
+
+        if (std::fabs(follow) <= tolAngle)
+            return false;
+
+        float const stepLen = 3.0f;
+        float const stepAngle = std::min(std::fabs(follow), stepLen / radius);
+        float const moveSign = follow >= 0.0f ? spinSign : -spinSign;
+        float const moveAngle = tankAngle + moveSign * stepAngle;
+
+        float const moveX = bossX + std::cos(moveAngle) * radius;
+        float const moveY = bossY + std::sin(moveAngle) * radius;
+
+        if (nearestBeamDist(moveX, moveY) <= RS_HALION_CUTTER_HALF_WIDTH)
+            return false;
+        if (!bot->IsWithinLOS(moveX, moveY, bot->GetPositionZ()))
+            return false;
+
+        return MoveTo(bot->GetMapId(), moveX, moveY, bot->GetPositionZ(), false, false, false, true,
+                      MovementPriority::MOVEMENT_FORCED, true);
+    }
+
+    return false;
+}

--- a/src/Ai/Raid/RS/Action/RSActions_SAV.cpp
+++ b/src/Ai/Raid/RS/Action/RSActions_SAV.cpp
@@ -1,0 +1,354 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <map>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include "Playerbots.h"
+#include "RSActions.h"
+
+namespace
+{
+    constexpr int RS_SAVIANA_BEACON_SLOTS = 8;
+    constexpr float RS_SAVIANA_BEACON_RING = 18.0f;
+    constexpr float RS_SAVIANA_BEACON_REACH = 3.0f;
+
+    std::map<std::pair<uint32, ObjectGuid>, int> g_savianaBeaconSlot;
+
+    Position RsSavianaBeaconSlotPos(int slot)
+    {
+        float const angle = slot * (2.0f * static_cast<float>(M_PI) / RS_SAVIANA_BEACON_SLOTS);
+        return Position(RS_SAVIANA_TANK_POSITION.GetPositionX() + std::cos(angle) * RS_SAVIANA_BEACON_RING,
+                        RS_SAVIANA_TANK_POSITION.GetPositionY() + std::sin(angle) * RS_SAVIANA_BEACON_RING,
+                        RS_SAVIANA_TANK_POSITION.GetPositionZ());
+    }
+
+    constexpr int RS_SAVIANA_MELEE_INNER = 8;
+    constexpr int RS_SAVIANA_MELEE_OUTER = 12;
+    constexpr int RS_SAVIANA_MELEE_SLOTS = RS_SAVIANA_MELEE_INNER + RS_SAVIANA_MELEE_OUTER;
+    constexpr float RS_SAVIANA_MELEE_INNER_RING = 12.0f;
+    constexpr float RS_SAVIANA_MELEE_OUTER_RING = 20.0f;
+    constexpr float RS_SAVIANA_MELEE_REACH = 3.0f;
+
+    constexpr float RS_SAVIANA_BEACON_DANGER = 12.0f;
+
+    std::map<std::pair<uint32, ObjectGuid>, int> g_savianaMeleeSlot;
+
+    constexpr float RS_SAVIANA_FRONT_RANGE = 30.0f;
+
+    Position RsSavianaMeleeSlotPos(int slot)
+    {
+        bool const inner = slot < RS_SAVIANA_MELEE_INNER;
+        int const count = inner ? RS_SAVIANA_MELEE_INNER : RS_SAVIANA_MELEE_OUTER;
+        int const index = inner ? slot : slot - RS_SAVIANA_MELEE_INNER;
+        float const ring = inner ? RS_SAVIANA_MELEE_INNER_RING : RS_SAVIANA_MELEE_OUTER_RING;
+
+        float const offset = inner ? 0.0f : (static_cast<float>(M_PI) / count);
+        float const angle = index * (2.0f * static_cast<float>(M_PI) / count) + offset;
+
+        return Position(RS_SAVIANA_TANK_POSITION.GetPositionX() + std::cos(angle) * ring,
+                        RS_SAVIANA_TANK_POSITION.GetPositionY() + std::sin(angle) * ring,
+                        RS_SAVIANA_TANK_POSITION.GetPositionZ());
+    }
+}
+
+bool RsSavianaConflagrationAction::Execute(Event )
+{
+    uint32 const instanceId = bot->GetInstanceId();
+    auto const myKey = std::make_pair(instanceId, bot->GetGUID());
+
+    if (!bot->HasAura(SPELL_FLAME_BEACON))
+    {
+        g_savianaBeaconSlot.erase(myKey);
+        return false;
+    }
+
+    std::set<int> reserved;
+    if (Group* group = bot->GetGroup())
+    {
+        for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
+        {
+            Player* member = itr->GetSource();
+            if (!member || member == bot || !member->IsAlive())
+                continue;
+            if (!member->HasAura(SPELL_FLAME_BEACON))
+                continue;
+
+            auto it = g_savianaBeaconSlot.find(std::make_pair(instanceId, member->GetGUID()));
+            if (it != g_savianaBeaconSlot.end())
+                reserved.insert(it->second);
+        }
+    }
+
+    int mySlot = -1;
+
+    auto mem = g_savianaBeaconSlot.find(myKey);
+    if (mem != g_savianaBeaconSlot.end() && !reserved.count(mem->second))
+        mySlot = mem->second;
+
+    if (mySlot < 0)
+    {
+        float bestDist = std::numeric_limits<float>::max();
+        for (int i = 0; i < RS_SAVIANA_BEACON_SLOTS; ++i)
+        {
+            if (reserved.count(i))
+                continue;
+            Position const slotPos = RsSavianaBeaconSlotPos(i);
+            float const d = bot->GetExactDist2d(slotPos.GetPositionX(), slotPos.GetPositionY());
+            if (d < bestDist)
+            {
+                bestDist = d;
+                mySlot = i;
+            }
+        }
+    }
+
+    if (mySlot < 0)
+        return false;
+
+    g_savianaBeaconSlot[myKey] = mySlot;
+
+    Position const target = RsSavianaBeaconSlotPos(mySlot);
+    if (bot->GetExactDist2d(target.GetPositionX(), target.GetPositionY()) <= RS_SAVIANA_BEACON_REACH)
+        return false;
+
+    float destX = target.GetPositionX();
+    float destY = target.GetPositionY();
+    float destZ = target.GetPositionZ();
+
+    bool exact = true;
+    if (!bot->GetMap()->CheckCollisionAndGetValidCoords(bot, bot->GetPositionX(), bot->GetPositionY(),
+                                                        bot->GetPositionZ(), destX, destY, destZ))
+        exact = false;
+
+    return MoveTo(bot->GetMapId(), destX, destY, destZ, false, false, true, exact,
+                  MovementPriority::MOVEMENT_FORCED);
+}
+
+bool RsSavianaTankPositionAction::Execute(Event )
+{
+    if (!botAI->IsMainTank(bot))
+        return false;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "saviana ragefire");
+    if (!boss)
+        return false;
+
+    float const safeThreshold = 3.0f;
+    float const unsafeLeash = 20.0f;
+    float const leash = boss->IsLevitating() ? unsafeLeash : safeThreshold;
+
+    float const distance = bot->GetExactDist2d(RS_SAVIANA_TANK_POSITION.GetPositionX(),
+                                               RS_SAVIANA_TANK_POSITION.GetPositionY());
+
+    if (!boss->IsLevitating() && distance <= leash && !bot->IsWithinMeleeRange(boss))
+        return MoveTo(bot->GetMapId(), boss->GetPositionX(), boss->GetPositionY(), boss->GetPositionZ(),
+                      false, false, false, false, MovementPriority::MOVEMENT_COMBAT);
+
+    if (distance > leash)
+        return MoveTo(bot->GetMapId(), RS_SAVIANA_TANK_POSITION.GetPositionX(),
+                      RS_SAVIANA_TANK_POSITION.GetPositionY(), RS_SAVIANA_TANK_POSITION.GetPositionZ(),
+                      false, false, false, false, MovementPriority::MOVEMENT_COMBAT);
+
+    return false;
+}
+
+bool RsSavianaAvoidFrontAction::Execute(Event )
+{
+    if (botAI->IsTank(bot))
+        return false;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "saviana ragefire");
+    if (!boss || boss->IsLevitating())
+        return false;
+
+    if (!RsSpotInFrontArc(boss, bot->GetPositionX(), bot->GetPositionY(), RS_SAVIANA_FRONT_RANGE))
+        return false;
+
+    float const step = 5.0f;
+
+    if (!botAI->IsMelee(bot))
+    {
+        float const bossX = boss->GetPositionX();
+        float const bossY = boss->GetPositionY();
+        float const radius = bot->GetExactDist2d(bossX, bossY);
+
+        float const toBot = std::atan2(bot->GetPositionY() - bossY, bot->GetPositionX() - bossX);
+        float const leftFlank = boss->GetOrientation() + static_cast<float>(M_PI) / 2.0f;
+        float const rightFlank = boss->GetOrientation() - static_cast<float>(M_PI) / 2.0f;
+
+        float const flank = std::fabs(RsAngleDiff(toBot, leftFlank)) <= std::fabs(RsAngleDiff(toBot, rightFlank))
+            ? leftFlank : rightFlank;
+        float const flankX = bossX + std::cos(flank) * radius;
+        float const flankY = bossY + std::sin(flank) * radius;
+
+        float const dx = flankX - bot->GetPositionX();
+        float const dy = flankY - bot->GetPositionY();
+        float const dist = std::sqrt(dx * dx + dy * dy);
+        if (dist < 0.01f)
+            return false;
+
+        float const hop = std::min(step, dist);
+        float const moveX = bot->GetPositionX() + (dx / dist) * hop;
+        float const moveY = bot->GetPositionY() + (dy / dist) * hop;
+
+        if (!bot->IsWithinLOS(moveX, moveY, bot->GetPositionZ()))
+            return false;
+
+        return MoveTo(bot->GetMapId(), moveX, moveY, bot->GetPositionZ(), false, false, false, false,
+                      MovementPriority::MOVEMENT_COMBAT, true);
+    }
+
+    int const directions = 12;
+
+    for (int i = 0; i < directions; ++i)
+    {
+        float const angle = (i * 2.0f * static_cast<float>(M_PI)) / directions;
+        float const moveX = bot->GetPositionX() + step * std::cos(angle);
+        float const moveY = bot->GetPositionY() + step * std::sin(angle);
+        float const moveZ = bot->GetPositionZ();
+
+        if (RsSpotInFrontArc(boss, moveX, moveY, RS_SAVIANA_FRONT_RANGE))
+            continue;
+
+        if (!bot->IsWithinLOS(moveX, moveY, moveZ))
+            continue;
+
+        return MoveTo(bot->GetMapId(), moveX, moveY, moveZ, false, false, false, false,
+                      MovementPriority::MOVEMENT_COMBAT, true);
+    }
+
+    return false;
+}
+
+bool RsSavianaMeleeSpreadAction::Execute(Event )
+{
+    uint32 const instanceId = bot->GetInstanceId();
+    auto const myKey = std::make_pair(instanceId, bot->GetGUID());
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "saviana ragefire");
+    if (!boss || !boss->IsLevitating())
+    {
+        g_savianaMeleeSlot.erase(myKey);
+        return false;
+    }
+
+    auto moveChecked = [&](float destX, float destY, float destZ)
+    {
+        bool const exact = bot->GetMap()->CheckCollisionAndGetValidCoords(bot, bot->GetPositionX(),
+                                                                          bot->GetPositionY(), bot->GetPositionZ(),
+                                                                          destX, destY, destZ);
+        return MoveTo(bot->GetMapId(), destX, destY, destZ, false, false, true, exact,
+                      MovementPriority::MOVEMENT_FORCED);
+    };
+
+    std::set<int> reserved;
+    std::vector<Position> beacons;
+    if (Group* group = bot->GetGroup())
+    {
+        for (GroupReference* itr = group->GetFirstMember(); itr != nullptr; itr = itr->next())
+        {
+            Player* member = itr->GetSource();
+            if (!member || member == bot || !member->IsAlive())
+                continue;
+
+            if (member->HasAura(SPELL_FLAME_BEACON))
+            {
+                beacons.push_back(member->GetPosition());
+                continue;
+            }
+
+            auto it = g_savianaMeleeSlot.find(std::make_pair(instanceId, member->GetGUID()));
+            if (it != g_savianaMeleeSlot.end())
+                reserved.insert(it->second);
+        }
+    }
+
+    auto slotSafe = [&](int slot) -> bool
+    {
+        if (reserved.count(slot))
+            return false;
+        Position const slotPos = RsSavianaMeleeSlotPos(slot);
+        for (Position const& beacon : beacons)
+            if (beacon.GetExactDist2d(slotPos.GetPositionX(), slotPos.GetPositionY()) < RS_SAVIANA_BEACON_DANGER)
+                return false;
+        return true;
+    };
+
+    int mySlot = -1;
+
+    auto mem = g_savianaMeleeSlot.find(myKey);
+    if (mem != g_savianaMeleeSlot.end() && slotSafe(mem->second))
+        mySlot = mem->second;
+
+    if (mySlot < 0)
+    {
+        float bestDist = std::numeric_limits<float>::max();
+        for (int i = 0; i < RS_SAVIANA_MELEE_SLOTS; ++i)
+        {
+            if (!slotSafe(i))
+                continue;
+            Position const slotPos = RsSavianaMeleeSlotPos(i);
+            float const d = bot->GetExactDist2d(slotPos.GetPositionX(), slotPos.GetPositionY());
+            if (d < bestDist)
+            {
+                bestDist = d;
+                mySlot = i;
+            }
+        }
+    }
+
+    if (mySlot < 0)
+    {
+        g_savianaMeleeSlot.erase(myKey);
+
+        Position const* nearest = nullptr;
+        float nearestDist = std::numeric_limits<float>::max();
+        for (Position const& beacon : beacons)
+        {
+            float const d = bot->GetExactDist2d(beacon.GetPositionX(), beacon.GetPositionY());
+            if (d < nearestDist)
+            {
+                nearestDist = d;
+                nearest = &beacon;
+            }
+        }
+
+        if (!nearest || nearestDist >= RS_SAVIANA_BEACON_DANGER)
+            return false;
+
+        float dx = bot->GetPositionX() - nearest->GetPositionX();
+        float dy = bot->GetPositionY() - nearest->GetPositionY();
+        float const len = std::sqrt(dx * dx + dy * dy);
+        if (len < 0.01f)
+        {
+            dx = 1.0f;
+            dy = 0.0f;
+        }
+        else
+        {
+            dx /= len;
+            dy /= len;
+        }
+
+        float const stepOut = RS_SAVIANA_BEACON_DANGER - nearestDist + 2.0f;
+        return moveChecked(bot->GetPositionX() + dx * stepOut, bot->GetPositionY() + dy * stepOut,
+                           bot->GetPositionZ());
+    }
+
+    g_savianaMeleeSlot[myKey] = mySlot;
+
+    Position const target = RsSavianaMeleeSlotPos(mySlot);
+    if (bot->GetExactDist2d(target.GetPositionX(), target.GetPositionY()) <= RS_SAVIANA_MELEE_REACH)
+        return false;
+
+    return moveChecked(target.GetPositionX(), target.GetPositionY(), target.GetPositionZ());
+}

--- a/src/Ai/Raid/RS/Action/RSActions_ZAR.cpp
+++ b/src/Ai/Raid/RS/Action/RSActions_ZAR.cpp
@@ -1,0 +1,280 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include <limits>
+#include <vector>
+
+#include "NearestNpcsValue.h"
+#include "Playerbots.h"
+#include "RSActions.h"
+
+bool RsZarithrianAddsAction::Execute(Event )
+{
+    context->GetValue<std::string>("rti")->Set("skull");
+
+    if (!IsDesignatedMarker())
+        return false;
+
+    UpdateSkullMarker(FindPriorityAdd());
+    return false;
+}
+
+bool RsZarithrianAddsAction::IsDesignatedMarker()
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+        return true;
+
+    ObjectGuid lowest = bot->GetGUID();
+    for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
+    {
+        Player* member = itr->GetSource();
+        if (!member || !member->IsAlive())
+            continue;
+
+        PlayerbotAI* memberAI = sPlayerbotsMgr.GetPlayerbotAI(member);
+        if (!memberAI)
+            continue;
+
+        if (memberAI->IsTank(member) || memberAI->IsHeal(member))
+            continue;
+
+        if (member->GetMapId() != bot->GetMapId() || member->GetInstanceId() != bot->GetInstanceId())
+            continue;
+
+        if (member->GetGUID() < lowest)
+            lowest = member->GetGUID();
+    }
+
+    return bot->GetGUID() == lowest;
+}
+
+Unit* RsZarithrianAddsAction::FindPriorityAdd()
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+        return nullptr;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "general zarithrian");
+
+    Unit* current = botAI->GetUnit(group->GetTargetIcon(RtiTargetValue::skullIndex));
+    if (current && current->IsAlive() && current->GetEntry() == NPC_ONYX_FLAMECALLER)
+        return current;
+
+    constexpr float markRange = 20.0f;
+    Unit* best = nullptr;
+    GuidVector const targets = AI_VALUE(GuidVector, "possible targets no los");
+    for (ObjectGuid const& guid : targets)
+    {
+        Unit* unit = botAI->GetUnit(guid);
+        if (!unit || !unit->IsAlive() || unit->GetEntry() != NPC_ONYX_FLAMECALLER)
+            continue;
+
+        if (boss && unit->GetExactDist2d(boss) > markRange)
+            continue;
+
+        if (!best || unit->GetGUID() < best->GetGUID())
+            best = unit;
+    }
+
+    return best ? best : boss;
+}
+
+void RsZarithrianAddsAction::UpdateSkullMarker(Unit* priorityAdd)
+{
+    if (!priorityAdd)
+        return;
+
+    Group* group = bot->GetGroup();
+    if (!group)
+        return;
+
+    if (group->GetTargetIcon(RtiTargetValue::skullIndex) != priorityAdd->GetGUID())
+        group->SetTargetIcon(RtiTargetValue::skullIndex, bot->GetGUID(), priorityAdd->GetGUID());
+}
+
+uint32 RsZarithrianTankAction::GetCleaveStacks(Unit* unit)
+{
+    if (!unit)
+        return 0;
+
+    Aura* aura = botAI->GetAura("cleave armor", unit, false, true);
+    return aura ? aura->GetStackAmount() : 0;
+}
+
+Unit* RsZarithrianTankAction::FindBoss()
+{
+    GuidVector const targets = AI_VALUE(GuidVector, "possible targets no los");
+    for (ObjectGuid const& guid : targets)
+    {
+        Unit* unit = botAI->GetUnit(guid);
+        if (unit && unit->IsAlive() && unit->GetEntry() == NPC_GENERAL_ZARITHRIAN)
+            return unit;
+    }
+    return nullptr;
+}
+
+void RsZarithrianTankAction::CollectAdds(std::vector<Unit*>& adds)
+{
+    GuidVector const targets = AI_VALUE(GuidVector, "possible targets no los");
+    for (ObjectGuid const& guid : targets)
+    {
+        Unit* unit = botAI->GetUnit(guid);
+        if (unit && unit->IsAlive() && unit->GetEntry() == NPC_ONYX_FLAMECALLER)
+            adds.push_back(unit);
+    }
+}
+
+bool RsZarithrianTankAction::HoldBoss(Unit* boss)
+{
+    bot->SetTarget(boss->GetGUID());
+
+    if (boss->GetVictim() != bot)
+        RsCastClassTaunt(botAI, bot, boss);
+
+    bool const onSpot = bot->GetExactDist2d(RS_ZARITHRIAN_TANK_POSITION.GetPositionX(),
+                                            RS_ZARITHRIAN_TANK_POSITION.GetPositionY()) <= 3.0f;
+
+    if (!bot->IsWithinMeleeRange(boss) && onSpot)
+        return MoveTo(bot->GetMapId(), boss->GetPositionX(), boss->GetPositionY(), boss->GetPositionZ(),
+                      false, false, false, true, MovementPriority::MOVEMENT_COMBAT);
+
+    if (!onSpot)
+        return MoveTo(bot->GetMapId(), RS_ZARITHRIAN_TANK_POSITION.GetPositionX(),
+                      RS_ZARITHRIAN_TANK_POSITION.GetPositionY(), RS_ZARITHRIAN_TANK_POSITION.GetPositionZ(),
+                      false, false, false, true, MovementPriority::MOVEMENT_COMBAT);
+
+    return false;
+}
+
+bool RsZarithrianTankAction::RunAddsToBoss(Unit* boss, std::vector<Unit*> const& adds)
+{
+    for (Unit* add : adds)
+    {
+        if (!add || !add->IsAlive())
+            continue;
+
+        if (add->GetVictim() != bot)
+            RsCastClassTaunt(botAI, bot, add);
+    }
+
+    Unit* nearest = nullptr;
+    float best = std::numeric_limits<float>::max();
+    for (Unit* add : adds)
+    {
+        if (!add || !add->IsAlive())
+            continue;
+        float const d = bot->GetExactDist2d(add);
+        if (d < best)
+        {
+            best = d;
+            nearest = add;
+        }
+    }
+    Unit* meleeTarget = nearest ? nearest : boss;
+    bot->SetTarget(meleeTarget->GetGUID());
+
+    bool const onSpot = bot->GetExactDist2d(RS_ZARITHRIAN_TANK_POSITION.GetPositionX(),
+                                            RS_ZARITHRIAN_TANK_POSITION.GetPositionY()) <= 3.0f;
+
+    if (!bot->IsWithinMeleeRange(meleeTarget) && onSpot)
+        return MoveTo(bot->GetMapId(), meleeTarget->GetPositionX(), meleeTarget->GetPositionY(),
+                      meleeTarget->GetPositionZ(), false, false, false, true,
+                      MovementPriority::MOVEMENT_COMBAT);
+
+    if (!onSpot)
+        return MoveTo(bot->GetMapId(), RS_ZARITHRIAN_TANK_POSITION.GetPositionX(),
+                      RS_ZARITHRIAN_TANK_POSITION.GetPositionY(), RS_ZARITHRIAN_TANK_POSITION.GetPositionZ(),
+                      false, false, false, true, MovementPriority::MOVEMENT_COMBAT);
+
+    return false;
+}
+
+bool RsZarithrianTankAction::Execute(Event )
+{
+    if (!botAI->IsTank(bot))
+        return false;
+
+    Unit* boss = FindBoss();
+    if (!boss)
+        return false;
+
+    if (bot->GetMotionMaster()->GetCurrentMovementGeneratorType() == FOLLOW_MOTION_TYPE)
+    {
+        bot->AttackStop();
+        bot->InterruptNonMeleeSpells(true);
+        if (bot->GetTarget())
+            bot->SetTarget(ObjectGuid::Empty);
+        return false;
+    }
+
+    Player* mainTankPlayer = nullptr;
+    Player* assistTankPlayer = nullptr;
+    if (Group* group = bot->GetGroup())
+    {
+        for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
+        {
+            Player* member = itr->GetSource();
+            if (!member || !member->IsAlive())
+                continue;
+
+            if (!mainTankPlayer && botAI->IsMainTank(member))
+                mainTankPlayer = member;
+
+            if (!assistTankPlayer && botAI->IsAssistTank(member))
+                assistTankPlayer = member;
+
+            if (mainTankPlayer && assistTankPlayer)
+                break;
+        }
+    }
+
+    std::vector<Unit*> adds;
+    CollectAdds(adds);
+
+    if (!mainTankPlayer || !assistTankPlayer || mainTankPlayer == assistTankPlayer)
+    {
+        for (Unit* add : adds)
+        {
+            if (add && add->IsAlive() && add->GetVictim() != bot)
+                RsCastClassTaunt(botAI, bot, add);
+        }
+        return HoldBoss(boss);
+    }
+
+    if (GetCleaveStacks(bot) >= RS_ZARITHRIAN_CLEAVE_SWAP_STACKS)
+    {
+
+        if (boss->GetVictim() == bot)
+            bot->AttackStop();
+
+        return RunAddsToBoss(boss, adds);
+    }
+
+    Player* bossVictimTank = nullptr;
+    if (Unit* victim = boss->GetVictim())
+    {
+        if (victim == mainTankPlayer || victim == assistTankPlayer)
+            bossVictimTank = victim->ToPlayer();
+    }
+
+    if (bossVictimTank == bot)
+        return HoldBoss(boss);
+
+    bool const holderShredded =
+        bossVictimTank && GetCleaveStacks(bossVictimTank) >= RS_ZARITHRIAN_CLEAVE_SWAP_STACKS;
+    if (!bossVictimTank || holderShredded)
+    {
+        Player* takeOverTank = mainTankPlayer;
+        if (holderShredded)
+            takeOverTank = (bossVictimTank == mainTankPlayer) ? assistTankPlayer : mainTankPlayer;
+
+        if (bot == takeOverTank)
+            return HoldBoss(boss);
+    }
+
+    return RunAddsToBoss(boss, adds);
+}

--- a/src/Ai/Raid/RS/RSActionContext.h
+++ b/src/Ai/Raid/RS/RSActionContext.h
@@ -1,0 +1,78 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef _PLAYERBOT_RSACTIONCONTEXT_H
+#define _PLAYERBOT_RSACTIONCONTEXT_H
+
+#include "Action.h"
+#include "NamedObjectContext.h"
+#include "RSActions.h"
+
+class RaidRsActionContext : public NamedObjectContext<Action>
+{
+public:
+    RaidRsActionContext()
+    {
+        creators["rs baltharus brand"] = &RaidRsActionContext::rs_baltharus_brand;
+        creators["rs baltharus tank position"] = &RaidRsActionContext::rs_baltharus_tank_position;
+        creators["rs baltharus avoid front"] = &RaidRsActionContext::rs_baltharus_avoid_front;
+        creators["rs baltharus healer position"] = &RaidRsActionContext::rs_baltharus_healer_position;
+        creators["rs saviana conflagration"] = &RaidRsActionContext::rs_saviana_conflagration;
+        creators["rs saviana avoid front"] = &RaidRsActionContext::rs_saviana_avoid_front;
+        creators["rs saviana tank position"] = &RaidRsActionContext::rs_saviana_tank_position;
+        creators["rs saviana melee spread"] = &RaidRsActionContext::rs_saviana_melee_spread;
+        creators["rs zarithrian adds"] = &RaidRsActionContext::rs_zarithrian_adds;
+        creators["rs zarithrian tank"] = &RaidRsActionContext::rs_zarithrian_tank;
+        creators["rs halion tank position"] = &RaidRsActionContext::rs_halion_tank_position;
+        creators["rs halion avoid cones"] = &RaidRsActionContext::rs_halion_avoid_cones;
+        creators["rs halion combustion"] = &RaidRsActionContext::rs_halion_combustion;
+        creators["rs halion meteor"] = &RaidRsActionContext::rs_halion_meteor;
+        creators["rs halion adds"] = &RaidRsActionContext::rs_halion_adds;
+        creators["rs halion add tank"] = &RaidRsActionContext::rs_halion_add_tank;
+        creators["rs halion start position"] = &RaidRsActionContext::rs_halion_start_position;
+        creators["rs halion enter portal"] = &RaidRsActionContext::rs_halion_enter_portal;
+        creators["rs halion p2 tank position"] = &RaidRsActionContext::rs_halion_p2_tank_position;
+        creators["rs halion p2 avoid cones"] = &RaidRsActionContext::rs_halion_p2_avoid_cones;
+        creators["rs halion consumption"] = &RaidRsActionContext::rs_halion_consumption;
+        creators["rs halion cutter"] = &RaidRsActionContext::rs_halion_cutter;
+        creators["rs halion heal consumption"] = &RaidRsActionContext::rs_halion_heal_consumption;
+        creators["rs trash adds"] = &RaidRsActionContext::rs_trash_adds;
+        creators["rs trash main tank"] = &RaidRsActionContext::rs_trash_main_tank;
+        creators["rs trash assist tank"] = &RaidRsActionContext::rs_trash_assist_tank;
+        creators["rs trash ranged"] = &RaidRsActionContext::rs_trash_ranged;
+    }
+
+private:
+    static Action* rs_baltharus_brand(PlayerbotAI* ai) { return new RsBaltharusBrandAction(ai); }
+    static Action* rs_baltharus_tank_position(PlayerbotAI* ai) { return new RsBaltharusTankPositionAction(ai); }
+    static Action* rs_baltharus_avoid_front(PlayerbotAI* ai) { return new RsBaltharusAvoidFrontAction(ai); }
+    static Action* rs_baltharus_healer_position(PlayerbotAI* ai) { return new RsBaltharusHealerPositionAction(ai); }
+    static Action* rs_saviana_conflagration(PlayerbotAI* ai) { return new RsSavianaConflagrationAction(ai); }
+    static Action* rs_saviana_avoid_front(PlayerbotAI* ai) { return new RsSavianaAvoidFrontAction(ai); }
+    static Action* rs_saviana_tank_position(PlayerbotAI* ai) { return new RsSavianaTankPositionAction(ai); }
+    static Action* rs_saviana_melee_spread(PlayerbotAI* ai) { return new RsSavianaMeleeSpreadAction(ai); }
+    static Action* rs_zarithrian_adds(PlayerbotAI* ai) { return new RsZarithrianAddsAction(ai); }
+    static Action* rs_zarithrian_tank(PlayerbotAI* ai) { return new RsZarithrianTankAction(ai); }
+    static Action* rs_halion_tank_position(PlayerbotAI* ai) { return new RsHalionTankPositionAction(ai); }
+    static Action* rs_halion_avoid_cones(PlayerbotAI* ai) { return new RsHalionAvoidConesAction(ai); }
+    static Action* rs_halion_combustion(PlayerbotAI* ai) { return new RsHalionCombustionAction(ai); }
+    static Action* rs_halion_meteor(PlayerbotAI* ai) { return new RsHalionMeteorAction(ai); }
+    static Action* rs_halion_adds(PlayerbotAI* ai) { return new RsHalionAddsAction(ai); }
+    static Action* rs_halion_add_tank(PlayerbotAI* ai) { return new RsHalionAddTankAction(ai); }
+    static Action* rs_halion_start_position(PlayerbotAI* ai) { return new RsHalionStartPositionAction(ai); }
+    static Action* rs_halion_enter_portal(PlayerbotAI* ai) { return new RsHalionEnterPortalAction(ai); }
+    static Action* rs_halion_p2_tank_position(PlayerbotAI* ai) { return new RsHalionP2TankPositionAction(ai); }
+    static Action* rs_halion_p2_avoid_cones(PlayerbotAI* ai) { return new RsHalionP2AvoidConesAction(ai); }
+    static Action* rs_halion_consumption(PlayerbotAI* ai) { return new RsHalionConsumptionAction(ai); }
+    static Action* rs_halion_cutter(PlayerbotAI* ai) { return new RsHalionCutterAction(ai); }
+    static Action* rs_halion_heal_consumption(PlayerbotAI* ai) { return new RsHalionHealConsumptionAction(ai); }
+    static Action* rs_trash_adds(PlayerbotAI* ai) { return new RsTrashAddsAction(ai); }
+    static Action* rs_trash_main_tank(PlayerbotAI* ai) { return new RsTrashMainTankAction(ai); }
+    static Action* rs_trash_assist_tank(PlayerbotAI* ai) { return new RsTrashAssistTankAction(ai); }
+    static Action* rs_trash_ranged(PlayerbotAI* ai) { return new RsTrashRangedAction(ai); }
+};
+
+#endif

--- a/src/Ai/Raid/RS/RSMultipliers.cpp
+++ b/src/Ai/Raid/RS/RSMultipliers.cpp
@@ -1,0 +1,380 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "RSMultipliers.h"
+
+#include "FollowActions.h"
+#include "ChooseTargetActions.h"
+#include "MovementActions.h"
+#include "NearestNpcsValue.h"
+#include "Playerbots.h"
+#include "DKActions.h"
+#include "DruidActions.h"
+#include "DruidBearActions.h"
+#include "DruidCatActions.h"
+#include "GenericActions.h"
+#include "GenericSpellActions.h"
+#include "HunterActions.h"
+#include "MageActions.h"
+#include "WarlockActions.h"
+#include "PaladinActions.h"
+#include "PriestActions.h"
+#include "ICCActions.h"
+#include "ReachTargetActions.h"
+#include "RogueActions.h"
+#include "ShamanActions.h"
+#include "UseMeetingStoneAction.h"
+#include "WarriorActions.h"
+#include "RSActions.h"
+#include "RSTriggers.h"
+#include "RSScripts.h"
+#include "Timer.h"
+
+float RsSavianaBeaconMultiplier::GetValue(Action* action)
+{
+    if (!bot->HasAura(SPELL_FLAME_BEACON))
+        return 1.0f;
+
+    if (dynamic_cast<MovementAction*>(action) && !dynamic_cast<RsSavianaConflagrationAction*>(action))
+        return 0.0f;
+
+    return 1.0f;
+}
+
+float RsBaltharusBrandSafeMultiplier::GetValue(Action* action)
+{
+    if (botAI->IsTank(bot) || !bot->HasAura(SPELL_ENERVATING_BRAND))
+        return 1.0f;
+
+    Group* group = bot->GetGroup();
+    if (!group)
+        return 1.0f;
+
+    if (dynamic_cast<DpsAoeAction*>(action) || dynamic_cast<CastHurricaneAction*>(action) ||
+        dynamic_cast<CastVolleyAction*>(action) || dynamic_cast<CastBlizzardAction*>(action) ||
+        dynamic_cast<CastStarfallAction*>(action) || dynamic_cast<FanOfKnivesAction*>(action) ||
+        dynamic_cast<CastWhirlwindAction*>(action) || dynamic_cast<CastMindSearAction*>(action) ||
+        dynamic_cast<CastArmyOfTheDeadAction*>(action))
+        return 0.0f;
+
+    for (GroupReference* itr = group->GetFirstMember(); itr; itr = itr->next())
+    {
+        Player* member = itr->GetSource();
+        if (member && member != bot && member->IsAlive() &&
+            member->GetExactDist2d(bot) < RS_BALTHARUS_BRAND_RANGE)
+            return 1.0f;
+    }
+
+    if (dynamic_cast<MovementAction*>(action) && !dynamic_cast<RsBaltharusBrandAction*>(action))
+        return 0.0f;
+
+    return 1.0f;
+}
+
+float RsSavianaMeleeSpreadMultiplier::GetValue(Action* action)
+{
+    if (botAI->IsTank(bot) || (!botAI->IsMelee(bot) && !botAI->IsHeal(bot)))
+        return 1.0f;
+
+    if (bot->HasAura(SPELL_FLAME_BEACON))
+        return 1.0f;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "saviana ragefire");
+    if (!boss || !boss->IsLevitating())
+        return 1.0f;
+
+    if (dynamic_cast<MovementAction*>(action) && !dynamic_cast<RsSavianaMeleeSpreadAction*>(action))
+        return 0.0f;
+
+    return 1.0f;
+}
+
+float RsZarithrianAddsMultiplier::GetValue(Action* action)
+{
+    if (botAI->IsTank(bot) || botAI->IsHeal(bot))
+        return 1.0f;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "general zarithrian");
+    if (!boss)
+        return 1.0f;
+
+    bool addAlive = false;
+    GuidVector const targets = AI_VALUE(GuidVector, "possible targets no los");
+    for (ObjectGuid const& guid : targets)
+    {
+        Unit* unit = botAI->GetUnit(guid);
+        if (unit && unit->IsAlive() && unit->GetEntry() == NPC_ONYX_FLAMECALLER)
+        {
+            addAlive = true;
+            break;
+        }
+    }
+
+    if (!addAlive)
+        return 1.0f;
+
+    if (dynamic_cast<CombatFormationMoveAction*>(action) || dynamic_cast<FollowAction*>(action))
+        return 0.0f;
+
+    return 1.0f;
+}
+
+float RsZarithrianTankSwapMultiplier::GetValue(Action* action)
+{
+    if (!botAI->IsTank(bot))
+        return 1.0f;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "general zarithrian");
+    if (!boss)
+        return 1.0f;
+
+    Aura* aura = botAI->GetAura("cleave armor", bot, false, true);
+    if (!aura || aura->GetStackAmount() < RS_ZARITHRIAN_CLEAVE_SWAP_STACKS)
+        return 1.0f;
+
+    if (dynamic_cast<CastTauntAction*>(action) || dynamic_cast<CastDarkCommandAction*>(action) ||
+        dynamic_cast<CastHandOfReckoningAction*>(action) || dynamic_cast<CastGrowlAction*>(action))
+        return 0.0f;
+
+    if (dynamic_cast<MovementAction*>(action) || dynamic_cast<RsZarithrianTankAction*>(action))
+        return 1.0f;
+
+    return 0.0f;
+}
+
+float RsHalionCombustionMultiplier::GetValue(Action* action)
+{
+
+    if (RsHalionEngaged(botAI) && RsHalionCombustionNotClear(bot))
+    {
+        if (dynamic_cast<CurePartyMemberAction*>(action) || dynamic_cast<CastDispelMagicAction*>(action) ||
+            dynamic_cast<CastCleanseMagicAction*>(action) || dynamic_cast<CastCleanseSpiritAction*>(action))
+            return 0.0f;
+    }
+
+    if (botAI->IsTank(bot) && !RsHalionAssistTankAsMelee(botAI))
+        return 1.0f;
+
+    if (!RsHalionHasCombustion(bot))
+        return 1.0f;
+
+    if (dynamic_cast<DpsAoeAction*>(action) || dynamic_cast<CastHurricaneAction*>(action) ||
+        dynamic_cast<CastVolleyAction*>(action) || dynamic_cast<CastBlizzardAction*>(action) ||
+        dynamic_cast<CastStarfallAction*>(action) || dynamic_cast<FanOfKnivesAction*>(action) ||
+        dynamic_cast<CastWhirlwindAction*>(action) || dynamic_cast<CastMindSearAction*>(action) ||
+        dynamic_cast<CastArmyOfTheDeadAction*>(action))
+        return 0.0f;
+
+    if (dynamic_cast<MovementAction*>(action) && !dynamic_cast<RsHalionCombustionAction*>(action))
+        return 0.0f;
+
+    return 1.0f;
+}
+
+float RsHalionMeteorMultiplier::GetValue(Action* action)
+{
+    if (botAI->IsTank(bot) && !RsHalionAssistTankAsMelee(botAI))
+        return 1.0f;
+
+    if (RsHalionInTwilight(bot))
+        return 1.0f;
+
+    Unit* physBoss = RsHalionAnyPhysicalBoss(botAI);
+    if (!physBoss || !physBoss->IsInCombat())
+        return 1.0f;
+
+    if (RsHalionHasCombustion(bot) || RsHalionIsCombustionDispeller(botAI) || RsHalionCombustionReturning(bot))
+        return 1.0f;
+
+    if (!RsHalionMeteorShouldRally(bot))
+        return 1.0f;
+
+    if (dynamic_cast<MovementAction*>(action) && !dynamic_cast<RsHalionMeteorAction*>(action) &&
+        !dynamic_cast<RsHalionEnterPortalAction*>(action))
+        return 0.0f;
+
+    return 1.0f;
+}
+
+float RsHalionMeleeFlankMultiplier::GetValue(Action* action)
+{
+    if (!RsHalionEngaged(botAI))
+        return 1.0f;
+
+    if (dynamic_cast<CastChargeAction*>(action) || dynamic_cast<CastFeralChargeBearAction*>(action) ||
+        dynamic_cast<CastFeralChargeCatAction*>(action))
+        return 0.0f;
+
+    if (dynamic_cast<AvoidAoeAction*>(action) &&
+        (RsHalionEnteringTwilight(botAI, bot) || RsHalionPortalHeldForAdds(botAI)))
+        return 1.0f;
+
+    if (botAI->IsTank(bot) && dynamic_cast<AvoidAoeAction*>(action))
+        return 0.0f;
+
+    if (dynamic_cast<CastDisengageAction*>(action) || dynamic_cast<TankAssistAction*>(action) ||
+        dynamic_cast<CastBlinkBackAction*>(action))
+        return 0.0f;
+
+    if (dynamic_cast<CombatFormationMoveAction*>(action) || dynamic_cast<FollowAction*>(action))
+        return 0.0f;
+
+    if (RsHalionHasCombustion(bot) || RsHalionIsCombustionDispeller(botAI) || RsHalionCombustionReturning(bot))
+        return 1.0f;
+
+    if (Unit* boss = RsHalionPhase1Boss(botAI))
+        if (boss->HealthAbovePct(99) && RsHalionBossTank(botAI) != bot && dynamic_cast<ReachMeleeAction*>(action))
+            return 0.0f;
+
+    if (RsHalionAnyPhysicalBoss(botAI) && RsHalionBossTank(botAI) == bot && dynamic_cast<ReachMeleeAction*>(action))
+        return 0.0f;
+
+    if (Unit* boss = RsHalionAnyPhysicalBoss(botAI))
+        if ((!botAI->IsTank(bot) || RsHalionAssistTankAsMelee(botAI)) && botAI->IsMelee(bot) &&
+            bot->GetExactDist2d(boss->GetPositionX(), boss->GetPositionY()) <= RS_HALION_LINE_MELEE_MAX &&
+            dynamic_cast<ReachMeleeAction*>(action))
+            return 0.0f;
+
+    return 1.0f;
+}
+
+float RsHalionHpBalanceMultiplier::GetValue(Action* action)
+{
+    if (botAI->IsTank(bot) || botAI->IsHeal(bot))
+        return 1.0f;
+
+    if (!RsHalionRealmThrottled(botAI, bot))
+        return 1.0f;
+
+    if (!RsHalionInTwilight(bot) && RsHalionAnyAddAlive(botAI))
+        return 1.0f;
+
+    if (!RsHalionLeadingTooMuch(botAI, bot) && !RsHalionInThrottledHalf(botAI, bot))
+        return 1.0f;
+
+    if (dynamic_cast<RsHalionAvoidConesAction*>(action) ||
+        dynamic_cast<RsHalionMeteorAction*>(action) ||
+        dynamic_cast<RsHalionCombustionAction*>(action) ||
+        dynamic_cast<RsHalionConsumptionAction*>(action) ||
+        dynamic_cast<RsHalionCutterAction*>(action) ||
+        dynamic_cast<RsHalionP2AvoidConesAction*>(action) ||
+        dynamic_cast<RsHalionP2TankPositionAction*>(action) ||
+        dynamic_cast<RsHalionEnterPortalAction*>(action) ||
+        dynamic_cast<RsHalionHealConsumptionAction*>(action))
+        return 1.0f;
+
+    if (dynamic_cast<AttackAction*>(action))
+        return 0.0f;
+
+    if (dynamic_cast<PetAttackAction*>(action))
+        return 0.0f;
+
+    CastSpellAction* cast = dynamic_cast<CastSpellAction*>(action);
+    if (cast && cast->GetTargetName() == "current target")
+        return 0.0f;
+
+    return 1.0f;
+}
+
+float RsHalionRealmIsolationMultiplier::GetValue(Action* action)
+{
+    if (!RsHalionEngaged(botAI))
+        return 1.0f;
+
+    Unit* target = action->GetTarget();
+    if (!target || target == bot)
+        return 1.0f;
+
+    Player* member = target->ToPlayer();
+    if (!member || !member->IsAlive())
+        return 1.0f;
+
+    if (RsHalionInTwilight(member) != RsHalionInTwilight(bot))
+        return 0.0f;
+
+    return 1.0f;
+}
+
+float RsTrashAddsMultiplier::GetValue(Action* action)
+{
+    if (botAI->IsTank(bot) || botAI->IsHeal(bot))
+        return 1.0f;
+
+    if (!RsTrashActive(botAI, bot))
+        return 1.0f;
+
+    if (dynamic_cast<CombatFormationMoveAction*>(action) || dynamic_cast<FollowAction*>(action))
+        return 0.0f;
+
+    return 1.0f;
+}
+
+float RsHalionP2Multiplier::GetValue(Action* action)
+{
+    if (!RsHalionInTwilight(bot))
+        return 1.0f;
+
+    if (dynamic_cast<CastChargeAction*>(action) || dynamic_cast<CastFeralChargeBearAction*>(action) ||
+        dynamic_cast<CastFeralChargeCatAction*>(action))
+        return 0.0f;
+
+    if (dynamic_cast<CastCreateSoulstoneAction*>(action) || dynamic_cast<UseSoulstoneHealerAction*>(action)
+        || dynamic_cast<UseSoulstoneMasterAction*>(action) || dynamic_cast<UseSoulstoneSelfAction*>(action)
+        || dynamic_cast<UseSoulstoneTankAction*>(action))
+        return 0.0f;
+
+    if (!RsHalionTwilightBoss(botAI))
+    {
+        if (bot->HasAura(SPELL_MARK_OF_CONSUMPTION) || bot->HasAura(SPELL_SOUL_CONSUMPTION))
+            return 1.0f;
+
+        if (!RsHalionEnteringTwilight(botAI, bot) &&
+            !dynamic_cast<RsHalionP2AvoidConesAction*>(action) &&
+            !dynamic_cast<RsHalionCutterAction*>(action) &&
+            (dynamic_cast<MovementAction*>(action) || dynamic_cast<AttackAction*>(action)))
+            return 0.0f;
+
+        return 1.0f;
+    }
+
+    if (RsHalionConsumptionNotClear(botAI))
+    {
+        if (dynamic_cast<CurePartyMemberAction*>(action) || dynamic_cast<CastDispelMagicAction*>(action) ||
+            dynamic_cast<CastCleanseMagicAction*>(action) || dynamic_cast<CastCleanseSpiritAction*>(action))
+            return 0.0f;
+    }
+
+    if (bot->HasAura(SPELL_MARK_OF_CONSUMPTION) || bot->HasAura(SPELL_SOUL_CONSUMPTION))
+    {
+        if (dynamic_cast<MovementAction*>(action) && !dynamic_cast<RsHalionConsumptionAction*>(action))
+            return 0.0f;
+        return 1.0f;
+    }
+
+    if (RsHalionTwilightTank(botAI) != bot && RsHalionCutterShouldMove(bot->GetInstanceId()))
+    {
+        if ((bot->getClass() == CLASS_ROGUE || bot->getClass() == CLASS_WARRIOR) &&
+            !dynamic_cast<MeleeAction*>(action) &&
+            !dynamic_cast<RsHalionCutterAction*>(action) &&
+            !dynamic_cast<RsHalionEnterPortalAction*>(action) &&
+            !dynamic_cast<RsHalionP2AvoidConesAction*>(action))
+            return 0.0f;
+
+        if (RsHalionCutterBeamDanger(botAI, bot) &&
+            !dynamic_cast<RsHalionCutterAction*>(action) &&
+            !dynamic_cast<RsHalionEnterPortalAction*>(action) &&
+            !dynamic_cast<RsHalionP2AvoidConesAction*>(action))
+            return 0.0f;
+    }
+
+    if (RsHalionTwilightTank(botAI) != bot && dynamic_cast<ReachMeleeAction*>(action))
+        return 0.0f;
+
+    if (dynamic_cast<CombatFormationMoveAction*>(action) || dynamic_cast<FollowAction*>(action))
+        return 0.0f;
+
+    return 1.0f;
+}

--- a/src/Ai/Raid/RS/RSMultipliers.h
+++ b/src/Ai/Raid/RS/RSMultipliers.h
@@ -1,0 +1,96 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef _PLAYERBOT_RSM_H
+#define _PLAYERBOT_RSM_H
+
+#include "Multiplier.h"
+
+class RsSavianaBeaconMultiplier : public Multiplier
+{
+public:
+    RsSavianaBeaconMultiplier(PlayerbotAI* ai) : Multiplier(ai, "rs saviana beacon") {}
+    virtual float GetValue(Action* action);
+};
+
+class RsBaltharusBrandSafeMultiplier : public Multiplier
+{
+public:
+    RsBaltharusBrandSafeMultiplier(PlayerbotAI* ai) : Multiplier(ai, "rs baltharus brand safe") {}
+    virtual float GetValue(Action* action);
+};
+
+class RsSavianaMeleeSpreadMultiplier : public Multiplier
+{
+public:
+    RsSavianaMeleeSpreadMultiplier(PlayerbotAI* ai) : Multiplier(ai, "rs saviana melee spread") {}
+    virtual float GetValue(Action* action);
+};
+
+class RsZarithrianAddsMultiplier : public Multiplier
+{
+public:
+    RsZarithrianAddsMultiplier(PlayerbotAI* ai) : Multiplier(ai, "rs zarithrian adds") {}
+    virtual float GetValue(Action* action);
+};
+
+class RsZarithrianTankSwapMultiplier : public Multiplier
+{
+public:
+    RsZarithrianTankSwapMultiplier(PlayerbotAI* ai) : Multiplier(ai, "rs zarithrian tank swap") {}
+    virtual float GetValue(Action* action);
+};
+
+class RsHalionCombustionMultiplier : public Multiplier
+{
+public:
+    RsHalionCombustionMultiplier(PlayerbotAI* ai) : Multiplier(ai, "rs halion combustion safe") {}
+    virtual float GetValue(Action* action);
+};
+
+class RsHalionMeteorMultiplier : public Multiplier
+{
+public:
+    RsHalionMeteorMultiplier(PlayerbotAI* ai) : Multiplier(ai, "rs halion meteor") {}
+    virtual float GetValue(Action* action);
+};
+
+class RsHalionMeleeFlankMultiplier : public Multiplier
+{
+public:
+    RsHalionMeleeFlankMultiplier(PlayerbotAI* ai) : Multiplier(ai, "rs halion melee flank") {}
+    virtual float GetValue(Action* action);
+};
+
+class RsHalionP2Multiplier : public Multiplier
+{
+public:
+    RsHalionP2Multiplier(PlayerbotAI* ai) : Multiplier(ai, "rs halion p2") {}
+    virtual float GetValue(Action* action);
+};
+
+class RsHalionHpBalanceMultiplier : public Multiplier
+{
+public:
+    RsHalionHpBalanceMultiplier(PlayerbotAI* ai) : Multiplier(ai, "rs halion hp balance") {}
+    virtual float GetValue(Action* action);
+};
+
+class RsHalionRealmIsolationMultiplier : public Multiplier
+{
+public:
+    RsHalionRealmIsolationMultiplier(PlayerbotAI* ai) : Multiplier(ai, "rs halion realm isolation") {}
+    virtual float GetValue(Action* action);
+};
+
+class RsTrashAddsMultiplier : public Multiplier
+{
+public:
+    RsTrashAddsMultiplier(PlayerbotAI* ai) : Multiplier(ai, "rs trash adds") {}
+    virtual float GetValue(Action* action);
+};
+
+#endif

--- a/src/Ai/Raid/RS/RSScripts.cpp
+++ b/src/Ai/Raid/RS/RSScripts.cpp
@@ -1,0 +1,608 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "RSScripts.h"
+#include "Player.h"
+#include "RSActions.h"
+#include "RSTriggers.h"
+#include "ScriptMgr.h"
+#include "Spell.h"
+#include "SpellInfo.h"
+#include "Timer.h"
+#include "Vehicle.h"
+#include <algorithm>
+#include <cmath>
+#include <set>
+
+namespace RubySanctumHelpers
+{
+    std::recursive_mutex stateMutex;
+    std::unordered_map<uint32, MeteorPingPong> meteorPingPong;
+    std::unordered_map<uint32, CutterTiming> cutterTiming;
+    std::unordered_map<uint32, PortalAddGate> portalAddGate;
+    std::map<std::pair<uint32, ObjectGuid>, bool> p3TwilightAssignment;
+    std::unordered_map<uint32, HalionCorporeality> halionCorporeality;
+    std::unordered_map<uint32, BossHealth> bossHealth;
+
+    std::unordered_map<uint32, uint32> tankAuraLastApply;
+    std::unordered_map<uint32, uint32> addBuffLastApply;
+    std::unordered_map<uint32, uint32> halionRootLastScan;
+    std::unordered_map<uint32, uint32> portalCountdownLastShown;
+    std::unordered_map<uint32, std::map<ObjectGuid, uint32>> portalSeen;
+
+    std::unordered_map<ObjectGuid, uint32> breathTwilightGrant;
+    std::unordered_map<ObjectGuid, uint32> breathPhysicalGrant;
+    std::unordered_map<ObjectGuid, uint32> p3RescueGrant;
+    std::unordered_map<ObjectGuid, uint32> consumptionGrant;
+    std::set<ObjectGuid> meteorCommitted;
+    std::set<ObjectGuid> rallyCommitted;
+    std::set<ObjectGuid> combustionReturning;
+    std::map<ObjectGuid, std::pair<uint32, bool>> cutterDangerCache;
+    std::map<ObjectGuid, bool> realmThrottled;
+    std::map<ObjectGuid, bool> meteorSpotUsesA;
+    std::map<ObjectGuid, ObjectGuid> botPortalTarget;
+    std::set<ObjectGuid> clearedForConsumption;
+
+    void ResetInstance(uint32 instanceId, Map* map)
+    {
+        meteorPingPong.erase(instanceId);
+        cutterTiming.erase(instanceId);
+        portalAddGate.erase(instanceId);
+        halionCorporeality.erase(instanceId);
+        tankAuraLastApply.erase(instanceId);
+        addBuffLastApply.erase(instanceId);
+        halionRootLastScan.erase(instanceId);
+        portalCountdownLastShown.erase(instanceId);
+        portalSeen.erase(instanceId);
+        bossHealth.erase(instanceId);
+
+        for (auto it = p3TwilightAssignment.begin(); it != p3TwilightAssignment.end(); )
+        {
+            if (it->first.first == instanceId)
+                it = p3TwilightAssignment.erase(it);
+            else
+                ++it;
+        }
+
+        if (!map)
+            return;
+
+        Map::PlayerList const& players = map->GetPlayers();
+        for (Map::PlayerList::const_iterator it = players.begin(); it != players.end(); ++it)
+        {
+            Player* player = it->GetSource();
+            if (!player)
+                continue;
+
+            ObjectGuid const guid = player->GetGUID();
+            breathTwilightGrant.erase(guid);
+            breathPhysicalGrant.erase(guid);
+            p3RescueGrant.erase(guid);
+            consumptionGrant.erase(guid);
+            meteorCommitted.erase(guid);
+            rallyCommitted.erase(guid);
+            combustionReturning.erase(guid);
+            cutterDangerCache.erase(guid);
+            realmThrottled.erase(guid);
+            meteorSpotUsesA.erase(guid);
+            botPortalTarget.erase(guid);
+            clearedForConsumption.erase(guid);
+        }
+    }
+}
+
+static uint8 RsHalionReadCorporealityIndex(Creature* creature)
+{
+    using namespace RubySanctumHelpers;
+    for (uint8 i = 0; i <= 10; ++i)
+    {
+        if (creature->HasAura(HALION_CORPOREALITY_AURAS[i]))
+            return i;
+    }
+    return 5;
+}
+
+class RsHalionRootScript : public AllCreatureScript
+{
+public:
+    RsHalionRootScript() : AllCreatureScript("RsHalionRootScript") { }
+
+    void OnAllCreatureUpdate(Creature* creature, uint32 ) override
+    {
+        if (!creature || creature->GetMapId() != RS_MAP_RUBY_SANCTUM)
+            return;
+
+        std::lock_guard<std::recursive_mutex> lock(RubySanctumHelpers::stateMutex);
+
+        if (creature->GetEntry() == NPC_METEOR_STRIKE_MARK)
+        {
+            HandleMeteorMark(creature);
+            return;
+        }
+
+        if (creature->GetEntry() == NPC_HALION)
+            HandleHalionRoot(creature);
+
+        if (creature->GetEntry() == NPC_TWILIGHT_HALION)
+            HandleTwilightHalionRoot(creature);
+
+        if (creature->GetEntry() == NPC_ORB_CARRIER)
+            HandleCutterTiming(creature);
+
+        if ((creature->GetEntry() == NPC_LIVING_INFERNO || creature->GetEntry() == NPC_LIVING_EMBER) &&
+            creature->IsAlive())
+            RubySanctumHelpers::portalAddGate[creature->GetMap()->GetInstanceId()].lastAddAliveTime = getMSTime();
+    }
+
+private:
+    void HandleCutterTiming(Creature* carrier)
+    {
+        uint32 const instanceId = carrier->GetMap()->GetInstanceId();
+        RubySanctumHelpers::CutterTiming& state = RubySanctumHelpers::cutterTiming[instanceId];
+
+        bool firing = false;
+        Unit* tracked = nullptr;
+        if (Vehicle* vehicle = carrier->GetVehicleKit())
+        {
+            tracked = vehicle->GetPassenger(0);
+            for (int8 seat = 0; seat < 4; ++seat)
+            {
+                if (Unit* orb = vehicle->GetPassenger(seat); orb && orb->HasAura(SPELL_TWILIGHT_PULSE_PERIODIC))
+                {
+                    firing = true;
+                    break;
+                }
+            }
+        }
+
+        if (firing && !state.active)
+            state.lastShootTime = getMSTime();
+
+        state.active = firing;
+
+        if (tracked)
+        {
+            float const angle = std::atan2(tracked->GetPositionY() - carrier->GetPositionY(),
+                                           tracked->GetPositionX() - carrier->GetPositionX());
+            if (state.hasOrbAngle)
+            {
+                float const delta = RsAngleDiff(angle, state.lastOrbAngle);
+                if (std::fabs(delta) > 0.0005f)
+                    state.spinSign = delta > 0.0f ? 1.0f : -1.0f;
+            }
+            state.lastOrbAngle = angle;
+            state.hasOrbAngle = true;
+        }
+        else
+        {
+            state.hasOrbAngle = false;
+        }
+    }
+
+    void HandleTankAuras(Creature* creature)
+    {
+        uint32 const instanceId = creature->GetMap()->GetInstanceId();
+        uint32 const now = getMSTime();
+
+        auto& lastApply = RubySanctumHelpers::tankAuraLastApply;
+        uint32& last = lastApply[instanceId];
+        if (last != 0 && getMSTimeDiff(last, now) < 2000)
+            return;
+        last = now;
+
+        Map::PlayerList const& players = creature->GetMap()->GetPlayers();
+        for (Map::PlayerList::const_iterator it = players.begin(); it != players.end(); ++it)
+        {
+            Player* player = it->GetSource();
+            if (!player || !player->IsAlive() || !GET_PLAYERBOT_AI(player) || !PlayerbotAI::IsTank(player))
+                continue;
+            if (!player->HasAura(RS_SPELL_PAIN_SUPPRESION))
+                player->AddAura(RS_SPELL_PAIN_SUPPRESION, player);
+        }
+    }
+
+    void HandleAddBuff(Creature* creature)
+    {
+        uint32 const instanceId = creature->GetMap()->GetInstanceId();
+        uint32 const now = getMSTime();
+
+        auto& lastApply = RubySanctumHelpers::addBuffLastApply;
+        uint32& last = lastApply[instanceId];
+        if (last != 0 && getMSTimeDiff(last, now) < 2000)
+            return;
+        last = now;
+
+        bool addsAlive = false;
+        Map::PlayerList const& players = creature->GetMap()->GetPlayers();
+        for (Map::PlayerList::const_iterator it = players.begin(); it != players.end(); ++it)
+        {
+            Player* player = it->GetSource();
+            if (!player)
+                continue;
+            if (Creature* add = player->FindNearestCreature(NPC_LIVING_INFERNO, 200.0f); add && add->IsAlive())
+            {
+                addsAlive = true;
+                break;
+            }
+            if (Creature* add = player->FindNearestCreature(NPC_LIVING_EMBER, 200.0f); add && add->IsAlive())
+            {
+                addsAlive = true;
+                break;
+            }
+        }
+
+        for (Map::PlayerList::const_iterator it = players.begin(); it != players.end(); ++it)
+        {
+            Player* player = it->GetSource();
+            if (!player || !player->IsAlive() || !GET_PLAYERBOT_AI(player))
+                continue;
+            bool const wantEmpowered = addsAlive && !player->HasAura(SPELL_TWILIGHT_REALM);
+            if (wantEmpowered && !player->HasAura(RS_SPELL_EMPOWERED_BLOOD))
+                player->AddAura(RS_SPELL_EMPOWERED_BLOOD, player);
+            else if (!wantEmpowered && player->HasAura(RS_SPELL_EMPOWERED_BLOOD))
+                player->RemoveAura(RS_SPELL_EMPOWERED_BLOOD);
+        }
+    }
+
+    void HandleP3TankRescue(Creature* creature)
+    {
+        uint32 const now = getMSTime();
+        uint32 const rescueMs = 5000;
+        float const bossHp = creature->GetHealthPct();
+
+        auto& grantStart = RubySanctumHelpers::p3RescueGrant;
+
+        Map::PlayerList const& players = creature->GetMap()->GetPlayers();
+
+        bool physicalHealerAlive = false;
+        bool twilightHealerAlive = false;
+        for (Map::PlayerList::const_iterator it = players.begin(); it != players.end(); ++it)
+        {
+            Player* player = it->GetSource();
+            if (!player || !player->IsAlive() || !PlayerbotAI::IsHeal(player))
+                continue;
+            if (RsHalionInTwilight(player))
+                twilightHealerAlive = true;
+            else
+                physicalHealerAlive = true;
+        }
+
+        for (Map::PlayerList::const_iterator it = players.begin(); it != players.end(); ++it)
+        {
+            Player* player = it->GetSource();
+            if (!player || !player->IsAlive() || !GET_PLAYERBOT_AI(player) || !PlayerbotAI::IsTank(player))
+                continue;
+
+            bool const tankTwilight = RsHalionInTwilight(player);
+            bool const healerInRealm = tankTwilight ? twilightHealerAlive : physicalHealerAlive;
+
+            ObjectGuid const guid = player->GetGUID();
+
+            if (!tankTwilight && bossHp >= 46.0f)
+            {
+                player->AddAura(RS_SPELL_MAGIC_BARRIER, player);
+                grantStart.erase(guid);
+                continue;
+            }
+
+            if (bossHp > 50.0f)
+                continue;
+
+            auto granted = grantStart.find(guid);
+
+            if (granted != grantStart.end())
+            {
+                if (getMSTimeDiff(granted->second, now) >= rescueMs)
+                {
+                    player->RemoveAura(RS_SPELL_MAGIC_BARRIER);
+                    grantStart.erase(granted);
+                }
+                else
+                    player->AddAura(RS_SPELL_MAGIC_BARRIER, player);
+                continue;
+            }
+
+            if (!player->HealthAbovePct(50) && healerInRealm)
+            {
+                player->AddAura(RS_SPELL_MAGIC_BARRIER, player);
+                grantStart[guid] = now;
+            }
+        }
+    }
+
+    void HandleBreathGodMode(Creature* boss, uint32 const* breathIds, size_t breathCount, bool twilight)
+    {
+        uint32 const now = getMSTime();
+        uint32 const holdMs = 1000;
+
+        bool casting = false;
+        for (size_t i = 0; i < breathCount; ++i)
+        {
+            if (boss->FindCurrentSpellBySpellId(breathIds[i]))
+            {
+                casting = true;
+                break;
+            }
+        }
+
+        auto& twilightGrantStart = RubySanctumHelpers::breathTwilightGrant;
+        auto& physicalGrantStart = RubySanctumHelpers::breathPhysicalGrant;
+        std::unordered_map<ObjectGuid, uint32>& grantStart = twilight ? twilightGrantStart : physicalGrantStart;
+
+        Map::PlayerList const& players = boss->GetMap()->GetPlayers();
+        for (Map::PlayerList::const_iterator it = players.begin(); it != players.end(); ++it)
+        {
+            Player* player = it->GetSource();
+            if (!player || !player->IsAlive() || !GET_PLAYERBOT_AI(player) || PlayerbotAI::IsTank(player) || RsHalionInTwilight(player) != twilight)
+                continue;
+
+            ObjectGuid const guid = player->GetGUID();
+            if (casting)
+            {
+                player->AddAura(RS_SPELL_MAGIC_BARRIER, player);
+                grantStart[guid] = now;
+                continue;
+            }
+
+            auto granted = grantStart.find(guid);
+            if (granted == grantStart.end())
+                continue;
+
+            if (getMSTimeDiff(granted->second, now) >= holdMs)
+            {
+                player->RemoveAura(RS_SPELL_MAGIC_BARRIER);
+                grantStart.erase(granted);
+            }
+            else
+                player->AddAura(RS_SPELL_MAGIC_BARRIER, player);
+        }
+    }
+
+    void HandleCombustionDispel(Creature* physical)
+    {
+        Map::PlayerList const& players = physical->GetMap()->GetPlayers();
+        for (Map::PlayerList::const_iterator it = players.begin(); it != players.end(); ++it)
+        {
+            Player* player = it->GetSource();
+            if (!player || !player->IsAlive() || GET_PLAYERBOT_AI(player))
+                continue;
+            if (!RsHalionHasCombustion(player) || !RsHalionCombustionPlayerSafe(player))
+                continue;
+
+            player->RemoveAurasDueToSpell(SPELL_FIERY_COMBUSTION, ObjectGuid::Empty, 0, AURA_REMOVE_BY_EXPIRE);
+            player->RemoveAurasDueToSpell(SPELL_MARK_OF_COMBUSTION, ObjectGuid::Empty, 0, AURA_REMOVE_BY_EXPIRE);
+        }
+    }
+
+    void HandleConsumptionGodMode(Creature* twilight)
+    {
+        if (!twilight->GetMap()->IsHeroic())
+            return;
+
+        uint32 const now = getMSTime();
+        uint32 const holdMs = 2000;
+
+        auto& grantStart = RubySanctumHelpers::consumptionGrant;
+
+        Map::PlayerList const& players = twilight->GetMap()->GetPlayers();
+        for (Map::PlayerList::const_iterator it = players.begin(); it != players.end(); ++it)
+        {
+            Player* player = it->GetSource();
+            if (!player || !player->IsAlive() || !GET_PLAYERBOT_AI(player))
+                continue;
+
+            ObjectGuid const guid = player->GetGUID();
+            if (player->HasAura(SPELL_SOUL_CONSUMPTION))
+            {
+                player->AddAura(RS_SPELL_MAGIC_BARRIER, player);
+                grantStart[guid] = now;
+                continue;
+            }
+
+            auto granted = grantStart.find(guid);
+            if (granted == grantStart.end())
+                continue;
+
+            if (getMSTimeDiff(granted->second, now) >= holdMs)
+            {
+                player->RemoveAura(RS_SPELL_MAGIC_BARRIER);
+                grantStart.erase(granted);
+            }
+            else
+                player->AddAura(RS_SPELL_MAGIC_BARRIER, player);
+        }
+    }
+
+    void HandleConsumptionDispel(Creature* twilight)
+    {
+        float const bossX = twilight->GetPositionX();
+        float const bossY = twilight->GetPositionY();
+
+        Map::PlayerList const& players = twilight->GetMap()->GetPlayers();
+        for (Map::PlayerList::const_iterator it = players.begin(); it != players.end(); ++it)
+        {
+            Player* player = it->GetSource();
+            if (!player || !player->IsAlive() || GET_PLAYERBOT_AI(player))
+                continue;
+            if (!RsHalionHasConsumption(player))
+                continue;
+
+            float const distToBoss = player->GetExactDist2d(bossX, bossY);
+            if (distToBoss < RS_HALION_CONSUMPTION_OUT_DIST - RS_HALION_CONSUMPTION_OUT_REACH)
+                continue;
+
+            player->RemoveAurasDueToSpell(SPELL_SOUL_CONSUMPTION, ObjectGuid::Empty, 0, AURA_REMOVE_BY_EXPIRE);
+            player->RemoveAurasDueToSpell(SPELL_MARK_OF_CONSUMPTION, ObjectGuid::Empty, 0, AURA_REMOVE_BY_EXPIRE);
+        }
+    }
+
+    void HandleTwilightHalionRoot(Creature* creature)
+    {
+        uint32 const instanceId = creature->GetMap()->GetInstanceId();
+
+        if (creature->IsAlive() && creature->IsInCombat())
+        {
+            RubySanctumHelpers::HalionCorporeality& corp = RubySanctumHelpers::halionCorporeality[instanceId];
+            corp.twilightIndex = RsHalionReadCorporealityIndex(creature);
+            corp.twilightStamp = getMSTime();
+            RubySanctumHelpers::bossHealth[instanceId] = { uint8(creature->GetHealthPct()), getMSTime() };
+        }
+
+        RubySanctumHelpers::CutterTiming& state = RubySanctumHelpers::cutterTiming[instanceId];
+        if (state.bossGuid != creature->GetGUID())
+        {
+            state = RubySanctumHelpers::CutterTiming{};
+            state.bossGuid = creature->GetGUID();
+        }
+        if (state.encounterStart == 0 && creature->IsInCombat())
+            state.encounterStart = getMSTime();
+
+        bool twilightTankAlive = false;
+        Map::PlayerList const& players = creature->GetMap()->GetPlayers();
+        for (Map::PlayerList::const_iterator it = players.begin(); it != players.end(); ++it)
+        {
+            Player* player = it->GetSource();
+            if (player && player->IsAlive() && PlayerbotAI::IsTank(player) && RsHalionInTwilight(player))
+            {
+                twilightTankAlive = true;
+                break;
+            }
+        }
+
+        bool const shouldRoot = creature->IsAlive() && creature->IsInCombat() && twilightTankAlive;
+        bool const rooted = creature->HasUnitState(UNIT_STATE_ROOT);
+
+        if (shouldRoot && !rooted)
+            creature->SetControlled(true, UNIT_STATE_ROOT);
+        else if (!shouldRoot && rooted)
+            creature->SetControlled(false, UNIT_STATE_ROOT);
+
+        if (shouldRoot)
+        {
+            Position const& home = creature->GetHomePosition();
+            if (creature->GetExactDist2d(home.GetPositionX(), home.GetPositionY()) > 3.0f)
+                creature->NearTeleportTo(home.GetPositionX(), home.GetPositionY(),
+                                         home.GetPositionZ(), home.GetOrientation());
+        }
+
+        if (creature->IsAlive() && creature->IsInCombat())
+        {
+            HandleTankAuras(creature);
+            HandleAddBuff(creature);
+            static uint32 const darkBreathIds[] = {
+                SPELL_DARK_BREATH, SPELL_DARK_BREATH_25N, SPELL_DARK_BREATH_10H, SPELL_DARK_BREATH_25H
+            };
+            HandleBreathGodMode(creature, darkBreathIds, sizeof(darkBreathIds) / sizeof(darkBreathIds[0]), true);
+            HandleConsumptionDispel(creature);
+            HandleConsumptionGodMode(creature);
+        }
+    }
+    void HandleMeteorMark(Creature* mark)
+    {
+        if (!mark->IsAlive())
+            return;
+
+        uint32 const instanceId = mark->GetMap()->GetInstanceId();
+
+        static std::set<ObjectGuid> seenMarks;
+        if (!seenMarks.insert(mark->GetGUID()).second)
+            return;
+
+        if (seenMarks.size() > 256)
+            seenMarks.clear();
+
+        RubySanctumHelpers::MeteorPingPong& state = RubySanctumHelpers::meteorPingPong[instanceId];
+        state.lastCastTime = getMSTime();
+
+        bool const tankMeteor = mark->GetExactDist2d(RS_HALION_TANK_POSITION.GetPositionX(), RS_HALION_TANK_POSITION.GetPositionY()) <= 10.0f;
+        bool const tankEscapeMeteor = mark->GetExactDist2d(RS_HALION_TANK_METEOR_SPOT.GetPositionX(), RS_HALION_TANK_METEOR_SPOT.GetPositionY()) <= 10.0f;
+        if (tankMeteor)
+            state.tankMeteorTime = getMSTime();
+        else if (tankEscapeMeteor)
+            state.tankReturnTime = getMSTime();
+        else
+            ++state.count;
+    }
+
+    void HandleHalionRoot(Creature* creature)
+    {
+        uint32 const instanceId = creature->GetMap()->GetInstanceId();
+
+        auto& lastScan = RubySanctumHelpers::halionRootLastScan;
+
+        bool const fightActive = creature->IsAlive() && creature->IsInCombat();
+
+        if (fightActive)
+        {
+            RubySanctumHelpers::HalionCorporeality& corp = RubySanctumHelpers::halionCorporeality[instanceId];
+            corp.physicalIndex = RsHalionReadCorporealityIndex(creature);
+            corp.physicalStamp = getMSTime();
+            corp.physicalGuid = creature->GetGUID();
+            RubySanctumHelpers::bossHealth[instanceId] = { uint8(creature->GetHealthPct()), getMSTime() };
+        }
+
+        if (!fightActive)
+        {
+            if (creature->HasUnitState(UNIT_STATE_ROOT))
+                creature->SetControlled(false, UNIT_STATE_ROOT);
+            RubySanctumHelpers::ResetInstance(instanceId, creature->GetMap());
+            return;
+        }
+
+        HandleTankAuras(creature);
+        HandleAddBuff(creature);
+
+        static uint32 const flameBreathIds[] = {
+            SPELL_FLAME_BREATH, SPELL_FLAME_BREATH_ALT1, SPELL_FLAME_BREATH_ALT2, SPELL_FLAME_BREATH_ALT3,
+            SPELL_FLAME_BREATH_ALT4, SPELL_FLAME_BREATH_ALT5, SPELL_FLAME_BREATH_ALT6
+        };
+        HandleBreathGodMode(creature, flameBreathIds, sizeof(flameBreathIds) / sizeof(flameBreathIds[0]), false);
+        HandleCombustionDispel(creature);
+
+        bool const physicalActive = creature->GetDisplayId() == creature->GetNativeDisplayId();
+
+        if (!physicalActive)
+        {
+            if (creature->HasUnitState(UNIT_STATE_ROOT))
+                creature->SetControlled(false, UNIT_STATE_ROOT);
+            return;
+        }
+
+        if (creature->GetMap()->IsHeroic() && !creature->HealthAbovePct(51))
+            HandleP3TankRescue(creature);
+
+        uint32 const now = getMSTime();
+        uint32& last = lastScan[instanceId];
+        if (last != 0 && getMSTimeDiff(last, now) < 1000)
+            return;
+        last = now;
+
+        bool mainTankAlive = false;
+        Map::PlayerList const& players = creature->GetMap()->GetPlayers();
+        for (Map::PlayerList::const_iterator it = players.begin(); it != players.end(); ++it)
+        {
+            Player* player = it->GetSource();
+            if (player && player->IsAlive() && PlayerbotAI::IsMainTank(player))
+            {
+                mainTankAlive = true;
+                break;
+            }
+        }
+
+        bool const shouldRoot = mainTankAlive;
+        bool const rooted = creature->HasUnitState(UNIT_STATE_ROOT);
+
+        if (shouldRoot && !rooted)
+            creature->SetControlled(true, UNIT_STATE_ROOT);
+        else if (!shouldRoot && rooted)
+            creature->SetControlled(false, UNIT_STATE_ROOT);
+    }
+};
+
+void AddSC_RubySanctumBotScripts()
+{
+    new RsHalionRootScript();
+}

--- a/src/Ai/Raid/RS/RSScripts.h
+++ b/src/Ai/Raid/RS/RSScripts.h
@@ -1,0 +1,111 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef _PLAYERBOT_RSSCRIPTS_H
+#define _PLAYERBOT_RSSCRIPTS_H
+
+#include <map>
+#include <mutex>
+#include <set>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include "ObjectGuid.h"
+#include "Position.h"
+
+class Map;
+
+namespace RubySanctumHelpers
+{
+
+    extern std::recursive_mutex stateMutex;
+
+    struct MeteorPingPong
+    {
+        uint32 count;
+        uint32 lastCastTime;
+        uint32 tankMeteorTime;
+        uint32 tankReturnTime;
+    };
+
+    extern std::unordered_map<uint32, MeteorPingPong> meteorPingPong;
+
+    struct CutterTiming
+    {
+        uint32 lastShootTime;
+        bool active;
+        uint32 encounterStart;
+        ObjectGuid bossGuid;
+        float spinSign;
+        float lastOrbAngle;
+        bool hasOrbAngle;
+    };
+
+    extern std::unordered_map<uint32, CutterTiming> cutterTiming;
+
+    struct PortalAddGate
+    {
+        uint32 armTime;
+        uint32 lastAddAliveTime;
+    };
+
+    extern std::unordered_map<uint32, PortalAddGate> portalAddGate;
+
+    extern std::map<std::pair<uint32, ObjectGuid>, bool> p3TwilightAssignment;
+
+    struct HalionCorporeality
+    {
+        uint8 physicalIndex;
+        uint32 physicalStamp;
+        uint8 twilightIndex;
+        uint32 twilightStamp;
+        ObjectGuid physicalGuid;
+    };
+
+    extern std::unordered_map<uint32, HalionCorporeality> halionCorporeality;
+
+    // boss health % stamped server-side (visible in every phase), read by bots that cannot see the boss through a portal
+    struct BossHealth
+    {
+        uint8 pct;
+        uint32 stamp;
+    };
+
+    extern std::unordered_map<uint32, BossHealth> bossHealth;
+
+    // throttle/state keyed by instance, cleared on encounter reset
+    extern std::unordered_map<uint32, uint32> tankAuraLastApply;
+    extern std::unordered_map<uint32, uint32> addBuffLastApply;
+    extern std::unordered_map<uint32, uint32> halionRootLastScan;
+    extern std::unordered_map<uint32, uint32> portalCountdownLastShown;
+    extern std::unordered_map<uint32, std::map<ObjectGuid, uint32>> portalSeen;
+
+    // per-bot transient fight state keyed by bot guid, cleared on encounter reset
+    extern std::unordered_map<ObjectGuid, uint32> breathTwilightGrant;
+    extern std::unordered_map<ObjectGuid, uint32> breathPhysicalGrant;
+    extern std::unordered_map<ObjectGuid, uint32> p3RescueGrant;
+    extern std::unordered_map<ObjectGuid, uint32> consumptionGrant;
+    extern std::set<ObjectGuid> meteorCommitted;
+    extern std::set<ObjectGuid> rallyCommitted;
+    extern std::set<ObjectGuid> combustionReturning;
+    extern std::map<ObjectGuid, std::pair<uint32, bool>> cutterDangerCache;
+    extern std::map<ObjectGuid, bool> realmThrottled;
+    extern std::map<ObjectGuid, bool> meteorSpotUsesA;
+    extern std::map<ObjectGuid, ObjectGuid> botPortalTarget;
+    extern std::set<ObjectGuid> clearedForConsumption;
+
+    // clear every per-instance and per-bot entry for an instance (encounter reset / kill / idle)
+    void ResetInstance(uint32 instanceId, Map* map);
+
+    inline constexpr uint32 HALION_CORPOREALITY_AURAS[11] =
+    {
+        74836, 74835, 74834, 74833, 74832, 74826, 74827, 74828, 74829, 74830, 74831
+    };
+}
+
+void AddSC_RubySanctumBotScripts();
+
+#endif

--- a/src/Ai/Raid/RS/RSStrategy.cpp
+++ b/src/Ai/Raid/RS/RSStrategy.cpp
@@ -1,0 +1,99 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "RSStrategy.h"
+
+#include "RSMultipliers.h"
+
+void RaidRsStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+{
+
+    triggers.push_back(new TriggerNode("rs baltharus brand",
+        { NextAction("rs baltharus brand", ACTION_RAID + 7) }));
+    triggers.push_back(new TriggerNode("rs baltharus tank position",
+        { NextAction("rs baltharus tank position", ACTION_RAID + 6) }));
+    triggers.push_back(new TriggerNode("rs baltharus avoid front",
+        { NextAction("rs baltharus avoid front", ACTION_RAID + 5) }));
+    triggers.push_back(new TriggerNode("rs baltharus healer position",
+        { NextAction("rs baltharus healer position", ACTION_RAID + 4) }));
+
+    triggers.push_back(new TriggerNode("rs saviana conflagration",
+        { NextAction("rs saviana conflagration", ACTION_RAID + 7) }));
+    triggers.push_back(new TriggerNode("rs saviana avoid front",
+        { NextAction("rs saviana avoid front", ACTION_RAID + 6) }));
+    triggers.push_back(new TriggerNode("rs saviana tank position",
+        { NextAction("rs saviana tank position", ACTION_RAID + 7) }));
+    triggers.push_back(new TriggerNode("rs saviana melee spread",
+        { NextAction("rs saviana melee spread", ACTION_RAID + 7) }));
+
+    triggers.push_back(new TriggerNode("rs zarithrian adds",
+        { NextAction("rs zarithrian adds", ACTION_RAID + 5),
+          NextAction("attack rti target", ACTION_RAID + 4) }));
+
+    triggers.push_back(new TriggerNode("rs zarithrian tank",
+        { NextAction("rs zarithrian tank", ACTION_RAID + 6) }));
+
+    triggers.push_back(new TriggerNode("rs halion start position",
+        { NextAction("rs halion start position", ACTION_RAID + 6) }));
+    triggers.push_back(new TriggerNode("rs halion combustion",
+        { NextAction("rs halion combustion", ACTION_RAID + 7) }));
+    triggers.push_back(new TriggerNode("rs halion meteor",
+        { NextAction("rs halion meteor", ACTION_RAID + 7) }));
+    triggers.push_back(new TriggerNode("rs halion tank position",
+        { NextAction("rs halion tank position", ACTION_RAID + 6),
+          NextAction("attack rti target", ACTION_RAID + 5) }));
+    triggers.push_back(new TriggerNode("rs halion avoid cones",
+        { NextAction("rs halion avoid cones", ACTION_RAID + 5) }));
+
+    triggers.push_back(new TriggerNode("rs halion adds",
+        { NextAction("rs halion adds", ACTION_RAID + 6),
+          NextAction("attack rti target", ACTION_RAID + 5) }));
+    triggers.push_back(new TriggerNode("rs halion add tank",
+        { NextAction("rs halion add tank", ACTION_RAID + 6) }));
+
+    triggers.push_back(new TriggerNode("rs halion enter portal",
+        { NextAction("rs halion enter portal", ACTION_RAID + 8) }));
+    triggers.push_back(new TriggerNode("rs halion cutter",
+        { NextAction("rs halion cutter", ACTION_RAID + 8) }));
+    triggers.push_back(new TriggerNode("rs halion consumption",
+        { NextAction("rs halion consumption", ACTION_RAID + 7) }));
+    triggers.push_back(new TriggerNode("rs halion heal consumption",
+        { NextAction("rs halion heal consumption", ACTION_RAID + 7) }));
+    triggers.push_back(new TriggerNode("rs halion p2 tank position",
+        { NextAction("rs halion p2 tank position", ACTION_RAID + 6),
+          NextAction("attack rti target", ACTION_RAID + 5) }));
+    triggers.push_back(new TriggerNode("rs halion p2 avoid cones",
+        { NextAction("rs halion p2 avoid cones", ACTION_RAID + 5),
+          NextAction("attack rti target", ACTION_RAID + 4) }));
+
+    triggers.push_back(new TriggerNode("rs trash main tank",
+        { NextAction("rs trash main tank", ACTION_RAID + 6) }));
+    triggers.push_back(new TriggerNode("rs trash assist tank",
+        { NextAction("rs trash assist tank", ACTION_RAID + 6) }));
+    triggers.push_back(new TriggerNode("rs trash ranged",
+        { NextAction("rs trash ranged", ACTION_RAID + 5) }));
+    triggers.push_back(new TriggerNode("rs trash melee flank",
+        { NextAction("rear flank", ACTION_RAID + 5) }));
+    triggers.push_back(new TriggerNode("rs trash adds",
+        { NextAction("rs trash adds", ACTION_RAID + 5),
+          NextAction("attack rti target", ACTION_RAID + 4) }));
+}
+
+void RaidRsStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
+{
+    multipliers.push_back(new RsBaltharusBrandSafeMultiplier(botAI));
+    multipliers.push_back(new RsSavianaBeaconMultiplier(botAI));
+    multipliers.push_back(new RsSavianaMeleeSpreadMultiplier(botAI));
+    multipliers.push_back(new RsZarithrianAddsMultiplier(botAI));
+    multipliers.push_back(new RsZarithrianTankSwapMultiplier(botAI));
+    multipliers.push_back(new RsHalionCombustionMultiplier(botAI));
+    multipliers.push_back(new RsHalionMeteorMultiplier(botAI));
+    multipliers.push_back(new RsHalionMeleeFlankMultiplier(botAI));
+    multipliers.push_back(new RsHalionP2Multiplier(botAI));
+    multipliers.push_back(new RsHalionHpBalanceMultiplier(botAI));
+    multipliers.push_back(new RsHalionRealmIsolationMultiplier(botAI));
+    multipliers.push_back(new RsTrashAddsMultiplier(botAI));
+}

--- a/src/Ai/Raid/RS/RSStrategy.h
+++ b/src/Ai/Raid/RS/RSStrategy.h
@@ -1,0 +1,21 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef _PLAYERBOT_RSS_H
+#define _PLAYERBOT_RSS_H
+
+#include "Strategy.h"
+
+class RaidRsStrategy : public Strategy
+{
+public:
+    RaidRsStrategy(PlayerbotAI* ai) : Strategy(ai) {}
+    virtual std::string const getName() override { return "rs"; }
+    virtual void InitTriggers(std::vector<TriggerNode*>& triggers) override;
+    virtual void InitMultipliers(std::vector<Multiplier*> &multipliers) override;
+};
+
+#endif

--- a/src/Ai/Raid/RS/RSTriggerContext.h
+++ b/src/Ai/Raid/RS/RSTriggerContext.h
@@ -1,0 +1,79 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef _PLAYERBOT_RSTRIGGERCONTEXT_H
+#define _PLAYERBOT_RSTRIGGERCONTEXT_H
+
+#include "NamedObjectContext.h"
+#include "RSTriggers.h"
+
+class RaidRsTriggerContext : public NamedObjectContext<Trigger>
+{
+public:
+    RaidRsTriggerContext()
+    {
+        creators["rs baltharus brand"] = &RaidRsTriggerContext::rs_baltharus_brand;
+        creators["rs baltharus tank position"] = &RaidRsTriggerContext::rs_baltharus_tank_position;
+        creators["rs baltharus avoid front"] = &RaidRsTriggerContext::rs_baltharus_avoid_front;
+        creators["rs baltharus healer position"] = &RaidRsTriggerContext::rs_baltharus_healer_position;
+        creators["rs saviana conflagration"] = &RaidRsTriggerContext::rs_saviana_conflagration;
+        creators["rs saviana avoid front"] = &RaidRsTriggerContext::rs_saviana_avoid_front;
+        creators["rs saviana tank position"] = &RaidRsTriggerContext::rs_saviana_tank_position;
+        creators["rs saviana melee spread"] = &RaidRsTriggerContext::rs_saviana_melee_spread;
+        creators["rs zarithrian adds"] = &RaidRsTriggerContext::rs_zarithrian_adds;
+        creators["rs zarithrian tank"] = &RaidRsTriggerContext::rs_zarithrian_tank;
+        creators["rs halion tank position"] = &RaidRsTriggerContext::rs_halion_tank_position;
+        creators["rs halion avoid cones"] = &RaidRsTriggerContext::rs_halion_avoid_cones;
+        creators["rs halion combustion"] = &RaidRsTriggerContext::rs_halion_combustion;
+        creators["rs halion meteor"] = &RaidRsTriggerContext::rs_halion_meteor;
+        creators["rs halion adds"] = &RaidRsTriggerContext::rs_halion_adds;
+        creators["rs halion add tank"] = &RaidRsTriggerContext::rs_halion_add_tank;
+        creators["rs halion start position"] = &RaidRsTriggerContext::rs_halion_start_position;
+        creators["rs halion enter portal"] = &RaidRsTriggerContext::rs_halion_enter_portal;
+        creators["rs halion p2 tank position"] = &RaidRsTriggerContext::rs_halion_p2_tank_position;
+        creators["rs halion p2 avoid cones"] = &RaidRsTriggerContext::rs_halion_p2_avoid_cones;
+        creators["rs halion consumption"] = &RaidRsTriggerContext::rs_halion_consumption;
+        creators["rs halion cutter"] = &RaidRsTriggerContext::rs_halion_cutter;
+        creators["rs halion heal consumption"] = &RaidRsTriggerContext::rs_halion_heal_consumption;
+        creators["rs trash adds"] = &RaidRsTriggerContext::rs_trash_adds;
+        creators["rs trash main tank"] = &RaidRsTriggerContext::rs_trash_main_tank;
+        creators["rs trash assist tank"] = &RaidRsTriggerContext::rs_trash_assist_tank;
+        creators["rs trash ranged"] = &RaidRsTriggerContext::rs_trash_ranged;
+        creators["rs trash melee flank"] = &RaidRsTriggerContext::rs_trash_melee_flank;
+    }
+
+private:
+    static Trigger* rs_baltharus_brand(PlayerbotAI* ai) { return new RsBaltharusBrandTrigger(ai); }
+    static Trigger* rs_baltharus_tank_position(PlayerbotAI* ai) { return new RsBaltharusTankPositionTrigger(ai); }
+    static Trigger* rs_baltharus_avoid_front(PlayerbotAI* ai) { return new RsBaltharusAvoidFrontTrigger(ai); }
+    static Trigger* rs_baltharus_healer_position(PlayerbotAI* ai) { return new RsBaltharusHealerPositionTrigger(ai); }
+    static Trigger* rs_saviana_conflagration(PlayerbotAI* ai) { return new RsSavianaConflagrationTrigger(ai); }
+    static Trigger* rs_saviana_avoid_front(PlayerbotAI* ai) { return new RsSavianaAvoidFrontTrigger(ai); }
+    static Trigger* rs_saviana_tank_position(PlayerbotAI* ai) { return new RsSavianaTankPositionTrigger(ai); }
+    static Trigger* rs_saviana_melee_spread(PlayerbotAI* ai) { return new RsSavianaMeleeSpreadTrigger(ai); }
+    static Trigger* rs_zarithrian_adds(PlayerbotAI* ai) { return new RsZarithrianAddsTrigger(ai); }
+    static Trigger* rs_zarithrian_tank(PlayerbotAI* ai) { return new RsZarithrianTankTrigger(ai); }
+    static Trigger* rs_halion_tank_position(PlayerbotAI* ai) { return new RsHalionTankPositionTrigger(ai); }
+    static Trigger* rs_halion_avoid_cones(PlayerbotAI* ai) { return new RsHalionAvoidConesTrigger(ai); }
+    static Trigger* rs_halion_combustion(PlayerbotAI* ai) { return new RsHalionCombustionTrigger(ai); }
+    static Trigger* rs_halion_meteor(PlayerbotAI* ai) { return new RsHalionMeteorTrigger(ai); }
+    static Trigger* rs_halion_adds(PlayerbotAI* ai) { return new RsHalionAddsTrigger(ai); }
+    static Trigger* rs_halion_add_tank(PlayerbotAI* ai) { return new RsHalionAddTankTrigger(ai); }
+    static Trigger* rs_halion_start_position(PlayerbotAI* ai) { return new RsHalionStartPositionTrigger(ai); }
+    static Trigger* rs_halion_enter_portal(PlayerbotAI* ai) { return new RsHalionEnterPortalTrigger(ai); }
+    static Trigger* rs_halion_p2_tank_position(PlayerbotAI* ai) { return new RsHalionP2TankPositionTrigger(ai); }
+    static Trigger* rs_halion_p2_avoid_cones(PlayerbotAI* ai) { return new RsHalionP2AvoidConesTrigger(ai); }
+    static Trigger* rs_halion_consumption(PlayerbotAI* ai) { return new RsHalionConsumptionTrigger(ai); }
+    static Trigger* rs_halion_cutter(PlayerbotAI* ai) { return new RsHalionCutterTrigger(ai); }
+    static Trigger* rs_halion_heal_consumption(PlayerbotAI* ai) { return new RsHalionHealConsumptionTrigger(ai); }
+    static Trigger* rs_trash_adds(PlayerbotAI* ai) { return new RsTrashAddsTrigger(ai); }
+    static Trigger* rs_trash_main_tank(PlayerbotAI* ai) { return new RsTrashMainTankTrigger(ai); }
+    static Trigger* rs_trash_assist_tank(PlayerbotAI* ai) { return new RsTrashAssistTankTrigger(ai); }
+    static Trigger* rs_trash_ranged(PlayerbotAI* ai) { return new RsTrashRangedTrigger(ai); }
+    static Trigger* rs_trash_melee_flank(PlayerbotAI* ai) { return new RsTrashMeleeFlankTrigger(ai); }
+};
+
+#endif

--- a/src/Ai/Raid/RS/RSTriggers.cpp
+++ b/src/Ai/Raid/RS/RSTriggers.cpp
@@ -1,0 +1,316 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "RSTriggers.h"
+#include "RSActions.h"
+#include "RSScripts.h"
+#include "Playerbots.h"
+#include "Trigger.h"
+#include "Timer.h"
+#include <set>
+
+bool RsBaltharusBrandTrigger::IsActive()
+{
+    if (!bot->HasAura(SPELL_ENERVATING_BRAND))
+        return false;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "baltharus the warborn");
+    return boss != nullptr;
+}
+
+bool RsBaltharusTankPositionTrigger::IsActive()
+{
+    if (!botAI->IsTank(bot))
+        return false;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "baltharus the warborn");
+    return boss != nullptr;
+}
+
+bool RsBaltharusHealerPositionTrigger::IsActive()
+{
+    if (!botAI->IsHeal(bot) || botAI->IsTank(bot))
+        return false;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "baltharus the warborn");
+    return boss != nullptr;
+}
+
+bool RsBaltharusAvoidFrontTrigger::IsActive()
+{
+    if (botAI->IsTank(bot))
+        return false;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "baltharus the warborn");
+    return boss != nullptr;
+}
+
+bool RsSavianaConflagrationTrigger::IsActive()
+{
+    if (!bot->HasAura(SPELL_FLAME_BEACON))
+        return false;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "saviana ragefire");
+    return boss != nullptr;
+}
+
+bool RsSavianaTankPositionTrigger::IsActive()
+{
+    if (!botAI->IsMainTank(bot))
+        return false;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "saviana ragefire");
+    return boss != nullptr;
+}
+
+bool RsSavianaAvoidFrontTrigger::IsActive()
+{
+    if (botAI->IsTank(bot))
+        return false;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "saviana ragefire");
+    if (!boss)
+        return false;
+
+    return !boss->IsLevitating();
+}
+
+bool RsSavianaMeleeSpreadTrigger::IsActive()
+{
+    if (botAI->IsTank(bot) || (!botAI->IsMelee(bot) && !botAI->IsHeal(bot)))
+        return false;
+
+    if (bot->HasAura(SPELL_FLAME_BEACON))
+        return false;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "saviana ragefire");
+    if (!boss)
+        return false;
+
+    return boss->IsLevitating();
+}
+
+bool RsZarithrianAddsTrigger::IsActive()
+{
+    if (botAI->IsTank(bot) || botAI->IsHeal(bot))
+        return false;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "general zarithrian");
+    if (!boss || !boss->IsAlive())
+        return false;
+
+    return true;
+}
+
+bool RsZarithrianTankTrigger::IsActive()
+{
+    if (!botAI->IsTank(bot))
+        return false;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "general zarithrian");
+    return boss != nullptr;
+}
+
+bool RsHalionTankPositionTrigger::IsActive()
+{
+    if (RsHalionInTwilight(bot))
+        return false;
+
+    Unit* boss = RsHalionAnyPhysicalBoss(botAI);
+    if (!boss || !boss->IsInCombat())
+        return false;
+
+    return RsHalionBossTank(botAI) == bot;
+}
+
+bool RsHalionAvoidConesTrigger::IsActive()
+{
+    if (RsHalionInTwilight(bot))
+        return false;
+
+    if (botAI->IsTank(bot) && !RsHalionAssistTankAsMelee(botAI))
+        return false;
+
+    Unit* boss = RsHalionAnyPhysicalBoss(botAI);
+    return boss != nullptr && boss->IsInCombat();
+}
+
+bool RsHalionCombustionTrigger::IsActive()
+{
+    if (RsHalionInTwilight(bot))
+        return false;
+
+    Unit* boss = RsHalionAnyPhysicalBoss(botAI);
+    if (!boss || !boss->IsInCombat())
+        return false;
+
+    if (RsHalionBossTank(botAI) == bot)
+        return false;
+
+    bool const returning = RsHalionCombustionReturning(bot);
+    return RsHalionHasCombustion(bot) || returning;
+}
+
+bool RsHalionMeteorTrigger::IsActive()
+{
+    if (RsHalionInTwilight(bot))
+        return false;
+
+    if (botAI->IsTank(bot) && !RsHalionAssistTankAsMelee(botAI))
+        return false;
+
+    Unit* boss = RsHalionAnyPhysicalBoss(botAI);
+    if (!boss || !boss->IsInCombat())
+        return false;
+
+    if (RsHalionHasCombustion(bot))
+        return false;
+
+    return RsHalionMeteorShouldRally(bot);
+}
+
+bool RsHalionAddsTrigger::IsActive()
+{
+    if (RsHalionInTwilight(bot))
+        return false;
+
+    if (botAI->IsTank(bot) || botAI->IsHeal(bot) || botAI->IsMelee(bot))
+        return false;
+
+    if (RsHalionHasCombustion(bot))
+        return false;
+
+    if (!RsHalionEngaged(botAI))
+        return false;
+
+    return RsHalionAnyAddAlive(botAI);
+}
+
+bool RsHalionAddTankTrigger::IsActive()
+{
+    if (!RsHalionEngaged(botAI))
+        return false;
+
+    return RsHalionTanksAdds(botAI, bot);
+}
+
+bool RsHalionStartPositionTrigger::IsActive()
+{
+    Unit* boss = RsHalionPhase1Boss(botAI);
+    if (!boss || !boss->HealthAbovePct(98) || !boss->IsInCombat())
+        return false;
+
+    return RsHalionBossTank(botAI) != bot;
+}
+
+bool RsHalionEnterPortalTrigger::IsActive()
+{
+    bool const inTwilight = RsHalionInTwilight(bot);
+
+    if (inTwilight)
+        return RsHalionPortalCommit(botAI, bot);
+
+    if (RsHalionEnteringTwilight(botAI, bot))
+        return true;
+
+    return !PlayerbotAI::IsMainTank(bot) && RsHalionPortalHeldForAdds(botAI);
+}
+
+bool RsHalionP2TankPositionTrigger::IsActive()
+{
+    if (RsHalionTwilightTank(botAI) != bot || !RsHalionInTwilight(bot))
+        return false;
+
+    return RsHalionTwilightBoss(botAI) != nullptr;
+}
+
+bool RsHalionP2AvoidConesTrigger::IsActive()
+{
+    if (!RsHalionInTwilight(bot))
+        return false;
+
+    if (RsHalionTwilightTank(botAI) == bot)
+        return false;
+
+    return RsHalionTwilightBoss(botAI) != nullptr;
+}
+
+bool RsHalionConsumptionTrigger::IsActive()
+{
+    if (!RsHalionInTwilight(bot))
+        return false;
+
+    if (!bot->HasAura(SPELL_MARK_OF_CONSUMPTION) && !bot->HasAura(SPELL_SOUL_CONSUMPTION))
+        return false;
+
+    return RsHalionTwilightBoss(botAI) != nullptr;
+}
+
+bool RsHalionCutterTrigger::IsActive()
+{
+    if (!RsHalionInTwilight(bot))
+        return false;
+
+    Unit* boss = RsHalionTwilightBoss(botAI);
+    if (!boss)
+        return false;
+
+    return boss->FindNearestCreature(NPC_ORB_CARRIER, 200.0f) != nullptr;
+}
+
+bool RsHalionHealConsumptionTrigger::IsActive()
+{
+    if (!botAI->IsHeal(bot) || !RsHalionInTwilight(bot))
+        return false;
+
+    if (!RsHalionIsPhase3(botAI))
+        return false;
+
+    return RsHalionConsumptionHealTarget(botAI) != nullptr;
+}
+
+bool RsTrashAddsTrigger::IsActive()
+{
+    if (botAI->IsTank(bot) || botAI->IsHeal(bot))
+        return false;
+
+    return RsTrashActive(botAI, bot);
+}
+
+bool RsTrashMainTankTrigger::IsActive()
+{
+    if (!botAI->IsMainTank(bot))
+        return false;
+
+    return RsTrashActive(botAI, bot);
+}
+
+bool RsTrashAssistTankTrigger::IsActive()
+{
+    if (!botAI->IsAssistTank(bot))
+        return false;
+
+    return RsTrashActive(botAI, bot);
+}
+
+bool RsTrashRangedTrigger::IsActive()
+{
+    if (botAI->IsTank(bot))
+        return false;
+
+    if (!botAI->IsRanged(bot) && !botAI->IsHeal(bot))
+        return false;
+
+    return RsTrashActive(botAI, bot);
+}
+
+bool RsTrashMeleeFlankTrigger::IsActive()
+{
+    if (botAI->IsTank(bot) || botAI->IsHeal(bot) || !botAI->IsMelee(bot))
+        return false;
+
+    return RsTrashActive(botAI, bot);
+}

--- a/src/Ai/Raid/RS/RSTriggers.h
+++ b/src/Ai/Raid/RS/RSTriggers.h
@@ -1,0 +1,297 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef _PLAYERBOT_RST_H
+#define _PLAYERBOT_RST_H
+
+#include "PlayerbotAI.h"
+#include "Playerbots.h"
+#include "Trigger.h"
+
+inline constexpr uint32 RS_MAP_RUBY_SANCTUM = 724;
+
+enum CreatureIdsRS
+{
+
+    NPC_BALTHARUS_THE_WARBORN           = 39751,
+    NPC_BALTHARUS_THE_WARBORN_CLONE     = 39899,
+
+    NPC_SAVIANA_RAGEFIRE                = 39747,
+
+    NPC_GENERAL_ZARITHRIAN              = 39746,
+    NPC_ONYX_FLAMECALLER                = 39814,
+
+    NPC_CHARSCALE_INVOKER               = 40417,
+    NPC_CHARSCALE_INVOKER_H             = 40418,
+    NPC_CHARSCALE_ASSAULTER             = 40419,
+    NPC_CHARSCALE_ASSAULTER_H           = 40420,
+    NPC_CHARSCALE_ELITE                 = 40421,
+    NPC_CHARSCALE_ELITE_H               = 40422,
+    NPC_CHARSCALE_COMMANDER             = 40423,
+    NPC_CHARSCALE_COMMANDER_H           = 40424,
+
+    NPC_HALION                          = 39863,
+    NPC_TWILIGHT_HALION                 = 40142,
+    NPC_METEOR_STRIKE_MARK              = 40029,
+    NPC_COMBUSTION                      = 40001,
+    NPC_LIVING_INFERNO                  = 40681,
+    NPC_LIVING_EMBER                    = 40683,
+    NPC_ORB_CARRIER                     = 40081,
+    NPC_CONSUMPTION                     = 40135
+};
+
+enum GameObjectIdsRS
+{
+    GO_HALION_PORTAL_1                  = 202794,
+    GO_HALION_PORTAL_2                  = 202795,
+    GO_HALION_PORTAL_3                  = 193988,
+    GO_HALION_PORTAL_4                  = 202796
+};
+
+enum SpellIdsRS
+{
+
+    SPELL_ENERVATING_BRAND              = 74502,
+
+    SPELL_CONFLAGRATION                 = 74452,
+    SPELL_FLAME_BEACON                  = 74453,
+
+    RS_SPELL_TAUNT_WARRIOR              = 355,
+    RS_SPELL_TAUNT_PALADIN              = 62124,
+    RS_SPELL_TAUNT_DK                   = 56222,
+    RS_SPELL_TAUNT_DRUID                = 6795,
+    RS_SPELL_PAIN_SUPPRESION            = 69910,
+    RS_SPELL_MAGIC_BARRIER              = 38112,
+
+    SPELL_FLAME_BREATH                  = 74525,
+    SPELL_FLAME_BREATH_ALT1             = 68970,
+    SPELL_FLAME_BREATH_ALT2             = 74403,
+    SPELL_FLAME_BREATH_ALT3             = 74404,
+    SPELL_FLAME_BREATH_ALT4             = 74526,
+    SPELL_FLAME_BREATH_ALT5             = 74527,
+    SPELL_FLAME_BREATH_ALT6             = 74528,
+    SPELL_CLEAVE                        = 74524,
+    SPELL_TAIL_LASH                     = 74531,
+
+    SPELL_FIERY_COMBUSTION              = 74562,
+    SPELL_MARK_OF_COMBUSTION            = 74567,
+
+    SPELL_METEOR_STRIKE_TARGETING       = 74638,
+    SPELL_METEOR_STRIKE                 = 74637,
+
+    SPELL_TWILIGHT_PHASING              = 74808,
+
+    SPELL_TWILIGHT_REALM                = 74807,
+    SPELL_DARK_BREATH                   = 74806,
+    SPELL_DARK_BREATH_25N               = 75954,
+    SPELL_DARK_BREATH_10H               = 75955,
+    SPELL_DARK_BREATH_25H               = 75956,
+    SPELL_SOUL_CONSUMPTION              = 74792,
+    SPELL_MARK_OF_CONSUMPTION           = 74795,
+    SPELL_TWILIGHT_CUTTER               = 74768,
+    SPELL_TWILIGHT_PULSE_PERIODIC       = 78861,
+
+    RS_SPELL_NITRO_BOOSTS               = 54861,
+    RS_SPELL_EMPOWERED_BLOOD            = 70227
+};
+
+class RsBaltharusBrandTrigger : public Trigger
+{
+public:
+    RsBaltharusBrandTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs baltharus brand") {}
+    bool IsActive() override;
+};
+
+class RsBaltharusTankPositionTrigger : public Trigger
+{
+public:
+    RsBaltharusTankPositionTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs baltharus tank position") {}
+    bool IsActive() override;
+};
+
+class RsBaltharusHealerPositionTrigger : public Trigger
+{
+public:
+    RsBaltharusHealerPositionTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs baltharus healer position") {}
+    bool IsActive() override;
+};
+
+class RsBaltharusAvoidFrontTrigger : public Trigger
+{
+public:
+    RsBaltharusAvoidFrontTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs baltharus avoid front") {}
+    bool IsActive() override;
+};
+
+class RsSavianaConflagrationTrigger : public Trigger
+{
+public:
+    RsSavianaConflagrationTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs saviana conflagration") {}
+    bool IsActive() override;
+};
+
+class RsSavianaTankPositionTrigger : public Trigger
+{
+public:
+    RsSavianaTankPositionTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs saviana tank position") {}
+    bool IsActive() override;
+};
+
+class RsSavianaAvoidFrontTrigger : public Trigger
+{
+public:
+    RsSavianaAvoidFrontTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs saviana avoid front") {}
+    bool IsActive() override;
+};
+
+class RsSavianaMeleeSpreadTrigger : public Trigger
+{
+public:
+    RsSavianaMeleeSpreadTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs saviana melee spread") {}
+    bool IsActive() override;
+};
+
+class RsZarithrianAddsTrigger : public Trigger
+{
+public:
+    RsZarithrianAddsTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs zarithrian adds") {}
+    bool IsActive() override;
+};
+
+class RsZarithrianTankTrigger : public Trigger
+{
+public:
+    RsZarithrianTankTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs zarithrian tank") {}
+    bool IsActive() override;
+};
+
+class RsHalionTankPositionTrigger : public Trigger
+{
+public:
+    RsHalionTankPositionTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs halion tank position") {}
+    bool IsActive() override;
+};
+
+class RsHalionAvoidConesTrigger : public Trigger
+{
+public:
+    RsHalionAvoidConesTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs halion avoid cones") {}
+    bool IsActive() override;
+};
+
+class RsHalionCombustionTrigger : public Trigger
+{
+public:
+    RsHalionCombustionTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs halion combustion") {}
+    bool IsActive() override;
+};
+
+class RsHalionMeteorTrigger : public Trigger
+{
+public:
+    RsHalionMeteorTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs halion meteor") {}
+    bool IsActive() override;
+};
+
+class RsHalionAddsTrigger : public Trigger
+{
+public:
+    RsHalionAddsTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs halion adds") {}
+    bool IsActive() override;
+};
+
+class RsHalionAddTankTrigger : public Trigger
+{
+public:
+    RsHalionAddTankTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs halion add tank") {}
+    bool IsActive() override;
+};
+
+class RsHalionStartPositionTrigger : public Trigger
+{
+public:
+    RsHalionStartPositionTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs halion start position") {}
+    bool IsActive() override;
+};
+
+class RsHalionEnterPortalTrigger : public Trigger
+{
+public:
+    RsHalionEnterPortalTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs halion enter portal") {}
+    bool IsActive() override;
+};
+
+class RsHalionP2TankPositionTrigger : public Trigger
+{
+public:
+    RsHalionP2TankPositionTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs halion p2 tank position") {}
+    bool IsActive() override;
+};
+
+class RsHalionP2AvoidConesTrigger : public Trigger
+{
+public:
+    RsHalionP2AvoidConesTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs halion p2 avoid cones") {}
+    bool IsActive() override;
+};
+
+class RsHalionConsumptionTrigger : public Trigger
+{
+public:
+    RsHalionConsumptionTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs halion consumption") {}
+    bool IsActive() override;
+};
+
+class RsHalionCutterTrigger : public Trigger
+{
+public:
+    RsHalionCutterTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs halion cutter") {}
+    bool IsActive() override;
+};
+
+class RsHalionHealConsumptionTrigger : public Trigger
+{
+public:
+    RsHalionHealConsumptionTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs halion heal consumption") {}
+    bool IsActive() override;
+};
+
+class RsTrashAddsTrigger : public Trigger
+{
+public:
+    RsTrashAddsTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs trash adds") {}
+    bool IsActive() override;
+};
+
+class RsTrashMainTankTrigger : public Trigger
+{
+public:
+    RsTrashMainTankTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs trash main tank") {}
+    bool IsActive() override;
+};
+
+class RsTrashAssistTankTrigger : public Trigger
+{
+public:
+    RsTrashAssistTankTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs trash assist tank") {}
+    bool IsActive() override;
+};
+
+class RsTrashRangedTrigger : public Trigger
+{
+public:
+    RsTrashRangedTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs trash ranged") {}
+    bool IsActive() override;
+};
+
+class RsTrashMeleeFlankTrigger : public Trigger
+{
+public:
+    RsTrashMeleeFlankTrigger(PlayerbotAI* botAI) : Trigger(botAI, "rs trash melee flank") {}
+    bool IsActive() override;
+};
+
+#endif

--- a/src/Ai/Raid/RaidStrategyContext.h
+++ b/src/Ai/Raid/RaidStrategyContext.h
@@ -20,6 +20,7 @@
 #include "UldStrategy.h"
 #include "OnyStrategy.h"
 #include "ICCStrategy.h"
+#include "RSStrategy.h"
 
 class RaidStrategyContext : public NamedObjectContext<Strategy>
 {
@@ -44,6 +45,7 @@ public:
         creators["ulduar"] = &RaidStrategyContext::ulduar;
         creators["onyxia"] = &RaidStrategyContext::onyxia;
         creators["icc"] = &RaidStrategyContext::icc;
+        creators["rs"] = &RaidStrategyContext::rs;
     }
 
 private:
@@ -65,6 +67,7 @@ private:
     static Strategy* onyxia(PlayerbotAI* botAI) { return new RaidOnyxiaStrategy(botAI); }
     static Strategy* ulduar(PlayerbotAI* botAI) { return new RaidUlduarStrategy(botAI); }
     static Strategy* icc(PlayerbotAI* botAI) { return new RaidIccStrategy(botAI); }
+    static Strategy* rs(PlayerbotAI* botAI) { return new RaidRsStrategy(botAI); }
 };
 
 #endif

--- a/src/Ai/Raid/SSC/SSCActions.cpp
+++ b/src/Ai/Raid/SSC/SSCActions.cpp
@@ -2339,7 +2339,7 @@ bool LadyVashjPassTheTaintedCoreAction::LineUpSecondCorePasser(
 }
 
 bool LadyVashjPassTheTaintedCoreAction::LineUpThirdCorePasser(
-    Player* designatedLooter, Player* firstCorePasser,
+    Player*, Player* firstCorePasser,
     Player* secondCorePasser, Unit* closestTrigger)
 {
     bool needThirdPasser =
@@ -2404,7 +2404,7 @@ bool LadyVashjPassTheTaintedCoreAction::LineUpThirdCorePasser(
 }
 
 bool LadyVashjPassTheTaintedCoreAction::LineUpFourthCorePasser(
-    Player* firstCorePasser, Player* secondCorePasser,
+    Player*, Player* secondCorePasser,
     Player* thirdCorePasser, Unit* closestTrigger)
 {
     bool needFourthPasser =

--- a/src/Ai/Raid/TK/TKActions.cpp
+++ b/src/Ai/Raid/TK/TKActions.cpp
@@ -1440,9 +1440,9 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
 
     if (axe)
     {
-        bool hasAggroFromWeapon = mace && mace->GetVictim() == bot ||
-                                  dagger && dagger->GetVictim() == bot ||
-                                  sword && sword->GetVictim() == bot;
+        bool hasAggroFromWeapon = (mace && mace->GetVictim() == bot) ||
+                                  (dagger && dagger->GetVictim() == bot) ||
+                                  (sword && sword->GetVictim() == bot);
         if (!botAI->IsTank(bot) ||
             (botAI->IsAssistTank(bot) && hasAggroFromWeapon))
         {
@@ -1608,7 +1608,7 @@ bool KaelthasSunstriderLootLegendaryWeaponsAction::ShouldBotLootWeapon(uint32 we
                    (bot->getClass() == CLASS_WARRIOR && tab != WARRIOR_TAB_ARMS);
 
         case NPC_WARP_SLICER:
-            return bot->getClass() == CLASS_ROGUE && tab != ROGUE_TAB_ASSASSINATION ||
+            return (bot->getClass() == CLASS_ROGUE && tab != ROGUE_TAB_ASSASSINATION) ||
                    (botAI->IsTank(bot) &&
                     (bot->getClass() == CLASS_DEATH_KNIGHT ||
                      bot->getClass() == CLASS_PALADIN));

--- a/src/Ai/Raid/Uld/UldActions.cpp
+++ b/src/Ai/Raid/Uld/UldActions.cpp
@@ -104,7 +104,7 @@ bool FlameLeviathanVehicleAction::MoveAvoidChasing(Unit* target)
         return false;
     if (avoidChaseIdx == -1)
     {
-        for (int i = 0; i < corners.size(); i++)
+        for (uint32 i = 0; i < corners.size(); i++)
         {
             if (bot->GetExactDist(corners[i]) > target->GetExactDist(corners[i]))
                 continue;
@@ -2633,7 +2633,7 @@ bool YoggSaronMarkTargetAction::Execute(Event /*event*/)
             if ((unit->GetEntry() == NPC_IMMORTAL_GUARDIAN || unit->GetEntry() == NPC_MARKED_IMMORTAL_GUARDIAN) &&
                 unit->GetHealthPct() > 10)
             {
-                if (unit->GetHealth() < lowestHealth)
+                if (unit->GetHealth() < uint32(lowestHealth))
                 {
                     lowestHealth = unit->GetHealth();
                     lowestHealthUnit = unit;

--- a/src/Ai/World/Rpg/Action/NewRpgAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.cpp
@@ -488,6 +488,8 @@ bool NewRpgTravelFlightAction::Execute(Event /*event*/)
     if (bot->IsMounted())
         bot->Dismount();
 
+    bot->GetSession()->SendLearnNewTaxiNode(flightMaster);
+
     if (!bot->ActivateTaxiPathTo(nodes, flightMaster, 0))
     {
         LOG_DEBUG("playerbots", "[New RPG] {} active taxi path {} (from {} to {}) failed", bot->GetName(),

--- a/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp
@@ -225,7 +225,7 @@ bool NewRpgBaseAction::MoveWorldObjectTo(ObjectGuid guid, float distance)
     return MoveTo(mapId, x, y, z, false, false, false, true);
 }
 
-bool NewRpgBaseAction::MoveRandomNear(float moveStep, MovementPriority priority, WorldObject* center)
+bool NewRpgBaseAction::MoveRandomNear(float moveStep, MovementPriority priority, WorldObject*)
 {
     if (IsWaitingForLastMove(priority))
         return false;
@@ -907,7 +907,7 @@ bool NewRpgBaseAction::GetQuestPOIPosAndObjectiveIdx(uint32 questId, std::vector
         bool inComplete = false;
         for (uint32 objective : incompleteObjectiveIdx)
         {
-            if (qPoi.ObjectiveIndex == objective)
+            if (qPoi.ObjectiveIndex == static_cast<int32>(objective))
             {
                 inComplete = true;
                 break;

--- a/src/Ai/World/Rpg/Action/NewRpgOutdoorPvP.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgOutdoorPvP.cpp
@@ -2,7 +2,7 @@
 #include "OutdoorPvP.h"
 #include "OutdoorPvPMgr.h"
 
-bool NewRpgOutdoorPvpAction::Execute(Event event)
+bool NewRpgOutdoorPvpAction::Execute(Event)
 {
     if (!bot->IsPvP())
     {

--- a/src/Ai/World/Rpg/Action/RpgAction.cpp
+++ b/src/Ai/World/Rpg/Action/RpgAction.cpp
@@ -107,7 +107,7 @@ bool RpgAction::SetNextRpgAction()
     {
         std::vector<std::pair<Action*, uint32>> sortedActions;
 
-        for (int i = 0; i < actions.size(); i++)
+        for (uint32 i = 0; i < actions.size(); i++)
             sortedActions.push_back(std::make_pair(actions[i], relevances[i]));
 
         std::sort(sortedActions.begin(), sortedActions.end(), [](std::pair<Action*, uint32>i, std::pair<Action*, uint32> j) {return i.second > j.second; });

--- a/src/Bot/Cmd/PlayerbotCommandServer.cpp
+++ b/src/Bot/Cmd/PlayerbotCommandServer.cpp
@@ -26,7 +26,7 @@ bool ReadLine(socket_ptr sock, std::string* buffer, std::string* line)
         char buf[1025];
         boost::system::error_code error;
         size_t n = sock->read_some(boost::asio::buffer(buf), error);
-        if (n == -1 || error == boost::asio::error::eof)
+        if (n == static_cast<size_t>(-1) || error == boost::asio::error::eof)
             return false;
         else if (error)
             throw boost::system::system_error(error);  // Some other error.

--- a/src/Bot/Engine/Action/Action.h
+++ b/src/Bot/Engine/Action/Action.h
@@ -17,8 +17,7 @@ class NextAction
 {
 public:
     NextAction(std::string const name, float relevance = 0.0f)
-        : relevance(relevance), name(name) {}                                  // name after relevance - whipowill
-    NextAction(NextAction const& o) : relevance(o.relevance), name(o.name) {}  // name after relevance - whipowill
+        : relevance(relevance), name(name) {}  // name after relevance - whipowill
 
     std::string const getName() { return name; }
     float getRelevance() { return relevance; }

--- a/src/Bot/Engine/BuildSharedActionContexts.cpp
+++ b/src/Bot/Engine/BuildSharedActionContexts.cpp
@@ -20,6 +20,7 @@
 #include "UldActionContext.h"
 #include "OnyActionContext.h"
 #include "ICCActionContext.h"
+#include "RSActionContext.h"
 #include "Ai/Dungeon/TbcDungeonActionContext.h"
 #include "Ai/Dungeon/WotlkDungeonActionContext.h"
 
@@ -46,6 +47,7 @@ void AiObjectContext::BuildSharedActionContexts(SharedNamedObjectContextList<Act
     actionContexts.Add(new RaidUlduarActionContext());
     actionContexts.Add(new RaidOnyxiaActionContext());
     actionContexts.Add(new RaidIccActionContext());
+    actionContexts.Add(new RaidRsActionContext());
     actionContexts.Add(new TbcDungeonAuchenaiCryptsActionContext());
     actionContexts.Add(new WotlkDungeonUKActionContext());
     actionContexts.Add(new WotlkDungeonNexActionContext());

--- a/src/Bot/Engine/BuildSharedTriggerContexts.cpp
+++ b/src/Bot/Engine/BuildSharedTriggerContexts.cpp
@@ -20,6 +20,7 @@
 #include "UldTriggerContext.h"
 #include "OnyTriggerContext.h"
 #include "ICCTriggerContext.h"
+#include "RSTriggerContext.h"
 #include "Ai/Dungeon/TbcDungeonTriggerContext.h"
 #include "Ai/Dungeon/WotlkDungeonTriggerContext.h"
 
@@ -46,6 +47,7 @@ void AiObjectContext::BuildSharedTriggerContexts(SharedNamedObjectContextList<Tr
     triggerContexts.Add(new RaidUlduarTriggerContext());
     triggerContexts.Add(new RaidOnyxiaTriggerContext());
     triggerContexts.Add(new RaidIccTriggerContext());
+    triggerContexts.Add(new RaidRsTriggerContext());
     triggerContexts.Add(new TbcDungeonAuchenaiCryptsTriggerContext());
     triggerContexts.Add(new WotlkDungeonUKTriggerContext());
     triggerContexts.Add(new WotlkDungeonNexTriggerContext());

--- a/src/Bot/Engine/Strategy/CustomStrategy.cpp
+++ b/src/Bot/Engine/Strategy/CustomStrategy.cpp
@@ -35,7 +35,7 @@ std::vector<NextAction> toNextActionArray(const std::string actions)
     const std::vector<std::string> tokens = split(actions, ',');
     std::vector<NextAction> res = {};
 
-    for (const std::string token : tokens)
+    for (const std::string& token : tokens)
         res.push_back(toNextAction(token));
 
     return res;

--- a/src/Bot/Engine/Trigger/Trigger.cpp
+++ b/src/Bot/Engine/Trigger/Trigger.cpp
@@ -36,7 +36,7 @@ bool Trigger::needCheck(uint32 now)
     if (checkInterval < 2)
         return true;
 
-    if (!lastCheckTime || now - lastCheckTime >= checkInterval)
+    if (!lastCheckTime || now - lastCheckTime >= uint32(checkInterval))
     {
         lastCheckTime = now;
         return true;

--- a/src/Bot/Engine/Value/Value.h
+++ b/src/Bot/Engine/Value/Value.h
@@ -7,6 +7,7 @@
 #define PLAYERBOTS_VALUE_H
 
 #include <time.h>
+#include <unordered_map>
 
 #include "AiObject.h"
 #include "ObjectGuid.h"
@@ -414,6 +415,19 @@ public:
     }
 private:
     std::list<FleeInfo> data = {};
+};
+
+class MissingBuffReagentNoticeValue : public ManualSetValue<std::unordered_map<std::string, uint32>&>
+{
+public:
+    MissingBuffReagentNoticeValue(
+        PlayerbotAI* botAI, std::string const name = "missing buff reagent notice")
+        : ManualSetValue<std::unordered_map<std::string, uint32>&>(botAI, noticeTimes, name)
+    {
+    }
+
+private:
+    std::unordered_map<std::string, uint32> noticeTimes;
 };
 
 #endif

--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -612,7 +612,7 @@ void PlayerbotFactory::Randomize(bool incremental)
     PerfMonitorOperation* pmo = sPerfMonitor.start(PERF_MON_RNDBOT, "PlayerbotFactory_Reset");
 
     if (!sPlayerbotAIConfig.equipAndSpecPersistence ||
-        level < sPlayerbotAIConfig.equipAndSpecPersistenceLevel)
+        level < uint32(sPlayerbotAIConfig.equipAndSpecPersistenceLevel))
     {
         bot->resetTalents(true);
     }
@@ -623,7 +623,7 @@ void PlayerbotFactory::Randomize(bool incremental)
         ClearSpells();
         ResetQuests();
         if (!sPlayerbotAIConfig.equipAndSpecPersistence ||
-            level < sPlayerbotAIConfig.equipAndSpecPersistenceLevel)
+            level < uint32(sPlayerbotAIConfig.equipAndSpecPersistenceLevel))
         {
             ClearAllItems();
         }
@@ -1189,7 +1189,7 @@ void PlayerbotFactory::InitPetTalents()
                 int index = urand(0, spells_row.size() - 1);
                 TalentEntry const* talentInfo = spells_row[index];
                 int maxRank = 0;
-                for (int rank = 0; rank < std::min((uint32)MAX_TALENT_RANK, (uint32)pet->GetFreeTalentPoints()); ++rank)
+                for (uint32 rank = 0; rank < std::min((uint32)MAX_TALENT_RANK, (uint32)pet->GetFreeTalentPoints()); ++rank)
                 {
                     uint32 spellId = talentInfo->RankID[rank];
                     if (!spellId)
@@ -2157,7 +2157,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
             ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
             if (!proto) continue;
             // Respect gear quality limit: trinket must not exceed itemQuality setting
-            if (static_cast<int32>(proto->Quality) > itemQuality) continue;
+            if (static_cast<int32>(proto->Quality) > static_cast<int32>(itemQuality)) continue;
             if (proto->RequiredLevel > level) continue;
             if (!CanEquipItem(proto)) continue;
             uint16 dest;
@@ -2227,7 +2227,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
 
         do
         {
-            for (uint32 requiredLevel = bot->GetLevel(); requiredLevel > std::max((int32)bot->GetLevel() - delta, 0);
+            for (uint32 requiredLevel = bot->GetLevel(); requiredLevel > uint32(std::max((int32)bot->GetLevel() - delta, 0));
                  requiredLevel--)
             {
                 for (InventoryType inventoryType : GetPossibleInventoryTypeListBySlot((EquipmentSlots)slot))
@@ -2262,7 +2262,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
                         if (proto->Class != ITEM_CLASS_WEAPON && proto->Class != ITEM_CLASS_ARMOR)
                             continue;
 
-                        if (proto->Quality != desiredQuality)
+                        if (proto->Quality != uint32(desiredQuality))
                             continue;
 
                         if (proto->Class == ITEM_CLASS_ARMOR &&
@@ -2298,7 +2298,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
         float bestScoreForSlot = -1;
         uint32 bestItemForSlot = 0;
         int32 bestRandomPropForSlot = 0;
-        for (int index = 0; index < ids.size(); index++)
+        for (size_t index = 0; index < ids.size(); index++)
         {
             uint32 newItemId = ids[index].first;
             int32 newItemProp = ids[index].second;
@@ -2419,7 +2419,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
             float bestScoreForSlot = -1;
             uint32 bestItemForSlot = 0;
             int32 bestRandomPropForSlot = 0;
-            for (int index = 0; index < ids.size(); index++)
+            for (size_t index = 0; index < ids.size(); index++)
             {
                 uint32 newItemId = ids[index].first;
                 int32 newItemProp = ids[index].second;
@@ -3391,7 +3391,7 @@ void PlayerbotFactory::InitTalents(uint32 specNo)
             int index = urand(0, spells_row.size() - 1);
             TalentEntry const* talentInfo = spells_row[index];
             int maxRank = 0;
-            for (int rank = 0; rank < std::min((uint32)MAX_TALENT_RANK, bot->GetFreeTalentPoints()); ++rank)
+            for (uint32 rank = 0; rank < std::min((uint32)MAX_TALENT_RANK, bot->GetFreeTalentPoints()); ++rank)
             {
                 uint32 spellId = talentInfo->RankID[rank];
                 if (!spellId)
@@ -3918,7 +3918,7 @@ void PlayerbotFactory::InitFood()
     }
 
     uint32 categories[] = {11, 59};
-    for (int i = 0; i < sizeof(categories) / sizeof(uint32); ++i)
+    for (size_t i = 0; i < sizeof(categories) / sizeof(uint32); ++i)
     {
         uint32 category = categories[i];
         std::vector<uint32>& ids = items[category];
@@ -5105,9 +5105,9 @@ void PlayerbotFactory::ApplyEnchantAndGemsNew(bool /*destroyOld*/)
                 if (curCount[0] != 0)
                 {
                     // Ensure meta gem activation
-                    for (int i = 1; i < curCount.size(); i++)
+                    for (size_t i = 1; i < curCount.size(); i++)
                     {
-                        if (curCount[i] < requiredActive && (gemProperties->color & (1 << i)))
+                        if (curCount[i] < (uint32)requiredActive && (gemProperties->color & (1 << i)))
                         {
                             score *= 2;
                             break;

--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -497,7 +497,7 @@ void PlayerbotFactory::Init()
             continue;
         }
 
-        if (sRandomItemMgr.IsTestItem(gemId))
+        if (sRandomItemMgr.IsInternalItem(proto))
         {
            continue;
         }
@@ -2232,7 +2232,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
             {
                 for (InventoryType inventoryType : GetPossibleInventoryTypeListBySlot((EquipmentSlots)slot))
                 {
-                    for (uint32 itemId : sRandomItemMgr.GetCachedEquipments(requiredLevel, inventoryType))
+                    for (uint32 itemId : sRandomItemMgr.GetEquipmentNew(requiredLevel, inventoryType))
                     {
                         uint32 skipProb = 25;
                         if (urand(1, 100) <= skipProb)
@@ -3618,15 +3618,20 @@ void PlayerbotFactory::ClearAllItems()
 
 void PlayerbotFactory::InitAmmo()
 {
-    if (bot->getClass() != CLASS_HUNTER && bot->getClass() != CLASS_ROGUE && bot->getClass() != CLASS_WARRIOR)
+    uint8 const botClass = bot->getClass();
+    if (botClass != CLASS_HUNTER && botClass != CLASS_ROGUE && botClass != CLASS_WARRIOR)
         return;
 
-    Item* const pItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_RANGED);
-    if (!pItem)
+    Item const* item = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_RANGED);
+    if (!item)
+        return;
+
+    ItemTemplate const* proto = item->GetTemplate();
+    if (!proto)
         return;
 
     uint32 subClass = 0;
-    switch (pItem->GetTemplate()->SubClass)
+    switch (proto->SubClass)
     {
         case ITEM_SUBCLASS_WEAPON_GUN:
             subClass = ITEM_SUBCLASS_BULLET;
@@ -3635,45 +3640,23 @@ void PlayerbotFactory::InitAmmo()
         case ITEM_SUBCLASS_WEAPON_CROSSBOW:
             subClass = ITEM_SUBCLASS_ARROW;
             break;
-        default:
-            break;
+        default: // invalid weapon type, nothing to do
+            return;
     }
 
-    if (!subClass)
-        return;
-
-    std::vector<uint32> ammoEntryList = sRandomItemMgr.GetAmmo(level, subClass);
-    uint32 entry = 0;
-    for (uint32 tEntry : ammoEntryList)
-    {
-        ItemTemplate const* proto = sObjectMgr->GetItemTemplate(tEntry);
-        if (!proto)
-            continue;
-
-        // disable next expansion ammo
-        if (sPlayerbotAIConfig.limitGearExpansion && bot->GetLevel() <= 60 && tEntry >= 23728)
-            continue;
-
-        if (sPlayerbotAIConfig.limitGearExpansion && bot->GetLevel() <= 70 && tEntry >= 35570)
-            continue;
-
-        entry = tEntry;
-        break;
-    }
-
+    uint32 entry = sRandomItemMgr.GetAmmo(level, subClass);
     if (!entry)
         return;
 
     uint32 count = bot->GetItemCount(entry);
-    uint32 maxCount = bot->getClass() == CLASS_HUNTER ? 6000 : 1000;
+    uint32 maxCount = botClass == CLASS_HUNTER ? 6000 : 1000;
 
     if (count < maxCount)
     {
         if (Item* newItem = StoreNewItemInInventorySlot(bot, entry, maxCount - count))
-        {
             newItem->AddToUpdateQueueOf(bot);
-        }
     }
+
     bot->SetAmmo(entry);
 }
 

--- a/src/Bot/Factory/RandomPlayerbotFactory.cpp
+++ b/src/Bot/Factory/RandomPlayerbotFactory.cpp
@@ -240,7 +240,7 @@ std::string const RandomPlayerbotFactory::CreateRandomBotName(NameRaceAndGender 
         botName += (botName.size() < 2) ? groupFormEnd[gender][rand() % 4] : "";
 
         // Replace Catagory value with random Letter from that Catagory's Letter string for a given bot gender
-        for (int i = 0; i < botName.size(); i++)
+        for (size_t i = 0; i < botName.size(); i++)
         {
             botName[i] = groupLetter[gender][groupCategory.find(botName[i])]
                                     [rand() % groupLetter[gender][groupCategory.find(botName[i])].size()];

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -1746,6 +1746,9 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
         case 668:
             strategyName = "wotlk-hor";  // Halls of Reflection
             break;
+        case 724:
+            strategyName = "rs";  // Ruby Sanctum
+            break;
         default:
             break;
     }

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -2034,7 +2034,7 @@ bool PlayerbotAI::HasAggro(Unit* unit)
     if (!IsValidUnit(unit))
         return false;
 
-    bool isMT = IsMainTank(bot);
+    bool isMT = IsExplicitMainTank(bot);
     Unit* victim = unit->GetVictim();
     if (victim && (victim->GetGUID() == bot->GetGUID() || (!isMT && victim->ToPlayer() && IsTank(victim->ToPlayer()))))
     {
@@ -2365,6 +2365,20 @@ bool PlayerbotAI::IsDps(Player* player, bool bySpec)
                 return true;
             }
             break;
+    }
+    return false;
+}
+
+bool PlayerbotAI::IsExplicitMainTank(Player* player)
+{
+    Group* group = player->GetGroup();
+    if (!group)
+        return false;
+
+    for (Group::member_citerator itr = group->GetMemberSlots().begin(); itr != group->GetMemberSlots().end(); ++itr)
+    {
+        if (itr->flags & MEMBER_FLAG_MAINTANK)
+            return player->GetGUID() == itr->guid;
     }
     return false;
 }

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -4395,6 +4395,16 @@ bool IsAlliance(uint8 race)
            race == RACE_DRAENEI;
 }
 
+BotType PlayerbotAI::GetBotType() const
+{
+    if (_botType == BotType::UNDEFINED)
+    {
+        LOG_ERROR("playerbots", "GetBotType() called before the bot type was initialized for bot {}",
+                  bot ? bot->GetName() : "<unknown>");
+    }
+    return _botType;
+}
+
 Player* PlayerbotAI::FindNewMaster()
 {
     // Ideally we want to have the leader as master.
@@ -4450,8 +4460,6 @@ bool PlayerbotAI::HasRealPlayerMaster()
 }
 
 bool PlayerbotAI::HasActivePlayerMaster() { return master && !GET_PLAYERBOT_AI(master); }
-
-bool PlayerbotAI::IsAlt() { return HasRealPlayerMaster() && !sRandomPlayerbotMgr.IsRandomBot(bot); }
 
 Player* PlayerbotAI::GetGroupLeader()
 {

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -4409,16 +4409,6 @@ bool IsAlliance(uint8 race)
            race == RACE_DRAENEI;
 }
 
-BotType PlayerbotAI::GetBotType() const
-{
-    if (_botType == BotType::UNDEFINED)
-    {
-        LOG_ERROR("playerbots", "GetBotType() called before the bot type was initialized for bot {}",
-                  bot ? bot->GetName() : "<unknown>");
-    }
-    return _botType;
-}
-
 Player* PlayerbotAI::FindNewMaster()
 {
     // Ideally we want to have the leader as master.
@@ -4474,6 +4464,8 @@ bool PlayerbotAI::HasRealPlayerMaster()
 }
 
 bool PlayerbotAI::HasActivePlayerMaster() { return master && !GET_PLAYERBOT_AI(master); }
+
+bool PlayerbotAI::IsAlt() { return HasRealPlayerMaster() && !sRandomPlayerbotMgr.IsRandomBot(bot); }
 
 Player* PlayerbotAI::GetGroupLeader()
 {

--- a/src/Bot/PlayerbotAI.h
+++ b/src/Bot/PlayerbotAI.h
@@ -230,6 +230,15 @@ enum class BotTypeNumber : uint8
     GUILDER_TYPE_NUMBER = 3,
 };
 
+enum class BotType : uint8
+{
+    UNDEFINED = 0,
+    ALTBOT,
+    RANDOMBOT,
+    ADDCLASSBOT,
+    REALPLAYER  // self-bot
+};
+
 enum class GrouperType : uint8
 {
     SOLO = 0,
@@ -533,15 +542,18 @@ public:
     Player* GetMaster() { return master; }
     Player* FindNewMaster();
 
-    // Checks if the bot is really a player. Players always have themselves as master.
-    bool IsRealPlayer() { return master ? (master == bot) : false; }
+    bool IsRealPlayer() { return GetBotType() == BotType::REALPLAYER; }
+    BotType GetBotType() const;
+    void SetBotType(BotType type) { _botType = type; }
+    bool IsRandomBot() { return GetBotType() == BotType::RANDOMBOT; }
+    bool IsAddclass() { return GetBotType() == BotType::ADDCLASSBOT; }
     // Bot has a master that is a player.
     bool HasRealPlayerMaster();
     // Bot has a master that is activly playing.
     bool HasActivePlayerMaster();
     // Get the group leader or the master of the bot.
     // Checks if the bot is summoned as alt of a player
-    bool IsAlt();
+    bool IsAlt() { return GetBotType() == BotType::ALTBOT; }
     Player* GetGroupLeader();
     uint32 GetFixedBotNumber(uint32 maxNum = 100);
     GrouperType GetGrouperType();
@@ -650,6 +662,7 @@ protected:
     Position jumpDestination = Position();
     uint32 nextTransportCheck = 0;
     bool spellInterruptRequested = false;
+    BotType _botType = BotType::UNDEFINED;
 };
 
 #endif

--- a/src/Bot/PlayerbotAI.h
+++ b/src/Bot/PlayerbotAI.h
@@ -230,15 +230,6 @@ enum class BotTypeNumber : uint8
     GUILDER_TYPE_NUMBER = 3,
 };
 
-enum class BotType : uint8
-{
-    UNDEFINED = 0,
-    ALTBOT,
-    RANDOMBOT,
-    ADDCLASSBOT,
-    REALPLAYER  // self-bot
-};
-
 enum class GrouperType : uint8
 {
     SOLO = 0,
@@ -543,18 +534,15 @@ public:
     Player* GetMaster() { return master; }
     Player* FindNewMaster();
 
-    bool IsRealPlayer() { return GetBotType() == BotType::REALPLAYER; }
-    BotType GetBotType() const;
-    void SetBotType(BotType type) { _botType = type; }
-    bool IsRandomBot() { return GetBotType() == BotType::RANDOMBOT; }
-    bool IsAddclass() { return GetBotType() == BotType::ADDCLASSBOT; }
+    // Checks if the bot is really a player. Players always have themselves as master.
+    bool IsRealPlayer() { return master ? (master == bot) : false; }
     // Bot has a master that is a player.
     bool HasRealPlayerMaster();
     // Bot has a master that is activly playing.
     bool HasActivePlayerMaster();
     // Get the group leader or the master of the bot.
     // Checks if the bot is summoned as alt of a player
-    bool IsAlt() { return GetBotType() == BotType::ALTBOT; }
+    bool IsAlt();
     Player* GetGroupLeader();
     uint32 GetFixedBotNumber(uint32 maxNum = 100);
     GrouperType GetGrouperType();
@@ -663,7 +651,6 @@ protected:
     Position jumpDestination = Position();
     uint32 nextTransportCheck = 0;
     bool spellInterruptRequested = false;
-    BotType _botType = BotType::UNDEFINED;
 };
 
 #endif

--- a/src/Bot/PlayerbotAI.h
+++ b/src/Bot/PlayerbotAI.h
@@ -435,6 +435,7 @@ public:
     static bool IsCombo(Player* player);
     static bool IsBotMainTank(Player* player);
     static bool IsMainTank(Player* player, bool ignoreMemberFlag = false);
+    static bool IsExplicitMainTank(Player* player);
     static uint32 GetGroupTankNum(Player* player);
     static bool IsAssistTank(Player* player);
     static bool IsAssistTankOfIndex(Player* player, uint8 index, bool ignoreDeadPlayers = false);

--- a/src/Bot/PlayerbotMgr.cpp
+++ b/src/Bot/PlayerbotMgr.cpp
@@ -556,15 +556,14 @@ void PlayerbotHolder::OnBotLogin(Player* const bot)
         Group* mgroup = master->GetGroup();
         if (mgroup->GetMembersCount() >= 5)
         {
-            if (!mgroup->isRaidGroup() && !mgroup->isLFGGroup() && !mgroup->isBGGroup() && !mgroup->isBFGroup())
+            // A 5-member party is full, so only a raid can take a 6th member. GroupInviteOperation::
+            // Execute() self-converts a non-raid group with >= 5 members to a raid before adding, so a
+            // separate ConvertToRaid is unnecessary here. Queue the invite for a raid OR a plain
+            // (non-LFG/BG/battlefield) party; we deliberately skip LFG/BG/BFG groups so a bot login
+            // never force-converts a live dungeon-finder or battleground group into a raid.
+            if (mgroup->isRaidGroup() || (!mgroup->isLFGGroup() && !mgroup->isBGGroup() && !mgroup->isBFGroup()))
             {
-                // Queue ConvertToRaid operation
-                auto convertOp = std::make_unique<GroupConvertToRaidOperation>(master->GetGUID());
-                PlayerbotWorldThreadProcessor::instance().QueueOperation(std::move(convertOp));
-            }
-            if (mgroup->isRaidGroup())
-            {
-                // Queue AddMember operation
+                // Queue AddMember operation; Execute() converts the party to a raid before adding.
                 auto addOp = std::make_unique<GroupInviteOperation>(master->GetGUID(), bot->GetGUID());
                 PlayerbotWorldThreadProcessor::instance().QueueOperation(std::move(addOp));
             }

--- a/src/Bot/PlayerbotMgr.cpp
+++ b/src/Bot/PlayerbotMgr.cpp
@@ -130,7 +130,7 @@ void PlayerbotHolder::AddPlayerBot(ObjectGuid playerGuid, uint32 masterAccountId
                 ++loadingForMaster;
         }
         uint32 count = mgr->GetPlayerbotsCount() + loadingForMaster;
-        if (count >= PlayerbotAIConfig::instance().maxAddedBots)
+        if (count >= uint32(PlayerbotAIConfig::instance().maxAddedBots))
         {
             allowed = false;
             out << "Failure: You have added too many bots (more than " << sPlayerbotAIConfig.maxAddedBots << ")";
@@ -367,7 +367,7 @@ void PlayerbotHolder::LogoutPlayerBot(ObjectGuid guid)
         bot->SaveToDB(false, false);
 
         WorldSession* botWorldSessionPtr = bot->GetSession();
-        WorldSession* masterWorldSessionPtr = nullptr;
+        [[maybe_unused]] WorldSession* masterWorldSessionPtr = nullptr;     // Remove [[maybe_unused]] tag if timed logout implemented.
 
         if (botWorldSessionPtr->isLogingOut())
             return;

--- a/src/Bot/PlayerbotMgr.cpp
+++ b/src/Bot/PlayerbotMgr.cpp
@@ -729,7 +729,7 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
     if (!bot)
         return "bot not found";
 
-    bool addClassBot = sRandomPlayerbotMgr.IsAddclassBot(guid.GetCounter());
+    bool addClassBot = sRandomPlayerbotMgr.IsAddclassBot(bot);
 
     if (!addClassBot)
     {
@@ -1068,6 +1068,7 @@ std::vector<std::string> PlayerbotHolder::HandlePlayerbotCommand(char const* arg
             messages.push_back("Enable player botAI");
             PlayerbotsMgr::instance().AddPlayerbotData(master, true);
             GET_PLAYERBOT_AI(master)->SetMaster(master);
+            GET_PLAYERBOT_AI(master)->SetBotType(BotType::REALPLAYER);
             PlayerbotRepository::instance().Load(GET_PLAYERBOT_AI(master));
         }
 
@@ -1632,6 +1633,13 @@ void PlayerbotMgr::OnBotLoginInternal(Player* const bot)
     }
     botAI->SetMaster(master);
     botAI->ResetStrategies();
+
+    // Any bot summoned off a randombot account (random pool or addclass) is
+    // treated as an addclass bot; only a player's own characters are alts.
+    uint32 botAccountId = bot->GetSession()->GetAccountId();
+    botAI->SetBotType(sPlayerbotAIConfig.IsInRandomAccountList(botAccountId)
+                              ? BotType::ADDCLASSBOT
+                              : BotType::ALTBOT);
 
     LOG_INFO("playerbots", "Bot {} logged in", bot->GetName().c_str());
 }

--- a/src/Bot/PlayerbotMgr.cpp
+++ b/src/Bot/PlayerbotMgr.cpp
@@ -359,6 +359,11 @@ void PlayerbotHolder::LogoutPlayerBot(ObjectGuid guid)
         PlayerbotWorldThreadProcessor::instance().QueueOperation(std::move(cleanupOp));
 
         LOG_DEBUG("playerbots", "Bot {} logging out", bot->GetName().c_str());
+
+        // Remove taxi cheat flag on alts.
+        if (!sRandomPlayerbotMgr.IsRandomBot(bot) && bot->isTaxiCheater())
+            bot->SetTaxiCheater(false);
+
         bot->SaveToDB(false, false);
 
         WorldSession* botWorldSessionPtr = bot->GetSession();

--- a/src/Bot/PlayerbotMgr.cpp
+++ b/src/Bot/PlayerbotMgr.cpp
@@ -734,7 +734,7 @@ std::string const PlayerbotHolder::ProcessBotCommand(std::string const cmd, Obje
     if (!bot)
         return "bot not found";
 
-    bool addClassBot = sRandomPlayerbotMgr.IsAddclassBot(bot);
+    bool addClassBot = sRandomPlayerbotMgr.IsAddclassBot(guid.GetCounter());
 
     if (!addClassBot)
     {
@@ -1073,7 +1073,6 @@ std::vector<std::string> PlayerbotHolder::HandlePlayerbotCommand(char const* arg
             messages.push_back("Enable player botAI");
             PlayerbotsMgr::instance().AddPlayerbotData(master, true);
             GET_PLAYERBOT_AI(master)->SetMaster(master);
-            GET_PLAYERBOT_AI(master)->SetBotType(BotType::REALPLAYER);
             PlayerbotRepository::instance().Load(GET_PLAYERBOT_AI(master));
         }
 
@@ -1638,13 +1637,6 @@ void PlayerbotMgr::OnBotLoginInternal(Player* const bot)
     }
     botAI->SetMaster(master);
     botAI->ResetStrategies();
-
-    // Any bot summoned off a randombot account (random pool or addclass) is
-    // treated as an addclass bot; only a player's own characters are alts.
-    uint32 botAccountId = bot->GetSession()->GetAccountId();
-    botAI->SetBotType(sPlayerbotAIConfig.IsInRandomAccountList(botAccountId)
-                              ? BotType::ADDCLASSBOT
-                              : BotType::ALTBOT);
 
     LOG_INFO("playerbots", "Bot {} logged in", bot->GetName().c_str());
 }

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -2100,20 +2100,16 @@ void RandomPlayerbotMgr::Refresh(Player* bot)
 
 bool RandomPlayerbotMgr::IsRandomBot(Player* bot)
 {
-    if (bot && GET_PLAYERBOT_AI(bot))
-    {
-        if (GET_PLAYERBOT_AI(bot)->IsRealPlayer())
-            return false;
-    }
-    if (bot)
-    {
-        return IsRandomBot(bot->GetGUID().GetCounter());
-    }
+    if (!bot)
+        return false;
 
-    return false;
+    if (PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot))
+        return botAI->GetBotType() == BotType::RANDOMBOT;
+
+    return isRandomBot(bot->GetGUID().GetCounter());
 }
 
-bool RandomPlayerbotMgr::IsRandomBot(ObjectGuid::LowType bot)
+bool RandomPlayerbotMgr::isRandomBot(ObjectGuid::LowType bot)
 {
     ObjectGuid guid = ObjectGuid::Create<HighGuid::Player>(bot);
     if (!sPlayerbotAIConfig.IsInRandomAccountList(sCharacterCache->GetCharacterAccountIdByGuid(guid)))
@@ -2127,17 +2123,13 @@ bool RandomPlayerbotMgr::IsRandomBot(ObjectGuid::LowType bot)
 
 bool RandomPlayerbotMgr::IsAddclassBot(Player* bot)
 {
-    if (bot && GET_PLAYERBOT_AI(bot))
-    {
-        if (GET_PLAYERBOT_AI(bot)->IsRealPlayer())
-            return false;
-    }
-    if (bot)
-    {
-        return IsAddclassBot(bot->GetGUID().GetCounter());
-    }
+    if (!bot)
+        return false;
 
-    return false;
+    if (PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot))
+        return botAI->GetBotType() == BotType::ADDCLASSBOT;
+
+    return IsAddclassBot(bot->GetGUID().GetCounter());
 }
 
 bool RandomPlayerbotMgr::IsAddclassBot(ObjectGuid::LowType bot)
@@ -2163,9 +2155,7 @@ bool RandomPlayerbotMgr::IsAddclassBot(ObjectGuid::LowType bot)
     // If not in cache, check the account type
     uint32 accountId = sCharacterCache->GetCharacterAccountIdByGuid(guid);
     if (accountId && IsAccountType(accountId, 2)) // Type 2 = AddClass
-    {
         return true;
-    }
 
     return false;
 }
@@ -2440,10 +2430,9 @@ bool RandomPlayerbotMgr::HandlePlayerbotConsoleCommand(ChatHandler* handler, cha
 
                     uint32 botId = fields[0].Get<uint32>();
                     ObjectGuid guid = ObjectGuid::Create<HighGuid::Player>(botId);
-                    if (!sRandomPlayerbotMgr.IsRandomBot(guid.GetCounter()))
-                    {
+                    if (!sRandomPlayerbotMgr.isRandomBot(guid.GetCounter()))
                         continue;
-                    }
+
                     Player* bot = ObjectAccessor::FindPlayer(guid);
                     if (!bot)
                         continue;
@@ -2538,10 +2527,11 @@ void RandomPlayerbotMgr::OnBotLoginInternal(Player* const bot)
                  sRandomPlayerbotMgr.GetMaxAllowedBotCount(), bot->GetName().c_str());
 
         if (playerBots.size() == sRandomPlayerbotMgr.GetMaxAllowedBotCount())
-        {
             _isBotLogging = false;
-        }
     }
+
+    if (PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot))
+        botAI->SetBotType(BotType::RANDOMBOT);
 
     // Run guild recovery/assignment at login to handle empty guild tables after restart.
     if (sPlayerbotAIConfig.randomBotGuildCount > 0)
@@ -2551,13 +2541,9 @@ void RandomPlayerbotMgr::OnBotLoginInternal(Player* const bot)
     }
 
     if (sPlayerbotAIConfig.randomBotFixedLevel)
-    {
         bot->SetPlayerFlag(PLAYER_FLAGS_NO_XP_GAIN);
-    }
     else
-    {
         bot->RemovePlayerFlag(PLAYER_FLAGS_NO_XP_GAIN);
-    }
 }
 
 void RandomPlayerbotMgr::OnPlayerLogin(Player* player)

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -2100,16 +2100,20 @@ void RandomPlayerbotMgr::Refresh(Player* bot)
 
 bool RandomPlayerbotMgr::IsRandomBot(Player* bot)
 {
-    if (!bot)
-        return false;
+    if (bot && GET_PLAYERBOT_AI(bot))
+    {
+        if (GET_PLAYERBOT_AI(bot)->IsRealPlayer())
+            return false;
+    }
+    if (bot)
+    {
+        return IsRandomBot(bot->GetGUID().GetCounter());
+    }
 
-    if (PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot))
-        return botAI->GetBotType() == BotType::RANDOMBOT;
-
-    return isRandomBot(bot->GetGUID().GetCounter());
+    return false;
 }
 
-bool RandomPlayerbotMgr::isRandomBot(ObjectGuid::LowType bot)
+bool RandomPlayerbotMgr::IsRandomBot(ObjectGuid::LowType bot)
 {
     ObjectGuid guid = ObjectGuid::Create<HighGuid::Player>(bot);
     if (!sPlayerbotAIConfig.IsInRandomAccountList(sCharacterCache->GetCharacterAccountIdByGuid(guid)))
@@ -2123,13 +2127,17 @@ bool RandomPlayerbotMgr::isRandomBot(ObjectGuid::LowType bot)
 
 bool RandomPlayerbotMgr::IsAddclassBot(Player* bot)
 {
-    if (!bot)
-        return false;
+    if (bot && GET_PLAYERBOT_AI(bot))
+    {
+        if (GET_PLAYERBOT_AI(bot)->IsRealPlayer())
+            return false;
+    }
+    if (bot)
+    {
+        return IsAddclassBot(bot->GetGUID().GetCounter());
+    }
 
-    if (PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot))
-        return botAI->GetBotType() == BotType::ADDCLASSBOT;
-
-    return IsAddclassBot(bot->GetGUID().GetCounter());
+    return false;
 }
 
 bool RandomPlayerbotMgr::IsAddclassBot(ObjectGuid::LowType bot)
@@ -2155,7 +2163,9 @@ bool RandomPlayerbotMgr::IsAddclassBot(ObjectGuid::LowType bot)
     // If not in cache, check the account type
     uint32 accountId = sCharacterCache->GetCharacterAccountIdByGuid(guid);
     if (accountId && IsAccountType(accountId, 2)) // Type 2 = AddClass
+    {
         return true;
+    }
 
     return false;
 }
@@ -2430,9 +2440,10 @@ bool RandomPlayerbotMgr::HandlePlayerbotConsoleCommand(ChatHandler* /*handler*/,
 
                     uint32 botId = fields[0].Get<uint32>();
                     ObjectGuid guid = ObjectGuid::Create<HighGuid::Player>(botId);
-                    if (!sRandomPlayerbotMgr.isRandomBot(guid.GetCounter()))
+                    if (!sRandomPlayerbotMgr.IsRandomBot(guid.GetCounter()))
+                    {
                         continue;
-
+                    }
                     Player* bot = ObjectAccessor::FindPlayer(guid);
                     if (!bot)
                         continue;
@@ -2527,11 +2538,10 @@ void RandomPlayerbotMgr::OnBotLoginInternal(Player* const bot)
                  sRandomPlayerbotMgr.GetMaxAllowedBotCount(), bot->GetName().c_str());
 
         if (playerBots.size() == sRandomPlayerbotMgr.GetMaxAllowedBotCount())
+        {
             _isBotLogging = false;
+        }
     }
-
-    if (PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot))
-        botAI->SetBotType(BotType::RANDOMBOT);
 
     // Run guild recovery/assignment at login to handle empty guild tables after restart.
     if (sPlayerbotAIConfig.randomBotGuildCount > 0)
@@ -2541,9 +2551,13 @@ void RandomPlayerbotMgr::OnBotLoginInternal(Player* const bot)
     }
 
     if (sPlayerbotAIConfig.randomBotFixedLevel)
+    {
         bot->SetPlayerFlag(PLAYER_FLAGS_NO_XP_GAIN);
+    }
     else
+    {
         bot->RemovePlayerFlag(PLAYER_FLAGS_NO_XP_GAIN);
+    }
 }
 
 void RandomPlayerbotMgr::OnPlayerLogin(Player* player)

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -1619,7 +1619,7 @@ void RandomPlayerbotMgr::RandomTeleport(Player* bot, std::vector<WorldLocation>&
         tlocs.push_back(WorldPosition(loc));
     // Do not teleport to maps disabled in config
     tlocs.erase(std::remove_if(tlocs.begin(), tlocs.end(),
-                               [bot](WorldPosition l)
+                               [](WorldPosition l)
                                {
                                    std::vector<uint32>::iterator i =
                                        find(sPlayerbotAIConfig.randomBotMaps.begin(),
@@ -2022,7 +2022,7 @@ void RandomPlayerbotMgr::Clear(Player* bot)
     factory.ClearEverything();
 }
 
-uint32 RandomPlayerbotMgr::GetZoneLevel(uint16 mapId, float teleX, float teleY, float teleZ)
+uint32 RandomPlayerbotMgr::GetZoneLevel(uint16 mapId, float teleX, float teleY, float /*teleZ*/)
 {
     uint32 maxLevel = sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL);
 
@@ -2353,7 +2353,7 @@ void RandomPlayerbotMgr::SetValue(Player* bot, std::string const& type, uint32 v
     SetValue(bot->GetGUID().GetCounter(), type, value, data);
 }
 
-bool RandomPlayerbotMgr::HandlePlayerbotConsoleCommand(ChatHandler* handler, char const* args)
+bool RandomPlayerbotMgr::HandlePlayerbotConsoleCommand(ChatHandler* /*handler*/, char const* args)
 {
     if (!sPlayerbotAIConfig.enabled)
     {

--- a/src/Bot/RandomPlayerbotMgr.h
+++ b/src/Bot/RandomPlayerbotMgr.h
@@ -102,7 +102,6 @@ public:
     uint32 activeBots = 0;
     static bool HandlePlayerbotConsoleCommand(ChatHandler* handler, char const* args);
     bool IsRandomBot(Player* bot);
-    bool IsRandomBot(ObjectGuid::LowType bot);
     bool IsAddclassBot(Player* bot);
     bool IsAddclassBot(ObjectGuid::LowType bot);
     void Randomize(Player* bot);
@@ -249,6 +248,7 @@ private:
     std::list<uint32> currentBots;
     uint32 bgBotsCount;
     uint32 playersLevel;
+    bool isRandomBot(ObjectGuid::LowType bot);
 
     // Account lists
     std::vector<uint32> rndBotTypeAccounts;             // Accounts marked as RNDbot (type 1)

--- a/src/Bot/RandomPlayerbotMgr.h
+++ b/src/Bot/RandomPlayerbotMgr.h
@@ -102,6 +102,7 @@ public:
     uint32 activeBots = 0;
     static bool HandlePlayerbotConsoleCommand(ChatHandler* handler, char const* args);
     bool IsRandomBot(Player* bot);
+    bool IsRandomBot(ObjectGuid::LowType bot);
     bool IsAddclassBot(Player* bot);
     bool IsAddclassBot(ObjectGuid::LowType bot);
     void Randomize(Player* bot);
@@ -248,7 +249,6 @@ private:
     std::list<uint32> currentBots;
     uint32 bgBotsCount;
     uint32 playersLevel;
-    bool isRandomBot(ObjectGuid::LowType bot);
 
     // Account lists
     std::vector<uint32> rndBotTypeAccounts;             // Accounts marked as RNDbot (type 1)

--- a/src/Mgr/Item/RandomItemMgr.cpp
+++ b/src/Mgr/Item/RandomItemMgr.cpp
@@ -5,32 +5,32 @@
 
 #include "RandomItemMgr.h"
 
+#include "DBCStores.h"
 #include "ItemTemplate.h"
-#include "LootValues.h"
 #include "Playerbots.h"
 
-char* strstri(char const* str1, char const* str2);
-std::set<uint32> RandomItemMgr::itemCache;
-
-uint64 BotEquipKey::GetKey() { return level + 100 * clazz + 10000 * slot + 1000000 * quality; }
+std::unordered_set<uint32> RandomItemMgr::itemCache;
 
 class RandomItemGuildTaskPredicate : public RandomItemPredicate
 {
 public:
     bool Apply(ItemTemplate const* proto) override
     {
-        if (proto->Bonding == BIND_WHEN_PICKED_UP || proto->Bonding == BIND_QUEST_ITEM ||
-            proto->Bonding == BIND_WHEN_USE)
+        if (!proto)
+            return false;
+
+        if (proto->Bonding == BIND_WHEN_PICKED_UP || proto->Bonding == BIND_WHEN_USE ||
+            proto->Bonding == BIND_QUEST_ITEM)
             return false;
 
         if (proto->Quality < ITEM_QUALITY_NORMAL)
             return false;
 
-        if ((proto->Class == ITEM_CLASS_ARMOR || proto->Class == ITEM_CLASS_WEAPON) &&
+        if ((proto->Class == ITEM_CLASS_WEAPON || proto->Class == ITEM_CLASS_ARMOR) &&
             proto->Quality >= ITEM_QUALITY_RARE)
             return true;
 
-        if (proto->Class == ITEM_CLASS_TRADE_GOODS || proto->Class == ITEM_CLASS_CONSUMABLE)
+        if (proto->Class == ITEM_CLASS_CONSUMABLE || proto->Class == ITEM_CLASS_TRADE_GOODS)
             return true;
 
         return false;
@@ -44,8 +44,11 @@ public:
 
     bool Apply(ItemTemplate const* proto) override
     {
-        if (proto->Bonding == BIND_WHEN_PICKED_UP || proto->Bonding == BIND_QUEST_ITEM ||
-            proto->Bonding == BIND_WHEN_USE)
+        if (!proto)
+            return false;
+
+        if (proto->Bonding == BIND_WHEN_PICKED_UP || proto->Bonding == BIND_WHEN_USE ||
+            proto->Bonding == BIND_QUEST_ITEM)
             return false;
 
         if (proto->Class == ITEM_CLASS_QUEST)
@@ -57,7 +60,7 @@ public:
             if (proto->Quality < desiredQuality || proto->Quality >= ITEM_QUALITY_EPIC)
                 return false;
 
-            if (proto->Class == ITEM_CLASS_ARMOR || proto->Class == ITEM_CLASS_WEAPON)
+            if (proto->Class == ITEM_CLASS_WEAPON || proto->Class == ITEM_CLASS_ARMOR)
                 return true;
         }
         else
@@ -66,7 +69,7 @@ public:
             if (proto->Quality < desiredQuality || proto->Quality >= ITEM_QUALITY_RARE)
                 return false;
 
-            if (proto->Class == ITEM_CLASS_TRADE_GOODS || proto->Class == ITEM_CLASS_CONSUMABLE)
+            if (proto->Class == ITEM_CLASS_CONSUMABLE || proto->Class == ITEM_CLASS_TRADE_GOODS)
                 return true;
         }
 
@@ -80,101 +83,49 @@ private:
 
 RandomItemMgr::RandomItemMgr()
 {
-    predicates[RANDOM_ITEM_GUILD_TASK] = new RandomItemGuildTaskPredicate();
-    predicates[RANDOM_ITEM_GUILD_TASK_REWARD_EQUIP_GREEN] = new RandomItemGuildTaskRewardPredicate(true, false);
-    predicates[RANDOM_ITEM_GUILD_TASK_REWARD_EQUIP_BLUE] = new RandomItemGuildTaskRewardPredicate(true, true);
-    predicates[RANDOM_ITEM_GUILD_TASK_REWARD_TRADE] = new RandomItemGuildTaskRewardPredicate(false, false);
-    predicates[RANDOM_ITEM_GUILD_TASK_REWARD_TRADE_RARE] = new RandomItemGuildTaskRewardPredicate(false, true);
+    InitWeaponProficiency();
+    InitPredicates();
+    InitViableSlots();
+    InitWeightLinks();
+}
 
-    viableSlots[EQUIPMENT_SLOT_HEAD].insert(INVTYPE_HEAD);
-    viableSlots[EQUIPMENT_SLOT_NECK].insert(INVTYPE_NECK);
-    viableSlots[EQUIPMENT_SLOT_SHOULDERS].insert(INVTYPE_SHOULDERS);
-    viableSlots[EQUIPMENT_SLOT_BODY].insert(INVTYPE_BODY);
-    viableSlots[EQUIPMENT_SLOT_CHEST].insert(INVTYPE_CHEST);
-    viableSlots[EQUIPMENT_SLOT_CHEST].insert(INVTYPE_ROBE);
-    viableSlots[EQUIPMENT_SLOT_WAIST].insert(INVTYPE_WAIST);
-    viableSlots[EQUIPMENT_SLOT_LEGS].insert(INVTYPE_LEGS);
-    viableSlots[EQUIPMENT_SLOT_FEET].insert(INVTYPE_FEET);
-    viableSlots[EQUIPMENT_SLOT_WRISTS].insert(INVTYPE_WRISTS);
-    viableSlots[EQUIPMENT_SLOT_HANDS].insert(INVTYPE_HANDS);
-    viableSlots[EQUIPMENT_SLOT_FINGER1].insert(INVTYPE_FINGER);
-    viableSlots[EQUIPMENT_SLOT_FINGER2].insert(INVTYPE_FINGER);
-    viableSlots[EQUIPMENT_SLOT_TRINKET1].insert(INVTYPE_TRINKET);
-    viableSlots[EQUIPMENT_SLOT_TRINKET2].insert(INVTYPE_TRINKET);
-    viableSlots[EQUIPMENT_SLOT_MAINHAND].insert(INVTYPE_WEAPON);
-    viableSlots[EQUIPMENT_SLOT_MAINHAND].insert(INVTYPE_2HWEAPON);
-    viableSlots[EQUIPMENT_SLOT_MAINHAND].insert(INVTYPE_WEAPONMAINHAND);
-    viableSlots[EQUIPMENT_SLOT_OFFHAND].insert(INVTYPE_WEAPON);
-    viableSlots[EQUIPMENT_SLOT_OFFHAND].insert(INVTYPE_2HWEAPON);
-    viableSlots[EQUIPMENT_SLOT_OFFHAND].insert(INVTYPE_SHIELD);
-    viableSlots[EQUIPMENT_SLOT_OFFHAND].insert(INVTYPE_WEAPONMAINHAND);
-    viableSlots[EQUIPMENT_SLOT_OFFHAND].insert(INVTYPE_HOLDABLE);
-    viableSlots[EQUIPMENT_SLOT_RANGED].insert(INVTYPE_RANGED);
-    viableSlots[EQUIPMENT_SLOT_RANGED].insert(INVTYPE_THROWN);
-    viableSlots[EQUIPMENT_SLOT_RANGED].insert(INVTYPE_RANGEDRIGHT);
-    viableSlots[EQUIPMENT_SLOT_RANGED].insert(INVTYPE_RELIC);
-    viableSlots[EQUIPMENT_SLOT_TABARD].insert(INVTYPE_TABARD);
-    viableSlots[EQUIPMENT_SLOT_BACK].insert(INVTYPE_CLOAK);
+RandomItemMgr::~RandomItemMgr()
+{
+    for (auto& pair : predicates)
+        delete pair.second;
 
-    weightStatLink["sta"] = ITEM_MOD_STAMINA;
-    weightStatLink["str"] = ITEM_MOD_STRENGTH;
-    weightStatLink["agi"] = ITEM_MOD_AGILITY;
-    weightStatLink["int"] = ITEM_MOD_INTELLECT;
-    weightStatLink["spi"] = ITEM_MOD_SPIRIT;
-
-    weightStatLink["splpwr"] = ITEM_MOD_SPELL_POWER;
-    weightStatLink["atkpwr"] = ITEM_MOD_ATTACK_POWER;
-
-    weightStatLink["exprtng"] = ITEM_MOD_EXPERTISE_RATING;
-    weightStatLink["critstrkrtng"] = ITEM_MOD_CRIT_RATING;
-    weightStatLink["hitrtng"] = ITEM_MOD_HIT_RATING;
-    weightStatLink["hastertng"] = ITEM_MOD_HASTE_RATING;
-    weightStatLink["armorpenrtng"] = ITEM_MOD_ARMOR_PENETRATION_RATING;
-
-    weightStatLink["defrtng"] = ITEM_MOD_DEFENSE_SKILL_RATING;
-    weightStatLink["dodgertng"] = ITEM_MOD_DODGE_RATING;
-    weightStatLink["block"] = ITEM_MOD_BLOCK_VALUE;
-    weightStatLink["blockrtng"] = ITEM_MOD_BLOCK_RATING;
-    weightStatLink["parryrtng"] = ITEM_MOD_PARRY_RATING;
-
-    weightStatLink["manargn"] = ITEM_MOD_MANA_REGENERATION;
-
-    weightRatingLink["exprtng"] = CR_EXPERTISE;
-    weightRatingLink["critstrkrtng"] = CR_CRIT_MELEE;
-    weightRatingLink["hitrtng"] = CR_HIT_MELEE;
-    weightRatingLink["hastertng"] = CR_HASTE_MELEE;
-    weightRatingLink["armorpenrtng"] = CR_ARMOR_PENETRATION;
-
-    weightRatingLink["defrtng"] = CR_DEFENSE_SKILL;
-    weightRatingLink["dodgertng"] = CR_DODGE;
-    weightRatingLink["blockrtng"] = CR_BLOCK;
-    weightRatingLink["parryrtng"] = CR_PARRY;
+    predicates.clear();
 }
 
 void RandomItemMgr::Init()
 {
-    BuildItemInfoCache();
-    // BuildEquipCache();
-    BuildEquipCacheNew();
-    BuildAmmoCache();
-    BuildPotionCache();
-    BuildFoodCache();
-    BuildTradeCache();
+    // Prevent double initialization when the reload command is executed.
+    // Use exchange so only the first caller continues; others stop.
+    // NOTE: If someone implements reload/rebuild hash, update all getters from
+    //       returning by reference to returning by value. Also, replace all
+    //       DEFAULT_MAX_LEVEL maxLevel with randomBotMaxLevel and clear caches
+    //       before processing.
+    if (m_initialized.exchange(true))
+        return;
+
+    BuildCacheItemInfo();
+    // if (!LoadCacheEquip())
+    //     BuildCacheEquip();
+    BuildCacheEquipNew();
+    BuildCacheAmmo();
+    BuildCacheFood();
+    BuildCachePotion();
+    BuildCacheTrade();
     LoadEnchantmentPool();
 }
 
 void RandomItemMgr::InitAfterAhBot()
 {
-    BuildRandomItemCache();
-    // BuildRarityCache();
-}
-
-RandomItemMgr::~RandomItemMgr()
-{
-    for (std::map<RandomItemType, RandomItemPredicate*>::iterator i = predicates.begin(); i != predicates.end(); ++i)
-        delete i->second;
-
-    predicates.clear();
+    if (!LoadCacheRandomItem())
+        BuildCacheRandomItem();
+    DebugCacheRandomItem();
+    // if (!LoadCacheRarity())
+    //     BuildCacheRarity();
 }
 
 bool RandomItemMgr::HandleConsoleCommand(ChatHandler* /*handler*/, char const* args)
@@ -188,14 +139,19 @@ bool RandomItemMgr::HandleConsoleCommand(ChatHandler* /*handler*/, char const* a
     return false;
 }
 
-RandomItemList RandomItemMgr::Query(uint32 level, RandomItemType type, RandomItemPredicate* predicate)
+RandomItemList RandomItemMgr::Query(uint32 level, RandomItemType type, RandomItemPredicate* predicate) const
 {
-    RandomItemList& list = randomItemCache[(level - 1) / 10][type];
+    auto const levelItr = randomItemCache.find((level - 1) / 10);
+    if (levelItr == randomItemCache.end())
+        return {};
+
+    auto const typeItr = levelItr->second.find(type);
+    if (typeItr == levelItr->second.end())
+        return {};
 
     RandomItemList result;
-    for (RandomItemList::iterator i = list.begin(); i != list.end(); ++i)
+    for (uint32 const itemId : typeItr->second)
     {
-        uint32 itemId = *i;
         ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
         if (!proto)
             continue;
@@ -209,248 +165,1636 @@ RandomItemList RandomItemMgr::Query(uint32 level, RandomItemType type, RandomIte
     return result;
 }
 
-void RandomItemMgr::BuildRandomItemCache()
+uint32 RandomItemMgr::GetUpgrade(Player* player, std::string spec, uint8 slot, uint32 quality, uint32 itemId)
 {
-    if (PreparedQueryResult result =
-            PlayerbotsDatabase.Query(PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_SEL_RNDITEM_CACHE)))
+    if (!player)
+        return 0;
+
+    // get old item statWeight
+    uint32 oldStatWeight = 0;
+    uint32 specId = 0;
+    uint32 closestUpgrade = 0;
+    uint32 closestUpgradeWeight = 0;
+    std::vector<uint32> classspecs;
+
+    for (uint32 specNum = 1; specNum < 5; ++specNum)
     {
-        LOG_INFO("server.loading", "Loading random item cache");
-        uint32 count = 0;
-        do
-        {
-            Field* fields = result->Fetch();
-            uint32 level = fields[0].Get<uint32>();
-            uint32 type = fields[1].Get<uint32>();
-            uint32 itemId = fields[2].Get<uint32>();
+        if (!m_weightScales[player->getClass()][specNum].info.id)
+            continue;
 
-            RandomItemType rit = (RandomItemType)type;
-            randomItemCache[level][rit].push_back(itemId);
-            ++count;
+        classspecs.push_back(m_weightScales[player->getClass()][specNum].info.id);
 
-        } while (result->NextRow());
-
-        LOG_INFO("server.loading", "Equipment cache loaded from {} records", count);
+        if (m_weightScales[player->getClass()][specNum].info.name == spec)
+            specId = m_weightScales[player->getClass()][specNum].info.id;
     }
-    else
+    if (!specId)
+        return 0;
+
+    if (itemId && itemInfoCache.find(itemId) != itemInfoCache.end())
     {
-        ItemTemplateContainer const* itemTemplates = sObjectMgr->GetItemTemplateStore();
-        LOG_INFO("server.loading", "Building random item cache from {} items", itemTemplates->size());
+        oldStatWeight = itemInfoCache[itemId].weights[specId];
 
-        for (auto const& itr : *itemTemplates)
+        if (oldStatWeight)
+            LOG_INFO("playerbots", "Old Item: {}, weight: {}", itemId, oldStatWeight);
+        else
+            LOG_INFO("playerbots", "Old item has no stat weight");
+    }
+
+    for (std::unordered_map<uint32, ItemInfoEntry>::iterator i = itemInfoCache.begin(); i != itemInfoCache.end(); ++i)
+    {
+        ItemInfoEntry& info = i->second;
+
+        // skip useless items
+        if (info.weights[specId] == 0)
+            continue;
+
+        // skip higher lvl
+        if (info.minLevel > player->GetLevel())
+            continue;
+
+        // skip too low level
+        if (info.minLevel < (player->GetLevel() - 10))
+            continue;
+
+        // skip wrong team
+        if (info.team != TEAM_NEUTRAL && info.team != player->GetTeamId())
+            continue;
+
+        // skip wrong slot
+        if ((EquipmentSlots)info.slot != (EquipmentSlots)slot)
+            continue;
+
+        // skip higher quality
+        if (quality && info.quality != quality)
+            continue;
+
+        // skip worse items
+        if (info.weights[specId] <= oldStatWeight)
+            continue;
+
+        // skip items that only fit in slot, but not stats
+        if (!itemId && info.weights[specId] == 1 && player->GetLevel() > 40)
+            continue;
+
+        // skip quest items
+        if (info.source == ITEM_SOURCE_QUEST)
         {
-            ItemTemplate const* proto = &itr.second;
-            if (!proto)
+            if (player->GetQuestRewardStatus(info.sourceId) != QUEST_STATUS_COMPLETE)
                 continue;
+        }
 
-            if (proto->Duration & 0x80000000)
-                continue;
+        // skip no stats trinkets
+        if (info.weights[specId] == 1 && (info.slot == EQUIPMENT_SLOT_NECK || info.slot == EQUIPMENT_SLOT_TRINKET1 ||
+            info.slot == EQUIPMENT_SLOT_TRINKET2 || info.slot == EQUIPMENT_SLOT_FINGER1 ||
+            info.slot == EQUIPMENT_SLOT_FINGER2))
+            continue;
 
-            if (strstri(proto->Name1.c_str(), "qa") || strstri(proto->Name1.c_str(), "test") ||
-                strstri(proto->Name1.c_str(), "deprecated"))
-                continue;
-
-            if (!proto->ItemLevel)
-                continue;
-
-            if (!proto->SellPrice)
-                continue;
-
-            uint32 level = proto->ItemLevel;
-            for (uint32 type = RANDOM_ITEM_GUILD_TASK; type <= RANDOM_ITEM_GUILD_TASK_REWARD_TRADE_RARE; type++)
+        // check if item stat score is the best among class specs
+        uint32 bestSpecId = 0;
+        uint32 bestSpecScore = 0;
+        for (std::vector<uint32>::iterator i = classspecs.begin(); i != classspecs.end(); ++i)
+        {
+            if (info.weights[*i] > bestSpecScore)
             {
-                RandomItemType rit = (RandomItemType)type;
-                if (predicates[rit] && !predicates[rit]->Apply(proto))
-                    continue;
-
-                randomItemCache[level / 10][rit].push_back(itr.first);
-
-                PlayerbotsDatabasePreparedStatement* stmt =
-                    PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_INS_RNDITEM_CACHE);
-                stmt->SetData(0, level / 10);
-                stmt->SetData(1, type);
-                stmt->SetData(2, itr.first);
-                PlayerbotsDatabase.Execute(stmt);
+                bestSpecId = *i;
+                bestSpecScore = info.weights[specId];
             }
         }
 
-        uint32 maxLevel = sPlayerbotAIConfig.randomBotMaxLevel;
-        if (maxLevel > sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL))
-            maxLevel = sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL);
+        if (bestSpecId && bestSpecId != specId && player->GetLevel() > 40)
+            return 0;
 
-        for (uint32 level = 0; level < maxLevel / 10; level++)
+        if (!closestUpgrade)
         {
-            for (uint32 type = RANDOM_ITEM_GUILD_TASK; type <= RANDOM_ITEM_GUILD_TASK_REWARD_TRADE_RARE; type++)
+            closestUpgrade = info.itemId;
+            closestUpgradeWeight = info.weights[specId];
+        }
+
+        // pick closest upgrade
+        if (info.weights[specId] < closestUpgradeWeight)
+        {
+            closestUpgrade = info.itemId;
+            closestUpgradeWeight = info.weights[specId];
+        }
+    }
+
+    if (closestUpgrade)
+        LOG_INFO("playerbots", "New Item: {}, weight: {}", closestUpgrade, closestUpgradeWeight);
+
+    return closestUpgrade;
+}
+
+std::vector<uint32> RandomItemMgr::GetUpgradeList(Player* player, std::string spec, uint8 slot, uint32 quality,
+                                                  uint32 itemId, uint32 /*amount*/)
+{
+    std::vector<uint32> listItems;
+    if (!player)
+        return listItems;
+
+    // get old item statWeight
+    uint32 oldStatWeight = 0;
+    uint32 specId = 0;
+    uint32 closestUpgradeWeight = 0;
+    std::vector<uint32> classspecs;
+
+    for (uint32 specNum = 1; specNum < 5; ++specNum)
+    {
+        if (!m_weightScales[player->getClass()][specNum].info.id)
+            continue;
+
+        classspecs.push_back(m_weightScales[player->getClass()][specNum].info.id);
+
+        if (m_weightScales[player->getClass()][specNum].info.name == spec)
+            specId = m_weightScales[player->getClass()][specNum].info.id;
+    }
+
+    if (!specId)
+        return listItems;
+
+    if (itemId && itemInfoCache.find(itemId) != itemInfoCache.end())
+    {
+        oldStatWeight = itemInfoCache[itemId].weights[specId];
+
+        if (oldStatWeight)
+            LOG_INFO("playerbots", "Old Item: {}, weight: {}", itemId, oldStatWeight);
+        else
+            LOG_INFO("playerbots", "Old item has no stat weight");
+    }
+
+    for (std::unordered_map<uint32, ItemInfoEntry>::iterator i = itemInfoCache.begin(); i != itemInfoCache.end(); ++i)
+    {
+        ItemInfoEntry& info = i->second;
+
+        // skip useless items
+        if (info.weights[specId] == 0)
+            continue;
+
+        // skip higher lvl
+        if (info.minLevel > player->GetLevel())
+            continue;
+
+        // skip too low level
+        if ((int32)info.minLevel < (int32)(player->GetLevel() - 20))
+            continue;
+
+        // skip wrong team
+        if (info.team != TEAM_NEUTRAL && info.team != player->GetTeamId())
+            continue;
+
+        // skip wrong slot
+        if ((EquipmentSlots)info.slot != (EquipmentSlots)slot)
+            continue;
+
+        // skip higher quality
+        if (quality && info.quality != quality)
+            continue;
+
+        // skip worse items
+        if (info.weights[specId] <= oldStatWeight)
+            continue;
+
+        // skip items that only fit in slot, but not stats
+        if (!itemId && info.weights[specId] == 1 && player->GetLevel() > 40)
+            continue;
+
+        // skip quest items
+        if (info.source == ITEM_SOURCE_QUEST)
+        {
+            if (player->GetQuestRewardStatus(info.sourceId) != QUEST_STATUS_COMPLETE)
+                continue;
+        }
+
+        // skip no stats trinkets
+        if (info.weights[specId] < 2 && (info.slot == EQUIPMENT_SLOT_NECK || info.slot == EQUIPMENT_SLOT_TRINKET1 ||
+                                         info.slot == EQUIPMENT_SLOT_TRINKET2 || info.slot == EQUIPMENT_SLOT_FINGER1 ||
+                                         info.slot == EQUIPMENT_SLOT_FINGER2))
+            continue;
+
+        // if (player->GetLevel() >= 40)
+        //{
+        //     // check if item stat score is the best among class specs
+        //     uint32 bestSpecId = 0;
+        //     uint32 bestSpecScore = 0;
+        //     for (vector<uint32>::iterator i = classspecs.begin(); i != classspecs.end(); ++i)
+        //     {
+        //         if (info->weights[*i] > bestSpecScore)
+        //         {
+        //             bestSpecId = *i;
+        //             bestSpecScore = info->weights[specId];
+        //         }
+        //     }
+
+        //    if (bestSpecId && bestSpecId != specId)
+        //        continue;
+        //}
+
+        listItems.push_back(info.itemId);
+        // continue;
+
+        // pick closest upgrade
+        if (info.weights[specId] > closestUpgradeWeight)
+        {
+            closestUpgradeWeight = info.weights[specId];
+        }
+    }
+
+    if (listItems.size())
+        LOG_INFO("playerbots", "New Items: {}, Old item:%d, New items max: {}", listItems.size(), oldStatWeight,
+                 closestUpgradeWeight);
+
+    return listItems;
+}
+
+bool RandomItemMgr::HasStatWeight(uint32 itemId)
+{
+    auto itr = itemInfoCache.find(itemId);
+    return itr != itemInfoCache.end();
+}
+
+uint32 RandomItemMgr::CalculateStatWeight(ItemTemplate const* proto, uint8 playerclass, uint8 spec)
+{
+    if (!proto)
+        return false;
+
+    uint32 statWeight = 0;
+    bool isCasterItem = false;
+    bool isAttackItem = false;
+    bool noCaster = (Classes)playerclass == CLASS_WARRIOR || (Classes)playerclass == CLASS_ROGUE ||
+                    (Classes)playerclass == CLASS_DEATH_KNIGHT || (Classes)playerclass == CLASS_HUNTER;
+    uint32 spellPower = 0;
+    uint32 spellHeal = 0;
+    uint32 attackPower = 0;
+    bool hasInt = false;
+    bool hasMana = !((Classes)playerclass == CLASS_WARRIOR || (Classes)playerclass == CLASS_ROGUE ||
+                     (Classes)playerclass == CLASS_DEATH_KNIGHT);
+
+    if (proto->SubClass == ITEM_SUBCLASS_ARMOR_LIBRAM || proto->SubClass == ITEM_SUBCLASS_ARMOR_IDOL ||
+        proto->SubClass == ITEM_SUBCLASS_ARMOR_TOTEM || proto->SubClass == ITEM_SUBCLASS_ARMOR_SIGIL)
+        return (uint32)(proto->Quality + proto->ItemLevel);
+
+    // check basic item stats
+    int32 basicStatsWeight = 0;
+    for (uint8 j = 0; j < MAX_ITEM_PROTO_STATS; ++j)
+    {
+        uint32 statType;
+        int32 val;
+        std::string weightName;
+
+        // if (j >= proto->StatsCount)
+        //     continue;
+
+        statType = proto->ItemStat[j].ItemStatType;
+        val = proto->ItemStat[j].ItemStatValue;
+
+        if (val == 0)
+            continue;
+
+        for (std::unordered_map<std::string, uint32>::iterator i = weightStatLink.begin(); i != weightStatLink.end(); ++i)
+        {
+            uint32 modd = i->second;
+            if (modd == statType)
             {
-                RandomItemList list = randomItemCache[level][(RandomItemType)type];
-                LOG_INFO("playerbots", "    Level {}..{} Type {} - {} random items cached", level * 10, level * 10 + 9,
-                         type, list.size());
+                weightName = i->first;
+                break;
+            }
+        }
 
-                for (RandomItemList::iterator i = list.begin(); i != list.end(); ++i)
+        if (weightName.empty())
+            continue;
+
+        uint32 singleStat = CalculateSingleStatWeight(playerclass, spec, weightName, val);
+        basicStatsWeight += singleStat;
+
+        if (val)
+        {
+            if (weightName == "int" && !noCaster)
+                isCasterItem = true;
+
+            if (weightName == "int")
+                hasInt = true;
+
+            if (weightName == "splpwr")
+                isCasterItem = true;
+
+            if (weightName == "str")
+                isAttackItem = true;
+
+            if (weightName == "agi")
+                isAttackItem = true;
+
+            if (weightName == "atkpwr")
+                isAttackItem = true;
+        }
+    }
+
+    // check armor & block
+    statWeight += CalculateSingleStatWeight(playerclass, spec, "armor", proto->Armor);
+    statWeight += CalculateSingleStatWeight(playerclass, spec, "block", proto->Block);
+
+    // check weapon dps
+    if (proto->IsWeaponVellum())
+    {
+        //WeaponAttackType attType = BASE_ATTACK; //not used, line marked for removal.
+
+        uint32 dps = 0;
+        for (uint8 i = 0; i < MAX_ITEM_PROTO_DAMAGES; i++)
+        {
+            if (proto->Damage[i].DamageMax == 0)
+                break;
+
+            dps = (proto->Damage[i].DamageMin + proto->Damage[i].DamageMax) / (float)(proto->Delay / 1000.0f) / 2;
+            if (dps)
+            {
+                if (proto->IsRangedWeapon())
+                    statWeight += CalculateSingleStatWeight(playerclass, spec, "rgddps", dps);
+                else
+                    statWeight += CalculateSingleStatWeight(playerclass, spec, "mledps", dps);
+            }
+        }
+    }
+
+    // check item spells
+    for (auto const& spellData : proto->Spells)
+    {
+        // no spell
+        if (!spellData.SpellId)
+            continue;
+
+        // apply only at-equip spells
+        if (spellData.SpellTrigger != ITEM_SPELLTRIGGER_ON_EQUIP)
+            continue;
+
+        // check if it is valid spell
+        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellData.SpellId);
+        if (!spellInfo)
+            continue;
+
+        uint32 spellDamage = 0;
+        uint32 spellHealing = 0;
+        for (uint32 j = 0; j < MAX_SPELL_EFFECTS; j++)
+        {
+            if (spellInfo->Effects[j].Effect == SPELL_EFFECT_APPLY_AURA && spellInfo->Effects[j].BasePoints)
+            {
+                // spell damage
+                // SPELL_AURA_MOD_DAMAGE_DONE
+                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_DAMAGE_DONE)
                 {
-                    uint32 itemId = *i;
-                    ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
-                    if (!proto)
-                        continue;
+                    spellDamage = spellInfo->Effects[j].BasePoints + 1;
+                }
 
-                    LOG_DEBUG("playerbots", "        [{}] {}", itemId, proto->Name1.c_str());
+                // spell healing
+                // SPELL_AURA_MOD_HEALING_DONE
+                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_HEALING_DONE)
+                {
+                    spellHealing = spellInfo->Effects[j].BasePoints + 1;
+                }
+
+                // check spell power
+                if (spellDamage && spellDamage == spellHealing)
+                {
+                    isCasterItem = true;
+                    spellPower += CalculateSingleStatWeight(playerclass, spec, "splpwr", spellDamage);
+                }
+
+                // spell hit rating (pre tbc)
+                // SPELL_AURA_MOD_SPELL_HIT_CHANCE
+                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_SPELL_HIT_CHANCE)
+                {
+                    statWeight += CalculateSingleStatWeight(playerclass, spec, "spellhitrtng",
+                                                            spellInfo->Effects[j].BasePoints + 1);
+                }
+
+                // spell crit rating (pre tbc)
+                // SPELL_AURA_MOD_SPELL_CRIT_CHANCE
+                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_SPELL_CRIT_CHANCE)
+                {
+                    statWeight += CalculateSingleStatWeight(playerclass, spec, "spellcritstrkrtng",
+                                                            spellInfo->Effects[j].BasePoints + 1);
+                }
+
+                // spell penetration
+                // SPELL_AURA_MOD_TARGET_RESISTANCE
+                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_TARGET_RESISTANCE)
+                {
+                    // check if magic type
+                    if (spellInfo->Effects[j].MiscValue == SPELL_SCHOOL_MASK_SPELL)
+                        statWeight += CalculateSingleStatWeight(playerclass, spec, "spellpenrtng",
+                                                                abs(spellInfo->Effects[j].BasePoints + 1));
+                }
+
+                // check attack power
+                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_ATTACK_POWER)
+                {
+                    isAttackItem = true;
+                    attackPower +=
+                        CalculateSingleStatWeight(playerclass, spec, "atkpwr", spellInfo->Effects[j].BasePoints + 1);
+                }
+
+                // check ranged ap
+                // SPELL_AURA_MOD_RANGED_ATTACK_POWER
+                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_RANGED_ATTACK_POWER)
+                {
+                    isAttackItem = true;
+                    attackPower +=
+                        CalculateSingleStatWeight(playerclass, spec, "atkpwr", spellInfo->Effects[j].BasePoints + 1);
+                }
+
+                // check block
+                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_SHIELD_BLOCKVALUE)
+                {
+                    statWeight +=
+                        CalculateSingleStatWeight(playerclass, spec, "block", spellInfo->Effects[j].BasePoints + 1);
+                }
+
+                // block chance
+                // SPELL_AURA_MOD_BLOCK_PERCENT
+                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_BLOCK_PERCENT)
+                {
+                    statWeight +=
+                        CalculateSingleStatWeight(playerclass, spec, "blockrtng", spellInfo->Effects[j].BasePoints + 1);
+                }
+
+                // armor penetration
+                // SPELL_AURA_MOD_TARGET_RESISTANCE
+                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_TARGET_RESISTANCE)
+                {
+                    // check if physical type
+                    if (spellInfo->Effects[j].MiscValue == SPELL_SCHOOL_MASK_NORMAL)
+                        statWeight += CalculateSingleStatWeight(playerclass, spec, "armorpenrtng",
+                                                                abs(spellInfo->Effects[j].BasePoints + 1));
+                }
+
+                // hit rating (pre tbc)
+                // SPELL_AURA_MOD_HIT_CHANCE
+                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_HIT_CHANCE)
+                {
+                    statWeight +=
+                        CalculateSingleStatWeight(playerclass, spec, "hitrtng", spellInfo->Effects[j].BasePoints + 1);
+                }
+
+                // crit rating (pre tbc)
+                // SPELL_AURA_MOD_HIT_CHANCE
+                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_CRIT_PCT)
+                {
+                    statWeight += CalculateSingleStatWeight(playerclass, spec, "critstrkrtng",
+                                                            spellInfo->Effects[j].BasePoints + 1);
+                }
+
+                // check defense SPELL_AURA_MOD_SKILL
+                // check block
+                // if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_SKILL)
+                //{
+                //    statWeight += CalculateSingleStatWeight(playerclass, spec, "block",
+                //    spellInfo->Effects[j].BasePoints + 1);
+                //}
+
+                // ratings
+                // enum CombatRating
+                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_RATING)
+                {
+                    for (uint32 rating = 0; rating < MAX_COMBAT_RATING; ++rating)
+                    {
+                        if (spellInfo->Effects[j].MiscValue & (1 << rating))
+                        {
+                            int32 val = spellInfo->Effects[j].BasePoints + 1;
+                            std::string weightName;
+
+                            for (std::unordered_map<std::string, uint32>::iterator i = weightRatingLink.begin();
+                                 i != weightRatingLink.end(); ++i)
+                            {
+                                uint32 modd = i->second;
+                                if (modd == rating)
+                                {
+                                    weightName = i->first;
+                                    break;
+                                }
+                            }
+
+                            if (weightName.empty())
+                                continue;
+
+                            statWeight += CalculateSingleStatWeight(playerclass, spec, weightName, val);
+                        }
+                    }
+                }
+
+                // mana regen
+                // SPELL_AURA_MOD_POWER_REGEN
+                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_POWER_REGEN)
+                {
+                    statWeight +=
+                        CalculateSingleStatWeight(playerclass, spec, "manargn", spellInfo->Effects[j].BasePoints + 1);
                 }
             }
         }
     }
+
+    // check for caster item
+    if (isCasterItem || hasInt)
+    {
+        if ((!hasMana || noCaster) && spellPower)
+            return 0;
+
+        if (!hasMana && hasInt)
+            return 0;
+
+        if ((!hasMana && noCaster && playerclass != CLASS_PALADIN) && spellPower > attackPower)
+            return 0;
+
+        bool playerCaster = false;
+        for (std::vector<WeightScaleStat>::iterator i = m_weightScales[playerclass][spec].stats.begin();
+             i != m_weightScales[playerclass][spec].stats.end(); ++i)
+        {
+            if (i->stat == "splpwr" || i->stat == "int" || i->stat == "manargn")
+            {
+                playerCaster = true;
+            }
+        }
+
+        if (!playerCaster)
+            return 0;
+    }
+
+    // check for caster item
+    if (isAttackItem)
+    {
+        if (hasMana && !noCaster && !(hasInt || spellPower))
+            return 0;
+        // if (!noCaster && attackPower)
+        //     return 0;
+
+        bool playerAttacker = false;
+        for (std::vector<WeightScaleStat>::iterator i = m_weightScales[playerclass][spec].stats.begin();
+             i != m_weightScales[playerclass][spec].stats.end(); ++i)
+        {
+            if (i->stat == "str" || i->stat == "agi" || i->stat == "atkpwr" || i->stat == "mledps" ||
+                i->stat == "rgddps")
+            {
+                playerAttacker = true;
+            }
+        }
+
+        if (!playerAttacker)
+            return 0;
+    }
+
+    statWeight += spellPower;
+    statWeight += spellHeal;
+    statWeight += attackPower;
+
+    // handle negative stats
+    if (basicStatsWeight < 0)
+    {
+        uint32 const absVal = static_cast<uint32>(abs(basicStatsWeight));
+        statWeight = (absVal >= statWeight) ? 0 : statWeight - absVal;
+    }
+    else
+        statWeight += static_cast<uint32>(basicStatsWeight);
+
+    return statWeight;
 }
 
-uint32 RandomItemMgr::GetRandomItem(uint32 level, RandomItemType type, RandomItemPredicate* predicate)
+uint32 RandomItemMgr::CalculateSingleStatWeight(uint8 playerclass, uint8 spec, std::string stat, uint32 value)
 {
-    RandomItemList const& list = Query(level, type, predicate);
+    uint32 statWeight = 0;
+    for (std::vector<WeightScaleStat>::iterator i = m_weightScales[playerclass][spec].stats.begin();
+         i != m_weightScales[playerclass][spec].stats.end(); ++i)
+    {
+        if (stat == i->stat)
+        {
+            statWeight = i->weight * value;
+            // if (statWeight)
+            //     LOG_INFO("playerbots", "stat: {}, val: {}, weight: {}, total: {}, class: {}, spec: {}",
+            //         stat, value, i->weight, statWeight, playerclass, m_weightScales[playerclass][spec].info.name);
+            return statWeight;
+        }
+    }
+
+    return statWeight;
+}
+
+uint32 RandomItemMgr::GetStatWeight(Player* player, uint32 itemId)
+{
+    if (!player || !itemId)
+        return 0;
+
+    auto itr = itemInfoCache.find(itemId);
+    if (itr == itemInfoCache.end())
+        return 0;
+
+    uint32 statWeight = 0;
+    uint32 specId = 0;
+    std::vector<uint32> classspecs;
+
+    std::string const& specName = AiFactory::GetPlayerSpecName(player);
+    if (specName.empty())
+        return 0;
+
+    for (uint32 specNum = 1; specNum < 5; ++specNum)
+    {
+        if (!m_weightScales[player->getClass()][specNum].info.id)
+            continue;
+
+        classspecs.push_back(m_weightScales[player->getClass()][specNum].info.id);
+
+        if (m_weightScales[player->getClass()][specNum].info.name == specName)
+            specId = m_weightScales[player->getClass()][specNum].info.id;
+
+        if (m_weightScales[player->getClass()][specNum].info.name == specName)
+        {
+            specId = specNum;
+            break;
+        }
+    }
+
+    if (!specId)
+        return 0;
+
+    statWeight = itr->second.weights[specId];
+
+    return statWeight;
+}
+
+uint32 RandomItemMgr::GetLiveStatWeight(Player* player, uint32 itemId)
+{
+    if (!player || !itemId)
+        return 0;
+
+    auto itr = itemInfoCache.find(itemId);
+    if (itr == itemInfoCache.end())
+        return 0;
+
+    uint32 statWeight = 0;
+    uint32 specId = 0;
+    std::vector<uint32> classspecs;
+
+    std::string const& specName = AiFactory::GetPlayerSpecName(player);
+    if (specName.empty())
+        return 0;
+
+    for (uint32 specNum = 1; specNum < 5; ++specNum)
+    {
+        if (!m_weightScales[player->getClass()][specNum].info.id)
+            continue;
+
+        // for bestSpec check
+        // classspecs.push_back(m_weightScales[player->getClass()][specNum].info.id);
+
+        if (m_weightScales[player->getClass()][specNum].info.name == specName)
+            specId = m_weightScales[player->getClass()][specNum].info.id;
+    }
+    if (!specId)
+        return 0;
+
+    statWeight = itr->second.weights[specId];
+
+    // skip higher lvl
+    if (itr->second.minLevel > player->GetLevel())
+        return 0;
+
+    // skip too low level
+    // if ((int32)info->minLevel < (int32)(player->GetLevel() - 20))
+    //    return 0;
+
+    // skip wrong team
+    if (itr->second.team != TEAM_NEUTRAL && itr->second.team != player->GetTeamId())
+        return 0;
+
+    // skip quest items
+    if (itr->second.source == ITEM_SOURCE_QUEST && itr->second.sourceId)
+    {
+        if (player->GetQuestRewardStatus(itr->second.sourceId) != QUEST_STATUS_COMPLETE)
+            return 0;
+    }
+
+    // skip pvp items
+    if (itr->second.source == ITEM_SOURCE_PVP)
+    {
+        if (!player->GetHonorPoints() && !player->GetArenaPoints())
+            return 0;
+    }
+
+    // skip no stats trinkets
+    if (itr->second.weights[specId] == 1 &&
+        (itr->second.slot == EQUIPMENT_SLOT_NECK || itr->second.slot == EQUIPMENT_SLOT_TRINKET1 ||
+         itr->second.slot == EQUIPMENT_SLOT_TRINKET2 || itr->second.slot == EQUIPMENT_SLOT_FINGER1 ||
+         itr->second.slot == EQUIPMENT_SLOT_FINGER2))
+        return 0;
+
+    // skip items that only fit in slot, but not stats
+    if (!itemId && itr->second.weights[specId] == 1 && player->GetLevel() > 20)
+        return 0;
+
+    // check if item stat score is the best among class specs
+    /*uint32 bestSpecId = 0;
+    uint32 bestSpecScore = 0;
+    for (vector<uint32>::iterator i = classspecs.begin(); i != classspecs.end(); ++i)
+    {
+        if (itemCache[itemId]->weights[*i] > bestSpecScore && itemCache[itemId]->weights[*i] > 1)
+        {
+            bestSpecId = *i;
+            bestSpecScore = itemCache[itemId]->weights[specId];
+        }
+    }
+
+    if (bestSpecId && bestSpecId != specId && player->GetLevel() >= 60)
+        return 0;*/
+
+    return statWeight;
+}
+
+uint32 RandomItemMgr::GetMinLevelFromCache(uint32 itemId) const
+{
+    auto itr = itemInfoCache.find(itemId);
+    if (itr == itemInfoCache.end())
+        return 0;
+
+    return itr->second.minLevel;
+}
+
+RandomItemList const& RandomItemMgr::GetEquipment(uint32 level, uint8 clazz, uint8 slot, uint32 quality) const
+{
+    static RandomItemList const empty;
+
+    level = NormalizeLevel(level);
+
+    BotEquipKey const key(level, clazz, slot, quality);
+    auto const itr = equipCache.find(key);
+    if (itr == equipCache.end())
+        return empty;
+
+    return itr->second;
+}
+
+RandomItemList const& RandomItemMgr::GetEquipmentNew(uint32 level, InventoryType invType) const
+{
+    static RandomItemList const empty;
+
+    level = NormalizeLevel(level);
+
+    auto const levelItr = equipCacheNew.find(level);
+    if (levelItr == equipCacheNew.end())
+        return empty;
+
+    auto const typeItr = levelItr->second.find(invType);
+    if (typeItr == levelItr->second.end())
+        return empty;
+
+    return typeItr->second;
+}
+
+uint32 RandomItemMgr::GetRandomItem(uint32 level, RandomItemType type, RandomItemPredicate* predicate) const
+{
+    level = NormalizeLevel(level);
+
+    RandomItemList const list = Query(level, type, predicate);
     if (list.empty())
         return 0;
 
-    uint32 index = urand(0, list.size() - 1);
-    uint32 itemId = list[index];
-
-    return itemId;
+    return Acore::Containers::SelectRandomContainerElement(list);
 }
 
-bool RandomItemMgr::CanEquipItem(BotEquipKey key, ItemTemplate const* proto)
+uint32 RandomItemMgr::GetAmmo(uint32 level, uint32 subClass) const
 {
-    if (proto->Duration & 0x80000000)
-        return false;
+    level = NormalizeLevel(level);
 
-    if (proto->Quality != key.quality)
-        return false;
+    auto const levelItr = ammoCache.find(level);
+    if (levelItr == ammoCache.end())
+        return 0;
 
-    if (proto->Bonding == BIND_QUEST_ITEM || proto->Bonding == BIND_WHEN_USE)
-        return false;
+    auto const subItr = levelItr->second.find(subClass);
+    if (subItr == levelItr->second.end() || subItr->second.empty())
+        return 0;
 
-    if (proto->Class == ITEM_CLASS_CONTAINER)
-        return true;
+    std::vector<uint32> const& ammo = subItr->second;
+    if (!sPlayerbotAIConfig.limitGearExpansion)
+        return ammo.front();
 
-    std::set<InventoryType> slots = viableSlots[(EquipmentSlots)key.slot];
-    if (slots.find((InventoryType)proto->InventoryType) == slots.end())
-        return false;
+    static constexpr uint32 EXPANSION_ITEM_ID_TBC   = 23728; // approx. first item in TBC content (patch 2.0)
+    static constexpr uint32 EXPANSION_ITEM_ID_WOTLK = 35570; // approx. first item in WotLK content (patch 3.0)
+    uint32 const maxEntryId = level <= 60 ? EXPANSION_ITEM_ID_TBC :
+                              level <= 70 ? EXPANSION_ITEM_ID_WOTLK :
+                              std::numeric_limits<uint32>::max();
 
-    uint32 requiredLevel = proto->RequiredLevel;
-    if (!requiredLevel)
+    for (uint32 entry : ammo)
     {
-        requiredLevel = GetMinLevelFromCache(proto->ItemId);
+        if (entry < maxEntryId)
+            return entry;
     }
 
-    if (!requiredLevel)
-        requiredLevel = key.level;
+    return 0;
+}
 
-    uint32 level = key.level;
+uint32 RandomItemMgr::GetRandomPotion(uint32 level, uint32 effect) const
+{
+    level = NormalizeLevel(level);
 
-    uint32 delta = 2;
-    if (level < 15)
-        delta = 15;
-    else if (level < 40)
-        delta = 10;  // urand(5, 10);
-    else if (level < 60)
-        delta = 6;  // urand(3, 7);
-    else if (level < 70)
-        delta = 9;  // urand(2, 5);
-    else if (level < 80)
-        delta = 9;  // urand(2, 4);
-    else if (level == 80)
-        delta = 9;  // urand(2, 4);
+    auto const levelItr = potionCache.find(level);
+    if (levelItr == potionCache.end())
+        return 0;
 
-    if (key.quality > ITEM_QUALITY_NORMAL && (requiredLevel > level || requiredLevel < level - delta))
+    auto const effectItr = levelItr->second.find(effect);
+    if (effectItr == levelItr->second.end() || effectItr->second.empty())
+        return 0;
+
+    return Acore::Containers::SelectRandomContainerElement(effectItr->second);
+}
+
+uint32 RandomItemMgr::GetRandomFood(uint32 level, uint32 category) const
+{
+    level = NormalizeLevel(level);
+
+    uint32 const bucket = (level - 1) / 10;
+
+    auto const levelItr = foodCache.find(bucket);
+    if (levelItr == foodCache.end())
+        return 0;
+
+    auto const catItr = levelItr->second.find(category);
+    if (catItr == levelItr->second.end() || catItr->second.empty())
+        return 0;
+
+    return Acore::Containers::SelectRandomContainerElement(catItr->second);
+}
+
+uint32 RandomItemMgr::GetRandomTrade(uint32 level) const
+{
+    level = NormalizeLevel(level);
+    uint32 const bucket = (level - 1) / 10;
+
+    auto const itr = tradeCache.find(bucket);
+    if (itr == tradeCache.end() || itr->second.empty())
+        return 0;
+
+    return Acore::Containers::SelectRandomContainerElement(itr->second);
+}
+
+float RandomItemMgr::GetItemRarity(uint32 itemId) const
+{
+    auto const itr = rarityCache.find(itemId);
+    return itr != rarityCache.end() ? itr->second : 0.0f;
+}
+
+std::vector<uint32> const& RandomItemMgr::GetEnchantmentPool(uint32 entry) const
+{
+    static std::vector<uint32> const empty;
+    auto it = enchPoolCache.find(entry);
+    if (it == enchPoolCache.end())
+        return empty;
+    return it->second;
+}
+
+bool RandomItemMgr::CanEquipArmor(ItemTemplate const* proto, uint8 clazz, uint32 level) const
+{
+    // skip null proto or invalid class
+    if (!proto || clazz >= MAX_CLASSES)
         return false;
 
-    // for (uint32 gap = 60; gap <= 80; gap += 10)
-    // {
-    //     if (level > gap && requiredLevel <= gap)
-    //         return false;
-    // }
+    // skip non-armor and out-of-range armor subclasses
+    if (proto->Class != ITEM_CLASS_ARMOR || proto->SubClass >= MAX_ITEM_SUBCLASS_ARMOR)
+        return false;
+
+    // skip items with no viable equip slot
+    if (!GetViableSlots(static_cast<InventoryType>(proto->InventoryType)))
+        return false;
+
+    // skip additional checks for tabards - always equippable
+    if (proto->InventoryType == INVTYPE_TABARD)
+        return true;
+
+    if ((clazz == CLASS_WARRIOR || clazz == CLASS_PALADIN || clazz == CLASS_SHAMAN) &&
+        proto->SubClass == ITEM_SUBCLASS_ARMOR_SHIELD)
+        return true;
+
+    uint32 const requiredSubClass = [&]() -> uint32
+    {
+        if (clazz == CLASS_WARRIOR || clazz == CLASS_PALADIN)
+            return level >= 40 ? ITEM_SUBCLASS_ARMOR_PLATE : ITEM_SUBCLASS_ARMOR_MAIL;
+        if (clazz == CLASS_HUNTER || clazz == CLASS_SHAMAN)
+            return level >= 40 ? ITEM_SUBCLASS_ARMOR_MAIL : ITEM_SUBCLASS_ARMOR_LEATHER;
+        if (clazz == CLASS_DRUID || clazz == CLASS_ROGUE)
+            return ITEM_SUBCLASS_ARMOR_LEATHER;
+        return ITEM_SUBCLASS_ARMOR_CLOTH; // mage/warlock/priest
+    }();
+
+    // skip armor of wrong subclass (cloaks are exempt)
+    if (proto->InventoryType != INVTYPE_CLOAK && proto->SubClass != requiredSubClass)
+        return false;
+
+    // skip stats calculation for poor/normal quality items (grey/white)
+    if (proto->Quality < ITEM_QUALITY_UNCOMMON)
+        return true;
+
+    uint8 sp = 0;
+    uint8 ap = 0;
+    uint8 tank = 0;
+
+    for (uint8 j = 0; j < MAX_ITEM_PROTO_STATS; ++j)
+    {
+        // skip items with no stats value
+        if (!proto->ItemStat[j].ItemStatValue)
+            continue;
+
+        AddItemStats(proto->ItemStat[j].ItemStatType, sp, ap, tank);
+    }
+
+    return CanUseItemStats(clazz, sp, ap, tank);
+}
+
+bool RandomItemMgr::CanEquipWeapon(ItemTemplate const* proto, uint8 clazz) const
+{
+    // skip null proto or invalid class
+    if (!proto || clazz >= MAX_CLASSES)
+        return false;
+
+    // skip non-weapon and out-of-range weapon subclasses
+    if (proto->Class != ITEM_CLASS_WEAPON || proto->SubClass >= MAX_ITEM_SUBCLASS_WEAPON)
+        return false;
+
+    // skip items with no viable equip slot
+    if (!GetViableSlots(static_cast<InventoryType>(proto->InventoryType)))
+        return false;
+
+    // skip weapons the class has no proficiency for
+    return (m_weaponProficiency[clazz] & (1u << proto->SubClass)) != 0;
+}
+
+bool RandomItemMgr::ShouldEquipArmorForSpec(ItemTemplate const* proto, uint8 clazz, uint8 spec) const
+{
+    if (!proto)
+        return false;
+
+    // skip additional checks for tabards - always equippable
+    if (proto->InventoryType == INVTYPE_TABARD)
+        return true;
+
+    std::unordered_map<uint8, WeightScale> const& specMap = m_weightScales[clazz];
+    auto const itr = specMap.find(spec);
+    if (itr == specMap.end() || !itr->second.info.id)
+        return false;
+
+    WeightScale const& scale = itr->second;
+    std::string const& specName = scale.info.name;
+    uint32 const subClass = proto->SubClass;
+    bool const isHoldable = proto->InventoryType == INVTYPE_HOLDABLE;
+
+    switch (clazz)
+    {
+        case CLASS_DEATH_KNIGHT:
+            if (isHoldable)
+                return false;
+            return subClass == ITEM_SUBCLASS_ARMOR_SIGIL || subClass == ITEM_SUBCLASS_ARMOR_PLATE;
+
+        case CLASS_WARRIOR:
+            if (isHoldable)
+                return false;
+            if (specName == "arms" || specName == "fury")
+                return subClass == ITEM_SUBCLASS_ARMOR_LEATHER || subClass == ITEM_SUBCLASS_ARMOR_MAIL ||
+                       subClass == ITEM_SUBCLASS_ARMOR_PLATE;
+            return subClass == ITEM_SUBCLASS_ARMOR_MAIL || subClass == ITEM_SUBCLASS_ARMOR_PLATE;
+
+        case CLASS_PALADIN:
+            if (specName != "holy")
+            {
+                if (isHoldable)
+                    return false;
+
+                return subClass == ITEM_SUBCLASS_ARMOR_MAIL || subClass == ITEM_SUBCLASS_ARMOR_PLATE ||
+                       subClass == ITEM_SUBCLASS_ARMOR_LIBRAM;
+            }
+            return subClass == ITEM_SUBCLASS_ARMOR_CLOTH || subClass == ITEM_SUBCLASS_ARMOR_LEATHER ||
+                   subClass == ITEM_SUBCLASS_ARMOR_MAIL  || subClass == ITEM_SUBCLASS_ARMOR_PLATE   ||
+                   subClass == ITEM_SUBCLASS_ARMOR_LIBRAM;
+
+        case CLASS_HUNTER:
+            if (isHoldable)
+                return false;
+            return subClass == ITEM_SUBCLASS_ARMOR_CLOTH || subClass == ITEM_SUBCLASS_ARMOR_LEATHER ||
+                   subClass == ITEM_SUBCLASS_ARMOR_MAIL;
+
+        case CLASS_ROGUE:
+            if (isHoldable)
+                return false;
+            return subClass == ITEM_SUBCLASS_ARMOR_CLOTH || subClass == ITEM_SUBCLASS_ARMOR_LEATHER;
+
+        case CLASS_PRIEST:
+        case CLASS_MAGE:
+        case CLASS_WARLOCK:
+            return subClass == ITEM_SUBCLASS_ARMOR_CLOTH;
+
+        case CLASS_SHAMAN:
+            if (specName == "enhance" && isHoldable)
+                return false;
+            return subClass == ITEM_SUBCLASS_ARMOR_TOTEM   || subClass == ITEM_SUBCLASS_ARMOR_CLOTH ||
+                   subClass == ITEM_SUBCLASS_ARMOR_LEATHER || subClass == ITEM_SUBCLASS_ARMOR_MAIL;
+
+        case CLASS_DRUID:
+            if ((specName == "feraltank" || specName == "feraldps") && isHoldable)
+                return false;
+            return subClass == ITEM_SUBCLASS_ARMOR_IDOL || subClass == ITEM_SUBCLASS_ARMOR_CLOTH ||
+                   subClass == ITEM_SUBCLASS_ARMOR_LEATHER;
+
+        default:
+            return false;
+    }
+}
+
+bool RandomItemMgr::ShouldEquipWeaponForSpec(ItemTemplate const* proto, uint8 clazz, uint8 spec) const
+{
+    if (!proto)
+        return false;
+
+    std::unordered_map<uint8, WeightScale> const& specMap = m_weightScales[clazz];
+    auto const itr = specMap.find(spec);
+    if (itr == specMap.end() || !itr->second.info.id)
+        return false;
+
+    bool hasMH = false, hasOH = false, hasRH = false;
+
+    if (auto const* slots = GetViableSlots(static_cast<InventoryType>(proto->InventoryType)))
+    {
+        for (EquipmentSlots slot : *slots)
+        {
+            if (slot == EQUIPMENT_SLOT_MAINHAND) hasMH = true;
+            if (slot == EQUIPMENT_SLOT_OFFHAND)  hasOH = true;
+            if (slot == EQUIPMENT_SLOT_RANGED)   hasRH = true;
+        }
+    }
+
+    if (!hasMH && !hasOH && !hasRH)
+        return false;
+
+    WeightScale const& scale = itr->second;
+    std::string const& specName = scale.info.name;
+    uint32 const subClass = proto->SubClass;
+
+    auto inSlot = [&](bool hasSlot, std::initializer_list<uint32> list) {
+        if (!hasSlot) return false;
+        for (uint32 sc : list) if (sc == subClass) return true;
+        return false;
+    };
+
+    switch (clazz)
+    {
+        case CLASS_DEATH_KNIGHT:
+            return inSlot(hasMH, {ITEM_SUBCLASS_WEAPON_SWORD2, ITEM_SUBCLASS_WEAPON_AXE2, ITEM_SUBCLASS_WEAPON_MACE2,
+                                  ITEM_SUBCLASS_WEAPON_POLEARM}) ||
+                   inSlot(hasRH, {ITEM_SUBCLASS_ARMOR_SIGIL});
+
+        case CLASS_WARRIOR:
+            if (specName == "prot")
+                return inSlot(hasMH, {ITEM_SUBCLASS_WEAPON_SWORD, ITEM_SUBCLASS_WEAPON_AXE, ITEM_SUBCLASS_WEAPON_MACE,
+                                      ITEM_SUBCLASS_WEAPON_DAGGER, ITEM_SUBCLASS_WEAPON_FIST}) ||
+                       inSlot(hasOH, {ITEM_SUBCLASS_ARMOR_SHIELD}) ||
+                       inSlot(hasRH, {ITEM_SUBCLASS_WEAPON_BOW, ITEM_SUBCLASS_WEAPON_CROSSBOW, ITEM_SUBCLASS_WEAPON_GUN});
+            return inSlot(hasMH, {ITEM_SUBCLASS_WEAPON_SWORD2, ITEM_SUBCLASS_WEAPON_AXE2, ITEM_SUBCLASS_WEAPON_MACE2,
+                                  ITEM_SUBCLASS_WEAPON_STAFF, ITEM_SUBCLASS_WEAPON_POLEARM}) ||
+                   inSlot(hasRH, {ITEM_SUBCLASS_WEAPON_BOW, ITEM_SUBCLASS_WEAPON_CROSSBOW, ITEM_SUBCLASS_WEAPON_GUN});
+
+        case CLASS_PALADIN:
+            if (specName == "prot")
+                return inSlot(hasMH, {ITEM_SUBCLASS_WEAPON_SWORD, ITEM_SUBCLASS_WEAPON_AXE, ITEM_SUBCLASS_WEAPON_MACE}) ||
+                       inSlot(hasOH, {ITEM_SUBCLASS_ARMOR_SHIELD}) ||
+                       inSlot(hasRH, {ITEM_SUBCLASS_ARMOR_LIBRAM});
+            if (specName == "holy")
+                return inSlot(hasMH, {ITEM_SUBCLASS_WEAPON_SWORD, ITEM_SUBCLASS_WEAPON_AXE, ITEM_SUBCLASS_WEAPON_MACE}) ||
+                       inSlot(hasOH, {ITEM_SUBCLASS_ARMOR_SHIELD, ITEM_SUBCLASS_ARMOR_MISC}) ||
+                       inSlot(hasRH, {ITEM_SUBCLASS_ARMOR_LIBRAM});
+            return inSlot(hasMH, {ITEM_SUBCLASS_WEAPON_SWORD2, ITEM_SUBCLASS_WEAPON_AXE2, ITEM_SUBCLASS_WEAPON_MACE2,
+                                  ITEM_SUBCLASS_WEAPON_POLEARM}) ||
+                   inSlot(hasRH, {ITEM_SUBCLASS_ARMOR_LIBRAM});
+
+        case CLASS_HUNTER:
+            return inSlot(hasMH, {ITEM_SUBCLASS_WEAPON_SWORD2, ITEM_SUBCLASS_WEAPON_AXE2, ITEM_SUBCLASS_WEAPON_STAFF,
+                                  ITEM_SUBCLASS_WEAPON_POLEARM}) ||
+                   inSlot(hasRH, {ITEM_SUBCLASS_WEAPON_BOW, ITEM_SUBCLASS_WEAPON_CROSSBOW, ITEM_SUBCLASS_WEAPON_GUN});
+
+        case CLASS_ROGUE:
+            return inSlot(hasMH, {ITEM_SUBCLASS_WEAPON_DAGGER}) ||
+                   inSlot(hasOH, {ITEM_SUBCLASS_WEAPON_DAGGER}) ||
+                   inSlot(hasRH, {ITEM_SUBCLASS_WEAPON_BOW, ITEM_SUBCLASS_WEAPON_CROSSBOW, ITEM_SUBCLASS_WEAPON_GUN});
+
+        case CLASS_PRIEST:
+            return inSlot(hasMH, {ITEM_SUBCLASS_WEAPON_STAFF, ITEM_SUBCLASS_WEAPON_DAGGER, ITEM_SUBCLASS_WEAPON_MACE}) ||
+                   inSlot(hasOH, {ITEM_SUBCLASS_ARMOR_MISC}) ||
+                   inSlot(hasRH, {ITEM_SUBCLASS_WEAPON_WAND});
+
+        case CLASS_SHAMAN:
+            if (specName == "resto")
+                return inSlot(hasMH, {ITEM_SUBCLASS_WEAPON_DAGGER, ITEM_SUBCLASS_WEAPON_AXE, ITEM_SUBCLASS_WEAPON_MACE,
+                                      ITEM_SUBCLASS_WEAPON_FIST}) ||
+                       inSlot(hasOH, {ITEM_SUBCLASS_ARMOR_MISC, ITEM_SUBCLASS_ARMOR_SHIELD}) ||
+                       inSlot(hasRH, {ITEM_SUBCLASS_ARMOR_TOTEM});
+            if (specName == "enhance")
+                return inSlot(hasMH, {ITEM_SUBCLASS_WEAPON_MACE2, ITEM_SUBCLASS_WEAPON_AXE2, ITEM_SUBCLASS_WEAPON_DAGGER,
+                                      ITEM_SUBCLASS_WEAPON_AXE, ITEM_SUBCLASS_WEAPON_MACE, ITEM_SUBCLASS_WEAPON_FIST}) ||
+                       inSlot(hasOH, {ITEM_SUBCLASS_ARMOR_SHIELD}) ||
+                       inSlot(hasRH, {ITEM_SUBCLASS_ARMOR_TOTEM});
+            return inSlot(hasMH, {ITEM_SUBCLASS_WEAPON_STAFF}) ||
+                   inSlot(hasRH, {ITEM_SUBCLASS_ARMOR_TOTEM});
+
+        case CLASS_MAGE:
+        case CLASS_WARLOCK:
+            return inSlot(hasMH, {ITEM_SUBCLASS_WEAPON_STAFF, ITEM_SUBCLASS_WEAPON_DAGGER, ITEM_SUBCLASS_WEAPON_SWORD}) ||
+                   inSlot(hasOH, {ITEM_SUBCLASS_ARMOR_MISC}) ||
+                   inSlot(hasRH, {ITEM_SUBCLASS_WEAPON_WAND});
+
+        case CLASS_DRUID:
+            if (specName == "feraltank" || specName == "feraldps")
+                return inSlot(hasMH, {ITEM_SUBCLASS_WEAPON_STAFF, ITEM_SUBCLASS_WEAPON_MACE2}) ||
+                       inSlot(hasRH, {ITEM_SUBCLASS_ARMOR_IDOL});
+            if (specName == "resto")
+                return inSlot(hasMH, {ITEM_SUBCLASS_WEAPON_STAFF, ITEM_SUBCLASS_WEAPON_DAGGER, ITEM_SUBCLASS_WEAPON_FIST,
+                                      ITEM_SUBCLASS_WEAPON_MACE}) ||
+                       inSlot(hasOH, {ITEM_SUBCLASS_ARMOR_MISC}) ||
+                       inSlot(hasRH, {ITEM_SUBCLASS_ARMOR_IDOL});
+            return inSlot(hasMH, {ITEM_SUBCLASS_WEAPON_STAFF}) ||
+                   inSlot(hasRH, {ITEM_SUBCLASS_ARMOR_IDOL});
+
+        default:
+            return false;
+    }
+}
+
+uint32 RandomItemMgr::GetQuestIdForItem(uint32 itemId) const
+{
+    for (auto const& [id, quest] : sObjectMgr->GetQuestTemplates())
+    {
+        for (uint32 i = 0; i < quest->GetRewItemsCount(); ++i)
+        {
+            if (quest->RewardItemId[i] == itemId)
+                return quest->GetQuestId();
+        }
+
+        for (uint32 i = 0; i < quest->GetRewChoiceItemsCount(); ++i)
+        {
+            if (quest->RewardChoiceItemId[i] == itemId)
+                return quest->GetQuestId();
+        }
+    }
+
+    return 0;
+}
+
+std::vector<uint32> RandomItemMgr::GetQuestIdsForItem(uint32 itemId) const
+{
+    std::vector<uint32> questIds;
+
+    for (auto const& [id, quest] : sObjectMgr->GetQuestTemplates())
+    {
+        for (uint32 i = 0; i < quest->GetRewItemsCount(); ++i)
+        {
+            if (quest->RewardItemId[i] == itemId)
+            {
+                questIds.push_back(quest->GetQuestId());
+                break;
+            }
+        }
+
+        for (uint32 i = 0; i < quest->GetRewChoiceItemsCount(); ++i)
+        {
+            if (quest->RewardChoiceItemId[i] == itemId)
+            {
+                questIds.push_back(quest->GetQuestId());
+                break;
+            }
+        }
+    }
+
+    return questIds;
+}
+
+bool RandomItemMgr::IsInternalItem(ItemTemplate const* proto)
+{
+    if (!proto)
+        return false;
+
+    if (proto->HasFlag(ITEM_FLAG_DEPRECATED))
+        return true;
+
+    char const* name = proto->Name1.c_str();
+    return strstr(name, "NPC ")        ||  // 4859
+           strstr(name, "Monster ")    ||  // 574
+           strstr(name, "Test")        ||  // 427 -- "(Test)", "Test ", " Test"
+           strstr(name, "Deprecated ") ||  // 399
+           strstr(name, "[PH]")        ||  // 138
+           strstr(name, "TEST")        ||  // 108 -- "(TEST)", "TEST ", " TEST", "(JEFFTEST)"
+           strstr(name, "Unused ")     ||  // 19
+           strstr(name, "zzOLD")       ||  // 11
+           strstr(name, "(test)")      ||  // 8
+           strstr(name, "(OLD)")       ||  // 7
+           strstr(name, "QR")          ||  // 5
+           strstr(name, "2200 ");          // 4
+}
+
+bool RandomItemMgr::IsValidItem(ItemTemplate const* proto)
+{
+    if (!proto)
+        return false;
+
+    // check items with no item level
+    if (proto->ItemLevel == 0)
+        return false;
+
+    // check temporary/expiring items
+    if (proto->Duration)
+        return false;
+
+    // check area-, or map-restricted items
+    if (proto->Area || proto->Map)
+        return false;
+
+    // check city-rank-, or pvp-rank-restricted items
+    if (proto->RequiredCityRank || proto->RequiredHonorRank)
+        return false;
+
+    // check class-restricted items
+    if ((proto->AllowableClass & CLASSMASK_ALL_PLAYABLE) == 0)
+        return false;
+
+    constexpr uint32 RACEMASK_ALL_PLAYABLE =
+        (1 << (RACE_HUMAN - 1))         |
+        (1 << (RACE_ORC - 1))           |
+        (1 << (RACE_DWARF - 1))         |
+        (1 << (RACE_NIGHTELF - 1))      |
+        (1 << (RACE_UNDEAD_PLAYER - 1)) |
+        (1 << (RACE_TAUREN - 1))        |
+        (1 << (RACE_GNOME - 1))         |
+        (1 << (RACE_TROLL - 1))         |
+        (1 << (RACE_BLOODELF - 1))      |
+        (1 << (RACE_DRAENEI - 1));
+
+    // check race-restricted items
+    if ((proto->AllowableRace & RACEMASK_ALL_PLAYABLE) == 0)
+        return false;
+
+    // check test/internal items
+    if (IsInternalItem(proto))
+        return false;
+
+    // skip items flagged as unobtainable
+    if (sPlayerbotAIConfig.unobtainableItems.contains(proto->ItemId))
+        return false;
 
     return true;
 }
 
-bool RandomItemMgr::CanEquipItemNew(ItemTemplate const* proto)
+static bool IsCraftedBySpellInfo(uint32 itemId, SpellInfo const* spellInfo)
 {
-    if (proto->Duration & 0x80000000)
-        return false;
-
-    if (proto->Bonding == BIND_QUEST_ITEM || proto->Bonding == BIND_WHEN_USE)
-        return false;
-
-    if (proto->Class == ITEM_CLASS_CONTAINER)
-        return false;
-
-    bool properSlot = false;
-    for (std::map<EquipmentSlots, std::set<InventoryType> >::iterator i = viableSlots.begin(); i != viableSlots.end();
-         ++i)
+    for (uint8 x = 0; x < MAX_SPELL_REAGENTS; ++x)
     {
-        std::set<InventoryType> const& slots = viableSlots[(EquipmentSlots)i->first];
-        if (slots.find((InventoryType)proto->InventoryType) != slots.end())
-            properSlot = true;
+        if (spellInfo->Reagent[x] <= 0)
+            continue;
+
+        if (itemId == static_cast<uint32>(spellInfo->Reagent[x]))
+            return true;
     }
 
-    return properSlot;
+    for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
+    {
+        if (spellInfo->Effects[i].Effect == SPELL_EFFECT_CREATE_ITEM &&
+            spellInfo->Effects[i].ItemType == itemId)
+            return true;
+    }
+
+    return false;
 }
 
-void RandomItemMgr::AddItemStats(uint32 mod, uint8& sp, uint8& ap, uint8& tank)
+static bool IsCraftedBySpell(uint32 itemId, uint32 spellId)
 {
-    switch (mod)
+    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+    if (!spellInfo)
+        return false;
+
+    if (IsCraftedBySpellInfo(itemId, spellInfo))
+        return true;
+
+    for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
     {
-        case ITEM_MOD_HEALTH:
-        case ITEM_MOD_STAMINA:
-        case ITEM_MOD_MANA:
-        case ITEM_MOD_INTELLECT:
-        case ITEM_MOD_SPIRIT:
-            ++sp;
+        SpellInfo const* triggerSpellInfo = sSpellMgr->GetSpellInfo(spellInfo->Effects[i].TriggerSpell);
+        if (!triggerSpellInfo)
+            continue;
+
+        if (IsCraftedBySpellInfo(itemId, triggerSpellInfo))
+            return true;
+    }
+
+    return false;
+}
+
+static bool IsCraftedBySkill(uint32 itemId, uint32 skillId)
+{
+    for (SkillLineAbilityEntry const* skillLine : GetSkillLineAbilitiesBySkillLine(skillId))
+    {
+        if (IsCraftedBySpell(itemId, skillLine->Spell))
+            return true;
+    }
+
+    std::vector<ItemTemplate*> const* itemTemplates = sObjectMgr->GetItemTemplateStoreFast();
+    for (ItemTemplate const* recipe : *itemTemplates)
+    {
+        if (!recipe || recipe->Class != ITEM_CLASS_RECIPE)
+            continue;
+
+        uint32 skillType = 0;
+        switch (recipe->SubClass)
+        {
+            case ITEM_SUBCLASS_LEATHERWORKING_PATTERN: skillType = SKILL_LEATHERWORKING; break;
+            case ITEM_SUBCLASS_TAILORING_PATTERN:      skillType = SKILL_TAILORING; break;
+            case ITEM_SUBCLASS_ENGINEERING_SCHEMATIC:  skillType = SKILL_ENGINEERING; break;
+            case ITEM_SUBCLASS_BLACKSMITHING:          skillType = SKILL_BLACKSMITHING; break;
+            case ITEM_SUBCLASS_COOKING_RECIPE:         skillType = SKILL_COOKING; break;
+            case ITEM_SUBCLASS_ALCHEMY_RECIPE:         skillType = SKILL_ALCHEMY; break;
+            case ITEM_SUBCLASS_FIRST_AID_MANUAL:       skillType = SKILL_FIRST_AID; break;
+            case ITEM_SUBCLASS_ENCHANTING_FORMULA:     skillType = SKILL_ENCHANTING; break;
+            case ITEM_SUBCLASS_JEWELCRAFTING_RECIPE:   skillType = SKILL_JEWELCRAFTING; break;
+            case ITEM_SUBCLASS_FISHING_MANUAL:         skillType = SKILL_FISHING; break;
+            default: break;
+        }
+
+        if (!skillType)
+            continue;
+
+        for (uint32 i = 0; i < MAX_ITEM_PROTO_SPELLS; ++i)
+        {
+            if (IsCraftedBySpell(itemId, recipe->Spells[i].SpellId))
+                return true;
+        }
+    }
+
+    return false;
+}
+
+bool RandomItemMgr::IsUsedBySkill(ItemTemplate const* proto, uint32 skillId)
+{
+    if (!proto)
+        return false;
+
+    if (itemCache.contains(proto->ItemId))
+        return true;
+
+    switch (proto->Class)
+    {
+        case ITEM_CLASS_TRADE_GOODS:
+        case ITEM_CLASS_MISC:
+        case ITEM_CLASS_REAGENT:
+        case ITEM_CLASS_GEM:
+            if (IsCraftedBySkill(proto->ItemId, skillId))
+            {
+                itemCache.insert(proto->ItemId);
+                return true;
+            }
+            break;
+        default:
             break;
     }
 
-    switch (mod)
-    {
-        case ITEM_MOD_AGILITY:
-        case ITEM_MOD_STRENGTH:
-        case ITEM_MOD_HEALTH:
-        case ITEM_MOD_STAMINA:
-            ++tank;
-            break;
-    }
+    return false;
+}
 
-    switch (mod)
+static uint32 GetWeaponSkillId(uint32 subClass)
+{
+    switch (subClass)
     {
-        case ITEM_MOD_HEALTH:
-        case ITEM_MOD_STAMINA:
-        case ITEM_MOD_AGILITY:
-        case ITEM_MOD_STRENGTH:
-            ++ap;
-            break;
+        case ITEM_SUBCLASS_WEAPON_AXE:      return SKILL_AXES;
+        case ITEM_SUBCLASS_WEAPON_AXE2:     return SKILL_2H_AXES;
+        case ITEM_SUBCLASS_WEAPON_BOW:      return SKILL_BOWS;
+        case ITEM_SUBCLASS_WEAPON_GUN:      return SKILL_GUNS;
+        case ITEM_SUBCLASS_WEAPON_MACE:     return SKILL_MACES;
+        case ITEM_SUBCLASS_WEAPON_MACE2:    return SKILL_2H_MACES;
+        case ITEM_SUBCLASS_WEAPON_POLEARM:  return SKILL_POLEARMS;
+        case ITEM_SUBCLASS_WEAPON_SWORD:    return SKILL_SWORDS;
+        case ITEM_SUBCLASS_WEAPON_SWORD2:   return SKILL_2H_SWORDS;
+        case ITEM_SUBCLASS_WEAPON_STAFF:    return SKILL_STAVES;
+        case ITEM_SUBCLASS_WEAPON_FIST:     return SKILL_FIST_WEAPONS;
+        case ITEM_SUBCLASS_WEAPON_DAGGER:   return SKILL_DAGGERS;
+        case ITEM_SUBCLASS_WEAPON_THROWN:   return SKILL_THROWN;
+        case ITEM_SUBCLASS_WEAPON_CROSSBOW: return SKILL_CROSSBOWS;
+        case ITEM_SUBCLASS_WEAPON_WAND:     return SKILL_WANDS;
+        default:                            return SKILL_NONE;
     }
 }
 
-bool RandomItemMgr::CheckItemStats(uint8 clazz, uint8 sp, uint8 ap, uint8 tank)
+void RandomItemMgr::InitWeaponProficiency()
 {
-    switch (clazz)
-    {
-        case CLASS_PRIEST:
-        case CLASS_MAGE:
-        case CLASS_WARLOCK:
-            if (!sp || ap > sp || tank > sp)
-                return false;
-            break;
-        case CLASS_PALADIN:
-        case CLASS_WARRIOR:
-            if ((!ap && !tank) || sp > ap || sp > tank)
-                return false;
-            break;
-        case CLASS_HUNTER:
-        case CLASS_ROGUE:
-            if (!ap || sp > ap || sp > tank)
-                return false;
-            break;
-    }
+    m_weaponProficiency.fill(0);
 
-    return sp || ap || tank;
+    for (uint32 subClass = 0; subClass < MAX_ITEM_SUBCLASS_WEAPON; ++subClass)
+    {
+        uint32 const skillId = GetWeaponSkillId(subClass);
+        if (!skillId)
+            continue; // ITEM_SUBCLASS_WEAPON_SPEAR, FISHING_POLE, OBSOLETE, etc.
+
+        for (uint8 cls = CLASS_WARRIOR; cls < MAX_CLASSES; ++cls)
+        {
+            if (!((1u << (cls - 1)) & CLASSMASK_ALL_PLAYABLE))
+                continue;
+
+            // Weapon proficiencies in WotLK are class-based, not race-based, so
+            // using RACE_HUMAN here is acceptable as a placeholder. Otherwise,
+            // method GetSkillRaceClassInfo should be splitted into two separate
+            // methods for race and class.
+            if (GetSkillRaceClassInfo(skillId, RACE_HUMAN, cls))
+                m_weaponProficiency[cls] |= (1u << subClass);
+        }
+    }
 }
 
-std::vector<uint32> RandomItemMgr::GetCachedEquipments(uint32 requiredLevel, uint32 inventoryType)
+void RandomItemMgr::InitPredicates()
 {
-    return equipCacheNew[requiredLevel][inventoryType];
+    predicates[RANDOM_ITEM_GUILD_TASK] = new RandomItemGuildTaskPredicate();
+    predicates[RANDOM_ITEM_GUILD_TASK_REWARD_EQUIP_GREEN] = new RandomItemGuildTaskRewardPredicate(true, false);
+    predicates[RANDOM_ITEM_GUILD_TASK_REWARD_EQUIP_BLUE] = new RandomItemGuildTaskRewardPredicate(true, true);
+    predicates[RANDOM_ITEM_GUILD_TASK_REWARD_TRADE] = new RandomItemGuildTaskRewardPredicate(false, false);
+    predicates[RANDOM_ITEM_GUILD_TASK_REWARD_TRADE_RARE] = new RandomItemGuildTaskRewardPredicate(false, true);
+}
+
+void RandomItemMgr::InitViableSlots()
+{
+    auto addEquipmentSlot = [&](InventoryType invType, EquipmentSlots slot)
+    {
+        viableSlots[invType].push_back(slot);
+    };
+
+    addEquipmentSlot(INVTYPE_HEAD,           EQUIPMENT_SLOT_HEAD);
+    addEquipmentSlot(INVTYPE_NECK,           EQUIPMENT_SLOT_NECK);
+    addEquipmentSlot(INVTYPE_SHOULDERS,      EQUIPMENT_SLOT_SHOULDERS);
+    addEquipmentSlot(INVTYPE_BODY,           EQUIPMENT_SLOT_BODY);
+    addEquipmentSlot(INVTYPE_CHEST,          EQUIPMENT_SLOT_CHEST);
+    addEquipmentSlot(INVTYPE_ROBE,           EQUIPMENT_SLOT_CHEST);
+    addEquipmentSlot(INVTYPE_WAIST,          EQUIPMENT_SLOT_WAIST);
+    addEquipmentSlot(INVTYPE_LEGS,           EQUIPMENT_SLOT_LEGS);
+    addEquipmentSlot(INVTYPE_FEET,           EQUIPMENT_SLOT_FEET);
+    addEquipmentSlot(INVTYPE_WRISTS,         EQUIPMENT_SLOT_WRISTS);
+    addEquipmentSlot(INVTYPE_HANDS,          EQUIPMENT_SLOT_HANDS);
+    addEquipmentSlot(INVTYPE_FINGER,         EQUIPMENT_SLOT_FINGER1);
+    addEquipmentSlot(INVTYPE_FINGER,         EQUIPMENT_SLOT_FINGER2);
+    addEquipmentSlot(INVTYPE_TRINKET,        EQUIPMENT_SLOT_TRINKET1);
+    addEquipmentSlot(INVTYPE_TRINKET,        EQUIPMENT_SLOT_TRINKET2);
+
+    addEquipmentSlot(INVTYPE_WEAPON,         EQUIPMENT_SLOT_MAINHAND);
+    addEquipmentSlot(INVTYPE_2HWEAPON,       EQUIPMENT_SLOT_MAINHAND);
+    addEquipmentSlot(INVTYPE_WEAPONMAINHAND, EQUIPMENT_SLOT_MAINHAND);
+
+    addEquipmentSlot(INVTYPE_WEAPON,         EQUIPMENT_SLOT_OFFHAND);
+    addEquipmentSlot(INVTYPE_WEAPONOFFHAND,  EQUIPMENT_SLOT_OFFHAND);
+    addEquipmentSlot(INVTYPE_SHIELD,         EQUIPMENT_SLOT_OFFHAND);
+    addEquipmentSlot(INVTYPE_HOLDABLE,       EQUIPMENT_SLOT_OFFHAND);
+
+    addEquipmentSlot(INVTYPE_RANGED,         EQUIPMENT_SLOT_RANGED);
+    addEquipmentSlot(INVTYPE_THROWN,         EQUIPMENT_SLOT_RANGED);
+    addEquipmentSlot(INVTYPE_RANGEDRIGHT,    EQUIPMENT_SLOT_RANGED);
+    addEquipmentSlot(INVTYPE_RELIC,          EQUIPMENT_SLOT_RANGED);
+
+    addEquipmentSlot(INVTYPE_TABARD,         EQUIPMENT_SLOT_TABARD);
+    addEquipmentSlot(INVTYPE_CLOAK,          EQUIPMENT_SLOT_BACK);
+}
+
+void RandomItemMgr::InitWeightLinks()
+{
+    // primary stats
+    weightStatLink["sta"] = ITEM_MOD_STAMINA;
+    weightStatLink["str"] = ITEM_MOD_STRENGTH;
+    weightStatLink["agi"] = ITEM_MOD_AGILITY;
+    weightStatLink["int"] = ITEM_MOD_INTELLECT;
+    weightStatLink["spi"] = ITEM_MOD_SPIRIT;
+
+    // offensive stats
+    weightStatLink["splpwr"] = ITEM_MOD_SPELL_POWER;
+    weightStatLink["atkpwr"] = ITEM_MOD_ATTACK_POWER;
+    weightStatLink["exprtng"] = ITEM_MOD_EXPERTISE_RATING;
+    weightStatLink["critstrkrtng"] = ITEM_MOD_CRIT_RATING;
+    weightStatLink["hitrtng"] = ITEM_MOD_HIT_RATING;
+    weightStatLink["hastertng"] = ITEM_MOD_HASTE_RATING;
+    weightStatLink["armorpenrtng"] = ITEM_MOD_ARMOR_PENETRATION_RATING;
+
+    // defensive stats
+    weightStatLink["defrtng"] = ITEM_MOD_DEFENSE_SKILL_RATING;
+    weightStatLink["dodgertng"] = ITEM_MOD_DODGE_RATING;
+    weightStatLink["block"] = ITEM_MOD_BLOCK_VALUE;
+    weightStatLink["blockrtng"] = ITEM_MOD_BLOCK_RATING;
+    weightStatLink["parryrtng"] = ITEM_MOD_PARRY_RATING;
+
+    // misc
+    weightStatLink["manargn"] = ITEM_MOD_MANA_REGENERATION;
+
+    // combat rating links
+    weightRatingLink["exprtng"] = CR_EXPERTISE;
+    weightRatingLink["critstrkrtng"] = CR_CRIT_MELEE;
+    weightRatingLink["hitrtng"] = CR_HIT_MELEE;
+    weightRatingLink["hastertng"] = CR_HASTE_MELEE;
+    weightRatingLink["armorpenrtng"] = CR_ARMOR_PENETRATION;
+    weightRatingLink["defrtng"] = CR_DEFENSE_SKILL;
+    weightRatingLink["dodgertng"] = CR_DODGE;
+    weightRatingLink["blockrtng"] = CR_BLOCK;
+    weightRatingLink["parryrtng"] = CR_PARRY;
+}
+
+bool RandomItemMgr::LoadCacheEquip()
+{
+    uint32 const oldMSTime = getMSTime();
+
+    LOG_INFO("server.loading", "Loading equipment cache...");
+
+    PreparedQueryResult result =
+        PlayerbotsDatabase.Query(PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_SEL_EQUIP_CACHE));
+
+    if (!result)
+    {
+        LOG_WARN("server.loading", ">> Loaded 0 equipment items. DB table `playerbots_equip_cache` is empty!");
+        LOG_INFO("server.loading", " ");
+        return false;
+    }
+
+    uint32 count = 0;
+    do
+    {
+        Field* fields  = result->Fetch();
+        uint8  clazz   = fields[0].Get<uint8>();
+        uint32 level   = fields[1].Get<uint32>();
+        uint8  slot    = fields[2].Get<uint8>();
+        uint32 quality = fields[3].Get<uint32>();
+        uint32 itemId  = fields[4].Get<uint32>();
+
+        BotEquipKey key(level, clazz, slot, quality);
+        equipCache[key].push_back(itemId);
+
+        ++count;
+    } while (result->NextRow());
+
+    LOG_INFO("server.loading", ">> Loaded {} equipment records in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
+    LOG_INFO("server.loading", " ");
+
+    return true;
+}
+
+bool RandomItemMgr::LoadCacheRandomItem()
+{
+    uint32 const oldMSTime = getMSTime();
+
+    LOG_INFO("server.loading", "Loading random item cache...");
+
+    PreparedQueryResult result =
+        PlayerbotsDatabase.Query(PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_SEL_RNDITEM_CACHE));
+
+    if (!result)
+    {
+        LOG_WARN("server.loading", ">> Loaded 0 random items. DB table `playerbots_rnditem_cache` is empty!");
+        LOG_INFO("server.loading", " ");
+        return false;
+    }
+
+    uint32 count = 0;
+    do
+    {
+        Field* fields = result->Fetch();
+        uint32 bucket = fields[0].Get<uint32>();
+        uint32 type   = fields[1].Get<uint32>();
+        uint32 itemId = fields[2].Get<uint32>();
+
+        RandomItemType const rit = static_cast<RandomItemType>(type);
+
+        randomItemCache[bucket][rit].push_back(itemId);
+
+        ++count;
+    } while (result->NextRow());
+
+    LOG_INFO("server.loading", ">> Loaded {} random item records in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
+    LOG_INFO("server.loading", " ");
+
+    return true;
+}
+
+bool RandomItemMgr::LoadCacheRarity()
+{
+    uint32 const oldMSTime = getMSTime();
+
+    LOG_INFO("server.loading", "Loading items rarity cache...");
+
+    PreparedQueryResult result =
+        PlayerbotsDatabase.Query(PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_SEL_RARITY_CACHE));
+
+    if (!result)
+    {
+        LOG_WARN("server.loading", ">> Loaded 0 rarity items. DB table `playerbots_rarity_cache` is empty!");
+        LOG_INFO("server.loading", " ");
+        return false;
+    }
+
+    do
+    {
+        Field* fields = result->Fetch();
+        uint32 itemId = fields[0].Get<uint32>();
+        float rarity  = fields[1].Get<float>();
+
+        rarityCache[itemId] = rarity;
+    } while (result->NextRow());
+
+    LOG_INFO("server.loading", ">> Loaded {} items rarity records in {} ms", rarityCache.size(),
+             GetMSTimeDiffToNow(oldMSTime));
+    LOG_INFO("server.loading", " ");
+
+    return true;
 }
 
 void RandomItemMgr::LoadEnchantmentPool()
@@ -477,398 +1821,251 @@ void RandomItemMgr::LoadEnchantmentPool()
     LOG_INFO("playerbots", "Loaded {} item enchantment pool rows for bot autogear", count);
 }
 
-std::vector<uint32> const& RandomItemMgr::GetEnchantmentPool(uint32 entry) const
+void RandomItemMgr::BuildCacheRandomItem()
 {
-    static std::vector<uint32> const empty;
-    auto it = enchPoolCache.find(entry);
-    if (it == enchPoolCache.end())
-        return empty;
-    return it->second;
-}
+    uint32 const oldMSTime = getMSTime();
 
-bool RandomItemMgr::ShouldEquipArmorForSpec(uint8 playerclass, uint8 spec, ItemTemplate const* proto)
-{
-    if (proto->InventoryType == INVTYPE_TABARD)
-        return true;
+    ItemTemplateContainer const* itemTemplates = sObjectMgr->GetItemTemplateStore();
+    LOG_INFO("server.loading", "Building random item cache from {} items", itemTemplates->size());
 
-    if (!m_weightScales[playerclass][spec].info.id)
-        return false;
+    PlayerbotsDatabaseTransaction trans = PlayerbotsDatabase.BeginTransaction();
 
-    std::unordered_set<uint32> resultArmorSubClass = {ITEM_SUBCLASS_ARMOR_CLOTH};
-
-    switch (playerclass)
+    uint32 count = 0;
+    for (auto const& itr : *itemTemplates)
     {
-        case CLASS_WARRIOR:
-        {
-            if (proto->InventoryType == INVTYPE_HOLDABLE)
-                return false;
+        ItemTemplate const* proto = &itr.second;
 
-            if (m_weightScales[playerclass][spec].info.name == "arms" ||
-                m_weightScales[playerclass][spec].info.name == "fury")
-            {
-                resultArmorSubClass = {ITEM_SUBCLASS_ARMOR_LEATHER, ITEM_SUBCLASS_ARMOR_MAIL,
-                                       ITEM_SUBCLASS_ARMOR_PLATE};
-            }
-            else
-                resultArmorSubClass = {ITEM_SUBCLASS_ARMOR_MAIL, ITEM_SUBCLASS_ARMOR_PLATE};
-            break;
-        }
-        case CLASS_DEATH_KNIGHT:
-        {
-            if (proto->InventoryType == INVTYPE_HOLDABLE)
-                return false;
-
-            resultArmorSubClass = {ITEM_SUBCLASS_ARMOR_SIGIL, ITEM_SUBCLASS_ARMOR_PLATE};
-        }
-        case CLASS_PALADIN:
-        {
-            if (m_weightScales[playerclass][spec].info.name != "holy" && proto->InventoryType == INVTYPE_HOLDABLE)
-                return false;
-
-            if (m_weightScales[playerclass][spec].info.name != "holy")
-                resultArmorSubClass = {ITEM_SUBCLASS_ARMOR_MAIL, ITEM_SUBCLASS_ARMOR_PLATE, ITEM_SUBCLASS_ARMOR_LIBRAM};
-            else
-                resultArmorSubClass = {ITEM_SUBCLASS_ARMOR_CLOTH, ITEM_SUBCLASS_ARMOR_LEATHER, ITEM_SUBCLASS_ARMOR_MAIL,
-                                       ITEM_SUBCLASS_ARMOR_PLATE, ITEM_SUBCLASS_ARMOR_LIBRAM};
-            break;
-        }
-        case CLASS_HUNTER:
-        {
-            if (proto->InventoryType == INVTYPE_HOLDABLE)
-                return false;
-
-            resultArmorSubClass = {ITEM_SUBCLASS_ARMOR_CLOTH, ITEM_SUBCLASS_ARMOR_LEATHER, ITEM_SUBCLASS_ARMOR_MAIL};
-            break;
-        }
-        case CLASS_ROGUE:
-        {
-            if (proto->InventoryType == INVTYPE_HOLDABLE)
-                return false;
-
-            resultArmorSubClass = {ITEM_SUBCLASS_ARMOR_CLOTH, ITEM_SUBCLASS_ARMOR_LEATHER};
-            break;
-        }
-        case CLASS_PRIEST:
-        {
-            resultArmorSubClass = {ITEM_SUBCLASS_ARMOR_CLOTH};
-            break;
-        }
-        case CLASS_SHAMAN:
-        {
-            if (m_weightScales[playerclass][spec].info.name == "enhance" && proto->InventoryType == INVTYPE_HOLDABLE)
-                return false;
-
-            resultArmorSubClass = {ITEM_SUBCLASS_ARMOR_TOTEM, ITEM_SUBCLASS_ARMOR_CLOTH, ITEM_SUBCLASS_ARMOR_LEATHER,
-                                   ITEM_SUBCLASS_ARMOR_MAIL};
-            break;
-        }
-        case CLASS_MAGE:
-        case CLASS_WARLOCK:
-        {
-            resultArmorSubClass = {ITEM_SUBCLASS_ARMOR_CLOTH};
-            break;
-        }
-        case CLASS_DRUID:
-        {
-            if ((m_weightScales[playerclass][spec].info.name == "feraltank" ||
-                 m_weightScales[playerclass][spec].info.name == "feraldps") &&
-                proto->InventoryType == INVTYPE_HOLDABLE)
-                return false;
-
-            resultArmorSubClass = {ITEM_SUBCLASS_ARMOR_IDOL, ITEM_SUBCLASS_ARMOR_CLOTH, ITEM_SUBCLASS_ARMOR_LEATHER};
-            break;
-        }
-    }
-
-    return resultArmorSubClass.find(proto->SubClass) != resultArmorSubClass.end();
-}
-
-bool RandomItemMgr::ShouldEquipWeaponForSpec(uint8 playerclass, uint8 spec, ItemTemplate const* proto)
-{
-    EquipmentSlots slot_mh = EQUIPMENT_SLOT_START;
-    EquipmentSlots slot_oh = EQUIPMENT_SLOT_START;
-    EquipmentSlots slot_rh = EQUIPMENT_SLOT_START;
-    for (std::map<EquipmentSlots, std::set<InventoryType> >::iterator i = viableSlots.begin(); i != viableSlots.end();
-         ++i)
-    {
-        std::set<InventoryType> slots = viableSlots[(EquipmentSlots)i->first];
-        if (slots.find((InventoryType)proto->InventoryType) != slots.end())
-        {
-            if (i->first == EQUIPMENT_SLOT_MAINHAND)
-                slot_mh = i->first;
-            if (i->first == EQUIPMENT_SLOT_OFFHAND)
-                slot_oh = i->first;
-            if (i->first == EQUIPMENT_SLOT_RANGED)
-                slot_rh = i->first;
-        }
-    }
-
-    if (slot_mh == EQUIPMENT_SLOT_START && slot_oh == EQUIPMENT_SLOT_START && slot_rh == EQUIPMENT_SLOT_START)
-        return false;
-
-    if (!m_weightScales[playerclass][spec].info.id)
-        return false;
-
-    std::unordered_set<uint32> mh_weapons;
-    std::unordered_set<uint32> oh_weapons;
-    std::unordered_set<uint32> r_weapons;
-
-    switch (playerclass)
-    {
-        case CLASS_WARRIOR:
-        {
-            if (m_weightScales[playerclass][spec].info.name == "prot")
-            {
-                mh_weapons = {ITEM_SUBCLASS_WEAPON_SWORD, ITEM_SUBCLASS_WEAPON_AXE, ITEM_SUBCLASS_WEAPON_MACE,
-                              ITEM_SUBCLASS_WEAPON_DAGGER, ITEM_SUBCLASS_WEAPON_FIST};
-                oh_weapons = {ITEM_SUBCLASS_ARMOR_SHIELD};
-                r_weapons = {ITEM_SUBCLASS_WEAPON_BOW, ITEM_SUBCLASS_WEAPON_CROSSBOW, ITEM_SUBCLASS_WEAPON_GUN};
-            }
-            else
-            {
-                mh_weapons = {ITEM_SUBCLASS_WEAPON_SWORD2, ITEM_SUBCLASS_WEAPON_AXE2, ITEM_SUBCLASS_WEAPON_MACE2,
-                              ITEM_SUBCLASS_WEAPON_STAFF, ITEM_SUBCLASS_WEAPON_POLEARM};
-                r_weapons = {ITEM_SUBCLASS_WEAPON_BOW, ITEM_SUBCLASS_WEAPON_CROSSBOW, ITEM_SUBCLASS_WEAPON_GUN};
-            }
-            break;
-        }
-        case CLASS_PALADIN:
-        {
-            if (m_weightScales[playerclass][spec].info.name == "prot")
-            {
-                mh_weapons = {ITEM_SUBCLASS_WEAPON_SWORD, ITEM_SUBCLASS_WEAPON_AXE, ITEM_SUBCLASS_WEAPON_MACE};
-                oh_weapons = {ITEM_SUBCLASS_ARMOR_SHIELD};
-                r_weapons = {ITEM_SUBCLASS_ARMOR_LIBRAM};
-            }
-            else if (m_weightScales[playerclass][spec].info.name == "holy")
-            {
-                mh_weapons = {ITEM_SUBCLASS_WEAPON_SWORD, ITEM_SUBCLASS_WEAPON_AXE, ITEM_SUBCLASS_WEAPON_MACE};
-                oh_weapons = {ITEM_SUBCLASS_ARMOR_SHIELD, ITEM_SUBCLASS_ARMOR_MISC};
-                r_weapons = {ITEM_SUBCLASS_ARMOR_LIBRAM};
-            }
-            else
-            {
-                mh_weapons = {ITEM_SUBCLASS_WEAPON_SWORD2, ITEM_SUBCLASS_WEAPON_AXE2, ITEM_SUBCLASS_WEAPON_MACE2,
-                              ITEM_SUBCLASS_WEAPON_POLEARM};
-                r_weapons = {ITEM_SUBCLASS_ARMOR_LIBRAM};
-            }
-            break;
-        }
-        case CLASS_HUNTER:
-        {
-            mh_weapons = {ITEM_SUBCLASS_WEAPON_SWORD2, ITEM_SUBCLASS_WEAPON_AXE2, ITEM_SUBCLASS_WEAPON_STAFF,
-                          ITEM_SUBCLASS_WEAPON_POLEARM};
-            r_weapons = {ITEM_SUBCLASS_WEAPON_BOW, ITEM_SUBCLASS_WEAPON_CROSSBOW, ITEM_SUBCLASS_WEAPON_GUN};
-            break;
-        }
-        case CLASS_ROGUE:
-        {
-            mh_weapons = {ITEM_SUBCLASS_WEAPON_DAGGER};
-            oh_weapons = {ITEM_SUBCLASS_WEAPON_DAGGER};
-            r_weapons = {ITEM_SUBCLASS_WEAPON_BOW, ITEM_SUBCLASS_WEAPON_CROSSBOW, ITEM_SUBCLASS_WEAPON_GUN};
-            break;
-        }
-        case CLASS_PRIEST:
-        {
-            mh_weapons = {ITEM_SUBCLASS_WEAPON_STAFF, ITEM_SUBCLASS_WEAPON_DAGGER, ITEM_SUBCLASS_WEAPON_MACE};
-            oh_weapons = {ITEM_SUBCLASS_ARMOR_MISC};
-            r_weapons = {ITEM_SUBCLASS_WEAPON_WAND};
-            break;
-        }
-        case CLASS_SHAMAN:
-        {
-            if (m_weightScales[playerclass][spec].info.name == "resto")
-            {
-                mh_weapons = {ITEM_SUBCLASS_WEAPON_DAGGER, ITEM_SUBCLASS_WEAPON_AXE, ITEM_SUBCLASS_WEAPON_MACE,
-                              ITEM_SUBCLASS_WEAPON_FIST};
-                oh_weapons = {ITEM_SUBCLASS_ARMOR_MISC, ITEM_SUBCLASS_ARMOR_SHIELD};
-                r_weapons = {ITEM_SUBCLASS_ARMOR_TOTEM};
-            }
-            else if (m_weightScales[playerclass][spec].info.name == "enhance")
-            {
-                mh_weapons = {ITEM_SUBCLASS_WEAPON_MACE2, ITEM_SUBCLASS_WEAPON_AXE2, ITEM_SUBCLASS_WEAPON_DAGGER,
-                              ITEM_SUBCLASS_WEAPON_AXE,   ITEM_SUBCLASS_WEAPON_MACE, ITEM_SUBCLASS_WEAPON_FIST};
-                oh_weapons = {ITEM_SUBCLASS_ARMOR_SHIELD};
-                r_weapons = {ITEM_SUBCLASS_ARMOR_TOTEM};
-            }
-            else
-            {
-                mh_weapons = {ITEM_SUBCLASS_WEAPON_STAFF};
-                r_weapons = {ITEM_SUBCLASS_ARMOR_TOTEM};
-            }
-            break;
-        }
-        case CLASS_MAGE:
-        case CLASS_WARLOCK:
-        {
-            mh_weapons = {ITEM_SUBCLASS_WEAPON_STAFF, ITEM_SUBCLASS_WEAPON_DAGGER, ITEM_SUBCLASS_WEAPON_SWORD};
-            oh_weapons = {ITEM_SUBCLASS_ARMOR_MISC};
-            r_weapons = {ITEM_SUBCLASS_WEAPON_WAND};
-            break;
-        }
-        case CLASS_DRUID:
-        {
-            if (m_weightScales[playerclass][spec].info.name == "feraltank")
-            {
-                mh_weapons = {ITEM_SUBCLASS_WEAPON_STAFF, ITEM_SUBCLASS_WEAPON_MACE2};
-                r_weapons = {ITEM_SUBCLASS_ARMOR_IDOL};
-            }
-            else if (m_weightScales[playerclass][spec].info.name == "resto")
-            {
-                mh_weapons = {ITEM_SUBCLASS_WEAPON_STAFF, ITEM_SUBCLASS_WEAPON_DAGGER, ITEM_SUBCLASS_WEAPON_FIST,
-                              ITEM_SUBCLASS_WEAPON_MACE};
-                oh_weapons = {ITEM_SUBCLASS_ARMOR_MISC};
-                r_weapons = {ITEM_SUBCLASS_ARMOR_IDOL};
-            }
-            else if (m_weightScales[playerclass][spec].info.name == "feraldps")
-            {
-                mh_weapons = {ITEM_SUBCLASS_WEAPON_STAFF, ITEM_SUBCLASS_WEAPON_MACE2};
-                r_weapons = {ITEM_SUBCLASS_ARMOR_IDOL};
-            }
-            else
-            {
-                mh_weapons = {ITEM_SUBCLASS_WEAPON_STAFF};
-                r_weapons = {ITEM_SUBCLASS_ARMOR_IDOL};
-            }
-            break;
-        }
-    }
-
-    if (slot_mh == EQUIPMENT_SLOT_MAINHAND)
-    {
-        return mh_weapons.find(proto->SubClass) != mh_weapons.end();
-    }
-
-    if (slot_oh == EQUIPMENT_SLOT_OFFHAND)
-    {
-        return oh_weapons.find(proto->SubClass) != oh_weapons.end();
-    }
-
-    if (slot_rh == EQUIPMENT_SLOT_RANGED)
-    {
-        return r_weapons.find(proto->SubClass) != r_weapons.end();
-    }
-
-    return false;
-}
-
-bool RandomItemMgr::CanEquipArmor(uint8 clazz, uint32 level, ItemTemplate const* proto)
-{
-    if (proto->InventoryType == INVTYPE_TABARD)
-        return true;
-
-    if ((clazz == CLASS_WARRIOR || clazz == CLASS_PALADIN || clazz == CLASS_SHAMAN) &&
-        proto->SubClass == ITEM_SUBCLASS_ARMOR_SHIELD)
-        return true;
-
-    if ((clazz == CLASS_WARRIOR || clazz == CLASS_PALADIN) && level >= 40)
-    {
-        if (proto->SubClass != ITEM_SUBCLASS_ARMOR_PLATE && proto->InventoryType != INVTYPE_CLOAK)
-            return false;
-    }
-
-    if (((clazz == CLASS_WARRIOR || clazz == CLASS_PALADIN) && level < 40) ||
-        ((clazz == CLASS_HUNTER || clazz == CLASS_SHAMAN) && level >= 40))
-    {
-        if (proto->SubClass != ITEM_SUBCLASS_ARMOR_MAIL && proto->InventoryType != INVTYPE_CLOAK)
-            return false;
-    }
-
-    if (((clazz == CLASS_HUNTER || clazz == CLASS_SHAMAN) && level < 40) ||
-        (clazz == CLASS_DRUID || clazz == CLASS_ROGUE))
-    {
-        if (proto->SubClass != ITEM_SUBCLASS_ARMOR_LEATHER && proto->InventoryType != INVTYPE_CLOAK)
-            return false;
-    }
-
-    if (proto->Quality <= ITEM_QUALITY_NORMAL)
-        return true;
-
-    uint8 sp = 0, ap = 0, tank = 0;
-    for (uint8 j = 0; j < MAX_ITEM_PROTO_STATS; ++j)
-    {
-        // for ItemStatValue != 0
-        if (!proto->ItemStat[j].ItemStatValue)
+        // skip items that fail basic validatoin (level, duration, flags, etc.)
+        if (!IsValidItem(proto))
             continue;
 
-        AddItemStats(proto->ItemStat[j].ItemStatType, sp, ap, tank);
+        // skip items with no sell price
+        if (proto->SellPrice == 0)
+            continue;
+
+        uint32 const level = proto->ItemLevel;
+        uint32 const bucket = (level - 1) / 10;
+
+        for (uint8 type = RANDOM_ITEM_GUILD_TASK; type <= RANDOM_ITEM_GUILD_TASK_REWARD_TRADE_RARE; ++type)
+        {
+            RandomItemType const rit = static_cast<RandomItemType>(type);
+            if (predicates[rit] && !predicates[rit]->Apply(proto))
+                continue;
+
+            randomItemCache[bucket][rit].push_back(itr.first);
+            ++count;
+
+            PlayerbotsDatabasePreparedStatement* stmt =
+                PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_INS_RNDITEM_CACHE);
+            stmt->SetData(0, bucket);
+            stmt->SetData(1, type);
+            stmt->SetData(2, itr.first);
+            trans->Append(stmt);
+        }
     }
 
-    return CheckItemStats(clazz, sp, ap, tank);
+    PlayerbotsDatabase.CommitTransaction(trans);
+
+    LOG_INFO("server.loading", ">> Cached total {} random items in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
+    LOG_INFO("server.loading", " ");
 }
 
-bool RandomItemMgr::CanEquipWeapon(uint8 clazz, ItemTemplate const* proto)
+void RandomItemMgr::BuildCacheEquip()
 {
-    switch (clazz)
+    uint32 const oldMSTime = getMSTime();
+
+    LOG_INFO("server.loading", "Building equipment cache for {} levels...", DEFAULT_MAX_LEVEL);
+
+    ItemTemplateContainer const* itemTemplates = sObjectMgr->GetItemTemplateStore();
+
+    PlayerbotsDatabaseTransaction trans = PlayerbotsDatabase.BeginTransaction();
+
+    bool weaponOK = false;
+    bool armorOKBelow40Lvl = false;
+    bool armorOKAbove40Lvl = false;
+
+    uint32 count = 0;
+    for (auto const& itr : *itemTemplates)
     {
-        case CLASS_PRIEST:
-            if (proto->SubClass != ITEM_SUBCLASS_WEAPON_STAFF && proto->SubClass != ITEM_SUBCLASS_WEAPON_WAND &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_MACE && proto->SubClass != ITEM_SUBCLASS_WEAPON_DAGGER)
-                return false;
-            break;
-        case CLASS_MAGE:
-        case CLASS_WARLOCK:
-            if (proto->SubClass != ITEM_SUBCLASS_WEAPON_STAFF && proto->SubClass != ITEM_SUBCLASS_WEAPON_WAND &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_DAGGER && proto->SubClass != ITEM_SUBCLASS_WEAPON_SWORD)
-                return false;
-            break;
-        case CLASS_WARRIOR:
-            if (proto->SubClass != ITEM_SUBCLASS_WEAPON_MACE2 && proto->SubClass != ITEM_SUBCLASS_WEAPON_AXE &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_POLEARM && proto->SubClass != ITEM_SUBCLASS_WEAPON_SWORD2 &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_MACE && proto->SubClass != ITEM_SUBCLASS_WEAPON_SWORD &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_GUN && proto->SubClass != ITEM_SUBCLASS_WEAPON_CROSSBOW &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_BOW && proto->SubClass != ITEM_SUBCLASS_WEAPON_THROWN &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_AXE2 && proto->SubClass != ITEM_SUBCLASS_WEAPON_FIST &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_DAGGER && proto->SubClass != ITEM_SUBCLASS_WEAPON_STAFF)
-                return false;
-            break;
-        case CLASS_PALADIN:
-        case CLASS_DEATH_KNIGHT:
-            if (proto->SubClass != ITEM_SUBCLASS_WEAPON_MACE2 && proto->SubClass != ITEM_SUBCLASS_WEAPON_POLEARM &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_SWORD2 && proto->SubClass != ITEM_SUBCLASS_WEAPON_AXE2 &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_AXE && proto->SubClass != ITEM_SUBCLASS_WEAPON_MACE &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_SWORD)
-                return false;
-            break;
-        case CLASS_SHAMAN:
-            if (proto->SubClass != ITEM_SUBCLASS_WEAPON_MACE && proto->SubClass != ITEM_SUBCLASS_WEAPON_AXE &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_FIST && proto->SubClass != ITEM_SUBCLASS_WEAPON_MACE2 &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_AXE2 && proto->SubClass != ITEM_SUBCLASS_WEAPON_DAGGER &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_STAFF)
-                return false;
-            break;
-        case CLASS_DRUID:
-            if (proto->SubClass != ITEM_SUBCLASS_WEAPON_MACE && proto->SubClass != ITEM_SUBCLASS_WEAPON_MACE2 &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_DAGGER && proto->SubClass != ITEM_SUBCLASS_WEAPON_STAFF &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_POLEARM)
-                return false;
-            break;
-        case CLASS_HUNTER:
-            if (proto->SubClass != ITEM_SUBCLASS_WEAPON_DAGGER && proto->SubClass != ITEM_SUBCLASS_WEAPON_BOW &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_AXE2 && proto->SubClass != ITEM_SUBCLASS_WEAPON_AXE &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_SWORD2 && proto->SubClass != ITEM_SUBCLASS_WEAPON_SWORD &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_FIST && proto->SubClass != ITEM_SUBCLASS_WEAPON_GUN &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_CROSSBOW && proto->SubClass != ITEM_SUBCLASS_WEAPON_STAFF &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_POLEARM)
-                return false;
-            break;
-        case CLASS_ROGUE:
-            if (proto->SubClass != ITEM_SUBCLASS_WEAPON_DAGGER && proto->SubClass != ITEM_SUBCLASS_WEAPON_SWORD &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_FIST && proto->SubClass != ITEM_SUBCLASS_WEAPON_MACE &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_GUN && proto->SubClass != ITEM_SUBCLASS_WEAPON_CROSSBOW &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_BOW && proto->SubClass != ITEM_SUBCLASS_WEAPON_THROWN &&
-                proto->SubClass != ITEM_SUBCLASS_WEAPON_AXE)
-                return false;
-            break;
+        ItemTemplate const* proto = &itr.second;
+
+        // skip non-equipment classes
+        if (proto->Class != ITEM_CLASS_WEAPON && proto->Class != ITEM_CLASS_ARMOR)
+            continue;
+
+        // skip legendary, artifact and heirloom quality
+        if (proto->Quality > ITEM_QUALITY_EPIC)
+            continue;
+
+        // skip items that fail basic validatoin (level, duration, flags, etc.)
+        if (!IsValidItem(proto))
+            continue;
+
+        // skip items with no viable equip slot
+        auto const* slots = GetViableSlots(static_cast<InventoryType>(proto->InventoryType));
+        if (!slots)
+            continue;
+
+        for (uint8 clazz = CLASS_WARRIOR; clazz < MAX_CLASSES; ++clazz)
+        {
+            // skip non-playable classes
+            if (((1u << (clazz - 1)) & CLASSMASK_ALL_PLAYABLE) == 0)
+                continue;
+
+            // skip classes that cannot use this item
+            if ((proto->AllowableClass & (1u << (clazz - 1))) == 0)
+                continue;
+
+            // cache CanEquip results before processing level loop
+            weaponOK          = proto->Class == ITEM_CLASS_WEAPON && CanEquipWeapon(proto, clazz);
+            armorOKBelow40Lvl = proto->Class == ITEM_CLASS_ARMOR  && CanEquipArmor(proto, clazz, 1);
+            armorOKAbove40Lvl = proto->Class == ITEM_CLASS_ARMOR  && CanEquipArmor(proto, clazz, 40);
+
+            for (uint32 level = 1; level <= DEFAULT_MAX_LEVEL; ++level)
+            {
+                // skip if item cannot be equipped at this level
+                if (!CanEquipItem(proto, level))
+                    continue;
+
+                // skip weapons the class cannot use
+                if (proto->Class == ITEM_CLASS_WEAPON && !weaponOK)
+                    continue;
+
+                // skip armor the class cannot use at this level bracket
+                if (proto->Class == ITEM_CLASS_ARMOR)
+                {
+                    if ((level < 40 && !armorOKBelow40Lvl) || (level >= 40 && !armorOKAbove40Lvl))
+                        continue;
+                }
+
+                for (EquipmentSlots slot : *slots)
+                {
+                    BotEquipKey key(level, clazz, static_cast<uint8>(slot), proto->Quality);
+
+                    equipCache[key].push_back(itr.first);
+                    ++count;
+
+                    PlayerbotsDatabasePreparedStatement* stmt =
+                        PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_INS_EQUIP_CACHE);
+                    stmt->SetData(0, clazz);
+                    stmt->SetData(1, level);
+                    stmt->SetData(2, slot);
+                    stmt->SetData(3, proto->Quality);
+                    stmt->SetData(4, proto->ItemId);
+                    trans->Append(stmt);
+                }
+            }
+        }
     }
 
-    return true;
+    PlayerbotsDatabase.CommitTransaction(trans);
+
+    LOG_INFO("server.loading", ">> Cached total {} equipment entries in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
+    LOG_INFO("server.loading", " ");
 }
 
-void RandomItemMgr::BuildItemInfoCache()
+void RandomItemMgr::BuildCacheEquipNew()
 {
-    //uint32 maxLevel = sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL); //not used, line marked for removal.
+    uint32 const oldMSTime = getMSTime();
 
+    LOG_INFO("server.loading", "Building equipment cache (new) for {} levels...", DEFAULT_MAX_LEVEL);
+
+    std::unordered_set<uint32> questItemIds;
+    uint32 count = 0;
+
+    auto processQuestItem = [&](uint32 itemId, int32 itemQuestLevel)
+    {
+        // skip empty or already-processed item ids
+        if (!itemId || questItemIds.contains(itemId))
+            return;
+
+        ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
+        if (!proto)
+            return;
+
+        // skip non-equipment classes
+        if (proto->Class != ITEM_CLASS_WEAPON && proto->Class != ITEM_CLASS_ARMOR)
+            return;
+
+        // skip legendary, artifact and heirloom quality
+        if (proto->Quality > ITEM_QUALITY_EPIC)
+            return;
+
+        // skip items that fail basic validatoin (level, duration, flags, etc.)
+        if (!IsValidItem(proto))
+            return;
+
+        // skip items with no viable equip slot
+        InventoryType invType = static_cast<InventoryType>(proto->InventoryType);
+        if (!GetViableSlots(invType))
+            return;
+
+        uint32 const requiredLevel = static_cast<uint32>(
+            std::max(0, std::max(static_cast<int32>(proto->RequiredLevel), itemQuestLevel)));
+
+        equipCacheNew[requiredLevel][invType].push_back(itemId);
+        questItemIds.insert(itemId);
+        ++count;
+    };
+
+    for (auto const& [_, quest] : sObjectMgr->GetQuestTemplates())
+    {
+        // skip repeatable quests
+        if (quest->IsRepeatable())
+            continue;
+
+        // skip quests with invalid or out-of-range level
+        int32 const questLevel = quest->GetQuestLevel();
+        if (questLevel <= 0 || static_cast<uint32>(questLevel) > DEFAULT_MAX_LEVEL)
+            continue;
+
+        // skip class-restricted quests
+        if (quest->GetRequiredClasses())
+            continue;
+
+        for (uint32 i = 0; i < quest->GetRewItemsCount(); ++i)
+            processQuestItem(quest->RewardItemId[i], questLevel);
+
+        for (uint32 i = 0; i < quest->GetRewChoiceItemsCount(); ++i)
+            processQuestItem(quest->RewardChoiceItemId[i], questLevel);
+    }
+
+    ItemTemplateContainer const* itemTemplates = sObjectMgr->GetItemTemplateStore();
+    for (auto const& itr : *itemTemplates)
+    {
+        ItemTemplate const* proto = &itr.second;
+
+        // skip non-equipment classes
+        if (proto->Class != ITEM_CLASS_WEAPON && proto->Class != ITEM_CLASS_ARMOR)
+            continue;
+
+        // skip legendary, artifact and heirloom quality
+        if (proto->Quality > ITEM_QUALITY_EPIC)
+            continue;
+
+        // skip items already added from quests
+        if (questItemIds.contains(proto->ItemId))
+            continue;
+
+        // skip items that fail basic validatoin (level, duration, flags, etc.)
+        if (!IsValidItem(proto))
+            continue;
+
+        // skip items with no viable equip slot
+        InventoryType invType = static_cast<InventoryType>(proto->InventoryType);
+        if (!GetViableSlots(invType))
+            continue;
+
+        equipCacheNew[proto->RequiredLevel][invType].push_back(proto->ItemId);
+        ++count;
+    }
+
+    LOG_INFO("server.loading", ">> Cached total {} equipment entries in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
+    LOG_INFO("server.loading", " ");
+}
+
+void RandomItemMgr::BuildCacheItemInfo()
+{
     // load weightscales
     LOG_INFO("playerbots", "Loading weightscales info");
 
@@ -940,93 +2137,76 @@ void RandomItemMgr::BuildItemInfoCache()
         return;
     }
 
-    // vendor items
-    LOG_INFO("playerbots", "Loading vendor item list...");
+    /**
+     * DEADCODE: Remove or rewrite the code below in the next refactor. Also
+     *           move weightscales loading operations into separate methods.
+     */
 
-    std::set<uint32> vendorItems;
-    vendorItems.clear();
-    if (QueryResult result = WorldDatabase.Query("SELECT item FROM npc_vendor"))
-    {
-        do
-        {
-            Field* fields = result->Fetch();
-            int32 entry = fields[0].Get<int32>();
-            if (entry <= 0)
-                continue;
+    // // vendor items
+    // LOG_INFO("playerbots", "Loading vendor item list...");
 
-            vendorItems.insert(entry);
-        } while (result->NextRow());
-    }
+    // std::set<uint32> vendorItems;
+    // vendorItems.clear();
+    // if (QueryResult result = WorldDatabase.Query("SELECT item FROM npc_vendor"))
+    // {
+    //     do
+    //     {
+    //         Field* fields = result->Fetch();
+    //         int32 entry = fields[0].Get<int32>();
+    //         if (entry <= 0)
+    //             continue;
 
-    LOG_INFO("playerbots", "Loaded {} vendor items...", vendorItems.size());
+    //         vendorItems.insert(entry);
+    //     } while (result->NextRow());
+    // }
 
-    // calculate drop source
-    LOG_INFO("playerbots", "Loading loot templates...");
-    DropMap* dropMap = new DropMap;
+    // LOG_INFO("playerbots", "Loaded {} vendor items...", vendorItems.size());
 
-    if (CreatureTemplateContainer const* creatures = sObjectMgr->GetCreatureTemplates())
-    {
-        for (CreatureTemplateContainer::const_iterator itr = creatures->begin(); itr != creatures->end(); ++itr)
-        {
-            uint32 sEntry = itr->first;
-            if (LootTemplateAccess const* lTemplateA =
-                    DropMapValue::GetLootTemplate(ObjectGuid::Create<HighGuid::Unit>(sEntry, uint32(1)), LOOT_CORPSE))
-                for (auto const& lItem : lTemplateA->Entries)
-                    dropMap->insert(std::make_pair(lItem->itemid, sEntry));
-        }
-    }
+    // // calculate drop source
+    // LOG_INFO("playerbots", "Loading loot templates...");
+    // DropMap* dropMap = new DropMap;
 
-    if (GameObjectTemplateContainer const* gameobjects = sObjectMgr->GetGameObjectTemplates())
-    {
-        for (auto const& itr : *gameobjects)
-        {
-            uint32 sEntry = itr.first;
-            if (LootTemplateAccess const* lTemplateA = DropMapValue::GetLootTemplate(
-                    ObjectGuid::Create<HighGuid::GameObject>(sEntry, uint32(1)), LOOT_CORPSE))
-                for (auto const& lItem : lTemplateA->Entries)
-                    dropMap->insert(std::make_pair(lItem->itemid, sEntry));
-        }
-    }
+    // if (CreatureTemplateContainer const* creatures = sObjectMgr->GetCreatureTemplates())
+    // {
+    //     for (CreatureTemplateContainer::const_iterator itr = creatures->begin(); itr != creatures->end(); ++itr)
+    //     {
+    //         uint32 sEntry = itr->first;
+    //         if (LootTemplateAccess const* lTemplateA =
+    //                 DropMapValue::GetLootTemplate(ObjectGuid::Create<HighGuid::Unit>(sEntry, uint32(1)), LOOT_CORPSE))
+    //             for (auto const& lItem : lTemplateA->Entries)
+    //                 dropMap->insert(std::make_pair(lItem->itemid, sEntry));
+    //     }
+    // }
 
-    LOG_INFO("playerbots", "Loaded {} loot templates...", dropMap->size());
+    // if (GameObjectTemplateContainer const* gameobjects = sObjectMgr->GetGameObjectTemplates())
+    // {
+    //     for (auto const& itr : *gameobjects)
+    //     {
+    //         uint32 sEntry = itr.first;
+    //         if (LootTemplateAccess const* lTemplateA = DropMapValue::GetLootTemplate(
+    //                 ObjectGuid::Create<HighGuid::GameObject>(sEntry, uint32(1)), LOOT_CORPSE))
+    //             for (auto const& lItem : lTemplateA->Entries)
+    //                 dropMap->insert(std::make_pair(lItem->itemid, sEntry));
+    //     }
+    // }
 
-    ItemTemplateContainer const* itemTemplate = sObjectMgr->GetItemTemplateStore();
-    LOG_INFO("playerbots", "Calculating stat weights for {} items...", itemTemplate->size());
+    // LOG_INFO("playerbots", "Loaded {} loot templates...", dropMap->size());
 
-    PlayerbotsDatabaseTransaction trans = PlayerbotsDatabase.BeginTransaction();
+    // ItemTemplateContainer const* itemTemplate = sObjectMgr->GetItemTemplateStore();
+    // LOG_INFO("playerbots", "Calculating stat weights for {} items...", itemTemplate->size());
+
+    /*PlayerbotsDatabaseTransaction trans = PlayerbotsDatabase.BeginTransaction();
 
     for (auto const& itr : *itemTemplate)
     {
         ItemTemplate const* proto = &itr.second;
-        if (!proto)
-            continue;
 
-        // skip test items
-        if (strstr(proto->Name1.c_str(), "(Test)") || strstr(proto->Name1.c_str(), "(TEST)") ||
-            strstr(proto->Name1.c_str(), "(test)") || strstr(proto->Name1.c_str(), "(JEFFTEST)") ||
-            strstr(proto->Name1.c_str(), "Test ") || strstr(proto->Name1.c_str(), "Test") ||
-            strstr(proto->Name1.c_str(), "TEST") || strstr(proto->Name1.c_str(), "TEST ") ||
-            strstr(proto->Name1.c_str(), " TEST") || strstr(proto->Name1.c_str(), "2200 ") ||
-            strstr(proto->Name1.c_str(), "Deprecated ") || strstr(proto->Name1.c_str(), "Unused ") ||
-            strstr(proto->Name1.c_str(), "Monster ") || strstr(proto->Name1.c_str(), "[PH]") ||
-            strstr(proto->Name1.c_str(), "(OLD)") || strstr(proto->Name1.c_str(), "QR") ||
-            strstr(proto->Name1.c_str(), "zzOLD"))
-        {
-            itemForTest.insert(proto->ItemId);
-            continue;
-        }
-
-        if (proto->HasFlag(ITEM_FLAG_DEPRECATED))
-        {
-            itemForTest.insert(proto->ItemId);
-            continue;
-        }
-        // skip items with rank/rep requirements
-        /*if (proto->RequiredHonorRank > 0 ||
-            proto->RequiredSkillRank > 0 ||
-            proto->RequiredCityRank > 0 ||
-            proto->RequiredReputationRank > 0)
-            continue;*/
+        // // skip items with rank/rep requirements
+        // if (proto->RequiredHonorRank > 0 ||
+        //     proto->RequiredSkillRank > 0 ||
+        //     proto->RequiredCityRank > 0 ||
+        //     proto->RequiredReputationRank > 0)
+        //     continue;
 
         // if (proto->RequiredHonorRank > 0 || proto->RequiredSkillRank > 0 || proto->RequiredCityRank > 0)
         //     continue;
@@ -1298,1637 +2478,567 @@ void RandomItemMgr::BuildItemInfoCache()
         // itemInfoCache[cacheInfo.itemId] = std::move(cacheInfo);
     }
 
-    PlayerbotsDatabase.CommitTransaction(trans);
+    PlayerbotsDatabase.CommitTransaction(trans);*/
 }
 
-uint32 RandomItemMgr::CalculateStatWeight(uint8 playerclass, uint8 spec, ItemTemplate const* proto)
+void RandomItemMgr::BuildCacheAmmo()
 {
-    uint32 statWeight = 0;
-    bool isCasterItem = false;
-    bool isAttackItem = false;
-    bool noCaster = (Classes)playerclass == CLASS_WARRIOR || (Classes)playerclass == CLASS_ROGUE ||
-                    (Classes)playerclass == CLASS_DEATH_KNIGHT || (Classes)playerclass == CLASS_HUNTER;
-    uint32 spellPower = 0;
-    uint32 spellHeal = 0;
-    uint32 attackPower = 0;
-    bool hasInt = false;
-    bool hasMana = !((Classes)playerclass == CLASS_WARRIOR || (Classes)playerclass == CLASS_ROGUE ||
-                     (Classes)playerclass == CLASS_DEATH_KNIGHT);
+    uint32 const oldMSTime = getMSTime();
 
-    if (proto->SubClass == ITEM_SUBCLASS_ARMOR_LIBRAM || proto->SubClass == ITEM_SUBCLASS_ARMOR_IDOL ||
-        proto->SubClass == ITEM_SUBCLASS_ARMOR_TOTEM || proto->SubClass == ITEM_SUBCLASS_ARMOR_SIGIL)
-        return (uint32)(proto->Quality + proto->ItemLevel);
+    LOG_INFO("server.loading", "Building ammo cache for {} levels...", DEFAULT_MAX_LEVEL);
 
-    // check basic item stats
-    int32 basicStatsWeight = 0;
-    for (uint8 j = 0; j < MAX_ITEM_PROTO_STATS; ++j)
+    struct AmmoEntry
     {
-        uint32 statType;
-        int32 val;
-        std::string weightName;
+        uint32 entry;
+        uint32 subClass;
+        uint32 itemLevel;
+        uint32 requiredLevel;
+        uint32 stackable;
+    };
 
-        // if (j >= proto->StatsCount)
-        //     continue;
+    std::vector<AmmoEntry> ammoItems;
 
-        statType = proto->ItemStat[j].ItemStatType;
-        val = proto->ItemStat[j].ItemStatValue;
+    ItemTemplateContainer const* itemTemplates = sObjectMgr->GetItemTemplateStore();
+    for (auto const& itr : *itemTemplates)
+    {
+        ItemTemplate const* proto = &itr.second;
 
-        if (val == 0)
+        // skip non-projectile items
+        if (proto->Class != ITEM_CLASS_PROJECTILE)
             continue;
 
-        for (std::map<std::string, uint32>::iterator i = weightStatLink.begin(); i != weightStatLink.end(); ++i)
-        {
-            uint32 modd = i->second;
-            if (modd == statType)
-            {
-                weightName = i->first;
-                break;
-            }
-        }
-
-        if (weightName.empty())
+        // skip non-arrow and non-bullet subclasses
+        if (proto->SubClass != ITEM_SUBCLASS_ARROW && proto->SubClass != ITEM_SUBCLASS_BULLET)
             continue;
 
-        uint32 singleStat = CalculateSingleStatWeight(playerclass, spec, weightName, val);
-        basicStatsWeight += singleStat;
+        // skip items that fail basic validatoin (level, duration, flags, etc.)
+        if (!IsValidItem(proto))
+            continue;
 
-        if (val)
+        // skip items with no required level
+        // NOTE: This filters only three items: 3464 (Feathered Arrow), 3465
+        //       (Exploding Shot), and 4960 (Flash Pellet). In theory we could
+        //       set RequiredLevel = ItemLevel and use that instead.
+        if (proto->RequiredLevel == 0)
+            continue;
+
+        // skip items with no damage value
+        if (proto->Damage[0].DamageMin == 0.0f)
+            continue;
+
+        ammoItems.push_back({itr.first, proto->SubClass, proto->ItemLevel, proto->RequiredLevel,
+                            proto->GetMaxStackSize()});
+    }
+
+    // we want higher stack sizes first, then higher item levels, to ensure bots
+    // use the best available ammo for their current level
+    std::sort(ammoItems.begin(), ammoItems.end(), [](AmmoEntry const& a, AmmoEntry const& b)
+    {
+        if (a.stackable != b.stackable)
+            return a.stackable > b.stackable;
+        return a.itemLevel > b.itemLevel;
+    });
+
+    uint32 count = 0;
+    for (uint32 level = 1; level <= DEFAULT_MAX_LEVEL; ++level)
+    {
+        for (AmmoEntry const& ammo : ammoItems)
         {
-            if (weightName == "int" && !noCaster)
-                isCasterItem = true;
+            // skip ammo above bot's current level
+            if (ammo.requiredLevel > level)
+                continue;
 
-            if (weightName == "int")
-                hasInt = true;
-
-            if (weightName == "splpwr")
-                isCasterItem = true;
-
-            if (weightName == "str")
-                isAttackItem = true;
-
-            if (weightName == "agi")
-                isAttackItem = true;
-
-            if (weightName == "atkpwr")
-                isAttackItem = true;
+            ammoCache[level][ammo.subClass].push_back(ammo.entry);
+            ++count;
         }
     }
 
-    // check armor & block
-    statWeight += CalculateSingleStatWeight(playerclass, spec, "armor", proto->Armor);
-    statWeight += CalculateSingleStatWeight(playerclass, spec, "block", proto->Block);
+    LOG_INFO("server.loading", ">> Cached total {} ammo entries in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
+    LOG_INFO("server.loading", " ");
+}
 
-    // check weapon dps
-    if (proto->IsWeaponVellum())
+void RandomItemMgr::BuildCacheFood()
+{
+    uint32 const oldMSTime = getMSTime();
+
+    LOG_INFO("server.loading", "Building food cache for {} levels...", DEFAULT_MAX_LEVEL);
+
+    constexpr uint32 MAX_FOOD_LEVEL_DELTA = 10;
+
+    uint32 count = 0;
+    ItemTemplateContainer const* itemTemplates = sObjectMgr->GetItemTemplateStore();
+    for (auto const& itr : *itemTemplates)
     {
-        //WeaponAttackType attType = BASE_ATTACK; //not used, line marked for removal.
+        ItemTemplate const* proto = &itr.second;
 
-        uint32 dps = 0;
-        for (uint8 i = 0; i < MAX_ITEM_PROTO_DAMAGES; i++)
-        {
-            if (proto->Damage[i].DamageMax == 0)
-                break;
-
-            dps = (proto->Damage[i].DamageMin + proto->Damage[i].DamageMax) / (float)(proto->Delay / 1000.0f) / 2;
-            if (dps)
-            {
-                if (proto->IsRangedWeapon())
-                    statWeight += CalculateSingleStatWeight(playerclass, spec, "rgddps", dps);
-                else
-                    statWeight += CalculateSingleStatWeight(playerclass, spec, "mledps", dps);
-            }
-        }
-    }
-
-    // check item spells
-    for (auto const& spellData : proto->Spells)
-    {
-        // no spell
-        if (!spellData.SpellId)
+        // skip non-consumable items
+        if (proto->Class != ITEM_CLASS_CONSUMABLE)
             continue;
 
-        // apply only at-equip spells
-        if (spellData.SpellTrigger != ITEM_SPELLTRIGGER_ON_EQUIP)
+        // skip non-food and non-consumable subclasses
+        if (proto->SubClass != ITEM_SUBCLASS_CONSUMABLE && proto->SubClass != ITEM_SUBCLASS_FOOD)
             continue;
 
-        // check if it is valid spell
-        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellData.SpellId);
+        // skip bound items
+        if (proto->Bonding != NO_BIND)
+            continue;
+
+        // skip items that fail basic validatoin (level, duration, flags, etc.)
+        if (!IsValidItem(proto))
+            continue;
+
+        // skip items requiring a profession skill
+        if (proto->RequiredSkill)
+            continue;
+
+        // skip items that are neither food nor drink
+        if (proto->Spells[0].SpellCategory != SPELL_CATEGORY_FOOD &&
+            proto->Spells[0].SpellCategory != SPELL_CATEGORY_DRINK)
+            continue;
+
+        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(proto->Spells[0].SpellId);
         if (!spellInfo)
             continue;
 
-        uint32 spellDamage = 0;
-        uint32 spellHealing = 0;
-        for (uint32 j = 0; j < MAX_SPELL_EFFECTS; j++)
+        // skip items with spell effect inebriate (alcohol)
+        if (spellInfo->HasEffect(SPELL_EFFECT_INEBRIATE))
+            continue;
+
+        uint32 requiredLevel = proto->RequiredLevel;
+        uint32 category = proto->Spells[0].SpellCategory;
+        for (uint32 level = 1; level <= DEFAULT_MAX_LEVEL; level += 10)
         {
-            if (spellInfo->Effects[j].Effect == SPELL_EFFECT_APPLY_AURA && spellInfo->Effects[j].BasePoints)
+            if (requiredLevel)
             {
-                // spell damage
-                // SPELL_AURA_MOD_DAMAGE_DONE
-                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_DAMAGE_DONE)
-                {
-                    spellDamage = spellInfo->Effects[j].BasePoints + 1;
-                }
+                // skip items above the level bucket
+                if (requiredLevel > level)
+                    continue;
 
-                // spell healing
-                // SPELL_AURA_MOD_HEALING_DONE
-                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_HEALING_DONE)
-                {
-                    spellHealing = spellInfo->Effects[j].BasePoints + 1;
-                }
-
-                // check spell power
-                if (spellDamage && spellDamage == spellHealing)
-                {
-                    isCasterItem = true;
-                    spellPower += CalculateSingleStatWeight(playerclass, spec, "splpwr", spellDamage);
-                }
-
-                // spell hit rating (pre tbc)
-                // SPELL_AURA_MOD_SPELL_HIT_CHANCE
-                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_SPELL_HIT_CHANCE)
-                {
-                    statWeight += CalculateSingleStatWeight(playerclass, spec, "spellhitrtng",
-                                                            spellInfo->Effects[j].BasePoints + 1);
-                }
-
-                // spell crit rating (pre tbc)
-                // SPELL_AURA_MOD_SPELL_CRIT_CHANCE
-                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_SPELL_CRIT_CHANCE)
-                {
-                    statWeight += CalculateSingleStatWeight(playerclass, spec, "spellcritstrkrtng",
-                                                            spellInfo->Effects[j].BasePoints + 1);
-                }
-
-                // spell penetration
-                // SPELL_AURA_MOD_TARGET_RESISTANCE
-                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_TARGET_RESISTANCE)
-                {
-                    // check if magic type
-                    if (spellInfo->Effects[j].MiscValue == SPELL_SCHOOL_MASK_SPELL)
-                        statWeight += CalculateSingleStatWeight(playerclass, spec, "spellpenrtng",
-                                                                abs(spellInfo->Effects[j].BasePoints + 1));
-                }
-
-                // check attack power
-                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_ATTACK_POWER)
-                {
-                    isAttackItem = true;
-                    attackPower +=
-                        CalculateSingleStatWeight(playerclass, spec, "atkpwr", spellInfo->Effects[j].BasePoints + 1);
-                }
-
-                // check ranged ap
-                // SPELL_AURA_MOD_RANGED_ATTACK_POWER
-                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_RANGED_ATTACK_POWER)
-                {
-                    isAttackItem = true;
-                    attackPower +=
-                        CalculateSingleStatWeight(playerclass, spec, "atkpwr", spellInfo->Effects[j].BasePoints + 1);
-                }
-
-                // check block
-                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_SHIELD_BLOCKVALUE)
-                {
-                    statWeight +=
-                        CalculateSingleStatWeight(playerclass, spec, "block", spellInfo->Effects[j].BasePoints + 1);
-                }
-
-                // block chance
-                // SPELL_AURA_MOD_BLOCK_PERCENT
-                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_BLOCK_PERCENT)
-                {
-                    statWeight +=
-                        CalculateSingleStatWeight(playerclass, spec, "blockrtng", spellInfo->Effects[j].BasePoints + 1);
-                }
-
-                // armor penetration
-                // SPELL_AURA_MOD_TARGET_RESISTANCE
-                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_TARGET_RESISTANCE)
-                {
-                    // check if physical type
-                    if (spellInfo->Effects[j].MiscValue == SPELL_SCHOOL_MASK_NORMAL)
-                        statWeight += CalculateSingleStatWeight(playerclass, spec, "armorpenrtng",
-                                                                abs(spellInfo->Effects[j].BasePoints + 1));
-                }
-
-                // hit rating (pre tbc)
-                // SPELL_AURA_MOD_HIT_CHANCE
-                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_HIT_CHANCE)
-                {
-                    statWeight +=
-                        CalculateSingleStatWeight(playerclass, spec, "hitrtng", spellInfo->Effects[j].BasePoints + 1);
-                }
-
-                // crit rating (pre tbc)
-                // SPELL_AURA_MOD_HIT_CHANCE
-                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_CRIT_PCT)
-                {
-                    statWeight += CalculateSingleStatWeight(playerclass, spec, "critstrkrtng",
-                                                            spellInfo->Effects[j].BasePoints + 1);
-                }
-
-                // check defense SPELL_AURA_MOD_SKILL
-                // check block
-                // if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_SKILL)
-                //{
-                //    statWeight += CalculateSingleStatWeight(playerclass, spec, "block",
-                //    spellInfo->Effects[j].BasePoints + 1);
-                //}
-
-                // ratings
-                // enum CombatRating
-                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_RATING)
-                {
-                    for (uint32 rating = 0; rating < MAX_COMBAT_RATING; ++rating)
-                    {
-                        if (spellInfo->Effects[j].MiscValue & (1 << rating))
-                        {
-                            int32 val = spellInfo->Effects[j].BasePoints + 1;
-                            std::string weightName;
-
-                            for (std::map<std::string, uint32>::iterator i = weightRatingLink.begin();
-                                 i != weightRatingLink.end(); ++i)
-                            {
-                                uint32 modd = i->second;
-                                if (modd == rating)
-                                {
-                                    weightName = i->first;
-                                    break;
-                                }
-                            }
-
-                            if (weightName.empty())
-                                continue;
-
-                            statWeight += CalculateSingleStatWeight(playerclass, spec, weightName, val);
-                        }
-                    }
-                }
-
-                // mana regen
-                // SPELL_AURA_MOD_POWER_REGEN
-                if (spellInfo->Effects[j].ApplyAuraName == SPELL_AURA_MOD_POWER_REGEN)
-                {
-                    statWeight +=
-                        CalculateSingleStatWeight(playerclass, spec, "manargn", spellInfo->Effects[j].BasePoints + 1);
-                }
+                // skip items below the level bucket window
+                if (level > MAX_FOOD_LEVEL_DELTA && requiredLevel < level - MAX_FOOD_LEVEL_DELTA)
+                    continue;
             }
-        }
-    }
 
-    // check for caster item
-    if (isCasterItem || hasInt)
-    {
-        if ((!hasMana || noCaster) && spellPower)
-            return 0;
-
-        if (!hasMana && hasInt)
-            return 0;
-
-        if ((!hasMana && noCaster && playerclass != CLASS_PALADIN) && spellPower > attackPower)
-            return 0;
-
-        bool playerCaster = false;
-        for (std::vector<WeightScaleStat>::iterator i = m_weightScales[playerclass][spec].stats.begin();
-             i != m_weightScales[playerclass][spec].stats.end(); ++i)
-        {
-            if (i->stat == "splpwr" || i->stat == "int" || i->stat == "manargn")
-            {
-                playerCaster = true;
-            }
-        }
-
-        if (!playerCaster)
-            return 0;
-    }
-
-    // check for caster item
-    if (isAttackItem)
-    {
-        if (hasMana && !noCaster && !(hasInt || spellPower))
-            return 0;
-        // if (!noCaster && attackPower)
-        //     return 0;
-
-        bool playerAttacker = false;
-        for (std::vector<WeightScaleStat>::iterator i = m_weightScales[playerclass][spec].stats.begin();
-             i != m_weightScales[playerclass][spec].stats.end(); ++i)
-        {
-            if (i->stat == "str" || i->stat == "agi" || i->stat == "atkpwr" || i->stat == "mledps" ||
-                i->stat == "rgddps")
-            {
-                playerAttacker = true;
-            }
-        }
-
-        if (!playerAttacker)
-            return 0;
-    }
-
-    statWeight += spellPower;
-    statWeight += spellHeal;
-    statWeight += attackPower;
-
-    // handle negative stats
-    if (basicStatsWeight < 0 && (abs(basicStatsWeight) >= statWeight))
-        statWeight = 0;
-    else
-        statWeight += basicStatsWeight;
-
-    return statWeight;
-}
-
-uint32 RandomItemMgr::CalculateSingleStatWeight(uint8 playerclass, uint8 spec, std::string stat, uint32 value)
-{
-    uint32 statWeight = 0;
-    for (std::vector<WeightScaleStat>::iterator i = m_weightScales[playerclass][spec].stats.begin();
-         i != m_weightScales[playerclass][spec].stats.end(); ++i)
-    {
-        if (stat == i->stat)
-        {
-            statWeight = i->weight * value;
-            // if (statWeight)
-            //     LOG_INFO("playerbots", "stat: {}, val: {}, weight: {}, total: {}, class: {}, spec: {}",
-            //         stat, value, i->weight, statWeight, playerclass, m_weightScales[playerclass][spec].info.name);
-            return statWeight;
-        }
-    }
-
-    return statWeight;
-}
-
-uint32 RandomItemMgr::GetQuestIdForItem(uint32 itemId)
-{
-    bool isQuest = false;
-    uint32 questId = 0;
-    ObjectMgr::QuestMap const& questTemplates = sObjectMgr->GetQuestTemplates();
-    for (ObjectMgr::QuestMap::const_iterator i = questTemplates.begin(); i != questTemplates.end(); ++i)
-    {
-        Quest const* quest = i->second;
-
-        uint32 rewItemCount = quest->GetRewItemsCount();
-        for (uint32 i = 0; i < rewItemCount; ++i)
-        {
-            if (!quest->RewardItemId[i])
-                continue;
-
-            if (quest->RewardItemId[i] == itemId)
-            {
-                isQuest = true;
-                questId = quest->GetQuestId();
-                break;
-            }
-        }
-
-        uint32 rewChocieItemCount = quest->GetRewChoiceItemsCount();
-        for (uint32 i = 0; i < rewChocieItemCount; ++i)
-        {
-            if (!quest->RewardChoiceItemId[i])
-                continue;
-
-            if (quest->RewardChoiceItemId[i] == itemId)
-            {
-                isQuest = true;
-                questId = quest->GetQuestId();
-                break;
-            }
-        }
-        if (isQuest)
-            break;
-    }
-    return questId;
-}
-
-std::vector<uint32> RandomItemMgr::GetQuestIdsForItem(uint32 itemId)
-{
-    std::vector<uint32> questIds;
-    ObjectMgr::QuestMap const& questTemplates = sObjectMgr->GetQuestTemplates();
-    for (ObjectMgr::QuestMap::const_iterator i = questTemplates.begin(); i != questTemplates.end(); ++i)
-    {
-        Quest const* quest = i->second;
-
-        uint32 rewItemCount = quest->GetRewItemsCount();
-        for (uint32 i = 0; i < rewItemCount; ++i)
-        {
-            if (!quest->RewardItemId[i])
-                continue;
-
-            if (quest->RewardItemId[i] == itemId)
-            {
-                questIds.push_back(quest->GetQuestId());
-                break;
-            }
-        }
-
-        uint32 rewChocieItemCount = quest->GetRewChoiceItemsCount();
-        for (uint32 i = 0; i < rewChocieItemCount; ++i)
-        {
-            if (!quest->RewardChoiceItemId[i])
-                continue;
-
-            if (quest->RewardChoiceItemId[i] == itemId)
-            {
-                questIds.push_back(quest->GetQuestId());
-                break;
-            }
-        }
-    }
-
-    return questIds;
-}
-
-uint32 RandomItemMgr::GetUpgrade(Player* player, std::string spec, uint8 slot, uint32 quality, uint32 itemId)
-{
-    if (!player)
-        return 0;
-
-    // get old item statWeight
-    uint32 oldStatWeight = 0;
-    uint32 specId = 0;
-    uint32 closestUpgrade = 0;
-    uint32 closestUpgradeWeight = 0;
-    std::vector<uint32> classspecs;
-
-    for (uint32 specNum = 1; specNum < 5; ++specNum)
-    {
-        if (!m_weightScales[player->getClass()][specNum].info.id)
-            continue;
-
-        classspecs.push_back(m_weightScales[player->getClass()][specNum].info.id);
-
-        if (m_weightScales[player->getClass()][specNum].info.name == spec)
-            specId = m_weightScales[player->getClass()][specNum].info.id;
-    }
-    if (!specId)
-        return 0;
-
-    if (itemId && itemInfoCache.find(itemId) != itemInfoCache.end())
-    {
-        oldStatWeight = itemInfoCache[itemId].weights[specId];
-
-        if (oldStatWeight)
-            LOG_INFO("playerbots", "Old Item: {}, weight: {}", itemId, oldStatWeight);
-        else
-            LOG_INFO("playerbots", "Old item has no stat weight");
-    }
-
-    for (std::map<uint32, ItemInfoEntry>::iterator i = itemInfoCache.begin(); i != itemInfoCache.end(); ++i)
-    {
-        ItemInfoEntry& info = i->second;
-
-        // skip useless items
-        if (info.weights[specId] == 0)
-            continue;
-
-        // skip higher lvl
-        if (info.minLevel > player->GetLevel())
-            continue;
-
-        // skip too low level
-        if (info.minLevel < (player->GetLevel() - 10))
-            continue;
-
-        // skip wrong team
-        if (info.team != TEAM_NEUTRAL && info.team != player->GetTeamId())
-            continue;
-
-        // skip wrong slot
-        if ((EquipmentSlots)info.slot != (EquipmentSlots)slot)
-            continue;
-
-        // skip higher quality
-        if (quality && info.quality != quality)
-            continue;
-
-        // skip worse items
-        if (info.weights[specId] <= oldStatWeight)
-            continue;
-
-        // skip items that only fit in slot, but not stats
-        if (!itemId && info.weights[specId] == 1 && player->GetLevel() > 40)
-            continue;
-
-        // skip quest items
-        if (info.source == ITEM_SOURCE_QUEST)
-        {
-            if (player->GetQuestRewardStatus(info.sourceId) != QUEST_STATUS_COMPLETE)
-                continue;
-        }
-
-        // skip no stats trinkets
-        if (info.weights[specId] == 1 && info.slot == EQUIPMENT_SLOT_NECK || info.slot == EQUIPMENT_SLOT_TRINKET1 ||
-            info.slot == EQUIPMENT_SLOT_TRINKET2 || info.slot == EQUIPMENT_SLOT_FINGER1 ||
-            info.slot == EQUIPMENT_SLOT_FINGER2)
-            continue;
-
-        // check if item stat score is the best among class specs
-        uint32 bestSpecId = 0;
-        uint32 bestSpecScore = 0;
-        for (std::vector<uint32>::iterator i = classspecs.begin(); i != classspecs.end(); ++i)
-        {
-            if (info.weights[*i] > bestSpecScore)
-            {
-                bestSpecId = *i;
-                bestSpecScore = info.weights[specId];
-            }
-        }
-
-        if (bestSpecId && bestSpecId != specId && player->GetLevel() > 40)
-            return 0;
-
-        if (!closestUpgrade)
-        {
-            closestUpgrade = info.itemId;
-            closestUpgradeWeight = info.weights[specId];
-        }
-
-        // pick closest upgrade
-        if (info.weights[specId] < closestUpgradeWeight)
-        {
-            closestUpgrade = info.itemId;
-            closestUpgradeWeight = info.weights[specId];
-        }
-    }
-
-    if (closestUpgrade)
-        LOG_INFO("playerbots", "New Item: {}, weight: {}", closestUpgrade, closestUpgradeWeight);
-
-    return closestUpgrade;
-}
-
-std::vector<uint32> RandomItemMgr::GetUpgradeList(Player* player, std::string spec, uint8 slot, uint32 quality,
-                                                  uint32 itemId, uint32 /*amount*/)
-{
-    std::vector<uint32> listItems;
-    if (!player)
-        return listItems;
-
-    // get old item statWeight
-    uint32 oldStatWeight = 0;
-    uint32 specId = 0;
-    uint32 closestUpgradeWeight = 0;
-    std::vector<uint32> classspecs;
-
-    for (uint32 specNum = 1; specNum < 5; ++specNum)
-    {
-        if (!m_weightScales[player->getClass()][specNum].info.id)
-            continue;
-
-        classspecs.push_back(m_weightScales[player->getClass()][specNum].info.id);
-
-        if (m_weightScales[player->getClass()][specNum].info.name == spec)
-            specId = m_weightScales[player->getClass()][specNum].info.id;
-    }
-
-    if (!specId)
-        return listItems;
-
-    if (itemId && itemInfoCache.find(itemId) != itemInfoCache.end())
-    {
-        oldStatWeight = itemInfoCache[itemId].weights[specId];
-
-        if (oldStatWeight)
-            LOG_INFO("playerbots", "Old Item: {}, weight: {}", itemId, oldStatWeight);
-        else
-            LOG_INFO("playerbots", "Old item has no stat weight");
-    }
-
-    for (std::map<uint32, ItemInfoEntry>::iterator i = itemInfoCache.begin(); i != itemInfoCache.end(); ++i)
-    {
-        ItemInfoEntry& info = i->second;
-
-        // skip useless items
-        if (info.weights[specId] == 0)
-            continue;
-
-        // skip higher lvl
-        if (info.minLevel > player->GetLevel())
-            continue;
-
-        // skip too low level
-        if ((int32)info.minLevel < (int32)(player->GetLevel() - 20))
-            continue;
-
-        // skip wrong team
-        if (info.team != TEAM_NEUTRAL && info.team != player->GetTeamId())
-            continue;
-
-        // skip wrong slot
-        if ((EquipmentSlots)info.slot != (EquipmentSlots)slot)
-            continue;
-
-        // skip higher quality
-        if (quality && info.quality != quality)
-            continue;
-
-        // skip worse items
-        if (info.weights[specId] <= oldStatWeight)
-            continue;
-
-        // skip items that only fit in slot, but not stats
-        if (!itemId && info.weights[specId] == 1 && player->GetLevel() > 40)
-            continue;
-
-        // skip quest items
-        if (info.source == ITEM_SOURCE_QUEST)
-        {
-            if (player->GetQuestRewardStatus(info.sourceId) != QUEST_STATUS_COMPLETE)
-                continue;
-        }
-
-        // skip no stats trinkets
-        if (info.weights[specId] < 2 && (info.slot == EQUIPMENT_SLOT_NECK || info.slot == EQUIPMENT_SLOT_TRINKET1 ||
-                                         info.slot == EQUIPMENT_SLOT_TRINKET2 || info.slot == EQUIPMENT_SLOT_FINGER1 ||
-                                         info.slot == EQUIPMENT_SLOT_FINGER2))
-            continue;
-
-        // if (player->GetLevel() >= 40)
-        //{
-        //     // check if item stat score is the best among class specs
-        //     uint32 bestSpecId = 0;
-        //     uint32 bestSpecScore = 0;
-        //     for (vector<uint32>::iterator i = classspecs.begin(); i != classspecs.end(); ++i)
-        //     {
-        //         if (info->weights[*i] > bestSpecScore)
-        //         {
-        //             bestSpecId = *i;
-        //             bestSpecScore = info->weights[specId];
-        //         }
-        //     }
-
-        //    if (bestSpecId && bestSpecId != specId)
-        //        continue;
-        //}
-
-        listItems.push_back(info.itemId);
-        // continue;
-
-        // pick closest upgrade
-        if (info.weights[specId] > closestUpgradeWeight)
-        {
-            closestUpgradeWeight = info.weights[specId];
-        }
-    }
-
-    if (listItems.size())
-        LOG_INFO("playerbots", "New Items: {}, Old item:%d, New items max: {}", listItems.size(), oldStatWeight,
-                 closestUpgradeWeight);
-
-    return listItems;
-}
-
-bool RandomItemMgr::HasStatWeight(uint32 itemId)
-{
-    auto itr = itemInfoCache.find(itemId);
-    return itr != itemInfoCache.end();
-}
-
-uint32 RandomItemMgr::GetMinLevelFromCache(uint32 itemId)
-{
-    auto itr = itemInfoCache.find(itemId);
-    if (itr == itemInfoCache.end())
-        return 0;
-
-    return itr->second.minLevel;
-}
-
-uint32 RandomItemMgr::GetStatWeight(Player* player, uint32 itemId)
-{
-    if (!player || !itemId)
-        return 0;
-
-    auto itr = itemInfoCache.find(itemId);
-    if (itr == itemInfoCache.end())
-        return 0;
-
-    uint32 statWeight = 0;
-    uint32 specId = 0;
-    std::vector<uint32> classspecs;
-
-    std::string const& specName = AiFactory::GetPlayerSpecName(player);
-    if (specName.empty())
-        return 0;
-
-    for (uint32 specNum = 1; specNum < 5; ++specNum)
-    {
-        if (!m_weightScales[player->getClass()][specNum].info.id)
-            continue;
-
-        classspecs.push_back(m_weightScales[player->getClass()][specNum].info.id);
-
-        if (m_weightScales[player->getClass()][specNum].info.name == specName)
-            specId = m_weightScales[player->getClass()][specNum].info.id;
-
-        if (m_weightScales[player->getClass()][specNum].info.name == specName)
-        {
-            specId = specNum;
-            break;
-        }
-    }
-
-    if (!specId)
-        return 0;
-
-    statWeight = itr->second.weights[specId];
-
-    return statWeight;
-}
-
-uint32 RandomItemMgr::GetLiveStatWeight(Player* player, uint32 itemId)
-{
-    if (!player || !itemId)
-        return 0;
-
-    auto itr = itemInfoCache.find(itemId);
-    if (itr == itemInfoCache.end())
-        return 0;
-
-    uint32 statWeight = 0;
-    uint32 specId = 0;
-    std::vector<uint32> classspecs;
-
-    std::string const& specName = AiFactory::GetPlayerSpecName(player);
-    if (specName.empty())
-        return 0;
-
-    for (uint32 specNum = 1; specNum < 5; ++specNum)
-    {
-        if (!m_weightScales[player->getClass()][specNum].info.id)
-            continue;
-
-        // for bestSpec check
-        // classspecs.push_back(m_weightScales[player->getClass()][specNum].info.id);
-
-        if (m_weightScales[player->getClass()][specNum].info.name == specName)
-            specId = m_weightScales[player->getClass()][specNum].info.id;
-    }
-    if (!specId)
-        return 0;
-
-    statWeight = itr->second.weights[specId];
-
-    // skip higher lvl
-    if (itr->second.minLevel > player->GetLevel())
-        return 0;
-
-    // skip too low level
-    // if ((int32)info->minLevel < (int32)(player->GetLevel() - 20))
-    //    return 0;
-
-    // skip wrong team
-    if (itr->second.team != TEAM_NEUTRAL && itr->second.team != player->GetTeamId())
-        return 0;
-
-    // skip quest items
-    if (itr->second.source == ITEM_SOURCE_QUEST && itr->second.sourceId)
-    {
-        if (player->GetQuestRewardStatus(itr->second.sourceId) != QUEST_STATUS_COMPLETE)
-            return 0;
-    }
-
-    // skip pvp items
-    if (itr->second.source == ITEM_SOURCE_PVP)
-    {
-        if (!player->GetHonorPoints() && !player->GetArenaPoints())
-            return 0;
-    }
-
-    // skip no stats trinkets
-    if (itr->second.weights[specId] == 1 &&
-        (itr->second.slot == EQUIPMENT_SLOT_NECK || itr->second.slot == EQUIPMENT_SLOT_TRINKET1 ||
-         itr->second.slot == EQUIPMENT_SLOT_TRINKET2 || itr->second.slot == EQUIPMENT_SLOT_FINGER1 ||
-         itr->second.slot == EQUIPMENT_SLOT_FINGER2))
-        return 0;
-
-    // skip items that only fit in slot, but not stats
-    if (!itemId && itr->second.weights[specId] == 1 && player->GetLevel() > 20)
-        return 0;
-
-    // check if item stat score is the best among class specs
-    /*uint32 bestSpecId = 0;
-    uint32 bestSpecScore = 0;
-    for (vector<uint32>::iterator i = classspecs.begin(); i != classspecs.end(); ++i)
-    {
-        if (itemCache[itemId]->weights[*i] > bestSpecScore && itemCache[itemId]->weights[*i] > 1)
-        {
-            bestSpecId = *i;
-            bestSpecScore = itemCache[itemId]->weights[specId];
-        }
-    }
-
-    if (bestSpecId && bestSpecId != specId && player->GetLevel() >= 60)
-        return 0;*/
-
-    return statWeight;
-}
-
-void RandomItemMgr::BuildEquipCache()
-{
-    uint32 maxLevel = sPlayerbotAIConfig.randomBotMaxLevel;
-    if (maxLevel > sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL))
-        maxLevel = sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL);
-
-    ItemTemplateContainer const* itemTemplates = sObjectMgr->GetItemTemplateStore();
-
-    PlayerbotsDatabasePreparedStatement* stmt = PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_SEL_EQUIP_CACHE);
-    if (PreparedQueryResult result = PlayerbotsDatabase.Query(stmt))
-    {
-        LOG_INFO("server.loading",
-                 "Loading equipment cache for {} classes, {} levels, {} slots, {} quality from {} items", MAX_CLASSES,
-                 maxLevel, EQUIPMENT_SLOT_END, ITEM_QUALITY_ARTIFACT, itemTemplates->size());
-
-        uint32 count = 0;
-        do
-        {
-            Field* fields = result->Fetch();
-            uint8 clazz = fields[0].Get<uint8>();
-            uint32 level = fields[1].Get<uint32>();
-            uint8 slot = fields[2].Get<uint8>();
-            uint32 quality = fields[3].Get<uint32>();
-            uint32 itemId = fields[4].Get<uint32>();
-
-            BotEquipKey key(level, clazz, slot, quality);
-            equipCache[key].push_back(itemId);
+            foodCache[(level - 1) / 10][category].push_back(itr.first);
             ++count;
-        } while (result->NextRow());
-
-        LOG_INFO("playerbots", "Equipment cache loaded from {} records", count);
-    }
-    else
-    {
-        uint64 total = MAX_CLASSES * maxLevel * EQUIPMENT_SLOT_END * ITEM_QUALITY_ARTIFACT;
-        LOG_INFO("server.loading",
-                 "Building equipment cache for {} classes, {} levels, {} slots, {} quality from {} items ({} total)",
-                 MAX_CLASSES, maxLevel, EQUIPMENT_SLOT_END, ITEM_QUALITY_ARTIFACT, itemTemplates->size(), total);
-
-        for (uint8 class_ = CLASS_WARRIOR; class_ < MAX_CLASSES; ++class_)
-        {
-            // skip nonexistent classes
-            if (!((1 << (class_ - 1)) & CLASSMASK_ALL_PLAYABLE) || !sChrClassesStore.LookupEntry(class_))
-                continue;
-
-            for (uint32 level = 1; level <= maxLevel; ++level)
-            {
-                for (uint8 slot = 0; slot < EQUIPMENT_SLOT_END; ++slot)
-                {
-                    for (uint32 quality = ITEM_QUALITY_POOR; quality <= ITEM_QUALITY_ARTIFACT; ++quality)
-                    {
-                        BotEquipKey key(level, class_, slot, quality);
-
-                        RandomItemList items;
-                        for (auto const& itr : *itemTemplates)
-                        {
-                            ItemTemplate const* proto = &itr.second;
-                            if (!proto)
-                                continue;
-
-                            if (proto->Class != ITEM_CLASS_WEAPON && proto->Class != ITEM_CLASS_ARMOR &&
-                                proto->Class != ITEM_CLASS_CONTAINER && proto->Class != ITEM_CLASS_PROJECTILE)
-                                continue;
-
-                            if (!CanEquipItem(key, proto))
-                                continue;
-
-                            if (proto->Class == ITEM_CLASS_ARMOR &&
-                                (slot == EQUIPMENT_SLOT_HEAD || slot == EQUIPMENT_SLOT_SHOULDERS ||
-                                 slot == EQUIPMENT_SLOT_CHEST || slot == EQUIPMENT_SLOT_WAIST ||
-                                 slot == EQUIPMENT_SLOT_LEGS || slot == EQUIPMENT_SLOT_FEET ||
-                                 slot == EQUIPMENT_SLOT_WRISTS || slot == EQUIPMENT_SLOT_HANDS) &&
-                                !CanEquipArmor(key.clazz, key.level, proto))
-                                continue;
-
-                            if (proto->Class == ITEM_CLASS_WEAPON && !CanEquipWeapon(key.clazz, proto))
-                                continue;
-
-                            if (slot == EQUIPMENT_SLOT_OFFHAND && key.clazz == CLASS_ROGUE &&
-                                proto->Class != ITEM_CLASS_WEAPON)
-                                continue;
-
-                            items.push_back(itr.first);
-
-                            PlayerbotsDatabasePreparedStatement* stmt =
-                                PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_INS_EQUIP_CACHE);
-                            stmt->SetData(0, class_);
-                            stmt->SetData(1, level);
-                            stmt->SetData(2, slot);
-                            stmt->SetData(3, quality);
-                            stmt->SetData(4, proto->ItemId);
-                            PlayerbotsDatabase.Execute(stmt);
-                        }
-
-                        equipCache[key] = items;
-
-                        LOG_DEBUG("playerbots",
-                                  "Equipment cache for class: {}, level {}, slot {}, quality {}: {} items", class_,
-                                  level, slot, quality, items.size());
-                    }
-                }
-            }
         }
-
-        LOG_INFO("server.loading", "Equipment cache saved to DB");
     }
+
+    LOG_INFO("server.loading", ">> Cached total {} food entries in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
+    LOG_INFO("server.loading", " ");
 }
 
-void RandomItemMgr::BuildEquipCacheNew()
+void RandomItemMgr::BuildCachePotion()
 {
-    LOG_INFO("playerbots", "Loading equipments cache...");
+    uint32 const oldMSTime = getMSTime();
 
-    std::unordered_set<uint32> questItemIds;
-    ObjectMgr::QuestMap const& questTemplates = sObjectMgr->GetQuestTemplates();
-    for (ObjectMgr::QuestMap::const_iterator i = questTemplates.begin(); i != questTemplates.end(); ++i)
-    {
-        //uint32 questId = i->first; //not used in this scope, line marked for removal.
-        Quest const* quest = i->second;
+    LOG_INFO("server.loading", "Building potion cache for {} levels...", DEFAULT_MAX_LEVEL);
 
-        if (quest->IsRepeatable())
-            continue;
+    constexpr uint32 MAX_POTION_LEVEL_DELTA = 13;
 
-        if (quest->GetQuestLevel() <= 0)
-            continue;
-
-        if (quest->GetRequiredClasses())
-            continue;
-
-        for (int j = 0; j < quest->GetRewChoiceItemsCount(); j++)
-            if (uint32 itemId = quest->RewardChoiceItemId[j])
-            {
-                ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
-                if (proto->Class != ITEM_CLASS_WEAPON && proto->Class != ITEM_CLASS_ARMOR)
-                    continue;
-                int requiredLevel = std::max((int)proto->RequiredLevel, quest->GetQuestLevel());
-                equipCacheNew[requiredLevel][proto->InventoryType].push_back(itemId);
-                questItemIds.insert(itemId);
-            }
-
-        for (int j = 0; j < quest->GetRewItemsCount(); j++)
-            if (uint32 itemId = quest->RewardItemId[j])
-            {
-                ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
-                if (proto->Class != ITEM_CLASS_WEAPON && proto->Class != ITEM_CLASS_ARMOR)
-                    continue;
-                int requiredLevel = std::max((int)proto->RequiredLevel, quest->GetQuestLevel());
-                equipCacheNew[requiredLevel][proto->InventoryType].push_back(itemId);
-                questItemIds.insert(itemId);
-            }
-    }
-
+    uint32 count = 0;
     ItemTemplateContainer const* itemTemplates = sObjectMgr->GetItemTemplateStore();
     for (auto const& itr : *itemTemplates)
     {
         ItemTemplate const* proto = &itr.second;
-        if (!proto)
-            continue;
-        uint32 itemId = proto->ItemId;
 
-        if (questItemIds.find(itemId) != questItemIds.end())
+        // skip non-consumable items
+        if (proto->Class != ITEM_CLASS_CONSUMABLE)
             continue;
 
-        if (IsTestItem(itemId))
+        // skip non-potion and non-flask subclasses
+        if (proto->SubClass != ITEM_SUBCLASS_POTION && proto->SubClass != ITEM_SUBCLASS_FLASK)
+            continue;
+
+        // skip bound items
+        if (proto->Bonding != NO_BIND)
+            continue;
+
+        // skip items that fail basic validatoin (level, duration, flags, etc.)
+        if (!IsValidItem(proto))
+            continue;
+
+        // skip items requiring a profession skill
+        if (proto->RequiredSkill)
+            continue;
+
+        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(proto->Spells[0].SpellId);
+        if (!spellInfo)
+            continue;
+
+        // skip potions whose primary effect is not heal or energize
+        if (spellInfo->Effects[EFFECT_0].Effect != SPELL_EFFECT_HEAL &&
+            spellInfo->Effects[EFFECT_0].Effect != SPELL_EFFECT_ENERGIZE)
+            continue;
+
+        // do not accept potions/flasks with more than one spell effects, only
+        // first one effect (EFFECT_0) should be set and eq. heal/energize
+        bool hasOtherEffects = false;
+        for (uint8 i = EFFECT_1; i < MAX_SPELL_EFFECTS; ++i)
         {
-            continue;
+            if (spellInfo->Effects[i].Effect != 0)
+            {
+                hasOtherEffects = true;
+                break;
+            }
         }
 
-        if (sPlayerbotAIConfig.unobtainableItems.find(itemId) != sPlayerbotAIConfig.unobtainableItems.end())
+        // skip potions with secondary spell effects
+        if (hasOtherEffects)
             continue;
 
-        equipCacheNew[proto->RequiredLevel][proto->InventoryType].push_back(itemId);
+        uint32 requiredLevel = proto->RequiredLevel;
+        uint32 effect = spellInfo->Effects[EFFECT_0].Effect;
+        for (uint32 level = std::max(1u, requiredLevel); level <= DEFAULT_MAX_LEVEL; ++level)
+        {
+            // skip levels outside the potion relevance window
+            if (level > MAX_POTION_LEVEL_DELTA && level - requiredLevel > MAX_POTION_LEVEL_DELTA)
+                break;
+
+            potionCache[level][effect].push_back(itr.first);
+            ++count;
+        }
     }
+
+    LOG_INFO("server.loading", ">> Cached total {} potion entries in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
+    LOG_INFO("server.loading", " ");
 }
 
-RandomItemList RandomItemMgr::Query(uint32 level, uint8 clazz, uint8 slot, uint32 quality)
+void RandomItemMgr::BuildCacheTrade()
 {
-    // return equipCache[key];
-    BotEquipKey key(level, clazz, slot, quality);
-    RandomItemList items;
+    uint32 const oldMSTime = getMSTime();
+
+    LOG_INFO("server.loading", "Building trade cache for {} levels...", DEFAULT_MAX_LEVEL);
+
+    constexpr uint32 MAX_TRADE_LEVEL_DELTA = 10;
+
+    uint32 count = 0;
     ItemTemplateContainer const* itemTemplates = sObjectMgr->GetItemTemplateStore();
     for (auto const& itr : *itemTemplates)
     {
         ItemTemplate const* proto = &itr.second;
-        if (!proto)
+
+        // skip non-trade-goods
+        if (proto->Class != ITEM_CLASS_TRADE_GOODS)
             continue;
 
-        if (proto->Class != ITEM_CLASS_WEAPON && proto->Class != ITEM_CLASS_ARMOR &&
-            proto->Class != ITEM_CLASS_CONTAINER && proto->Class != ITEM_CLASS_PROJECTILE)
+        // skip bound items
+        if (proto->Bonding != NO_BIND)
             continue;
 
-        if (!CanEquipItem(key, proto))
+        // skip items that fail basic validatoin (level, duration, flags, etc.)
+        if (!IsValidItem(proto))
             continue;
 
-        if (proto->Class == ITEM_CLASS_ARMOR &&
-            (slot == EQUIPMENT_SLOT_HEAD || slot == EQUIPMENT_SLOT_SHOULDERS || slot == EQUIPMENT_SLOT_CHEST ||
-             slot == EQUIPMENT_SLOT_WAIST || slot == EQUIPMENT_SLOT_LEGS || slot == EQUIPMENT_SLOT_FEET ||
-             slot == EQUIPMENT_SLOT_WRISTS || slot == EQUIPMENT_SLOT_HANDS) &&
-            !CanEquipArmor(key.clazz, key.level, proto))
+        // skip items requiring a profession skill
+        if (proto->RequiredSkill)
             continue;
 
-        if (proto->Class == ITEM_CLASS_WEAPON && !CanEquipWeapon(key.clazz, proto))
-            continue;
-
-        if (slot == EQUIPMENT_SLOT_OFFHAND && key.clazz == CLASS_ROGUE && proto->Class != ITEM_CLASS_WEAPON)
-            continue;
-
-        items.push_back(itr.first);
-    }
-    return items;
-}
-
-void RandomItemMgr::BuildAmmoCache()
-{
-    uint32 maxLevel = sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL);
-
-    LOG_INFO("server.loading", "Building ammo cache for {} levels", maxLevel);
-
-    uint32 counter = 0;
-    for (uint32 level = 1; level <= maxLevel; level += 1)
-    {
-        for (uint32 subClass = ITEM_SUBCLASS_ARROW; subClass <= ITEM_SUBCLASS_BULLET; subClass++)
+        uint32 requiredLevel = proto->RequiredLevel;
+        for (uint32 level = 1; level <= DEFAULT_MAX_LEVEL; level += 10)
         {
-            QueryResult results = WorldDatabase.Query(
-                "SELECT entry FROM item_template WHERE class = {} AND subclass = {} AND RequiredLevel <= {} AND duration = 0 "
-                "AND (Flags & 16) = 0 AND dmg_min1 != 0 AND RequiredLevel != 0  "
-                "ORDER BY stackable DESC, ItemLevel DESC",
-                ITEM_CLASS_PROJECTILE, subClass, level);
-            if (!results)
-                continue;
-            do
-            {
-                Field* fields = results->Fetch();
-                uint32 entry = fields[0].Get<uint32>();
-                ammoCache[level][subClass].push_back(entry);
-                ++counter;
-            } while (results->NextRow());
-        }
-    }
-
-    LOG_INFO("server.loading", "Cached {} ammo", counter);  // TEST
-}
-
-std::vector<uint32> RandomItemMgr::GetAmmo(uint32 level, uint32 subClass) { return ammoCache[level][subClass]; }
-
-void RandomItemMgr::BuildPotionCache()
-{
-    uint32 maxLevel = sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL);
-
-    LOG_INFO("playerbots", "Building potion cache for {} levels", maxLevel);
-
-    ItemTemplateContainer const* itemTemplates = sObjectMgr->GetItemTemplateStore();
-
-    uint32 counter = 0;
-    for (uint32 level = 1; level <= maxLevel; level++)
-    {
-        uint32 effects[] = {SPELL_EFFECT_HEAL, SPELL_EFFECT_ENERGIZE};
-        for (uint8 i = 0; i < 2; ++i)
-        {
-            uint32 effect = effects[i];
-
-            for (auto const& itr : *itemTemplates)
-            {
-                ItemTemplate const* proto = &itr.second;
-                if (!proto)
-                    continue;
-
-                if (proto->Class != ITEM_CLASS_CONSUMABLE ||
-                    (proto->SubClass != ITEM_SUBCLASS_POTION && proto->SubClass != ITEM_SUBCLASS_FLASK) ||
-                    proto->Bonding != NO_BIND)
-                    continue;
-
-                uint32 requiredLevel = proto->RequiredLevel;
-                if (requiredLevel > level || (level > 13 && requiredLevel < level - 13))
-                    continue;
-
-                if (proto->RequiredSkill)
-                    continue;
-
-                if (proto->Area || proto->Map || proto->RequiredCityRank || proto->RequiredHonorRank)
-                    continue;
-
-                if (proto->Duration & 0x80000000)
-                    continue;
-
-                if (proto->AllowableClass != -1)
-                    continue;
-
-                bool hybrid = false;
-                SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(proto->Spells[0].SpellId);
-                if (!spellInfo)
-                    continue;
-                // do not accept hybrid potion
-                for (uint8 i = 1; i < 3; i++)
-                {
-                    if (spellInfo->Effects[i].Effect != 0)
-                    {
-                        hybrid = true;
-                        break;
-                    }
-                }
-                if (hybrid)
-                    continue;
-
-                if (spellInfo->Effects[0].Effect == effect)
-                    potionCache[level][effect].push_back(itr.first);
-            }
-        }
-    }
-
-    for (uint32 level = 1; level <= maxLevel; level++)
-    {
-        uint32 effects[] = {SPELL_EFFECT_HEAL, SPELL_EFFECT_ENERGIZE};
-        for (uint8 i = 0; i < 2; ++i)
-        {
-            uint32 effect = effects[i];
-            uint32 size = potionCache[level][effect].size();
-            counter += size;
-        }
-    }
-
-    LOG_INFO("playerbots", "Cached {} potions", counter);
-}
-
-void RandomItemMgr::BuildFoodCache()
-{
-    uint32 maxLevel = sPlayerbotAIConfig.randomBotMaxLevel;
-    if (maxLevel > sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL))
-        maxLevel = sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL);
-
-    LOG_INFO("server.loading", "Building food cache for {} levels", maxLevel);
-
-    ItemTemplateContainer const* itemTemplates = sObjectMgr->GetItemTemplateStore();
-
-    uint32 counter = 0;
-    for (uint32 level = 1; level <= maxLevel + 1; level += 10)
-    {
-        uint32 categories[] = {11, 59};
-        for (int i = 0; i < 2; ++i)
-        {
-            uint32 category = categories[i];
-
-            for (auto const& itr : *itemTemplates)
-            {
-                ItemTemplate const* proto = &itr.second;
-                if (!proto)
-                    continue;
-
-                if (proto->Class != ITEM_CLASS_CONSUMABLE ||
-                    (proto->SubClass != ITEM_SUBCLASS_FOOD && proto->SubClass != ITEM_SUBCLASS_CONSUMABLE) ||
-                    (proto->Spells[0].SpellCategory != category) || proto->Bonding != NO_BIND)
-                    continue;
-
-                if (proto->RequiredLevel && (proto->RequiredLevel > level || proto->RequiredLevel < level - 10))
-                    continue;
-
-                if (proto->RequiredSkill)
-                    continue;
-
-                if (proto->Area || proto->Map || proto->RequiredCityRank || proto->RequiredHonorRank)
-                    continue;
-
-                if (proto->Duration & 0x80000000)
-                    continue;
-
-                foodCache[level / 10][category].push_back(itr.first);
-            }
-        }
-    }
-
-    for (uint32 level = 1; level <= maxLevel + 1; level += 10)
-    {
-        uint32 categories[] = {11, 59};
-        for (uint8 i = 0; i < 2; ++i)
-        {
-            uint32 category = categories[i];
-            uint32 size = foodCache[level / 10][category].size();
-            ++counter;
-            LOG_DEBUG("server.loading", "Food cache for level={}, category={}: {} items", level, category, size);
-        }
-    }
-
-    LOG_INFO("server.loading", "Cached {} types of food", counter);
-}
-
-uint32 RandomItemMgr::GetRandomPotion(uint32 level, uint32 effect)
-{
-    const std::vector<uint32> &potions = potionCache[level][effect];
-    if (potions.empty())
-        return 0;
-
-    return potions[urand(0, potions.size() - 1)];
-}
-
-uint32 RandomItemMgr::GetFood(uint32 level, uint32 category)
-{
-    std::initializer_list<uint32> items;
-    std::vector<uint32> food;
-    if (category == 11)
-    {
-        if (level < 5)
-            items = {787, 117, 4540, 2680};
-        else if (level < 15)
-            items = {2287, 4592, 4541, 21072};
-        else if (level < 25)
-            items = {3770, 16170, 4542, 20074};
-        else if (level < 35)
-            items = {4594, 3771, 1707, 4457};
-        else if (level < 45)
-            items = {4599, 4601, 21552, 17222 /*21030, 16168 */};
-        else if (level < 55)
-            items = {8950, 8952, 8957, 21023 /*21033, 21031 */};
-        else if (level < 65)
-            items = {29292, 27859, 30458, 27662};
-        else if (level < 75)
-            items = {29450, 29451, 29452};
-        else
-            items = {35947};
-    }
-
-    if (category == 59)
-    {
-        if (level < 5)
-            items = {159, 117};
-        else if (level < 15)
-            items = {1179, 21072};
-        else if (level < 25)
-            items = {1205};
-        else if (level < 35)
-            items = {1708};
-        else if (level < 45)
-            items = {1645};
-        else if (level < 55)
-            items = {8766};
-        else if (level < 65)
-            items = {28399};
-        else if (level < 75)
-            items = {27860};
-        else
-            items = {33445};
-    }
-
-    food.insert(food.end(), items);
-    if (food.empty())
-        return 0;
-    return food[urand(0, food.size() - 1)];
-}
-
-uint32 RandomItemMgr::GetRandomFood(uint32 level, uint32 category)
-{
-    std::vector<uint32> food = foodCache[(level - 1) / 10][category];
-    if (food.empty())
-        return 0;
-
-    return food[urand(0, food.size() - 1)];
-}
-
-void RandomItemMgr::BuildTradeCache()
-{
-    uint32 maxLevel = sPlayerbotAIConfig.randomBotMaxLevel;
-    if (maxLevel > sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL))
-        maxLevel = sWorld->getIntConfig(CONFIG_MAX_PLAYER_LEVEL);
-
-    LOG_INFO("server.loading", "Building trade cache for {} levels", maxLevel);
-
-    ItemTemplateContainer const* itemTemplates = sObjectMgr->GetItemTemplateStore();
-
-    uint32 counter = 0;
-    for (uint32 level = 1; level <= maxLevel + 1; level += 10)
-    {
-        for (auto const& itr : *itemTemplates)
-        {
-            ItemTemplate const* proto = &itr.second;
-            if (!proto)
-                continue;
-
-            if (proto->Class != ITEM_CLASS_TRADE_GOODS || proto->Bonding != NO_BIND)
-                continue;
-
+            // skip items whose item level is below the current bucket
             if (proto->ItemLevel < level)
                 continue;
 
-            if (proto->RequiredLevel && (proto->RequiredLevel > level || proto->RequiredLevel < level - 10))
-                continue;
+            if (requiredLevel)
+            {
+                // skip items above the level bucket
+                if (requiredLevel > level)
+                    continue;
 
-            if (proto->RequiredSkill)
-                continue;
+                // skip items below the level bucket window
+                if (level > MAX_TRADE_LEVEL_DELTA && requiredLevel < level - MAX_TRADE_LEVEL_DELTA)
+                    continue;
+            }
 
-            tradeCache[level / 10].push_back(itr.first);
-        }
-    }
-
-    for (uint32 level = 1; level <= maxLevel + 1; level += 10)
-    {
-        uint32 size = tradeCache[level / 10].size();
-        LOG_DEBUG("server.loading", "Trade cache for level={}: {} items", level, size);
-        ++counter;
-    }
-
-    LOG_INFO("server.loading", "Cached {} trade items", counter);  // TEST
-}
-
-uint32 RandomItemMgr::GetRandomTrade(uint32 level)
-{
-    std::vector<uint32> trade = tradeCache[(level - 1) / 10];
-    if (trade.empty())
-        return 0;
-
-    return trade[urand(0, trade.size() - 1)];
-}
-
-void RandomItemMgr::BuildRarityCache()
-{
-    if (PreparedQueryResult result =
-            PlayerbotsDatabase.Query(PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_SEL_RARITY_CACHE)))
-    {
-        LOG_INFO("playerbots", "Loading item rarity cache");
-
-        uint32 count = 0;
-        do
-        {
-            Field* fields = result->Fetch();
-            uint32 itemId = fields[0].Get<uint32>();
-            float rarity = fields[1].Get<float>();
-
-            rarityCache[itemId] = rarity;
+            tradeCache[(level - 1) / 10].push_back(itr.first);
             ++count;
-
-        } while (result->NextRow());
-
-        LOG_INFO("playerbots", "Item rarity cache loaded from {} records", count);
+        }
     }
-    else
+
+    LOG_INFO("server.loading", ">> Cached total {} trade entries in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
+    LOG_INFO("server.loading", " ");
+}
+
+void RandomItemMgr::BuildCacheRarity()
+{
+    uint32 const oldMSTime = getMSTime();
+
+    LOG_INFO("server.loading", "Building items rarity cache...");
+
+    QueryResult result = WorldDatabase.Query(
+        "SELECT item, MAX(q.chance) AS max_chance FROM ( "
+        // <-- creature
+        "SELECT lt.item, "
+        "    AVG(CASE "
+        "        WHEN lt.GroupId = 0 THEN lt.Chance "
+        "        WHEN lt.Chance > 0  THEN lt.Chance "
+        "        ELSE IFNULL(100 - lt.group_sum, 100) / NULLIF(lt.group_zero, 0) "
+        "    END) AS chance "
+        "FROM ( "
+        "    SELECT *, "
+        "        SUM(CASE WHEN Chance > 0 THEN Chance ELSE 0 END) OVER (PARTITION BY entry, GroupId) AS group_sum, "
+        "        SUM(CASE WHEN Chance = 0 THEN 1 ELSE 0 END)      OVER (PARTITION BY entry, GroupId) AS group_zero "
+        "    FROM creature_loot_template WHERE item != 0) lt "
+        "JOIN creature_template ct ON ct.LootId = lt.entry "
+        "JOIN creature c ON c.id1 = ct.entry "
+        "GROUP BY lt.item "
+        "UNION ALL "
+        // <-- gameobject
+        "SELECT lt.item, "
+        "    AVG(CASE "
+        "        WHEN lt.GroupId = 0 THEN lt.Chance "
+        "        WHEN lt.Chance > 0  THEN lt.Chance "
+        "        ELSE IFNULL(100 - lt.group_sum, 100) / NULLIF(lt.group_zero, 0) "
+        "    END) AS chance "
+        "FROM (SELECT *, "
+        "        SUM(CASE WHEN Chance > 0 THEN Chance ELSE 0 END) OVER (PARTITION BY entry, GroupId) AS group_sum, "
+        "        SUM(CASE WHEN Chance = 0 THEN 1 ELSE 0 END)      OVER (PARTITION BY entry, GroupId) AS group_zero "
+        "    FROM gameobject_loot_template WHERE item != 0) lt "
+        "JOIN gameobject_template ct ON ct.data1 = lt.entry "
+        "JOIN gameobject c ON c.id = ct.entry "
+        "GROUP BY lt.item "
+        "UNION ALL "
+        // <-- disenchant
+        "SELECT lt.item, "
+        "    AVG(CASE "
+        "        WHEN lt.GroupId = 0 THEN lt.Chance "
+        "        WHEN lt.Chance > 0  THEN lt.Chance "
+        "        ELSE IFNULL(100 - lt.group_sum, 100) / NULLIF(lt.group_zero, 0) "
+        "    END) AS chance "
+        "FROM (SELECT *, "
+        "        SUM(CASE WHEN Chance > 0 THEN Chance ELSE 0 END) OVER (PARTITION BY entry, GroupId) AS group_sum, "
+        "        SUM(CASE WHEN Chance = 0 THEN 1 ELSE 0 END)      OVER (PARTITION BY entry, GroupId) AS group_zero "
+        "    FROM disenchant_loot_template WHERE item != 0) lt "
+        "JOIN item_template ct ON ct.DisenchantID = lt.entry "
+        "GROUP BY lt.item "
+        "UNION ALL "
+        // <-- fishing
+        "SELECT lt.item, "
+        "    AVG(CASE "
+        "        WHEN lt.GroupId = 0 THEN lt.Chance "
+        "        WHEN lt.Chance > 0  THEN lt.Chance "
+        "        ELSE IFNULL(100 - lt.group_sum, 100) / NULLIF(lt.group_zero, 0) "
+        "    END) AS chance "
+        "FROM (SELECT *, "
+        "        SUM(CASE WHEN Chance > 0 THEN Chance ELSE 0 END) OVER (PARTITION BY entry, GroupId) AS group_sum, "
+        "        SUM(CASE WHEN Chance = 0 THEN 1 ELSE 0 END)      OVER (PARTITION BY entry, GroupId) AS group_zero "
+        "    FROM fishing_loot_template WHERE item != 0) lt "
+        "GROUP BY lt.item "
+        "UNION ALL "
+        // <-- skinning
+        "SELECT lt.item, "
+        "    AVG(CASE "
+        "        WHEN lt.GroupId = 0 THEN lt.Chance "
+        "        WHEN lt.Chance > 0  THEN lt.Chance "
+        "        ELSE IFNULL(100 - lt.group_sum, 100) * IFNULL(1.0 / NULLIF(lt.group_zero, 0), 1) "
+        "    END) AS chance "
+        "FROM (SELECT *, "
+        "       SUM(CASE WHEN Chance > 0 THEN Chance ELSE 0 END) OVER (PARTITION BY entry, GroupId) AS group_sum, "
+        "       SUM(CASE WHEN Chance = 0 THEN 1 ELSE 0 END)      OVER (PARTITION BY entry, GroupId) AS group_zero "
+        "   FROM skinning_loot_template WHERE item != 0) lt "
+        "JOIN creature_template ct ON ct.skinloot = lt.entry "
+        "JOIN creature c ON c.id1 = ct.entry "
+        "GROUP BY lt.item) q GROUP BY item HAVING max_chance > 0.01 ORDER BY item");
+
+    if (!result)
     {
-        ItemTemplateContainer const* itemTemplates = sObjectMgr->GetItemTemplateStore();
-        LOG_INFO("playerbots", "Building item rarity cache from {} items", itemTemplates->size());
+        LOG_WARN("server.loading", ">> Cached 0 rarity entries. SQL query result is empty!");
+        LOG_INFO("server.loading", " ");
+        return;
+    }
 
-        for (auto const& itr : *itemTemplates)
+    PlayerbotsDatabaseTransaction trans = PlayerbotsDatabase.BeginTransaction();
+
+    do
+    {
+        Field* fields = result->Fetch();
+        uint32 itemId = fields[0].Get<uint32>();
+        float  rarity = fields[1].Get<float>();
+
+        ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
+        if (!proto)
+            continue;
+
+        // skip poor, legendary, artifact and heirloom quality
+        // NOTE: There are only 5 items with loot source and above Epic quality:
+        //       Warglaive of Azzinoth (2), Bindings of the Windseeker (2), and
+        //       Shadowfrost Shard. The last two are quest-related items.
+        if (proto->Quality < ITEM_QUALITY_NORMAL || proto->Quality > ITEM_QUALITY_EPIC)
+            continue;
+
+        // skip items that fail basic validatoin (level, duration, flags, etc.)
+        if (!IsValidItem(proto))
+            continue;
+
+        rarityCache[itemId] = rarity;
+
+        PlayerbotsDatabasePreparedStatement* stmt =
+            PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_INS_RARITY_CACHE);
+        stmt->SetData(0, itemId);
+        stmt->SetData(1, rarity);
+        trans->Append(stmt);
+    } while (result->NextRow());
+
+    PlayerbotsDatabase.CommitTransaction(trans);
+
+    LOG_INFO("server.loading", ">> Cached total {} rarity entries in {} ms", rarityCache.size(),
+             GetMSTimeDiffToNow(oldMSTime));
+    LOG_INFO("server.loading", " ");
+}
+
+void RandomItemMgr::DebugCacheRandomItem()
+{
+    // NOTE: Not sure if anyone ever used this data, because it produces a huge
+    //       amount of output to the file/console. It might be better to create
+    //       separate command that shows the cache contents on demand.
+
+    if (!sLog->ShouldLog("playerbots", LogLevel::LOG_LEVEL_DEBUG))
+        return;
+
+    uint32 const maxBucket = (DEFAULT_MAX_LEVEL - 1) / 10;
+
+    for (uint32 bucket = 0; bucket <= maxBucket; ++bucket)
+    {
+        auto const bucketItr = randomItemCache.find(bucket);
+        if (bucketItr == randomItemCache.end())
+            continue;
+
+        uint32 const minLevel = bucket * 10 + 1;
+        uint32 const maxBucketLevel = std::min(minLevel + 9, static_cast<uint32>(DEFAULT_MAX_LEVEL));
+
+        for (auto const& [type, items] : bucketItr->second)
         {
-            ItemTemplate const* proto = &itr.second;
-            if (!proto)
-                continue;
+            LOG_DEBUG("playerbots", "    Bucket {} (levels {}..{}) Type {} - {} random items cached",
+                      bucket, minLevel, maxBucketLevel, type, items.size());
 
-            if (proto->Duration & 0x80000000)
-                continue;
-
-            if (proto->Quality == ITEM_QUALITY_POOR)
-                continue;
-
-            if (strstri(proto->Name1.c_str(), "qa") || strstri(proto->Name1.c_str(), "test") ||
-                strstri(proto->Name1.c_str(), "deprecated"))
-                continue;
-
-            if (!proto->ItemLevel)
-                continue;
-
-            QueryResult results = WorldDatabase.Query(
-                "SELECT MAX(q.chance) FROM ( "
-                // "-- Creature "
-                "SELECT  "
-                "AVG ( "
-                "   CASE  "
-                "    WHEN lt.groupid = 0 THEN lt.ChanceOrQuestChance  "
-                "    WHEN lt.ChanceOrQuestChance > 0 THEN lt.ChanceOrQuestChance "
-                "    ELSE   "
-                "    IFNULL(100 - (SELECT SUM(ChanceOrQuestChance) FROM creature_loot_template lt1 WHERE lt1.groupid = "
-                "lt.groupid AND lt1.entry = lt.entry AND lt1.ChanceOrQuestChance > 0), 100) "
-                "    / (SELECT COUNT(*) FROM creature_loot_template lt1 WHERE lt1.groupid = lt.groupid AND lt1.entry = "
-                "lt.entry AND lt1.ChanceOrQuestChance = 0) "
-                "    END "
-                ") chance, 'creature' type "
-                "FROM creature_loot_template lt "
-                "JOIN creature_template ct ON ct.LootId = lt.entry "
-                "JOIN creature c ON c.id = ct.entry "
-                "WHERE lt.item = {} "
-                "union all "
-                // "-- Gameobject "
-                "SELECT  "
-                "AVG ( "
-                "   CASE  "
-                "    WHEN lt.groupid = 0 THEN lt.ChanceOrQuestChance  "
-                "    WHEN lt.ChanceOrQuestChance > 0 THEN lt.ChanceOrQuestChance "
-                "    ELSE   "
-                "    IFNULL(100 - (SELECT SUM(ChanceOrQuestChance) FROM gameobject_loot_template lt1 WHERE lt1.groupid "
-                "= lt.groupid AND lt1.entry = lt.entry AND lt1.ChanceOrQuestChance > 0), 100) "
-                "    / (SELECT COUNT(*) FROM gameobject_loot_template lt1 WHERE lt1.groupid = lt.groupid AND lt1.entry "
-                "= lt.entry AND lt1.ChanceOrQuestChance = 0) "
-                "    END "
-                ") chance, 'gameobject' type "
-                "FROM gameobject_loot_template lt "
-                "JOIN gameobject_template ct ON ct.data1 = lt.entry "
-                "JOIN gameobject c ON c.id = ct.entry "
-                "WHERE lt.item = {} "
-                "union all "
-                // "-- Disenchant "
-                "SELECT  "
-                "AVG ( "
-                "   CASE  "
-                "    WHEN lt.groupid = 0 THEN lt.ChanceOrQuestChance  "
-                "    WHEN lt.ChanceOrQuestChance > 0 THEN lt.ChanceOrQuestChance "
-                "    ELSE   "
-                "    IFNULL(100 - (SELECT SUM(ChanceOrQuestChance) FROM disenchant_loot_template lt1 WHERE lt1.groupid "
-                "= lt.groupid AND lt1.entry = lt.entry AND lt1.ChanceOrQuestChance > 0), 100) "
-                "    / (SELECT COUNT(*) FROM disenchant_loot_template lt1 WHERE lt1.groupid = lt.groupid AND lt1.entry "
-                "= lt.entry AND lt1.ChanceOrQuestChance = 0) "
-                "    END "
-                ") chance, 'disenchant' type "
-                "FROM disenchant_loot_template lt "
-                "JOIN item_template ct ON ct.DisenchantID = lt.entry "
-                "WHERE lt.item = {} "
-                "union all "
-                // "-- Fishing "
-                "SELECT  "
-                "AVG ( "
-                "   CASE  "
-                "    WHEN lt.groupid = 0 THEN lt.ChanceOrQuestChance  "
-                "    WHEN lt.ChanceOrQuestChance > 0 THEN lt.ChanceOrQuestChance "
-                "    ELSE   "
-                "    IFNULL(100 - (SELECT SUM(ChanceOrQuestChance) FROM fishing_loot_template lt1 WHERE lt1.groupid = "
-                "lt.groupid AND lt1.entry = lt.entry AND lt1.ChanceOrQuestChance > 0), 100) "
-                "    / (SELECT COUNT(*) FROM fishing_loot_template lt1 WHERE lt1.groupid = lt.groupid AND lt1.entry = "
-                "lt.entry AND lt1.ChanceOrQuestChance = 0) "
-                "    END "
-                ") chance, 'fishing' type "
-                "FROM fishing_loot_template lt "
-                "WHERE lt.item = {} "
-                "union all "
-                // "-- Skinning "
-                "SELECT  "
-                "AVG ( "
-                "   CASE  "
-                "    WHEN lt.groupid = 0 THEN lt.ChanceOrQuestChance  "
-                "    WHEN lt.ChanceOrQuestChance > 0 THEN lt.ChanceOrQuestChance  "
-                "    ELSE   "
-                "    IFNULL(100 - (SELECT SUM(ChanceOrQuestChance) FROM skinning_loot_template lt1 WHERE lt1.groupid = "
-                "lt.groupid AND lt1.entry = lt.entry AND lt1.ChanceOrQuestChance > 0), 100) "
-                "    * IFNULL((SELECT 1/COUNT(*) FROM skinning_loot_template lt1 WHERE lt1.groupid = lt.groupid AND "
-                "lt1.entry = lt.entry AND lt1.ChanceOrQuestChance = 0), 1) "
-                "    END "
-                ") chance, 'skinning' type "
-                "FROM skinning_loot_template lt "
-                "JOIN creature_template ct ON ct.SkinningLootId = lt.entry "
-                "JOIN creature c ON c.id = ct.entry "
-                "WHERE lt.item = {}) q; ",
-                itr.first, itr.first, itr.first, itr.first, itr.first);
-
-            if (results)
+            for (uint32 const itemId : items)
             {
-                Field* fields = results->Fetch();
-                float rarity = fields[0].Get<float>();
-                if (rarity > 0.01)
-                {
-                    rarityCache[itr.first] = rarity;
+                ItemTemplate const* proto = sObjectMgr->GetItemTemplate(itemId);
+                if (!proto)
+                    continue;
 
-                    PlayerbotsDatabasePreparedStatement* stmt =
-                        PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_INS_RARITY_CACHE);
-                    stmt->SetData(0, itr.first);
-                    stmt->SetData(1, rarity);
-                    PlayerbotsDatabase.Execute(stmt);
-                }
-            }
-        }
-
-        LOG_INFO("playerbots", "Item rarity cache built from {} items", itemTemplates->size());
-    }
-}
-
-float RandomItemMgr::GetItemRarity(uint32 itemId) { return rarityCache[itemId]; }
-
-inline bool IsCraftedBySpellInfo(ItemTemplate const* proto, SpellInfo const* spellInfo)
-{
-    for (uint32 x = 0; x < MAX_SPELL_REAGENTS; ++x)
-    {
-        if (spellInfo->Reagent[x] <= 0)
-        {
-            continue;
-        }
-
-        if (proto->ItemId == spellInfo->Reagent[x])
-            return true;
-
-    }
-
-    for (uint8 i = 0; i < 3; ++i)
-    {
-        if (spellInfo->Effects[i].Effect == SPELL_EFFECT_CREATE_ITEM)
-        {
-            if (spellInfo->Effects[i].ItemType == proto->ItemId)
-                return true;
-        }
-    }
-
-    return false;
-}
-
-inline bool IsCraftedBySpell(ItemTemplate const* proto, uint32 spellId)
-{
-    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
-    if (!spellInfo)
-        return false;
-
-    return IsCraftedBySpellInfo(proto, spellInfo);
-}
-
-inline bool IsCraftedBy(ItemTemplate const* proto, uint32 spellId)
-{
-    if (IsCraftedBySpell(proto, spellId))
-        return true;
-
-    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
-    if (!spellInfo)
-        return false;
-
-    for (uint32 effect = 0; effect < 3; ++effect)
-    {
-        uint32 craftId = spellInfo->Effects[effect].TriggerSpell;
-        SpellInfo const* craftSpellInfo = sSpellMgr->GetSpellInfo(craftId);
-        if (!craftSpellInfo)
-            continue;
-
-        if (IsCraftedBySpellInfo(proto, craftSpellInfo))
-            return true;
-    }
-
-    return false;
-}
-
-inline bool ContainsInternal(ItemTemplate const* proto, uint32 skillId)
-{
-    for (uint32 j = 0; j < sSkillLineAbilityStore.GetNumRows(); ++j)
-    {
-        SkillLineAbilityEntry const* skillLine = sSkillLineAbilityStore.LookupEntry(j);
-        if (!skillLine || skillLine->ID != skillId)
-            continue;
-
-        if (IsCraftedBy(proto, skillLine->Spell))
-            return true;
-    }
-
-    CreatureTemplateContainer const* creatures = sObjectMgr->GetCreatureTemplates();
-    for (CreatureTemplateContainer::const_iterator itr = creatures->begin(); itr != creatures->end(); ++itr)
-    {
-        Trainer::Trainer* trainer = sObjectMgr->GetTrainer(itr->first);
-
-        if (!trainer)
-            continue;
-
-        if (trainer->GetTrainerType() != Trainer::Type::Tradeskill)
-            continue;
-
-        for (auto& spell : trainer->GetSpells())
-        {
-            if (spell.ReqSkillLine != skillId)
-                continue;
-
-            if (IsCraftedBy(proto, spell.SpellId))
-                return true;
-        }
-    }
-
-    std::vector<ItemTemplate*> const* itemTemplates = sObjectMgr->GetItemTemplateStoreFast();
-    for (ItemTemplate const* recipe : *itemTemplates)
-    {
-        if (!recipe)
-            continue;
-
-        if (recipe->Class == ITEM_CLASS_RECIPE &&
-            ((recipe->SubClass == ITEM_SUBCLASS_LEATHERWORKING_PATTERN && skillId == SKILL_LEATHERWORKING) ||
-             (recipe->SubClass == ITEM_SUBCLASS_TAILORING_PATTERN && skillId == SKILL_TAILORING) ||
-             (recipe->SubClass == ITEM_SUBCLASS_ENGINEERING_SCHEMATIC && skillId == SKILL_ENGINEERING) ||
-             (recipe->SubClass == ITEM_SUBCLASS_BLACKSMITHING && skillId == SKILL_BLACKSMITHING) ||
-             (recipe->SubClass == ITEM_SUBCLASS_COOKING_RECIPE && skillId == SKILL_COOKING) ||
-             (recipe->SubClass == ITEM_SUBCLASS_ALCHEMY_RECIPE && skillId == SKILL_ALCHEMY) ||
-             (recipe->SubClass == ITEM_SUBCLASS_FIRST_AID_MANUAL && skillId == SKILL_FIRST_AID) ||
-             (recipe->SubClass == ITEM_SUBCLASS_ENCHANTING_FORMULA && skillId == SKILL_ENCHANTING) ||
-             (recipe->SubClass == ITEM_SUBCLASS_JEWELCRAFTING_RECIPE && skillId == SKILL_JEWELCRAFTING) ||
-             (recipe->SubClass == ITEM_SUBCLASS_FISHING_MANUAL && skillId == SKILL_FISHING)))
-        {
-            for (uint32 i = 0; i < MAX_ITEM_PROTO_SPELLS; ++i)
-            {
-                if (IsCraftedBy(proto, recipe->Spells[i].SpellId))
-                    return true;
+                LOG_DEBUG("playerbots", "        [{}] {}", itemId, proto->Name1.c_str());
             }
         }
     }
-
-    return false;
 }
 
-bool RandomItemMgr::IsUsedBySkill(ItemTemplate const* proto, uint32 skillId)
+void RandomItemMgr::AddItemStats(uint32 mod, uint8& sp, uint8& ap, uint8& tank)
 {
-    if (itemCache.find(proto->ItemId) != itemCache.end())
-        return true;
-
-    switch (proto->Class)
+    switch (mod)
     {
-        case ITEM_CLASS_TRADE_GOODS:
-        case ITEM_CLASS_MISC:
-        case ITEM_CLASS_REAGENT:
-        case ITEM_CLASS_GEM:
+        case ITEM_MOD_HEALTH:
+        case ITEM_MOD_STAMINA:
+            ++sp; ++ap; ++tank;  // universal stats - benefit all roles
+            break;
+        case ITEM_MOD_AGILITY:
+        case ITEM_MOD_STRENGTH:
+            ++ap; ++tank;        // physical stats - no spellpower benefit
+            break;
+        case ITEM_MOD_MANA:
+        case ITEM_MOD_INTELLECT:
+        case ITEM_MOD_SPIRIT:
+            ++sp;                // caster-only stats
             break;
         default:
+            break;
+    }
+}
+
+bool RandomItemMgr::CanUseItemStats(uint8 clazz, uint8 sp, uint8 ap, uint8 tank)
+{
+    switch (clazz)
+    {
+        case CLASS_MAGE:
+        case CLASS_PRIEST:
+        case CLASS_WARLOCK:
+            // pure casters: must have sp, and sp must dominate
+            if (!sp || ap > sp || tank > sp)
+                return false;
+            break;
+        case CLASS_DEATH_KNIGHT:
+        case CLASS_PALADIN:
+        case CLASS_WARRIOR:
+            // pure melee/tank: must have ap and tank, sp must not dominate
+            if ((!ap && !tank) || sp > ap || sp > tank)
+                return false;
+            break;
+        case CLASS_HUNTER:
+        case CLASS_ROGUE:
+            // physical DPS: must have ap, sp must not dominate
+            if (!ap || sp > ap || sp > tank)
+                return false;
+            break;
+        default:
+            // CLASS_SHAMAN, CLASS_DRUID - hybrid classes, accept any item that
+            // has at least one relevant stat
+            break;
+    }
+
+    return sp || ap || tank;
+}
+
+bool RandomItemMgr::CanEquipItem(ItemTemplate const* proto, uint32 level) const
+{
+    if (!proto)
+        return false;
+
+    // skip items whose required level exceeds the bot's level
+    if (proto->RequiredLevel && proto->RequiredLevel > level)
+        return false;
+
+    // skip use-bound and quest-bound items
+    if (proto->Bonding > BIND_WHEN_EQUIPPED)
+        return false;
+
+    // skip items with no viable equip slot
+    if (!GetViableSlots(static_cast<InventoryType>(proto->InventoryType)))
+        return false;
+
+    if (proto->Quality > ITEM_QUALITY_NORMAL)
+    {
+        uint32 requiredLevel = proto->RequiredLevel;
+        /*
+         * DEADCODE: Uncomment the code below if BuildCacheItemInfo method will
+         *           process itemInfoCache; otherwise remove it completely.
+         */
+
+        // if (!requiredLevel)
+        //     requiredLevel = GetMinLevelFromCache(proto->ItemId);
+
+        if (!requiredLevel)
+            requiredLevel = level;
+
+        uint32 delta = 2;
+        if (level < 15)
+            delta = 15;
+        else if (level < 40)
+            delta = 10;
+        else if (level < 60)
+            delta = 6;
+        else
+            delta = 9;
+
+        // junk (poor/normal) - take anything that fits the slot; real gear should
+        // match the level relevance window
+        if (requiredLevel > level || (level >= delta && requiredLevel < level - delta))
             return false;
     }
 
-    bool contains = ContainsInternal(proto, skillId);
-    if (contains)
-        itemCache.insert(proto->ItemId);
+    return true;
+}
 
-    return contains;
+std::vector<EquipmentSlots> const* RandomItemMgr::GetViableSlots(InventoryType invType) const
+{
+    auto it = viableSlots.find(invType);
+    return it != viableSlots.end() ? &it->second : nullptr;
+}
+
+uint32 RandomItemMgr::NormalizeLevel(uint32 level) const
+{
+    uint32 const levelCap = std::min(sPlayerbotAIConfig.randomBotMaxLevel,
+                                     static_cast<uint32>(DEFAULT_MAX_LEVEL));
+    return std::min(level, levelCap);
 }

--- a/src/Mgr/Item/RandomItemMgr.h
+++ b/src/Mgr/Item/RandomItemMgr.h
@@ -13,14 +13,13 @@
 #include <unordered_set>
 #include <vector>
 
+#include "Player.h"
 #include "AiFactory.h"
 #include "ItemTemplate.h"
 
 class ChatHandler;
 
 struct ItemTemplate;
-
-enum EquipmentSlots : uint32;
 
 enum RandomItemType
 {

--- a/src/Mgr/Item/RandomItemMgr.h
+++ b/src/Mgr/Item/RandomItemMgr.h
@@ -6,8 +6,9 @@
 #ifndef PLAYERBOTS_RANDOMITEMMGR_H
 #define PLAYERBOTS_RANDOMITEMMGR_H
 
+#include <array>
+#include <atomic>
 #include <map>
-#include <set>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -66,9 +67,7 @@ struct ItemInfoEntry
         : minLevel(0), source(0), sourceId(0), team(0), repRank(0), repFaction(0), quality(0), slot(0), itemId(0)
     {
         for (uint8 i = 1; i <= MAX_STAT_SCALES; ++i)
-        {
             weights[i] = 0;
-        }
     }
 
     std::map<uint32, uint32> weights;
@@ -97,40 +96,70 @@ struct WeightScale
 class RandomItemPredicate
 {
 public:
-    virtual ~RandomItemPredicate(){};
+    virtual ~RandomItemPredicate() {};
 
     virtual bool Apply(ItemTemplate const* proto) = 0;
 };
 
 typedef std::vector<uint32> RandomItemList;
-typedef std::map<RandomItemType, RandomItemList> RandomItemCache;
+typedef std::unordered_map<RandomItemType, RandomItemList> RandomItemCache;
 
 class BotEquipKey
 {
 public:
-    BotEquipKey() : level(0), clazz(0), slot(0), quality(0), key(GetKey()) {}
+    BotEquipKey() : level(0), clazz(0), slot(0), quality(0), m_key(GetKey()) {}
     BotEquipKey(uint32 level, uint8 clazz, uint8 slot, uint32 quality)
-        : level(level), clazz(clazz), slot(slot), quality(quality), key(GetKey())
-    {
-    }
-    BotEquipKey(BotEquipKey const& other)
-        : level(other.level), clazz(other.clazz), slot(other.slot), quality(other.quality), key(GetKey())
+        : level(level), clazz(clazz), slot(slot), quality(quality), m_key(GetKey())
     {
     }
 
-    bool operator<(BotEquipKey const& other) const { return other.key < this->key; }
+    BotEquipKey(BotEquipKey const&) = default;
+    BotEquipKey& operator=(BotEquipKey const&) = default;
+
+    bool operator<(BotEquipKey const& other) const { return m_key < other.m_key; }
+    bool operator==(BotEquipKey const& other) const { return m_key == other.m_key; }
 
     uint32 level;
     uint8 clazz;
     uint8 slot;
     uint32 quality;
-    uint64 key;
 
 private:
-    uint64 GetKey();
+    uint64 m_key;
+
+    uint64 GetKey() const
+    {
+        // bit layout - 8 bits per field, masked to prevent uint32 overflow bleed
+        return (static_cast<uint64>(level   & 0xFFu) << 24) |
+               (static_cast<uint64>(clazz   & 0xFFu) << 16) |
+               (static_cast<uint64>(slot    & 0xFFu) <<  8) |
+               (static_cast<uint64>(quality & 0xFFu));
+    }
 };
 
-typedef std::map<BotEquipKey, RandomItemList> BotEquipCache;
+namespace std
+{
+    template<>
+    struct hash<BotEquipKey>
+    {
+        public:
+            std::size_t operator()(BotEquipKey const& key) const
+            {
+                // identical bit layout to BotEquipKey::GetKey()
+                uint64 const packed =
+                    (static_cast<uint64>(key.level   & 0xFFu) << 24) |
+                    (static_cast<uint64>(key.clazz   & 0xFFu) << 16) |
+                    (static_cast<uint64>(key.slot    & 0xFFu) <<  8) |
+                    (static_cast<uint64>(key.quality & 0xFFu));
+
+                return std::hash<uint64>()(packed);
+            }
+    };
+}
+
+typedef std::unordered_map<BotEquipKey, RandomItemList> BotEquipCache;
+typedef std::unordered_map<InventoryType, RandomItemList> EquipByInventoryType;
+typedef std::unordered_map<uint32, EquipByInventoryType> BotEquipCacheNew;
 
 class RandomItemMgr
 {
@@ -145,56 +174,76 @@ public:
 public:
     void Init();
     void InitAfterAhBot();
-    static bool HandleConsoleCommand(ChatHandler* handler, char const* args);
-    RandomItemList Query(uint32 level, RandomItemType type, RandomItemPredicate* predicate);
-    RandomItemList Query(uint32 level, uint8 clazz, uint8 slot, uint32 quality);
-    uint32 GetUpgrade(Player* player, std::string spec, uint8 slot, uint32 quality, uint32 itemId);
-    std::vector<uint32> GetUpgradeList(Player* player, std::string spec, uint8 slot, uint32 quality, uint32 itemId,
-                                       uint32 amount = 1);
-    bool HasStatWeight(uint32 itemId);
-    uint32 GetMinLevelFromCache(uint32 itemId);
-    uint32 GetStatWeight(Player* player, uint32 itemId);
-    uint32 GetLiveStatWeight(Player* player, uint32 itemId);
-    uint32 GetRandomItem(uint32 level, RandomItemType type, RandomItemPredicate* predicate = nullptr);
-    std::vector<uint32> GetAmmo(uint32 level, uint32 subClass);
-    uint32 GetRandomPotion(uint32 level, uint32 effect);
-    uint32 GetRandomFood(uint32 level, uint32 category);
-    uint32 GetFood(uint32 level, uint32 category);
-    uint32 GetRandomTrade(uint32 level);
-    uint32 CalculateStatWeight(uint8 playerclass, uint8 spec, ItemTemplate const* proto);
-    uint32 CalculateSingleStatWeight(uint8 playerclass, uint8 spec, std::string stat, uint32 value);
-    bool CanEquipArmor(uint8 clazz, uint32 level, ItemTemplate const* proto);
-    bool ShouldEquipArmorForSpec(uint8 playerclass, uint8 spec, ItemTemplate const* proto);
-    bool CanEquipWeapon(uint8 clazz, ItemTemplate const* proto);
-    bool ShouldEquipWeaponForSpec(uint8 playerclass, uint8 spec, ItemTemplate const* proto);
-    float GetItemRarity(uint32 itemId);
-    uint32 GetQuestIdForItem(uint32 itemId);
-    std::vector<uint32> GetQuestIdsForItem(uint32 itemId);
-    static bool IsUsedBySkill(ItemTemplate const* proto, uint32 skillId);
-    bool IsTestItem(uint32 itemId) { return itemForTest.find(itemId) != itemForTest.end(); }
-    std::vector<uint32> GetCachedEquipments(uint32 requiredLevel, uint32 inventoryType);
-    std::vector<uint32> const& GetEnchantmentPool(uint32 entry) const;
+
+    [[nodiscard]] static bool HandleConsoleCommand(ChatHandler* handler, char const* args);
+
+    [[nodiscard]] RandomItemList Query(uint32 level, RandomItemType type, RandomItemPredicate* predicate) const;
+
+    [[nodiscard]] uint32 GetUpgrade(Player* player, std::string spec, uint8 slot, uint32 quality, uint32 itemId);
+    [[nodiscard]] std::vector<uint32> GetUpgradeList(Player* player, std::string spec, uint8 slot, uint32 quality,
+                                                     uint32 itemId, uint32 amount = 1);
+
+    [[nodiscard]] bool HasStatWeight(uint32 itemId);
+    [[nodiscard]] uint32 CalculateStatWeight(ItemTemplate const* proto, uint8 playerclass, uint8 spec);
+    [[nodiscard]] uint32 CalculateSingleStatWeight(uint8 playerclass, uint8 spec, std::string stat, uint32 value);
+    [[nodiscard]] uint32 GetStatWeight(Player* player, uint32 itemId);
+    [[nodiscard]] uint32 GetLiveStatWeight(Player* player, uint32 itemId);
+
+    [[nodiscard]] uint32 GetMinLevelFromCache(uint32 itemId) const;
+
+    [[nodiscard]] RandomItemList const& GetEquipment(uint32 level, uint8 clazz, uint8 slot, uint32 quality) const;
+    [[nodiscard]] RandomItemList const& GetEquipmentNew(uint32 level, InventoryType invType) const;
+    [[nodiscard]] uint32 GetRandomItem(uint32 level, RandomItemType type, RandomItemPredicate* predicate = nullptr) const;
+    [[nodiscard]] uint32 GetAmmo(uint32 level, uint32 subClass) const;
+    [[nodiscard]] uint32 GetRandomPotion(uint32 level, uint32 effect) const;
+    [[nodiscard]] uint32 GetRandomFood(uint32 level, uint32 category) const;
+    [[nodiscard]] uint32 GetRandomTrade(uint32 level) const;
+    [[nodiscard]] float GetItemRarity(uint32 itemId) const;
+    [[nodiscard]] std::vector<uint32> const& GetEnchantmentPool(uint32 entry) const;
+
+    [[nodiscard]] bool CanEquipArmor(ItemTemplate const* proto, uint8 clazz, uint32 level) const;
+    [[nodiscard]] bool CanEquipWeapon(ItemTemplate const* proto, uint8 clazz) const;
+    [[nodiscard]] bool ShouldEquipArmorForSpec(ItemTemplate const* proto, uint8 clazz, uint8 spec) const;
+    [[nodiscard]] bool ShouldEquipWeaponForSpec(ItemTemplate const* proto, uint8 clazz, uint8 spec) const;
+
+    [[nodiscard]] uint32 GetQuestIdForItem(uint32 itemId) const;
+    [[nodiscard]] std::vector<uint32> GetQuestIdsForItem(uint32 itemId) const;
+
+    [[nodiscard]] static bool IsInternalItem(ItemTemplate const* proto);
+    [[nodiscard]] static bool IsValidItem(ItemTemplate const* proto);
+    [[nodiscard]] static bool IsUsedBySkill(ItemTemplate const* proto, uint32 skillId);
 
 private:
-    void BuildRandomItemCache();
+    void InitWeaponProficiency();
+    void InitPredicates();
+    void InitViableSlots();
+    void InitWeightLinks();
+
+    [[nodiscard]] bool LoadCacheEquip();
+    [[nodiscard]] bool LoadCacheRandomItem();
+    [[nodiscard]] bool LoadCacheRarity();
     void LoadEnchantmentPool();
-    void BuildEquipCache();
-    void BuildEquipCacheNew();
-    void BuildItemInfoCache();
-    void BuildAmmoCache();
-    void BuildFoodCache();
-    void BuildPotionCache();
-    void BuildTradeCache();
-    void BuildRarityCache();
-    bool CanEquipItem(BotEquipKey key, ItemTemplate const* proto);
-    bool CanEquipItemNew(ItemTemplate const* proto);
-    void AddItemStats(uint32 mod, uint8& sp, uint8& ap, uint8& tank);
-    bool CheckItemStats(uint8 clazz, uint8 sp, uint8 ap, uint8 tank);
+
+    void BuildCacheRandomItem();
+    void BuildCacheEquip();
+    void BuildCacheEquipNew();
+    void BuildCacheItemInfo();
+    void BuildCacheAmmo();
+    void BuildCacheFood();
+    void BuildCachePotion();
+    void BuildCacheTrade();
+    void BuildCacheRarity();
+
+    void DebugCacheRandomItem();
+
+    static void AddItemStats(uint32 mod, uint8& sp, uint8& ap, uint8& tank);
+    [[nodiscard]] static bool CanUseItemStats(uint8 clazz, uint8 sp, uint8 ap, uint8 tank);
+    [[nodiscard]] bool CanEquipItem(ItemTemplate const* proto, uint32 level) const;
+    [[nodiscard]] std::vector<EquipmentSlots> const* GetViableSlots(InventoryType invType) const;
+    [[nodiscard]] uint32 NormalizeLevel(uint32 level) const;
 
 private:
-    // Implemented in RandomItemMgr.cpp
     RandomItemMgr();
-    // Implemented in RandomItemMgr.cpp
     ~RandomItemMgr();
 
     RandomItemMgr(const RandomItemMgr&) = delete;
@@ -203,23 +252,27 @@ private:
     RandomItemMgr(RandomItemMgr&&) = delete;
     RandomItemMgr& operator=(RandomItemMgr&&) = delete;
 
-    std::map<uint32, RandomItemCache> randomItemCache;
-    std::map<RandomItemType, RandomItemPredicate*> predicates;
+    std::atomic<bool> m_initialized{false};
+    std::array<uint32, MAX_CLASSES> m_weaponProficiency = {};
+
+    static std::unordered_set<uint32> itemCache;
+
     BotEquipCache equipCache;
-    std::map<EquipmentSlots, std::set<InventoryType>> viableSlots;
-    std::map<uint32, std::map<uint32, std::vector<uint32>>> ammoCache;
-    std::map<uint32, std::map<uint32, std::vector<uint32>>> potionCache;
-    std::map<uint32, std::map<uint32, std::vector<uint32>>> foodCache;
-    std::map<uint32, std::vector<uint32>> tradeCache;
-    std::map<uint32, float> rarityCache;
-    std::map<uint8, WeightScale> m_weightScales[MAX_CLASSES];
-    std::map<std::string, uint32> weightStatLink;
-    std::map<std::string, uint32> weightRatingLink;
-    std::map<uint32, ItemInfoEntry> itemInfoCache;
-    std::unordered_set<uint32> itemForTest;
-    static std::set<uint32> itemCache;
-    // equipCacheNew[RequiredLevel][InventoryType]
-    std::map<uint32, std::map<uint32, std::vector<uint32>>> equipCacheNew;
+    BotEquipCacheNew equipCacheNew;
+
+    std::unordered_map<uint32, RandomItemCache> randomItemCache;
+    std::unordered_map<RandomItemType, RandomItemPredicate*> predicates;
+    std::unordered_map<InventoryType, std::vector<EquipmentSlots>> viableSlots;
+    std::unordered_map<uint32, std::unordered_map<uint32, RandomItemList>> ammoCache;
+    std::unordered_map<uint32, std::unordered_map<uint32, RandomItemList>> potionCache;
+    std::unordered_map<uint32, std::unordered_map<uint32, RandomItemList>> foodCache;
+    std::unordered_map<uint32, RandomItemList> tradeCache;
+    std::unordered_map<uint32, float> rarityCache;
+    std::unordered_map<uint8, WeightScale> m_weightScales[MAX_CLASSES];
+    std::unordered_map<std::string, uint32> weightStatLink;
+    std::unordered_map<std::string, uint32> weightRatingLink;
+    std::unordered_map<uint32, ItemInfoEntry> itemInfoCache;
+
     // enchPoolCache[item_enchantment_template.entry] -> list of enchantment ids
     std::unordered_map<uint32, std::vector<uint32>> enchPoolCache;
 };

--- a/src/Mgr/Item/StatsCollector.cpp
+++ b/src/Mgr/Item/StatsCollector.cpp
@@ -34,7 +34,7 @@ void StatsCollector::CollectItemStats(ItemTemplate const* proto)
     }
     stats[STATS_TYPE_ARMOR] += proto->Armor;
     stats[STATS_TYPE_BLOCK_VALUE] += proto->Block;
-    for (int i = 0; i < proto->StatsCount; i++)
+    for (uint32 i = 0; i < proto->StatsCount; i++)
     {
         const _ItemStat& stat = proto->ItemStat[i];
         const int32& val = stat.ItemStatValue;

--- a/src/Mgr/Talent/Talentspec.cpp
+++ b/src/Mgr/Talent/Talentspec.cpp
@@ -316,7 +316,7 @@ std::vector<TalentSpec::TalentListEntry> TalentSpec::GetTalentTree(uint32 tabpag
     std::vector<TalentListEntry> retList;
 
     for (auto& entry : talents)
-        if (entry.tabPage() == tabpage)
+        if (entry.tabPage() == uint32(tabpage))
             retList.push_back(entry);
 
     return retList;
@@ -332,7 +332,7 @@ uint32 TalentSpec::GetTalentPoints(std::vector<TalentListEntry>& talents, int32 
 
     uint32 tPoints = 0;
     for (auto& entry : talents)
-        if (entry.tabPage() == tabpage)
+        if (entry.tabPage() == uint32(tabpage))
             tPoints = tPoints + entry.rank;
 
     return tPoints;
@@ -448,7 +448,7 @@ std::vector<TalentSpec::TalentListEntry> TalentSpec::SubTalentList(std::vector<T
             {
                 if (reverse == ABSOLUTE_DIST)
                     newentry.rank = std::abs(int32(newentry.rank - oldentry.rank));
-                else if (reverse == ADDED_POINTS || reverse == REMOVED_POINTS)
+                else if (reverse == ADDED_POINTS || reverse == uint32(REMOVED_POINTS))
                     newentry.rank = std::max(0u, (newentry.rank - oldentry.rank) * (reverse / 2));
                 else
                     newentry.rank = (newentry.rank - oldentry.rank) * reverse;

--- a/src/Mgr/Travel/TravelMgr.cpp
+++ b/src/Mgr/Travel/TravelMgr.cpp
@@ -540,7 +540,7 @@ std::string const WorldPosition::getAreaName(bool fullName, bool zoneName)
     return areaName;
 }
 
-std::set<Transport*> WorldPosition::getTransports(uint32 entry)
+std::set<Transport*> WorldPosition::getTransports(uint32 /*entry*/)
 {
     /*
     if (!entry)
@@ -1258,7 +1258,7 @@ bool QuestObjectiveTravelDestination::isActive(Player* bot)
         GuidVector targets = AI_VALUE(GuidVector, "possible targets");
 
         for (auto& target : targets)
-            if (target.GetEntry() == getEntry() && target.IsCreature() && botAI->GetCreature(target) &&
+            if (target.GetEntry() == uint32(getEntry()) && target.IsCreature() && botAI->GetCreature(target) &&
                 botAI->GetCreature(target)->IsAlive())
                 return true;
 
@@ -1310,7 +1310,7 @@ bool RpgTravelDestination::isActive(Player* bot)
 
     for (ObjectGuid const guid : ignoreList)
     {
-        if (guid.GetEntry() == getEntry())
+        if (guid.GetEntry() == uint32(getEntry()))
             return false;
 
     }
@@ -1455,7 +1455,7 @@ bool BossTravelDestination::isActive(Player* bot)
         GuidVector targets = AI_VALUE(GuidVector, "possible targets");
 
         for (auto& target : targets)
-            if (target.GetEntry() == getEntry() && target.IsCreature() && botAI->GetCreature(target) &&
+            if (target.GetEntry() == uint32(getEntry()) && target.IsCreature() && botAI->GetCreature(target) &&
                 botAI->GetCreature(target)->IsAlive())
                 return true;
 
@@ -3836,7 +3836,7 @@ uint32 TravelMgr::getDialogStatus(Player* pPlayer, int32 questgiver, Quest const
 
 // Selects a random WorldPosition from a list. Use a distance weighted distribution.
 std::vector<WorldPosition*> TravelMgr::getNextPoint(WorldPosition* center, std::vector<WorldPosition*> points,
-                                                    uint32 amount)
+                                                    uint32 /*amount*/)
 {
     std::vector<WorldPosition*> retVec;
 
@@ -4746,7 +4746,7 @@ void TravelMgr::PrepareDestinationCache()
                 {
                     LevelBracket bracket = zone2LevelBracket[areaId];
                     WorldPosition loc(mapId, x + cos(orient) * 5.0f, y + sin(orient) * 5.0f, z + 0.5f, orient + M_PI);
-                    for (int i = bracket.low; i <= bracket.high; i++)
+                    for (uint32 i = bracket.low; i <= bracket.high; i++)
                     {
                         if (forHorde)
                             hordeHubsPerLevelCache[i].push_back(loc);
@@ -4762,7 +4762,7 @@ void TravelMgr::PrepareDestinationCache()
 
                 LevelBracket bracket = zone2LevelBracket[areaId];
                 WorldPosition loc(mapId, x + cos(orient) * 5.0f, y + sin(orient) * 5.0f, z + 0.5f, orient + M_PI);
-                for (int i = bracket.low; i <= bracket.high; i++)
+                for (uint32 i = bracket.low; i <= bracket.high; i++)
                 {
                     if (forHorde)
                         hordeHubsPerLevelCache[i].push_back(loc);
@@ -4787,7 +4787,7 @@ void TravelMgr::PrepareDestinationCache()
             bLoc.loc = WorldLocation(mapId, x + cos(orient) * 6.0f, y + sin(orient) * 6.0f, z + 2.0f, orient + M_PI);
             bLoc.entry = templateEntry;
             uint32 level = (creatureTemplate->minlevel + creatureTemplate->maxlevel + 1) / 2;
-            for (int32 l = 1; l <= maxLevel; l++)
+            for (uint32 l = 1; l <= maxLevel; l++)
             {
                 // Bots 1-60 go to base game bankers (all have minlevel 30 or 45)
                 if (l <=60 && level > 45)
@@ -4818,13 +4818,13 @@ void TravelMgr::PrepareDestinationCache()
             for (int32 l = (int32)level - (int32)sPlayerbotAIConfig.randomBotTeleLowerLevel;
                  l <= (int32)level + (int32)sPlayerbotAIConfig.randomBotTeleHigherLevel; l++)
             {
-                if (l < 1 || l > maxLevel)
+                if (l < 1 || l > int32(maxLevel))
                     continue;
 
-                    locsPerLevelCache[(uint8)l].push_back(WorldLocation(std::get<0>(gridTuple),
-                        static_cast<float>(std::get<1>(gridTuple)) * 50.0f,
-                        static_cast<float>(std::get<2>(gridTuple)) * 50.0f,
-                        static_cast<float>(std::get<3>(gridTuple)) * 50.0f));
+                locsPerLevelCache[(uint8)l].push_back(WorldLocation(std::get<0>(gridTuple),
+                    static_cast<float>(std::get<1>(gridTuple)) * 50.0f,
+                    static_cast<float>(std::get<2>(gridTuple)) * 50.0f,
+                    static_cast<float>(std::get<3>(gridTuple)) * 50.0f));
             }
         }
     }

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -949,14 +949,14 @@ std::vector<std::vector<uint32>> PlayerbotAIConfig::ParseTempTalentsOrder(uint32
     }
     for (int tab = 0; tab < 3; tab++)
     {
-        if (tab_links.size() <= tab)
+        if (tab_links.size() <= (size_t)tab)
         {
             break;
         }
         std::sort(spells[tab].begin(), spells[tab].end(),
                   [&](TalentEntry const* lhs, TalentEntry const* rhs)
                   { return lhs->Row != rhs->Row ? lhs->Row < rhs->Row : lhs->Col < rhs->Col; });
-        for (int i = 0; i < tab_links[tab].size(); i++)
+        for (uint32 i = 0; i < tab_links[tab].size(); i++)
         {
             if (i >= spells[tab].size())
             {
@@ -1005,7 +1005,7 @@ std::vector<std::vector<uint32>> PlayerbotAIConfig::ParseTempPetTalentsOrder(uin
     std::sort(spells.begin(), spells.end(),
               [&](TalentEntry const* lhs, TalentEntry const* rhs)
               { return lhs->Row != rhs->Row ? lhs->Row < rhs->Row : lhs->Col < rhs->Col; });
-    for (int i = 0; i < tab_link.size(); i++)
+    for (uint32 i = 0; i < tab_link.size(); i++)
     {
         if (i >= spells.size())
         {

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -140,6 +140,9 @@ bool PlayerbotAIConfig::Initialize()
             autoPartyBuffs = AutoPartyBuffMode::GROUP_OR_RAID;
             break;
     }
+    tellWhenMissingBuffReagents = sConfigMgr->GetOption<bool>("AiPlayerbot.TellWhenMissingBuffReagents", true);
+    missingBuffReagentMessageCooldown = sConfigMgr->GetOption<uint32>(
+        "AiPlayerbot.MissingBuffReagentMessageCooldown", 300);
     autoAvoidAoe = sConfigMgr->GetOption<bool>("AiPlayerbot.AutoAvoidAoe", true);
     maxAoeAvoidRadius = sConfigMgr->GetOption<float>("AiPlayerbot.MaxAoeAvoidRadius", 15.0f);
     LoadSet<std::set<uint32>>(sConfigMgr->GetOption<std::string>("AiPlayerbot.AoeAvoidSpellWhitelist", "50759,57491,13810,29946"),

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -103,6 +103,8 @@ public:
     uint32 saveManaThreshold;
     AutoPartyBuffMode autoGreaterBlessings;
     AutoPartyBuffMode autoPartyBuffs;
+    bool tellWhenMissingBuffReagents;
+    uint32 missingBuffReagentMessageCooldown;
     bool autoAvoidAoe;
     float maxAoeAvoidRadius;
     std::set<uint32> aoeAvoidSpellWhitelist;

--- a/src/Script/PlayerbotCommandScript.cpp
+++ b/src/Script/PlayerbotCommandScript.cpp
@@ -72,7 +72,7 @@ public:
         return GuildTaskMgr::HandleConsoleCommand(handler, args);
     }
 
-    static bool HandlePerfMonCommand(ChatHandler* handler, char const* args)
+    static bool HandlePerfMonCommand(ChatHandler* /*handler*/, char const* args)
     {
         if (!strcmp(args, "reset"))
         {

--- a/src/Script/Playerbots.cpp
+++ b/src/Script/Playerbots.cpp
@@ -527,6 +527,7 @@ void AddPlayerbotsSecureLoginScripts();
 
 void AddSC_TempestKeepBotScripts();
 void AddSC_IcecrownBotScripts();
+void AddSC_RubySanctumBotScripts();
 void AddSC_HyjalSummitBotScripts();
 
 void AddPlayerbotsScripts()
@@ -544,5 +545,6 @@ void AddPlayerbotsScripts()
     PlayerBotsGuildValidationScript();
     AddSC_TempestKeepBotScripts();
     AddSC_IcecrownBotScripts();
+    AddSC_RubySanctumBotScripts();
     AddSC_HyjalSummitBotScripts();
 }


### PR DESCRIPTION
Maintenance PR

Changelog:
* **Flight Path Cleanup**: Player-owned alt bots will now correctly have their temporary flight path cheats cleared upon logging out.
* **Flight Path Learning**: Bots will now properly learn flight path nodes when they interact with a flight master.
* **Gathering Configuration**: Players can now disable gathering behaviors (herbalism, mining, and skinning) on random bots to prevent them from competing for resource nodes.
* **Buff Reagent Announcements**: Bots can now announce in group or raid chat when they lack reagents for group buffs or greater blessings and have to fall back to casting single-target versions.
* **Performance Improvements**: Behind-the-scenes optimizations were made to how bot equipment and items are cached to improve server startup times and general performance.
* **Tank Threat and Taunting**: Tank bots will now prioritize holding threat on marked targets and will no longer taunt enemies off other tanks unless a main tank is explicitly designated.
* **Compiler Warning Cleanup**: Cleared various compiler warnings to improve code cleanliness.
* **Mount and Druid Form Fixes**: Druid bots will no longer stutter when using travel or flight forms, will correctly use swift flight form when matching a 310% mount master, and all bots will now prioritize summoning their fastest available mount.
* **Ruby Sanctum Raid Support**: Added full AI combat strategies and movement coordination for all boss encounters in the Ruby Sanctum raid.

AzerothCore fork: https://github.com/mod-playerbots/azerothcore-wotlk/tree/test-staging