### PR TITLE
BWL Bot Strategies: Razorgore & Vaelastrasz

### DIFF
--- a/src/Ai/Raid/BWL/BWLActionContext.h
+++ b/src/Ai/Raid/BWL/BWLActionContext.h
@@ -12,6 +12,14 @@ public:
     {
         creators["bwl check onyxia scale cloak"] = &RaidBwlActionContext::bwl_check_onyxia_scale_cloak;
         creators["bwl turn off suppression device"] = &RaidBwlActionContext::bwl_turn_off_suppression_device;
+
+        creators["bwl razorgore fire resistance"] = &RaidBwlActionContext::bwl_razorgore_fire_resistance_action;
+        creators["bwl razorgore avoid aoe"] = &RaidBwlActionContext::bwl_razorgore_avoid_aoe;
+        creators["bwl razorgore mark boss"] = &RaidBwlActionContext::bwl_razorgore_mark_boss;
+
+        creators["bwl vaelastrasz fire resistance"] = &RaidBwlActionContext::bwl_vaelastrasz_fire_resistance_action;
+        creators["bwl vaelastrasz move away"] = &RaidBwlActionContext::bwl_vaelastrasz_move_away;
+
         creators["bwl use hourglass sand"] = &RaidBwlActionContext::bwl_use_hourglass_sand;
         creators["bwl nefarian fear ward"] = &RaidBwlActionContext::bwl_nefarian_fear_ward;
         creators["bwl death talon wyrmguard tank move away"] = &RaidBwlActionContext::bwl_death_talon_wyrmguard_tank_move_away;
@@ -19,12 +27,17 @@ public:
     }
 
 private:
-    static Action* bwl_check_onyxia_scale_cloak(PlayerbotAI* botAI) { return new BwlOnyxiaScaleCloakAuraCheckAction(botAI); }
-    static Action* bwl_turn_off_suppression_device(PlayerbotAI* botAI) { return new BwlTurnOffSuppressionDeviceAction(botAI); }
-    static Action* bwl_use_hourglass_sand(PlayerbotAI* botAI) { return new BwlUseHourglassSandAction(botAI); }
-    static Action* bwl_nefarian_fear_ward(PlayerbotAI* botAI) { return new BwlNefarianFearWardAction(botAI); }
-    static Action* bwl_death_talon_wyrmguard_tank_move_away(PlayerbotAI* botAI) { return new BwlDeathTalonWyrmguardTankMoveAwayAction(botAI); }
-    static Action* bwl_death_talon_wyrmguard_ranged_move_away(PlayerbotAI* botAI) { return new BwlDeathTalonWyrmguardRangedMoveAwayAction(botAI); }
+    static Action* bwl_check_onyxia_scale_cloak(PlayerbotAI* ai) { return new BwlOnyxiaScaleCloakAuraCheckAction(ai); }
+    static Action* bwl_turn_off_suppression_device(PlayerbotAI* ai) { return new BwlTurnOffSuppressionDeviceAction(ai); }
+    static Action* bwl_razorgore_fire_resistance_action(PlayerbotAI* ai) { return new BossFireResistanceAction(ai, "razorgore the untamed"); }
+    static Action* bwl_razorgore_avoid_aoe(PlayerbotAI* ai) { return new BwlRazorgoreAvoidAoe(ai); }
+    static Action* bwl_razorgore_mark_boss(PlayerbotAI* ai) { return new BwlRazorgoreMarkBossAction(ai); }
+    static Action* bwl_vaelastrasz_fire_resistance_action(PlayerbotAI* ai) { return new BossFireResistanceAction(ai, "vaelastrasz the corrupt"); }
+    static Action* bwl_vaelastrasz_move_away(PlayerbotAI* ai) { return new BwlVaelastraszMoveAwayAction(ai); }
+    static Action* bwl_use_hourglass_sand(PlayerbotAI* ai) { return new BwlUseHourglassSandAction(ai); }
+    static Action* bwl_nefarian_fear_ward(PlayerbotAI* ai) { return new BwlNefarianFearWardAction(ai); }
+    static Action* bwl_death_talon_wyrmguard_tank_move_away(PlayerbotAI* ai) { return new BwlDeathTalonWyrmguardTankMoveAwayAction(ai); }
+    static Action* bwl_death_talon_wyrmguard_ranged_move_away(PlayerbotAI* ai) { return new BwlDeathTalonWyrmguardRangedMoveAwayAction(ai); }
 };
 
 #endif

--- a/src/Ai/Raid/BWL/BWLActionContext.h
+++ b/src/Ai/Raid/BWL/BWLActionContext.h
@@ -30,7 +30,7 @@ private:
     static Action* bwl_check_onyxia_scale_cloak(PlayerbotAI* ai) { return new BwlOnyxiaScaleCloakAuraCheckAction(ai); }
     static Action* bwl_turn_off_suppression_device(PlayerbotAI* ai) { return new BwlTurnOffSuppressionDeviceAction(ai); }
     static Action* bwl_razorgore_fire_resistance_action(PlayerbotAI* ai) { return new BossFireResistanceAction(ai, "razorgore the untamed"); }
-    static Action* bwl_razorgore_avoid_aoe(PlayerbotAI* ai) { return new BwlRazorgoreAvoidAoe(ai); }
+    static Action* bwl_razorgore_avoid_aoe(PlayerbotAI* ai) { return new BwlRazorgoreAvoidAoeAction(ai); }
     static Action* bwl_razorgore_mark_boss(PlayerbotAI* ai) { return new BwlRazorgoreMarkBossAction(ai); }
     static Action* bwl_vaelastrasz_fire_resistance_action(PlayerbotAI* ai) { return new BossFireResistanceAction(ai, "vaelastrasz the corrupt"); }
     static Action* bwl_vaelastrasz_move_away(PlayerbotAI* ai) { return new BwlVaelastraszMoveAwayAction(ai); }

--- a/src/Ai/Raid/BWL/BWLActions.cpp
+++ b/src/Ai/Raid/BWL/BWLActions.cpp
@@ -19,19 +19,19 @@ static constexpr float VAELASTRASZ_REPULSION_RANGE = 20.0f;
 static constexpr float VAELASTRASZ_TAIL_SWEEP_RECOVERY_RANGE = 30.0f;
 static constexpr float VAELASTRASZ_RANGED_BIAS_THRESHOLD = 25.0f;
 static constexpr float VAELASTRASZ_RANGED_BIAS_FLEE_WEIGHT = 0.7f;
-static constexpr float VAELASTRASZ_RANGED_BIAS_BOSS_WEIGHT = 1 - VAELASTRASZ_RANGED_BIAS_FLEE_WEIGHT;
+static constexpr float VAELASTRASZ_RANGED_BIAS_BOSS_WEIGHT = 1.0f - VAELASTRASZ_RANGED_BIAS_FLEE_WEIGHT;
 
 // General
 
 bool BwlOnyxiaScaleCloakAuraCheckAction::Execute(Event /*event*/)
 {
-    bot->AddAura(SPELL_ONYXIA_SCALE_CLOAK, bot);
+    bot->AddAura(static_cast<uint32>(BlackwingLairSpells::SPELL_ONYXIA_SCALE_CLOAK), bot);
     return true;
 }
 
 bool BwlOnyxiaScaleCloakAuraCheckAction::isUseful()
 {
-    return !bot->HasAura(SPELL_ONYXIA_SCALE_CLOAK);
+    return !bot->HasAura(static_cast<uint32>(BlackwingLairSpells::SPELL_ONYXIA_SCALE_CLOAK));
 }
 
 bool BwlTurnOffSuppressionDeviceAction::Execute(Event /*event*/)
@@ -48,23 +48,17 @@ bool BwlTurnOffSuppressionDeviceAction::Execute(Event /*event*/)
     return true;
 }
 
-bool BwlTurnOffSuppressionDeviceAction::isUseful()
-{
-    // Originally, only rogues could disarm suppression devices.
-    // If raid cheats are enabled, any bot can disarm the devices.
-    return bot->IsClass(CLASS_ROGUE) || botAI->HasCheat(BotCheatMask::raid);
-}
-
 // Razorgore the Untamed
 
