### PR TITLE
fix(CORE/Druid): Fall back to Bear Form for pull below level 40

### DIFF
--- a/src/Ai/Class/Druid/Strategy/DruidPullStrategy.cpp
+++ b/src/Ai/Class/Druid/Strategy/DruidPullStrategy.cpp
@@ -8,6 +8,8 @@
 #include "PlayerbotAI.h"
 #include "Playerbots.h"
 
+constexpr uint32 SPELL_DIRE_BEAR_FORM = 9634;
+
 std::string DruidPullStrategy::GetPullActionName() const
 {
     std::string const pullActionName = PullStrategy::GetPullActionName();
@@ -32,7 +34,7 @@ std::string DruidPullStrategy::GetPreActionName() const
         return "";
 
     // Fall back to Bear Form when Dire Bear Form isn't trained yet (< ~level 40).
-    if (!botAI->HasSpell("dire bear form"))
+    if (!botAI->GetBot()->HasSpell(SPELL_DIRE_BEAR_FORM))
         return "bear form";
 
     return PullStrategy::GetPreActionName();

--- a/src/Ai/Class/Druid/Strategy/DruidPullStrategy.cpp
+++ b/src/Ai/Class/Druid/Strategy/DruidPullStrategy.cpp
@@ -31,5 +31,9 @@ std::string DruidPullStrategy::GetPreActionName() const
     if (GetPullActionName() == "faerie fire")
         return "";
 
+    // Fall back to Bear Form when Dire Bear Form isn't trained yet (< ~level 40).
+    if (!botAI->HasSpell("dire bear form"))
+        return "bear form";
+
     return PullStrategy::GetPreActionName();
 }


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

The druid pull pre-action was hardcoded to "dire bear form", which is impossible for druids under ~level 40. Because the pull invokes it via DoSpecificAction() (which does not honor an action's getAlternatives() fallback), the shift failed and PullStartAction aborted, so lower-level feral bots could not pull at all.

Fall back to Bear Form when Dire Bear Form is untrained; behavior at level 40+ is unchanged (still pulls in Dire Bear Form).


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

Minimum logic: one extra check in DruidPullStrategy::GetPreActionName(). If the bot doesn't know Dire Bear Form, return "bear form" instead of "dire bear form". Nothing else changes.

Processing cost: one HasSpell() call, and only when a pull actually starts, not on the per-tick loop. It sits next to HasSpell()/CanCastSpell() calls the same function already makes, so there's no meaningful cost even with a lot of bots.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

**Setup:**

- 1 player + 1 Playerbot druid (alt bot or invited to group).
- The druid must be below level 40 (i.e., has not yet trained Dire Bear Form) and specced/set as feral tank.
- Give it the tank kit - whisper talents spec bear pve, then co +bear,+tank assist,+pull,+pull back.

**Steps:**

1. Put the bot in caster form.
2. Target a nearby enemy.
3. Whisper the bot - pull my target.

**Expected behavior:**

- Before this change: the bot fails to pull — it does nothing (the dire bear form pre-action returns "impossible", aborting the pull). If out of Bear Form, whispering do dire bear form also returns dire bear form: impossible.
- After this change: the bot shifts into Bear Form as the pull pre-action, casts its pull ability (Faerie Fire/Growl), and returns to its pull position — pulling works normally.

**Regression check (level 40+):**

Repeat with a druid that has trained Dire Bear Form. It should still pull using Dire Bear Form exactly as before confirming max-level behavior is unchanged.

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

Below level 40 the druid now shifts into Bear Form and pulls, instead of failing to pull. Level 40+ is unchanged.

- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [x] Yes (**explain below**)

One if-branch, the same shape PaladinPullStrategy::GetPreActionName() already uses.

## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [X] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

Used it to help trace the pull code path and to tidy up this write-up. The actual fix is one line, and I understand it and can explain it.

## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

-  [x] Stability is not compromised.
-  [x] Performance impact is understood, tested, and acceptable.
-  [x] Added logic complexity is justified and explained.
-  [x] Any new bot dialogue lines are translated. (N/A - no new dialogue.)
-  [x] Any code ported/adapted from another project is attributed. (N/A - original.)
-  [x] New source files use the GPLv2 header. (N/A - no new files.)
-  [x] Documentation updated if needed (Conf comments, WiKi commands). (N/A.)

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->

CastDireBearFormAction already lists "bear form" in getAlternatives(), but that fallback is only applied by the engine's normal action-selection loop (DoNextAction), not by the DoSpecificAction() path the pull pre-action uses. That's why the fix goes in GetPreActionName() rather than relying on the alternative.