-bool BwlRazorgoreAvoidAoe::Execute(Event /*event*/)
+bool BwlRazorgoreAvoidAoeAction::Execute(Event /*event*/)
 {
     Unit* boss = AI_VALUE2(Unit*, "find target", "razorgore the untamed");
     if (!boss)
         return false;
 
-    // The current tank should not move
-    if (PlayerbotAI::IsTank(bot) && boss->GetVictim() == bot)
+    // The current target should not move.
+    // Also prevents non-tanks from rotating the boss if they have aggro.
+    if (boss->GetVictim() == bot)
         return false;
 
     float distance = bot->GetDistance2d(boss);
@@ -91,7 +85,7 @@ bool BwlRazorgoreAvoidAoe::Execute(Event /*event*/)
         float moveY = bot->GetPositionY() + (dY / dist) * INCREMENTAL_MOVE_STEP_DISTANCE;
 
         return MoveTo(boss->GetMapId(), moveX, moveY, bot->GetPositionZ(), false, false,
-                      false, false, MovementPriority::MOVEMENT_COMBAT);
+                      false, false, MovementPriority::MOVEMENT_COMBAT, true);
     }
 
     // Ranged outside the cone but too close => back off to avoid War Stomp
@@ -167,7 +161,7 @@ bool BwlVaelastraszMoveAwayAction::CalculateFleeDirection(const Unit* boss, floa
                 continue;
 
             // Boss alive: ignore other Burning Adrenaline bots so they can group together
-            if (!bossDead && p->HasAura(SPELL_BURNING_ADRENALINE))
+            if (!bossDead && p->HasAura(static_cast<uint32>(BlackwingLairSpells::SPELL_BURNING_ADRENALINE)))
                 continue;
 
             // Compute a flee direction via weighted repulsion from other bots.
@@ -254,7 +248,7 @@ bool BwlVaelastraszMoveAwayAction::MoveAlongFleeDirection(const Unit* boss, floa
                 continue;
 
             if (MoveTo(bot->GetMapId(), targetX, targetY, bot->GetPositionZ(), false, false,
-                       false, false, MovementPriority::MOVEMENT_FORCED))
+                       false, false, MovementPriority::MOVEMENT_FORCED, true))
                 return true;
         }
     }
@@ -266,7 +260,7 @@ bool BwlVaelastraszMoveAwayAction::MoveAlongFleeDirection(const Unit* boss, floa
 
 bool BwlUseHourglassSandAction::Execute(Event /*event*/)
 {
-    return botAI->CastSpell(SPELL_HOURGLASS_SAND, bot);
+    return botAI->CastSpell(static_cast<uint32>(BlackwingLairSpells::SPELL_HOURGLASS_SAND), bot);
 }
 
 bool BwlNefarianFearWardAction::Execute(Event /*event*/)
@@ -292,7 +286,7 @@ Unit* BwlDeathTalonWyrmguardTankMoveAwayAction::GetTarget()
     for (auto const& [guid, ref] : bot->GetThreatMgr().GetThreatenedByMeList())
     {
         Unit* unit = ref->GetOwner();
-        if (!unit || !unit->IsAlive() || unit->GetEntry() != NPC_DEATH_TALON_WYRMGUARD)
+        if (!unit || !unit->IsAlive() || unit->GetEntry() != static_cast<uint32>(BlackwingLairNPCs::NPC_DEATH_TALON_WYRMGUARD))
             continue;
         if (bot->GetDistance2d(unit) > WYRMGUARD_SAFE_DISTANCE)
             continue;
@@ -312,7 +306,8 @@ bool BwlDeathTalonWyrmguardTankMoveAwayAction::isUseful()
     for (auto const& [guid, ref] : bot->GetThreatMgr().GetThreatenedByMeList())
     {
         Unit* unit = ref->GetOwner();
-        if (unit && unit->IsAlive() && unit->GetEntry() == NPC_DEATH_TALON_WYRMGUARD && unit->GetVictim() == bot)
+        if (unit && unit->IsAlive() && unit->GetEntry() == static_cast<uint32>(BlackwingLairNPCs::NPC_DEATH_TALON_WYRMGUARD) &&
+            unit->GetVictim() == bot)
             return true;
     }
     return false;
@@ -339,7 +334,7 @@ Unit* BwlDeathTalonWyrmguardRangedMoveAwayAction::GetTarget()
     for (auto const& [guid, ref] : bot->GetThreatMgr().GetThreatenedByMeList())
     {
         Unit* unit = ref->GetOwner();
-        if (!unit || !unit->IsAlive() || unit->GetEntry() != NPC_DEATH_TALON_WYRMGUARD)
+        if (!unit || !unit->IsAlive() || unit->GetEntry() != static_cast<uint32>(BlackwingLairNPCs::NPC_DEATH_TALON_WYRMGUARD))
             continue;
         float dist = bot->GetDistance2d(unit);
         if (dist < closestDist)

--- a/src/Ai/Raid/BWL/BWLActions.cpp
+++ b/src/Ai/Raid/BWL/BWLActions.cpp
@@ -1,9 +1,25 @@
 #include "BWLActions.h"
 
+#include "RtiTargetValue.h"
 #include "Playerbots.h"
 #include "BWLHelpers.h"
+#include "RaidBossHelpers.h"
 
 using namespace BlackwingLairHelpers;
+
+static constexpr float INCREMENTAL_MOVE_STEP_DISTANCE = 3.0f;
+
+static constexpr float RAZORGORE_CONE_RADIUS = 15.0f;
+static constexpr float RAZORGORE_CONE_ARC = M_PI;
+static constexpr float RAZORGORE_BACK_FUZZ_ARC = M_PI_4;
+static constexpr float RAZORGORE_RANGE_DISTANCE = 15.0f;
+static constexpr float RAZORGORE_MELEE_DISTANCE = 3.0f;
+
+static constexpr float VAELASTRASZ_REPULSION_RANGE = 20.0f;
+static constexpr float VAELASTRASZ_TAIL_SWEEP_RECOVERY_RANGE = 30.0f;
+static constexpr float VAELASTRASZ_RANGED_BIAS_THRESHOLD = 25.0f;
+static constexpr float VAELASTRASZ_RANGED_BIAS_FLEE_WEIGHT = 0.7f;
+static constexpr float VAELASTRASZ_RANGED_BIAS_BOSS_WEIGHT = 1 - VAELASTRASZ_RANGED_BIAS_FLEE_WEIGHT;
 
 // General
 
@@ -30,6 +46,220 @@ bool BwlTurnOffSuppressionDeviceAction::Execute(Event /*event*/)
         }
     }
     return true;
+}
+
+bool BwlTurnOffSuppressionDeviceAction::isUseful()
+{
+    // Originally, only rogues could disarm suppression devices.
+    // If raid cheats are enabled, any bot can disarm the devices.
+    return bot->IsClass(CLASS_ROGUE) || botAI->HasCheat(BotCheatMask::raid);
+}
+
+// Razorgore the Untamed
+
+bool BwlRazorgoreAvoidAoe::Execute(Event /*event*/)
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", "razorgore the untamed");
+    if (!boss)
+        return false;
+
+    // The current tank should not move
+    if (PlayerbotAI::IsTank(bot) && boss->GetVictim() == bot)
+        return false;
+
+    float distance = bot->GetDistance2d(boss);
+
+    // Bot is too close and standing in Razorgore's frontal cone
+    if (distance <= RAZORGORE_CONE_RADIUS && boss->HasInArc(RAZORGORE_CONE_ARC, bot))
+    {
+        // Target position: directly behind the boss with a small random fuzz
+        // to prevent all bots stacking on the same spot
+        float moveAngle = boss->GetOrientation() + M_PI + frand(-RAZORGORE_BACK_FUZZ_ARC, RAZORGORE_BACK_FUZZ_ARC);
+        float razorgoreRadius = PlayerbotAI::IsRanged(bot) ? RAZORGORE_RANGE_DISTANCE : RAZORGORE_MELEE_DISTANCE;
+
+        float targetMoveX = boss->GetPositionX() + razorgoreRadius * cos(moveAngle);
+        float targetMoveY = boss->GetPositionY() + razorgoreRadius * sin(moveAngle);
+
+        // Move incrementally toward the target. Allows course correction.
+        float dX = targetMoveX - bot->GetPositionX();
+        float dY = targetMoveY - bot->GetPositionY();
+        float dist = sqrt(dX * dX + dY * dY);
+        if (dist == 0.0f)
+            dist = 0.1f;
+
+        float moveX = bot->GetPositionX() + (dX / dist) * INCREMENTAL_MOVE_STEP_DISTANCE;
+        float moveY = bot->GetPositionY() + (dY / dist) * INCREMENTAL_MOVE_STEP_DISTANCE;
+
+        return MoveTo(boss->GetMapId(), moveX, moveY, bot->GetPositionZ(), false, false,
+                      false, false, MovementPriority::MOVEMENT_COMBAT);
+    }
+
+    // Ranged outside the cone but too close => back off to avoid War Stomp
+    if (PlayerbotAI::IsRanged(bot))
+    {
+        float distToTravel = RAZORGORE_RANGE_DISTANCE - distance;
+        if (distToTravel > 0)
+            return MoveAway(boss, distToTravel);
+    }
+
+    return false;
+}
+
+bool BwlRazorgoreMarkBossAction::Execute(Event /*event*/)
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", "razorgore the untamed");
+    if (!boss)
+        return false;
+
+    if (AreRazorgoreEggsAlive(botAI))
+    {
+        if (IsRazorgoreOffTank(bot))
+        {
+            MarkTargetWithMoon(bot, boss);
+            SetRtiTarget(botAI, "moon", boss);
+
+            if (AI_VALUE(Unit*, "current target") != boss)
+                return Attack(boss);
+        }
+    }
+    else
+    {
+        ClearTargetIcon(bot, RtiTargetValue::moonIndex);
+    }
+
+    return false;
+}
+
+bool BwlRazorgoreMarkBossAction::isUseful()
+{
+    return PlayerbotAI::IsTank(bot);
+}
+
+// Vaelastrasz the Corrupt
+
+bool BwlVaelastraszMoveAwayAction::Execute(Event /*event*/)
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", "vaelastrasz the corrupt");
+
+    // Current target with Burning Adrenaline stays put when Vaelastrasz is alive.
+    if (boss && boss->IsAlive() && boss->GetVictim() == bot)
+        return false;
+
+    float fleeX, fleeY;
+    if (!CalculateFleeDirection(boss, fleeX, fleeY))
+        return false;
+
+    return MoveAlongFleeDirection(boss, fleeX, fleeY);
+}
+
+bool BwlVaelastraszMoveAwayAction::CalculateFleeDirection(const Unit* boss, float& fleeX, float& fleeY) const
+{
+    fleeX = 0.0f;
+    fleeY = 0.0f;
+    bool bossDead = !boss || !boss->IsAlive();
+
+    if (const Group* group = bot->GetGroup())
+    {
+        for (const GroupReference* gref = group->GetFirstMember(); gref; gref = gref->next())
+        {
+            Player* p = gref->GetSource();
+            if (!p || p == bot || !p->IsAlive() || p->GetMapId() != bot->GetMapId())
+                continue;
+
+            // Boss alive: ignore other Burning Adrenaline bots so they can group together
+            if (!bossDead && p->HasAura(SPELL_BURNING_ADRENALINE))
+                continue;
+
+            // Compute a flee direction via weighted repulsion from other bots.
+            // Weighted repulsion: closer = stronger push (linear falloff to 20y)
+            float dist = bot->GetDistance2d(p);
+            if (dist < VAELASTRASZ_REPULSION_RANGE && dist > 0.1f)
+            {
+                float weight = 1.0f - dist / VAELASTRASZ_REPULSION_RANGE;
+                fleeX += (bot->GetPositionX() - p->GetPositionX()) / dist * weight;
+                fleeY += (bot->GetPositionY() - p->GetPositionY()) / dist * weight;
+            }
+        }
+    }
+
+    float fleeLen = sqrt(fleeX * fleeX + fleeY * fleeY);
+
+    // No repulsion
+    if (fleeLen < 0.1f)
+    {
+        // Tail Sweep recovery: move back toward boss
+        if (!bossDead && bot->GetDistance2d(boss) > VAELASTRASZ_TAIL_SWEEP_RECOVERY_RANGE)
+        {
+            float toBossX = boss->GetPositionX() - bot->GetPositionX();
+            float toBossY = boss->GetPositionY() - bot->GetPositionY();
+            float dist = sqrt(toBossX * toBossX + toBossY * toBossY);
+            if (dist > 0.1f)
+            {
+                fleeX = toBossX / dist;
+                fleeY = toBossY / dist;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    fleeX /= fleeLen;
+    fleeY /= fleeLen;
+
+    // Ranged: blend flee direction toward boss when >25y to stay in cast range
+    if (!bossDead && PlayerbotAI::IsRanged(bot))
+    {
+        float bossDist = bot->GetDistance2d(boss);
+        if (bossDist > VAELASTRASZ_RANGED_BIAS_THRESHOLD)
+        {
+            float toBossX = (boss->GetPositionX() - bot->GetPositionX()) / bossDist;
+            float toBossY = (boss->GetPositionY() - bot->GetPositionY()) / bossDist;
+            if (fleeX * toBossX + fleeY * toBossY < 0.0f)
+            {
+                fleeX = fleeX * VAELASTRASZ_RANGED_BIAS_FLEE_WEIGHT + toBossX * VAELASTRASZ_RANGED_BIAS_BOSS_WEIGHT;
+                fleeY = fleeY * VAELASTRASZ_RANGED_BIAS_FLEE_WEIGHT + toBossY * VAELASTRASZ_RANGED_BIAS_BOSS_WEIGHT;
+                float len = sqrt(fleeX * fleeX + fleeY * fleeY);
+                fleeX /= len;
+                fleeY /= len;
+            }
+        }
+    }
+
+    return true;
+}
+
+bool BwlVaelastraszMoveAwayAction::MoveAlongFleeDirection(const Unit* boss, float fleeX, float fleeY)
+{
+    bool bossDead = !boss || !boss->IsAlive();
+    float baseAngle = atan2(fleeY, fleeX);
+
+    // Pass 1: ranged try LOS positions first
+    // Pass 2: everyone, no LOS req
+    for (bool requireLos : {true, false})
+    {
+        // Ranged bots try LOS positions first, then fall back to no-LOS.
+        if (requireLos && (!PlayerbotAI::IsRanged(bot) || bossDead))
+            continue;
+
+        // Try 5 angles (0°, ±45°, ±90°) around the flee direction to slide along walls.
+        static constexpr float angleOffsets[] = {0.0f, M_PI_4, -M_PI_4, M_PI_2, -M_PI_2};
+        for (float offset : angleOffsets)
+        {
+            float angle = baseAngle + offset;
+            float targetX = bot->GetPositionX() + INCREMENTAL_MOVE_STEP_DISTANCE * cos(angle);
+            float targetY = bot->GetPositionY() + INCREMENTAL_MOVE_STEP_DISTANCE * sin(angle);
+
+            // Reject if LOS to boss would break (only checked in Pass 1 for ranged)
+            if (requireLos && boss && !boss->IsWithinLOS(targetX, targetY, bot->GetPositionZ()))
+                continue;
+
+            if (MoveTo(bot->GetMapId(), targetX, targetY, bot->GetPositionZ(), false, false,
+                       false, false, MovementPriority::MOVEMENT_FORCED))
+                return true;
+        }
+    }
+
+    return false;
 }
 
 // Chromaggus

--- a/src/Ai/Raid/BWL/BWLActions.h
+++ b/src/Ai/Raid/BWL/BWLActions.h
@@ -2,7 +2,7 @@
 #define PLAYERBOTS_BWLACTIONS_H
 
 #include "Action.h"
-#include "MovementActions.h"
+#include "AttackAction.h"
 
 // General
 
@@ -19,6 +19,37 @@ class BwlTurnOffSuppressionDeviceAction : public Action
 public:
     BwlTurnOffSuppressionDeviceAction(PlayerbotAI* botAI) : Action(botAI, "bwl turn off suppression device") {}
     bool Execute(Event event) override;
+    bool isUseful() override;
+};
+
+// Razorgore the Untamed
+
+class BwlRazorgoreAvoidAoe : public MovementAction
+{
+public:
+    BwlRazorgoreAvoidAoe(PlayerbotAI* botAI) : MovementAction(botAI, "bwl razorgore avoid aoe") {}
+    bool Execute(Event event) override;
+};
+
+class BwlRazorgoreMarkBossAction : public AttackAction
+{
+public:
+    BwlRazorgoreMarkBossAction(PlayerbotAI* botAI) : AttackAction(botAI, "bwl razorgore mark boss") {}
+    bool Execute(Event event) override;
+    bool isUseful() override;
+};
+
+// Vaelastrasz the Corrupt
+
+class BwlVaelastraszMoveAwayAction : public MovementAction
+{
+public:
+    BwlVaelastraszMoveAwayAction(PlayerbotAI* botAI) : MovementAction(botAI, "bwl vaelastrasz move away") {}
+    bool Execute(Event event) override;
+
+private:
+    bool CalculateFleeDirection(const Unit* boss, float& fleeX, float& fleeY) const;
+    bool MoveAlongFleeDirection(const Unit* boss, float fleeX, float fleeY);
 };
 
 // Chromaggus

--- a/src/Ai/Raid/BWL/BWLActions.h
+++ b/src/Ai/Raid/BWL/BWLActions.h
@@ -2,6 +2,7 @@
 #define PLAYERBOTS_BWLACTIONS_H
 
 #include "Action.h"
+#include "MovementActions.h"
 #include "AttackAction.h"
 
 // General
@@ -19,15 +20,14 @@ class BwlTurnOffSuppressionDeviceAction : public Action
 public:
     BwlTurnOffSuppressionDeviceAction(PlayerbotAI* botAI) : Action(botAI, "bwl turn off suppression device") {}
     bool Execute(Event event) override;
-    bool isUseful() override;
 };
 
 // Razorgore the Untamed
 
-class BwlRazorgoreAvoidAoe : public MovementAction
+class BwlRazorgoreAvoidAoeAction : public MovementAction
 {
 public:
-    BwlRazorgoreAvoidAoe(PlayerbotAI* botAI) : MovementAction(botAI, "bwl razorgore avoid aoe") {}
+    BwlRazorgoreAvoidAoeAction(PlayerbotAI* botAI) : MovementAction(botAI, "bwl razorgore avoid aoe") {}
     bool Execute(Event event) override;
 };
 

--- a/src/Ai/Raid/BWL/BWLHelpers.cpp
+++ b/src/Ai/Raid/BWL/BWLHelpers.cpp
@@ -1,12 +1,55 @@
 #include "BWLHelpers.h"
 
+#include "AiObjectContext.h"
+#include "Group.h"
+
 namespace BlackwingLairHelpers
 {
     bool IsActiveSuppressionDeviceInRange(const GameObject* go, const Player* bot)
     {
+        constexpr float suppressionDeviceInteractionDistance = 15.0f;
         return go &&
                go->GetEntry() == GO_SUPPRESSION_DEVICE &&
-               go->GetDistance(bot) < 15.0f &&
+               go->GetDistance(bot) < suppressionDeviceInteractionDistance &&
                go->GetGoState() == GO_STATE_READY;
+    }
+
+    bool AreRazorgoreEggsAlive(PlayerbotAI* botAI)
+    {
+        GuidVector gos = botAI->GetAiObjectContext()->GetValue<GuidVector>("nearest game objects")->Get();
+        for (auto const& guid : gos)
+        {
+            const GameObject* go = botAI->GetGameObject(guid);
+            if (go && go->GetEntry() == GO_BLACK_DRAGON_EGG)
+                return true;
+        }
+        return false;
+    }
+
+    bool IsRazorgoreOffTank(Player* bot)
+    {
+        return PlayerbotAI::IsAssistTankOfIndex(bot, 0, true);
+    }
+
+    bool IsNonBABotNearPosition(const Player* bot, Position const& position, float distance)
+    {
+        const Group* group = bot->GetGroup();
+        if (!group)
+            return false;
+
+        for (const GroupReference* gref = group->GetFirstMember(); gref; gref = gref->next())
+        {
+            const Player* p = gref->GetSource();
+            if (!p || p == bot || !p->IsAlive() || p->GetMapId() != bot->GetMapId())
+                continue;
+
+            if (p->HasAura(SPELL_BURNING_ADRENALINE))
+                continue;
+
+            if (p->GetDistance2d(position.GetPositionX(), position.GetPositionY()) < distance)
+                return true;
+        }
+
+        return false;
     }
 }

--- a/src/Ai/Raid/BWL/BWLHelpers.cpp
+++ b/src/Ai/Raid/BWL/BWLHelpers.cpp
@@ -9,7 +9,7 @@ namespace BlackwingLairHelpers
     {
         constexpr float suppressionDeviceInteractionDistance = 15.0f;
         return go &&
-               go->GetEntry() == GO_SUPPRESSION_DEVICE &&
+               go->GetEntry() == static_cast<uint32>(BlackwingLairGameObjects::GO_SUPPRESSION_DEVICE) &&
                go->GetDistance(bot) < suppressionDeviceInteractionDistance &&
                go->GetGoState() == GO_STATE_READY;
     }
@@ -20,7 +20,7 @@ namespace BlackwingLairHelpers
         for (auto const& guid : gos)
         {
             const GameObject* go = botAI->GetGameObject(guid);
-            if (go && go->GetEntry() == GO_BLACK_DRAGON_EGG)
+            if (go && go->GetEntry() == static_cast<uint32>(BlackwingLairGameObjects::GO_BLACK_DRAGON_EGG))
                 return true;
         }
         return false;
@@ -43,7 +43,7 @@ namespace BlackwingLairHelpers
             if (!p || p == bot || !p->IsAlive() || p->GetMapId() != bot->GetMapId())
                 continue;
 
-            if (p->HasAura(SPELL_BURNING_ADRENALINE))
+            if (p->HasAura(static_cast<uint32>(BlackwingLairSpells::SPELL_BURNING_ADRENALINE)))
                 continue;
 
             if (p->GetDistance2d(position.GetPositionX(), position.GetPositionY()) < distance)

--- a/src/Ai/Raid/BWL/BWLHelpers.h
+++ b/src/Ai/Raid/BWL/BWLHelpers.h
@@ -2,6 +2,7 @@
 #define PLAYERBOTS_BWLHELPERS_H
 
 #include "Player.h"
+#include "PlayerbotAI.h"
 
 namespace BlackwingLairHelpers
 {
@@ -9,6 +10,12 @@ namespace BlackwingLairHelpers
     {
         // General
         SPELL_ONYXIA_SCALE_CLOAK = 22683,
+
+        // Razorgore the Untamed
+        SPELL_MINDCONTROL = 19832,
+
+        // Vaelastrasz the Corrupt
+        SPELL_BURNING_ADRENALINE = 18173,
 
         // Chromaggus
         SPELL_BROOD_AFFLICTION_BRONZE = 23170,
@@ -21,7 +28,10 @@ namespace BlackwingLairHelpers
     enum BlackwingLairGameObjects
     {
         // General
-        GO_SUPPRESSION_DEVICE = 179784
+        GO_SUPPRESSION_DEVICE = 179784,
+
+        // Razorgore the Untamed
+        GO_BLACK_DRAGON_EGG = 177807
     };
 
     enum BlackwingLairNPCs
@@ -31,6 +41,9 @@ namespace BlackwingLairHelpers
     };
 
     bool IsActiveSuppressionDeviceInRange(const GameObject* go, const Player* bot);
+    bool AreRazorgoreEggsAlive(PlayerbotAI* botAI);
+    bool IsRazorgoreOffTank(Player* bot);
+    bool IsNonBABotNearPosition(const Player* bot, Position const& position, float distance);
 }
 
 #endif //_PLAYERBOT_RAIDBWLHELPERS_H

--- a/src/Ai/Raid/BWL/BWLHelpers.h
+++ b/src/Ai/Raid/BWL/BWLHelpers.h
@@ -6,7 +6,7 @@
 
 namespace BlackwingLairHelpers
 {
-    enum BlackwingLairSpells
+    enum class BlackwingLairSpells : uint32
     {
         // General
         SPELL_ONYXIA_SCALE_CLOAK = 22683,
@@ -25,7 +25,7 @@ namespace BlackwingLairHelpers
         SPELL_WILD_MAGIC = 23410
     };
 
-    enum BlackwingLairGameObjects
+    enum class BlackwingLairGameObjects : uint32
     {
         // General
         GO_SUPPRESSION_DEVICE = 179784,
@@ -34,7 +34,7 @@ namespace BlackwingLairHelpers
         GO_BLACK_DRAGON_EGG = 177807
     };
 
-    enum BlackwingLairNPCs
+    enum class BlackwingLairNPCs : uint32
     {
         // Trash
         NPC_DEATH_TALON_WYRMGUARD = 12460
@@ -46,4 +46,4 @@ namespace BlackwingLairHelpers
     bool IsNonBABotNearPosition(const Player* bot, Position const& position, float distance);
 }
 
-#endif //_PLAYERBOT_RAIDBWLHELPERS_H
+#endif

--- a/src/Ai/Raid/BWL/BWLMultipliers.cpp
+++ b/src/Ai/Raid/BWL/BWLMultipliers.cpp
@@ -19,7 +19,7 @@ using namespace BlackwingLairHelpers;
 
 static constexpr float VAELASTRASZ_BA_SAFE_DISTANCE = 20.0f;
 static constexpr float VAELASTRASZ_BA_BOSS_DISTANCE = 30.0f;
-static constexpr float VAELASTRASZ_WARLOCK_DRAIN_SOUL_THRESHOLD = 3;
+static constexpr float VAELASTRASZ_WARLOCK_DRAIN_SOUL_THRESHOLD = 3.0f;
 
 float RazorgoreTankMultiplier::GetValue(Action* action)
 {
@@ -67,7 +67,7 @@ float VaelastraszTankMultiplier::GetValue(Action* action)
 
 float VaelastraszBurningAdrenalineMultiplier::GetValue(Action* action)
 {
-    if (bot->HasAura(SPELL_BURNING_ADRENALINE))
+    if (bot->HasAura(static_cast<uint32>(BlackwingLairSpells::SPELL_BURNING_ADRENALINE)))
     {
         if (dynamic_cast<MovementAction*>(action))
         {

--- a/src/Ai/Raid/BWL/BWLMultipliers.cpp
+++ b/src/Ai/Raid/BWL/BWLMultipliers.cpp
@@ -13,13 +13,11 @@
 #include "HunterActions.h"
 #include "Playerbots.h"
 #include "ReachTargetActions.h"
-#include "WarlockActions.h"
 
 using namespace BlackwingLairHelpers;
 
 static constexpr float VAELASTRASZ_BA_SAFE_DISTANCE = 20.0f;
 static constexpr float VAELASTRASZ_BA_BOSS_DISTANCE = 30.0f;
-static constexpr float VAELASTRASZ_WARLOCK_DRAIN_SOUL_THRESHOLD = 3.0f;
 
 float RazorgoreTankMultiplier::GetValue(Action* action)
 {
@@ -88,24 +86,6 @@ float VaelastraszBurningAdrenalineMultiplier::GetValue(Action* action)
         if (dynamic_cast<CastReachTargetSpellAction*>(action))
             return 0.0f;
     }
-
-    return 1.0f;
-}
-
-float VaelastraszWarlockDrainSoulMultiplier::GetValue(Action* action)
-{
-    if (!bot->IsClass(CLASS_WARLOCK))
-        return 1.0f;
-
-    Unit* boss = AI_VALUE2(Unit*, "find target", "vaelastrasz the corrupt");
-    if (!boss)
-        return 1.0f;
-
-    // Vaelastrasz starts at 30% hp. Warlocks will try to use Drain Soul at 20% hp.
-    // Delay usage of Drain Soul until 3% hp because of low damage.
-    if (dynamic_cast<CastDrainSoulAction*>(action) && action->GetTarget() == boss &&
-        boss->GetHealthPct() > VAELASTRASZ_WARLOCK_DRAIN_SOUL_THRESHOLD)
-        return 0.0f;
 
     return 1.0f;
 }

--- a/src/Ai/Raid/BWL/BWLMultipliers.cpp
+++ b/src/Ai/Raid/BWL/BWLMultipliers.cpp
@@ -1,0 +1,111 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "BWLMultipliers.h"
+
+#include "BWLActions.h"
+#include "BWLHelpers.h"
+#include "ChooseTargetActions.h"
+#include "GenericActions.h"
+#include "HunterActions.h"
+#include "Playerbots.h"
+#include "ReachTargetActions.h"
+#include "WarlockActions.h"
+
+using namespace BlackwingLairHelpers;
+
+static constexpr float VAELASTRASZ_BA_SAFE_DISTANCE = 20.0f;
+static constexpr float VAELASTRASZ_BA_BOSS_DISTANCE = 30.0f;
+static constexpr float VAELASTRASZ_WARLOCK_DRAIN_SOUL_THRESHOLD = 3;
+
+float RazorgoreTankMultiplier::GetValue(Action* action)
+{
+    if (!PlayerbotAI::IsTank(bot))
+        return 1.0f;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "razorgore the untamed");
+    if (!boss)
+        return 1.0f;
+
+    if (AreRazorgoreEggsAlive(botAI))
+    {
+        // Off-tank picks up boss, blocks TankAssistAction to avoid changing targets
+        if (IsRazorgoreOffTank(bot) && bot->GetVictim() != nullptr && dynamic_cast<TankAssistAction*>(action))
+            return 0.0f;
+        return 1.0f;
+    }
+
+    // All eggs destroyed. Tanks not targeted by the boss don't run into the Cleave.
+    if (boss->GetVictim() != bot && dynamic_cast<TankFaceAction*>(action))
+        return 0.0f;
+    return 1.0f;
+}
+
+float VaelastraszTankMultiplier::GetValue(Action* action)
+{
+    if (!PlayerbotAI::IsTank(bot))
+        return 1.0f;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "vaelastrasz the corrupt");
+    if (!boss)
+        return 1.0f;
+
+    // Stay at rear flank position and don't move in front of the boss.
+    if (dynamic_cast<TankFaceAction*>(action))
+    {
+        Unit* victim = boss->GetVictim();
+        Player* victimPlayer = victim ? victim->ToPlayer() : nullptr;
+        if (victim != bot && victimPlayer && PlayerbotAI::IsTank(victimPlayer))
+            return 0.0f;
+    }
+
+    return 1.0f;
+}
+
+float VaelastraszBurningAdrenalineMultiplier::GetValue(Action* action)
+{
+    if (bot->HasAura(SPELL_BURNING_ADRENALINE))
+    {
+        if (dynamic_cast<MovementAction*>(action))
+        {
+            if (dynamic_cast<BwlVaelastraszMoveAwayAction*>(action))
+            {
+                // Allow movement when boss is dead or bot was knocked away
+                Unit* boss = AI_VALUE2(Unit*, "find target", "vaelastrasz the corrupt");
+                if (!boss || !boss->IsAlive() || bot->GetDistance2d(boss) > VAELASTRASZ_BA_BOSS_DISTANCE)
+                    return 1.0f;
+            }
+
+            // Block ALL other movement once bot is far enough from non-BA bots
+            if (!IsNonBABotNearPosition(bot, bot->GetPosition(), VAELASTRASZ_BA_SAFE_DISTANCE) ||
+                !dynamic_cast<BwlVaelastraszMoveAwayAction*>(action))
+                return 0.0f;
+        }
+        // Also block charge actions
+        if (dynamic_cast<CastReachTargetSpellAction*>(action))
+            return 0.0f;
+    }
+
+    return 1.0f;
+}
+
+float VaelastraszWarlockDrainSoulMultiplier::GetValue(Action* action)
+{
+    if (!bot->IsClass(CLASS_WARLOCK))
+        return 1.0f;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "vaelastrasz the corrupt");
+    if (!boss)
+        return 1.0f;
+
+    // Vaelastrasz starts at 30% hp. Warlocks will try to use Drain Soul at 20% hp.
+    // Delay usage of Drain Soul until 3% hp because of low damage.
+    if (dynamic_cast<CastDrainSoulAction*>(action) && action->GetTarget() == boss &&
+        boss->GetHealthPct() > VAELASTRASZ_WARLOCK_DRAIN_SOUL_THRESHOLD)
+        return 0.0f;
+
+    return 1.0f;
+}

--- a/src/Ai/Raid/BWL/BWLMultipliers.h
+++ b/src/Ai/Raid/BWL/BWLMultipliers.h
@@ -33,12 +33,4 @@ public:
     float GetValue(Action* action) override;
 };
 
-class VaelastraszWarlockDrainSoulMultiplier : public Multiplier
-{
-public:
-    VaelastraszWarlockDrainSoulMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "vaelastrasz warlock drain soul multiplier") {}
-    float GetValue(Action* action) override;
-};
-
 #endif

--- a/src/Ai/Raid/BWL/BWLMultipliers.h
+++ b/src/Ai/Raid/BWL/BWLMultipliers.h
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_BWLMULTIPLIERS_H
+#define PLAYERBOTS_BWLMULTIPLIERS_H
+
+#include "Multiplier.h"
+
+class RazorgoreTankMultiplier : public Multiplier
+{
+public:
+    RazorgoreTankMultiplier(
+        PlayerbotAI* botAI) : Multiplier(botAI, "razorgore tank multiplier") {}
+    float GetValue(Action* action) override;
+};
+
+class VaelastraszTankMultiplier : public Multiplier
+{
+public:
+    VaelastraszTankMultiplier(
+        PlayerbotAI* botAI) : Multiplier(botAI, "vaelastrasz tank multiplier") {}
+    float GetValue(Action* action) override;
+};
+
+class VaelastraszBurningAdrenalineMultiplier : public Multiplier
+{
+public:
+    VaelastraszBurningAdrenalineMultiplier(
+        PlayerbotAI* botAI) : Multiplier(botAI, "vaelastrasz burning adrenaline multiplier") {}
+    float GetValue(Action* action) override;
+};
+
+class VaelastraszWarlockDrainSoulMultiplier : public Multiplier
+{
+public:
+    VaelastraszWarlockDrainSoulMultiplier(
+        PlayerbotAI* botAI) : Multiplier(botAI, "vaelastrasz warlock drain soul multiplier") {}
+    float GetValue(Action* action) override;
+};
+
+#endif

--- a/src/Ai/Raid/BWL/BWLStrategy.cpp
+++ b/src/Ai/Raid/BWL/BWLStrategy.cpp
@@ -42,5 +42,4 @@ void RaidBwlStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
     multipliers.push_back(new RazorgoreTankMultiplier(botAI));
     multipliers.push_back(new VaelastraszTankMultiplier(botAI));
     multipliers.push_back(new VaelastraszBurningAdrenalineMultiplier(botAI));
-    multipliers.push_back(new VaelastraszWarlockDrainSoulMultiplier(botAI));
 }

--- a/src/Ai/Raid/BWL/BWLStrategy.cpp
+++ b/src/Ai/Raid/BWL/BWLStrategy.cpp
@@ -1,25 +1,46 @@
 #include "BWLStrategy.h"
 
+#include "BWLMultipliers.h"
+
 void RaidBwlStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
     triggers.push_back(new TriggerNode("often", {
         NextAction("bwl check onyxia scale cloak", ACTION_RAID) }));
-
     triggers.push_back(new TriggerNode("bwl suppression device", {
         NextAction("bwl turn off suppression device", ACTION_RAID) }));
+
+    triggers.push_back(new TriggerNode("bwl razorgore fire resistance", {
+        NextAction("bwl razorgore fire resistance", ACTION_RAID) }));
+    triggers.push_back(new TriggerNode("bwl razorgore not mind controlled", {
+        NextAction("bwl razorgore avoid aoe", ACTION_RAID) }));
+    triggers.push_back(new TriggerNode("bwl razorgore not mind controlled", {
+        NextAction("bwl razorgore mark boss", ACTION_RAID + 1) }));
+
+    triggers.push_back(new TriggerNode("bwl vaelastrasz fire resistance", {
+        NextAction("bwl vaelastrasz fire resistance", ACTION_RAID) }));
+    triggers.push_back(new TriggerNode("bwl vaelastrasz positioning", {
+        NextAction("rear flank", ACTION_MOVE + 4) }));
+    triggers.push_back(new TriggerNode("bwl vaelastrasz burning adrenaline", {
+        NextAction("bwl vaelastrasz move away", ACTION_RAID + 5) }));
 
     triggers.push_back(new TriggerNode("bwl affliction bronze", {
         NextAction("bwl use hourglass sand", ACTION_RAID) }));
 
     triggers.push_back(new TriggerNode("bwl wild magic", {
         NextAction("ice block", ACTION_RAID) }));
-
     triggers.push_back(new TriggerNode("bwl nefarian fear ward", {
         NextAction("bwl nefarian fear ward", ACTION_RAID) }));
 
     triggers.push_back(new TriggerNode("bwl death talon wyrmguard tank", {
         NextAction("bwl death talon wyrmguard tank move away", ACTION_RAID) }));
-
     triggers.push_back(new TriggerNode("bwl death talon wyrmguard ranged", {
         NextAction("bwl death talon wyrmguard ranged move away", ACTION_RAID) }));
+}
+
+void RaidBwlStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
+{
+    multipliers.push_back(new RazorgoreTankMultiplier(botAI));
+    multipliers.push_back(new VaelastraszTankMultiplier(botAI));
+    multipliers.push_back(new VaelastraszBurningAdrenalineMultiplier(botAI));
+    multipliers.push_back(new VaelastraszWarlockDrainSoulMultiplier(botAI));
 }

--- a/src/Ai/Raid/BWL/BWLStrategy.h
+++ b/src/Ai/Raid/BWL/BWLStrategy.h
@@ -1,4 +1,3 @@
-
 #ifndef PLAYERBOTS_BWLSTRATEGY_H
 #define PLAYERBOTS_BWLSTRATEGY_H
 
@@ -10,7 +9,7 @@ public:
     RaidBwlStrategy(PlayerbotAI* ai) : Strategy(ai) {}
     std::string const getName() override { return "bwl"; }
     void InitTriggers(std::vector<TriggerNode*>& triggers) override;
-    // void InitMultipliers(std::vector<Multiplier*> &multipliers) override;
+    void InitMultipliers(std::vector<Multiplier*> &multipliers) override;
 };
 
 #endif

--- a/src/Ai/Raid/BWL/BWLTriggerContext.h
+++ b/src/Ai/Raid/BWL/BWLTriggerContext.h
@@ -10,6 +10,14 @@ public:
     RaidBwlTriggerContext()
     {
         creators["bwl suppression device"] = &RaidBwlTriggerContext::bwl_suppression_device;
+
+        creators["bwl razorgore fire resistance"] = &RaidBwlTriggerContext::bwl_razorgore_fire_resistance_trigger;
+        creators["bwl razorgore not mind controlled"] = &RaidBwlTriggerContext::bwl_razorgore_not_mind_controlled;
+
+        creators["bwl vaelastrasz fire resistance"] = &RaidBwlTriggerContext::bwl_vaelastrasz_fire_resistance_trigger;
+        creators["bwl vaelastrasz positioning"] = &RaidBwlTriggerContext::bwl_vaelastrasz_positioning;
+        creators["bwl vaelastrasz burning adrenaline"] = &RaidBwlTriggerContext::bwl_vaelastrasz_burning_adrenaline;
+
         creators["bwl affliction bronze"] = &RaidBwlTriggerContext::bwl_affliction_bronze;
         creators["bwl wild magic"] = &RaidBwlTriggerContext::bwl_wild_magic;
         creators["bwl nefarian fear ward"] = &RaidBwlTriggerContext::bwl_nefarian_fear_ward;
@@ -19,6 +27,11 @@ public:
 
 private:
     static Trigger* bwl_suppression_device(PlayerbotAI* ai) { return new BwlSuppressionDeviceTrigger(ai); }
+    static Trigger* bwl_razorgore_fire_resistance_trigger(PlayerbotAI* ai) { return new BossFireResistanceTrigger(ai, "razorgore the untamed"); }
+    static Trigger* bwl_razorgore_not_mind_controlled(PlayerbotAI* ai) { return new BwlRazorgoreNotMindControlledTrigger(ai); }
+    static Trigger* bwl_vaelastrasz_fire_resistance_trigger(PlayerbotAI* ai) { return new BossFireResistanceTrigger(ai, "vaelastrasz the corrupt"); }
+    static Trigger* bwl_vaelastrasz_positioning(PlayerbotAI* ai) { return new BwlVaelastraszPositioningTrigger(ai); }
+    static Trigger* bwl_vaelastrasz_burning_adrenaline(PlayerbotAI* ai) { return new BwlVaelastraszBurningAdrenaline(ai); }
     static Trigger* bwl_affliction_bronze(PlayerbotAI* ai) { return new BwlAfflictionBronzeTrigger(ai); }
     static Trigger* bwl_wild_magic(PlayerbotAI* ai) { return new BwlWildMagicTrigger(ai); }
     static Trigger* bwl_nefarian_fear_ward(PlayerbotAI* ai) { return new BwlNefarianFearWardTrigger(ai); }

--- a/src/Ai/Raid/BWL/BWLTriggerContext.h
+++ b/src/Ai/Raid/BWL/BWLTriggerContext.h
@@ -31,7 +31,7 @@ private:
     static Trigger* bwl_razorgore_not_mind_controlled(PlayerbotAI* ai) { return new BwlRazorgoreNotMindControlledTrigger(ai); }
     static Trigger* bwl_vaelastrasz_fire_resistance_trigger(PlayerbotAI* ai) { return new BossFireResistanceTrigger(ai, "vaelastrasz the corrupt"); }
     static Trigger* bwl_vaelastrasz_positioning(PlayerbotAI* ai) { return new BwlVaelastraszPositioningTrigger(ai); }
-    static Trigger* bwl_vaelastrasz_burning_adrenaline(PlayerbotAI* ai) { return new BwlVaelastraszBurningAdrenaline(ai); }
+    static Trigger* bwl_vaelastrasz_burning_adrenaline(PlayerbotAI* ai) { return new BwlVaelastraszBurningAdrenalineTrigger(ai); }
     static Trigger* bwl_affliction_bronze(PlayerbotAI* ai) { return new BwlAfflictionBronzeTrigger(ai); }
     static Trigger* bwl_wild_magic(PlayerbotAI* ai) { return new BwlWildMagicTrigger(ai); }
     static Trigger* bwl_nefarian_fear_ward(PlayerbotAI* ai) { return new BwlNefarianFearWardTrigger(ai); }

--- a/src/Ai/Raid/BWL/BWLTriggers.cpp
+++ b/src/Ai/Raid/BWL/BWLTriggers.cpp
@@ -9,12 +9,17 @@ using namespace BlackwingLairHelpers;
 
 bool BwlSuppressionDeviceTrigger::IsActive()
 {
-    GuidVector gos = AI_VALUE(GuidVector, "nearest game objects");
-    for (auto i = gos.begin(); i != gos.end(); ++i)
+    // Until MoP, only rogues could disarm suppression devices.
+    // If raid cheats are enabled, any bot can disarm the devices.
+    if (botAI->HasCheat(BotCheatMask::raid) || bot->IsClass(CLASS_ROGUE))
     {
-        const GameObject* go = botAI->GetGameObject(*i);
-        if (IsActiveSuppressionDeviceInRange(go, bot))
-            return true;
+        GuidVector gos = AI_VALUE(GuidVector, "nearest game objects");
+        for (auto i = gos.begin(); i != gos.end(); ++i)
+        {
+            const GameObject* go = botAI->GetGameObject(*i);
+            if (IsActiveSuppressionDeviceInRange(go, bot))
+                return true;
+        }
     }
     return false;
 }
@@ -24,7 +29,7 @@ bool BwlSuppressionDeviceTrigger::IsActive()
 bool BwlRazorgoreNotMindControlledTrigger::IsActive()
 {
     if (Unit* boss = AI_VALUE2(Unit*, "find target", "razorgore the untamed"))
-        return !boss->HasAura(SPELL_MINDCONTROL);
+        return !boss->HasAura(static_cast<uint32>(BlackwingLairSpells::SPELL_MINDCONTROL));
     return false;
 }
 
@@ -38,24 +43,25 @@ bool BwlVaelastraszPositioningTrigger::IsActive()
     return false;
 }
 
-bool BwlVaelastraszBurningAdrenaline::IsActive()
+bool BwlVaelastraszBurningAdrenalineTrigger::IsActive()
 {
     // No check for Vaelastrasz, because bots may still have burning adrenaline even after Vaelastrasz died.
-    return bot->HasAura(SPELL_BURNING_ADRENALINE);
+    return bot->HasAura(static_cast<uint32>(BlackwingLairSpells::SPELL_BURNING_ADRENALINE));
 }
 
 // Chromaggus
 
 bool BwlAfflictionBronzeTrigger::IsActive()
 {
-    return bot->HasAura(SPELL_BROOD_AFFLICTION_BRONZE);
+    return bot->HasAura(static_cast<uint32>(BlackwingLairSpells::SPELL_BROOD_AFFLICTION_BRONZE));
 }
 
 // Nefarian
 
 bool BwlWildMagicTrigger::IsActive()
 {
-    return bot->getClass() == CLASS_MAGE && bot->HasAura(SPELL_WILD_MAGIC);
+    return bot->getClass() == CLASS_MAGE &&
+        bot->HasAura(static_cast<uint32>(BlackwingLairSpells::SPELL_WILD_MAGIC));
 }
 
 bool BwlNefarianFearWardTrigger::IsActive()

--- a/src/Ai/Raid/BWL/BWLTriggers.cpp
+++ b/src/Ai/Raid/BWL/BWLTriggers.cpp
@@ -14,11 +14,34 @@ bool BwlSuppressionDeviceTrigger::IsActive()
     {
         const GameObject* go = botAI->GetGameObject(*i);
         if (IsActiveSuppressionDeviceInRange(go, bot))
-        {
             return true;
-        }
     }
     return false;
+}
+
+// Razorgore the Untamed
+
+bool BwlRazorgoreNotMindControlledTrigger::IsActive()
+{
+    if (Unit* boss = AI_VALUE2(Unit*, "find target", "razorgore the untamed"))
+        return !boss->HasAura(SPELL_MINDCONTROL);
+    return false;
+}
+
+// Vaelastrasz the Corrupt
+
+bool BwlVaelastraszPositioningTrigger::IsActive()
+{
+    // Prevent non-tanks from rotating the boss while the tanks gain thread.
+    if (Unit* boss = AI_VALUE2(Unit*, "find target", "vaelastrasz the corrupt"))
+        return boss->GetVictim() != bot;
+    return false;
+}
+
+bool BwlVaelastraszBurningAdrenaline::IsActive()
+{
+    // No check for Vaelastrasz, because bots may still have burning adrenaline even after Vaelastrasz died.
+    return bot->HasAura(SPELL_BURNING_ADRENALINE);
 }
 
 // Chromaggus

--- a/src/Ai/Raid/BWL/BWLTriggers.h
+++ b/src/Ai/Raid/BWL/BWLTriggers.h
@@ -30,10 +30,10 @@ public:
     bool IsActive() override;
 };
 
-class BwlVaelastraszBurningAdrenaline : public Trigger
+class BwlVaelastraszBurningAdrenalineTrigger : public Trigger
 {
 public:
-    BwlVaelastraszBurningAdrenaline(PlayerbotAI* botAI) : Trigger(botAI, "bwl vaelastrasz burning adrenaline") {}
+    BwlVaelastraszBurningAdrenalineTrigger(PlayerbotAI* botAI) : Trigger(botAI, "bwl vaelastrasz burning adrenaline") {}
     bool IsActive() override;
 };
 

--- a/src/Ai/Raid/BWL/BWLTriggers.h
+++ b/src/Ai/Raid/BWL/BWLTriggers.h
@@ -12,6 +12,31 @@ public:
     bool IsActive() override;
 };
 
+// Razorgore the Untamed
+
+class BwlRazorgoreNotMindControlledTrigger : public Trigger
+{
+public:
+    BwlRazorgoreNotMindControlledTrigger(PlayerbotAI* botAI, const std::string& name = "bwl razorgore not mind controlled") : Trigger(botAI, name) {}
+    bool IsActive() override;
+};
+
+// Vaelastrasz the Corrupt
+
+class BwlVaelastraszPositioningTrigger : public Trigger
+{
+public:
+    BwlVaelastraszPositioningTrigger(PlayerbotAI* botAI) : Trigger(botAI, "bwl vaelastrasz positioning") {}
+    bool IsActive() override;
+};
+
+class BwlVaelastraszBurningAdrenaline : public Trigger
+{
+public:
+    BwlVaelastraszBurningAdrenaline(PlayerbotAI* botAI) : Trigger(botAI, "bwl vaelastrasz burning adrenaline") {}
+    bool IsActive() override;
+};
+
 // Chromaggus
 
 class BwlAfflictionBronzeTrigger : public Trigger

--- a/src/Ai/Raid/RaidBossHelpers.cpp
+++ b/src/Ai/Raid/RaidBossHelpers.cpp
@@ -57,6 +57,16 @@ void MarkTargetWithMoon(Player* bot, Unit* target)
     MarkTargetWithIcon(bot, target, RtiTargetValue::moonIndex);
 }
 
+void ClearTargetIcon(Player* bot, uint8 iconId)
+{
+    if (Group* group = bot->GetGroup())
+    {
+        ObjectGuid currentGuid = group->GetTargetIcon(iconId);
+        if (currentGuid != ObjectGuid::Empty)
+            group->SetTargetIcon(iconId, bot->GetGUID(), ObjectGuid::Empty);
+    }
+}
+
 // For bots to set their raid target icon to the specified icon on the specified target
 void SetRtiTarget(PlayerbotAI* botAI, const std::string& rtiName, Unit* target)
 {

--- a/src/Ai/Raid/RaidBossHelpers.h
+++ b/src/Ai/Raid/RaidBossHelpers.h
@@ -13,6 +13,7 @@ void MarkTargetWithDiamond(Player* bot, Unit* target);
 void MarkTargetWithTriangle(Player* bot, Unit* target);
 void MarkTargetWithCross(Player* bot, Unit* target);
 void MarkTargetWithMoon(Player* bot, Unit* target);
+void ClearTargetIcon(Player* bot, uint8 iconId);
 void SetRtiTarget(PlayerbotAI* botAI, const std::string& rtiName, Unit* target);
 bool IsMechanicTrackerBot(PlayerbotAI* botAI, Player* bot, uint32 mapId, Player* exclude = nullptr);
 Player* GetGroupMainTank(PlayerbotAI* botAI, Player* bot);


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
Implements bot behavior for _Razorgore the Untamed_ and _Vaelastrasz the Corrupt_ in Blackwing Lair.

**Razorgore**:
- General:
  - Fire resistance aura: Reduces damage from [Fireball Volley](https://www.wowhead.com/classic/spell=22425/fireball-volley) and [Conflagration](https://www.wowhead.com/classic/spell=16805/conflagration).
- Phase 1: Eggs
  - One tank bot marks Razorgore with the moon rti and tanks him whenever he is not mind-controlled.
    => All other bots ignore the boss (He wipes the raid if he dies before all eggs are destroyed!)
  - Mind-controlling the boss and destroying the eggs must be done by the real player.
- Phase 2: Razorgore
  - The moon rti is removed => Bots engage the boss
  - All bots except the current tank dodge the frontal cone AoE ([Cleave](https://www.wowhead.com/classic/spell=19632/cleave)) => move behind the boss
  - Additionally, ranged bots avoid [War Stomp](https://www.wowhead.com/classic/spell=24375/war-stomp) by moving away
  - Tanks not currently tanking the boss suppress TankFaceAction to avoid cleave damage

**Vaelastrasz**:
- General:
  - Fire resistance aura: Reduces damage from [Fire Nova](https://www.wowhead.com/classic/spell=23462/fire-nova)  and [Flame Breath](https://www.wowhead.com/classic/spell=23461/flame-breath).
  - All bots except the current tank position themselves on the rear flank to avoid damage from _Flame Breath_, [Cleave](https://www.wowhead.com/classic/spell=19983/cleave), and [Tail Sweep](https://www.wowhead.com/classic/spell=15847/tail-sweep)
  - Tanks not currently tanking the boss suppress TankFaceAction to avoid AoE damage
  - ~~Because the boss starts at 30% hp, warlocks suppress Drain Soul until 3% HP (negligible damage before that)~~
- Handling of [Burning Adrenaline](https://www.wowhead.com/classic/spell=18173/burning-adrenaline):
  - The current tank stays in place. The rear flank positioning ensures that other bots won't get hit by the explosion.
  - Other bots will move away from raid members.
    - Bots will prefer a position within LOS.
    - Ranged bots will try to find a spot where they can still reach the boss with their attacks.
    - If a bot gets pushed back by Tail Sweep, they will try to reach the boss without coming near other raid members.
    - If the boss is dead, bots with Burning Adrenaline will still try to avoid other raid members.
    - Movement direction is calculated using weighted repulsion.

**Miscellaneous**:
- _BwlTurnOffSuppressionDeviceAction_ restricted to Rogues (or raid cheat)
- New helpers _IsNonBABotNearPosition_, _ClearTargetIcon_
- Multiplier infrastructure enabled (was commented out)

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
  - Razorgore: check if eggs are alive (scans nearest game objects), boss position + frontal cone check for AoE avoidance, moon marker assignment by the off-tank
  - Vaelastrasz: group position comparison for weighted repulsion, aura check for Burning Adrenaline, tank comparison for flank positioning
- Describe the **processing cost** when this logic executes across many bots.
  - _AreRazorgoreEggsAlive()_: Scans all nearest game objects. Expensive, but only called by the Razorgore tank action and multiplier
  - Frontal cone check (_HasInArc_): inexpensive geometric calculations
  - Group iteration in _BwlVaelastraszMoveAwayAction_: O(n) over raid members, only active during Vaelastrasz encounter or while _Burning Adrenaline_ aura is active
  - All triggers/multipliers are encounter-bound, so they should never fire outside the instance


## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
1. Enter BWL with enough bots with the appropriate level.
2. Engage Razorgore in the first room: The player must mind control the boss and destroy the eggs
    Expected behavior:
    - A paladin bot should enable their fire resistance aura.
    - The off-tank should immediately mark and tank Razorgore until he gets mind controlled
    - Bots should handle all enemy NPCs
    - When all eggs are destroyed, the rti mark should be removed and all bots should engage the boss. 
    - Bots should position themselves to avoid AOE damage.
3. Engage Vaelastrasz in the next room: Talk to him and wait for the RP to finish.
    Expected behavior:
    - A paladin bot should enable their fire resistance aura.
    - A tank should gain threat. Every other bot will position itself at the rear flank.
    - If the current tank gets Burning Adrenaline, the bot will not run away.
    - Every other bot with Burning Adrenaline will try to find a safe spot to explode.
    - ~~Warlocks should not Drain Soul before 3%~~
    - If the boss is dead and a bot still has Burning Adrenaline, it will still try to avoid other raid members.
4. Reach the suppression room. If cheats are enabled, all bots should be able to deactivate the suppression devices. Otherwise only rogues will do that.

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

Encounter-bound triggers/actions, only active in BWL instance

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)
              
New boss behavior for Razorgore & Vaelastrasz (BWL-specific)

- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [x] Yes (**explain below**)
              
Self-contained within BWL modules (triggers/actions/multipliers), no changes to global systems

## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

**brainstorming and code generation**
The code in this PR is mostly written by me.
Originally, when bots got Burning Adrenaline from Vaelastrasz, they went to one of 12 hard-coded positions inside Vaelastrasz' room. But I didn't like that approach, so I asked Big Pickle from OpenCode for some advice and it generated the initial version of the current weighted repulsion approach. The following finalization of this code was done by me again.

**review** 
I used Big Pickle during development for code reviews. Reasonable suggestions were reviewed and applied by me.

Also the first iteration of the text of this PR was generated by AI.

## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note).
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->

I know that this PR only contains the first two bosses but I wanted to take a break from playing AzerothCore, so I decided to submit and merge my current progress.