### PR TITLE
feat(Core/Playerbots): add RPG_DO_GATHER gathering status

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1392,6 +1392,7 @@ AiPlayerbot.EnableNewRpgStrategy = 1
 # TravelFlight  (Default: 15  Go to the nearest flightmaster and fly to a level-appropriate area)
 # Rest          (Default: 5   Take a break for a while and do nothing)
 # OutdoorPvp    (Default: 10  Participate in outdoor PvP capture points if already in an outdoor PvP zone)
+# DoGather      (Default: 15  Roam the current zone harvesting herb/ore nodes; requires Herbalism or Mining)
 AiPlayerbot.RpgStatusProbWeight.WanderRandom = 15
 AiPlayerbot.RpgStatusProbWeight.WanderNpc = 20
 AiPlayerbot.RpgStatusProbWeight.GoGrind = 15
@@ -1400,6 +1401,7 @@ AiPlayerbot.RpgStatusProbWeight.DoQuest = 60
 AiPlayerbot.RpgStatusProbWeight.TravelFlight = 15
 AiPlayerbot.RpgStatusProbWeight.Rest = 5
 AiPlayerbot.RpgStatusProbWeight.OutdoorPvp = 10
+AiPlayerbot.RpgStatusProbWeight.DoGather = 15
 
 # Bots' minimum and maximum level when teleporting in and out of a zone, according to the new RPG strategy
 # Format: AiPlayerbot.ZoneBracket.zoneID = minLevel,maxLevel

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1416,6 +1416,7 @@ AiPlayerbot.EnableNewRpgStrategy = 1
 # TravelFlight  (Default: 15  Go to the nearest flightmaster and fly to a level-appropriate area)
 # Rest          (Default: 5   Take a break for a while and do nothing)
 # OutdoorPvp    (Default: 10  Participate in outdoor PvP capture points if already in an outdoor PvP zone)
+# DoGather      (Default: 15  Roam the current zone harvesting herb/ore nodes; requires Herbalism or Mining)
 AiPlayerbot.RpgStatusProbWeight.WanderRandom = 15
 AiPlayerbot.RpgStatusProbWeight.WanderNpc = 20
 AiPlayerbot.RpgStatusProbWeight.GoGrind = 15
@@ -1424,6 +1425,7 @@ AiPlayerbot.RpgStatusProbWeight.DoQuest = 60
 AiPlayerbot.RpgStatusProbWeight.TravelFlight = 15
 AiPlayerbot.RpgStatusProbWeight.Rest = 5
 AiPlayerbot.RpgStatusProbWeight.OutdoorPvp = 10
+AiPlayerbot.RpgStatusProbWeight.DoGather = 15
 
 # Bots' minimum and maximum level when teleporting in and out of a zone, according to the new RPG strategy
 # Format: AiPlayerbot.ZoneBracket.zoneID = minLevel,maxLevel

--- a/src/Ai/Base/ActionContext.h
+++ b/src/Ai/Base/ActionContext.h
@@ -44,6 +44,7 @@
 #include "MoveToTravelTargetAction.h"
 #include "MovementActions.h"
 #include "NewRpgAction.h"
+#include "NewRpgDoGather.h"
 #include "NewRpgOutdoorPvP.h"
 #include "NonCombatActions.h"
 #include "OutfitAction.h"
@@ -278,6 +279,7 @@ public:
         creators["new rpg do quest"] = &ActionContext::new_rpg_do_quest;
         creators["new rpg travel flight"] = &ActionContext::new_rpg_travel_flight;
         creators["new rpg outdoor pvp"] = &ActionContext::new_rpg_outdoor_pvp;
+        creators["new rpg do gather"] = &ActionContext::new_rpg_do_gather;
         creators["wait for attack keep safe distance"] = &ActionContext::wait_for_attack_keep_safe_distance;
     }
 
@@ -484,6 +486,7 @@ private:
     static Action* new_rpg_do_quest(PlayerbotAI* ai) { return new NewRpgDoQuestAction(ai); }
     static Action* new_rpg_travel_flight(PlayerbotAI* ai) { return new NewRpgTravelFlightAction(ai); }
     static Action* new_rpg_outdoor_pvp(PlayerbotAI* ai) { return new NewRpgOutdoorPvpAction(ai); }
+    static Action* new_rpg_do_gather(PlayerbotAI* ai) { return new NewRpgDoGatherAction(ai); }
     static Action* wait_for_attack_keep_safe_distance(PlayerbotAI* ai) { return new WaitForAttackKeepSafeDistanceAction(ai); }
 };
 

--- a/src/Ai/Base/ActionContext.h
+++ b/src/Ai/Base/ActionContext.h
@@ -45,6 +45,7 @@
 #include "MoveToTravelTargetAction.h"
 #include "MovementActions.h"
 #include "NewRpgAction.h"
+#include "NewRpgDoGather.h"
 #include "NewRpgOutdoorPvP.h"
 #include "NonCombatActions.h"
 #include "OutfitAction.h"
@@ -278,6 +279,7 @@ public:
         creators["new rpg do quest"] = &ActionContext::new_rpg_do_quest;
         creators["new rpg travel flight"] = &ActionContext::new_rpg_travel_flight;
         creators["new rpg outdoor pvp"] = &ActionContext::new_rpg_outdoor_pvp;
+        creators["new rpg do gather"] = &ActionContext::new_rpg_do_gather;
         creators["wait for attack keep safe distance"] = &ActionContext::wait_for_attack_keep_safe_distance;
     }
 
@@ -485,6 +487,7 @@ private:
     static Action* new_rpg_do_quest(PlayerbotAI* ai) { return new NewRpgDoQuestAction(ai); }
     static Action* new_rpg_travel_flight(PlayerbotAI* ai) { return new NewRpgTravelFlightAction(ai); }
     static Action* new_rpg_outdoor_pvp(PlayerbotAI* ai) { return new NewRpgOutdoorPvpAction(ai); }
+    static Action* new_rpg_do_gather(PlayerbotAI* ai) { return new NewRpgDoGatherAction(ai); }
     static Action* wait_for_attack_keep_safe_distance(PlayerbotAI* ai) { return new WaitForAttackKeepSafeDistanceAction(ai); }
 };
 

--- a/src/Ai/Base/ChatActionContext.h
+++ b/src/Ai/Base/ChatActionContext.h
@@ -42,6 +42,7 @@
 #include "MailAction.h"
 #include "NamedObjectContext.h"
 #include "NewRpgAction.h"
+#include "NewRpgDoGather.h"
 #include "OpenItemAction.h"
 #include "PassLeadershipToMasterAction.h"
 #include "PetsAction.h"
@@ -108,6 +109,7 @@ public:
         creators["los"] = &ChatActionContext::los;
         creators["rpg status"] = &ChatActionContext::rpg_status;
         creators["rpg do quest"] = &ChatActionContext::rpg_do_quest;
+        creators["rpg do gather"] = &ChatActionContext::rpg_do_gather;
         creators["aura"] = &ChatActionContext::aura;
         creators["drop"] = &ChatActionContext::drop;
         creators["clean quest log"] = &ChatActionContext::clean_quest_log;
@@ -300,6 +302,7 @@ private:
     static Action* los(PlayerbotAI* botAI) { return new TellLosAction(botAI); }
     static Action* rpg_status(PlayerbotAI* botAI) { return new TellRpgStatusAction(botAI); }
     static Action* rpg_do_quest(PlayerbotAI* botAI) { return new StartRpgDoQuestAction(botAI); }
+    static Action* rpg_do_gather(PlayerbotAI* botAI) { return new StartRpgDoGatherAction(botAI); }
     static Action* aura(PlayerbotAI* ai) { return new TellAuraAction(ai); }
     static Action* ll(PlayerbotAI* botAI) { return new LootStrategyAction(botAI); }
     static Action* ss(PlayerbotAI* botAI) { return new SkipSpellsListAction(botAI); }

--- a/src/Ai/Base/ChatTriggerContext.h
+++ b/src/Ai/Base/ChatTriggerContext.h
@@ -30,6 +30,7 @@ public:
         creators["los"] = &ChatTriggerContext::los;
         creators["rpg status"] = &ChatTriggerContext::rpg_status;
         creators["rpg do quest"] = &ChatTriggerContext::rpg_do_quest;
+        creators["rpg do gather"] = &ChatTriggerContext::rpg_do_gather;
         creators["aura"] = &ChatTriggerContext::aura;
         creators["drop"] = &ChatTriggerContext::drop;
         creators["share"] = &ChatTriggerContext::share;
@@ -256,6 +257,7 @@ private:
     static Trigger* los(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "los"); }
     static Trigger* rpg_status(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "rpg status"); }
     static Trigger* rpg_do_quest(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "rpg do quest"); }
+    static Trigger* rpg_do_gather(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "rpg do gather"); }
     static Trigger* aura(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "aura"); }
     static Trigger* loot_all(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "add all loot"); }
     static Trigger* release(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "release"); }

--- a/src/Ai/Base/ChatTriggerContext.h
+++ b/src/Ai/Base/ChatTriggerContext.h
@@ -30,6 +30,7 @@ public:
         creators["los"] = &ChatTriggerContext::los;
         creators["rpg status"] = &ChatTriggerContext::rpg_status;
         creators["rpg do quest"] = &ChatTriggerContext::rpg_do_quest;
+        creators["rpg do gather"] = &ChatTriggerContext::rpg_do_gather;
         creators["aura"] = &ChatTriggerContext::aura;
         creators["drop"] = &ChatTriggerContext::drop;
         creators["share"] = &ChatTriggerContext::share;
@@ -257,6 +258,7 @@ private:
     static Trigger* los(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "los"); }
     static Trigger* rpg_status(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "rpg status"); }
     static Trigger* rpg_do_quest(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "rpg do quest"); }
+    static Trigger* rpg_do_gather(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "rpg do gather"); }
     static Trigger* aura(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "aura"); }
     static Trigger* loot_all(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "add all loot"); }
     static Trigger* release(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "release"); }

--- a/src/Ai/Base/Strategy/ChatCommandHandlerStrategy.cpp
+++ b/src/Ai/Base/Strategy/ChatCommandHandlerStrategy.cpp
@@ -94,6 +94,7 @@ ChatCommandHandlerStrategy::ChatCommandHandlerStrategy(PlayerbotAI* botAI) : Pas
     supported.push_back("los");
     supported.push_back("rpg status");
     supported.push_back("rpg do quest");
+    supported.push_back("rpg do gather");
     supported.push_back("aura");
     supported.push_back("drop");
     supported.push_back("share");

--- a/src/Ai/Base/Strategy/ChatCommandHandlerStrategy.cpp
+++ b/src/Ai/Base/Strategy/ChatCommandHandlerStrategy.cpp
@@ -93,6 +93,7 @@ ChatCommandHandlerStrategy::ChatCommandHandlerStrategy(PlayerbotAI* botAI) : Pas
     supported.push_back("los");
     supported.push_back("rpg status");
     supported.push_back("rpg do quest");
+    supported.push_back("rpg do gather");
     supported.push_back("aura");
     supported.push_back("drop");
     supported.push_back("share");

--- a/src/Ai/Base/TriggerContext.h
+++ b/src/Ai/Base/TriggerContext.h
@@ -244,6 +244,7 @@ public:
         creators["do quest status"] = &TriggerContext::do_quest_status;
         creators["travel flight status"] = &TriggerContext::travel_flight_status;
         creators["outdoor pvp status"] = &TriggerContext::outdoor_pvp_status;
+        creators["do gather status"] = &TriggerContext::do_gather_status;
         creators["can self resurrect"] = &TriggerContext::can_self_resurrect;
         creators["can fish"] = &TriggerContext::can_fish;
         creators["can use fishing bobber"] = &TriggerContext::can_use_fishing_bobber;
@@ -459,6 +460,7 @@ private:
     static Trigger* do_quest_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, RPG_DO_QUEST); }
     static Trigger* travel_flight_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, RPG_TRAVEL_FLIGHT); }
     static Trigger* outdoor_pvp_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, RPG_OUTDOOR_PVP); }
+    static Trigger* do_gather_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, RPG_DO_GATHER); }
     static Trigger* can_self_resurrect(PlayerbotAI* ai) { return new SelfResurrectTrigger(ai); }
     static Trigger* can_fish(PlayerbotAI* ai) { return new CanFishTrigger(ai); }
     static Trigger* can_use_fishing_bobber(PlayerbotAI* ai) { return new CanUseFishingBobberTrigger(ai); }

--- a/src/Ai/Base/TriggerContext.h
+++ b/src/Ai/Base/TriggerContext.h
@@ -242,6 +242,7 @@ public:
         creators["do quest status"] = &TriggerContext::do_quest_status;
         creators["travel flight status"] = &TriggerContext::travel_flight_status;
         creators["outdoor pvp status"] = &TriggerContext::outdoor_pvp_status;
+        creators["do gather status"] = &TriggerContext::do_gather_status;
         creators["can self resurrect"] = &TriggerContext::can_self_resurrect;
         creators["can fish"] = &TriggerContext::can_fish;
         creators["can use fishing bobber"] = &TriggerContext::can_use_fishing_bobber;
@@ -456,6 +457,7 @@ private:
     static Trigger* do_quest_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, RPG_DO_QUEST); }
     static Trigger* travel_flight_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, RPG_TRAVEL_FLIGHT); }
     static Trigger* outdoor_pvp_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, RPG_OUTDOOR_PVP); }
+    static Trigger* do_gather_status(PlayerbotAI* botAI) { return new NewRpgStatusTrigger(botAI, RPG_DO_GATHER); }
     static Trigger* can_self_resurrect(PlayerbotAI* ai) { return new SelfResurrectTrigger(ai); }
     static Trigger* can_fish(PlayerbotAI* ai) { return new CanFishTrigger(ai); }
     static Trigger* can_use_fishing_bobber(PlayerbotAI* ai) { return new CanUseFishingBobberTrigger(ai); }

--- a/src/Ai/World/Rpg/Action/NewRpgAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.cpp
@@ -239,7 +239,7 @@ bool NewRpgStatusUpdateAction::Execute(Event /*event*/)
     {
         case RPG_IDLE:
             return RandomChangeStatus({RPG_GO_CAMP, RPG_GO_GRIND, RPG_WANDER_RANDOM, RPG_WANDER_NPC, RPG_DO_QUEST,
-                                       RPG_TRAVEL_FLIGHT, RPG_REST, RPG_OUTDOOR_PVP});
+                                       RPG_TRAVEL_FLIGHT, RPG_REST, RPG_OUTDOOR_PVP, RPG_DO_GATHER});
 
         case RPG_GO_GRIND:
         {
@@ -320,6 +320,16 @@ bool NewRpgStatusUpdateAction::Execute(Event /*event*/)
         case RPG_OUTDOOR_PVP:
         {
             if (info.HasStatusPersisted(statusOutDoorPvPDuration))
+            {
+                info.ChangeToIdle();
+                return true;
+            }
+            break;
+        }
+        case RPG_DO_GATHER:
+        {
+            // DO_GATHER -> IDLE
+            if (info.HasStatusPersisted(statusDoGatherDuration))
             {
                 info.ChangeToIdle();
                 return true;

--- a/src/Ai/World/Rpg/Action/NewRpgAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.cpp
@@ -235,7 +235,7 @@ bool NewRpgStatusUpdateAction::Execute(Event /*event*/)
     {
         case RPG_IDLE:
             return RandomChangeStatus({RPG_GO_CAMP, RPG_GO_GRIND, RPG_WANDER_RANDOM, RPG_WANDER_NPC, RPG_DO_QUEST,
-                                       RPG_TRAVEL_FLIGHT, RPG_REST, RPG_OUTDOOR_PVP});
+                                       RPG_TRAVEL_FLIGHT, RPG_REST, RPG_OUTDOOR_PVP, RPG_DO_GATHER});
 
         case RPG_GO_GRIND:
         {
@@ -316,6 +316,16 @@ bool NewRpgStatusUpdateAction::Execute(Event /*event*/)
         case RPG_OUTDOOR_PVP:
         {
             if (info.HasStatusPersisted(statusOutDoorPvPDuration))
+            {
+                info.ChangeToIdle();
+                return true;
+            }
+            break;
+        }
+        case RPG_DO_GATHER:
+        {
+            // DO_GATHER -> IDLE
+            if (info.HasStatusPersisted(statusDoGatherDuration))
             {
                 info.ChangeToIdle();
                 return true;

--- a/src/Ai/World/Rpg/Action/NewRpgAction.h
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.h
@@ -67,6 +67,7 @@ protected:
     const int32 statusRestDuration = 30 * IN_MILLISECONDS ;
     const int32 statusDoQuestDuration = 30 * MINUTE  * IN_MILLISECONDS ;
     const int32 statusOutDoorPvPDuration = HOUR * IN_MILLISECONDS ;
+    const int32 statusDoGatherDuration = 15 * MINUTE * IN_MILLISECONDS;
 };
 
 class NewRpgGoGrindAction : public NewRpgBaseAction

--- a/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp
@@ -9,6 +9,7 @@
 #include "ChatHelper.h"
 #include "Creature.h"
 #include "GameObject.h"
+#include "GatherNodeMgr.h"
 #include "GossipDef.h"
 #include "GridTerrainData.h"
 #include "IVMapMgr.h"
@@ -42,14 +43,15 @@ bool NewRpgBaseAction::MoveFarTo(WorldPosition dest)
     if (dest == WorldPosition())
         return false;
 
-    if (dest != botAI->rpgInfo.moveFarPos)
+    bool newDest = dest != botAI->rpgInfo.moveFarPos;
+    if (newDest)
     {
         // clear stuck information if it's a new dest
         botAI->rpgInfo.SetMoveFarTo(dest);
     }
 
     // performance optimization
-    if (IsWaitingForLastMove(MovementPriority::MOVEMENT_NORMAL))
+    if (!newDest && IsWaitingForLastMove(MovementPriority::MOVEMENT_NORMAL))
     {
         return false;
     }
@@ -72,6 +74,12 @@ bool NewRpgBaseAction::MoveFarTo(WorldPosition dest)
     // finish. The stuck counter below continues to track real
     // progress toward dest and triggers teleport recovery if the
     // committed paths genuinely aren't closing the gap.
+    //
+    // A changed destination (e.g. the gather state switching to a
+    // live node it passes, or a quest POI change) skips this gate:
+    // letting the old spline finish would keep walking the bot
+    // toward a target it no longer has.
+    if (!newDest)
     {
         LastMovement& lastMove = AI_VALUE(LastMovement&, "last movement");
         if (bot->isMoving() && lastMove.lastMoveToMapId == bot->GetMapId())
@@ -1179,6 +1187,11 @@ bool NewRpgBaseAction::RandomChangeStatus(std::vector<NewRpgStatus> candidateSta
             }
             return false;
         }
+        case RPG_DO_GATHER:
+        {
+            botAI->rpgInfo.ChangeToDoGather();
+            return true;
+        }
         case RPG_IDLE:
         {
             botAI->rpgInfo.ChangeToIdle();
@@ -1248,6 +1261,18 @@ bool NewRpgBaseAction::CheckRpgStatusAvailable(NewRpgStatus status)
                 }
             }
             return false;
+        }
+        case RPG_DO_GATHER:
+        {
+            if (!botAI->HasSkill(SKILL_HERBALISM) && !botAI->HasSkill(SKILL_MINING))
+                return false;
+
+            // No point farming with (nearly) full bags - the loot pipeline
+            // can't store the harvest (see StoreLootAction).
+            if (AI_VALUE(uint8, "bag space") > 80)
+                return false;
+
+            return sGatherNodeMgr.HasUsableNodes(bot);
         }
         case RPG_TRAVEL_FLIGHT:
         {

--- a/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp
@@ -9,6 +9,7 @@
 #include "ChatHelper.h"
 #include "Creature.h"
 #include "GameObject.h"
+#include "GatherNodeMgr.h"
 #include "GossipDef.h"
 #include "GridTerrainData.h"
 #include "IVMapMgr.h"
@@ -49,14 +50,15 @@ bool NewRpgBaseAction::MoveFarTo(WorldPosition dest)
     if (bot->IsInFlight())
         return true;
 
-    if (dest != botAI->rpgInfo.moveFarPos)
+    bool newDest = dest != botAI->rpgInfo.moveFarPos;
+    if (newDest)
     {
         // clear stuck information if it's a new dest
         botAI->rpgInfo.SetMoveFarTo(dest);
     }
 
     // performance optimization
-    if (IsWaitingForLastMove(MovementPriority::MOVEMENT_NORMAL))
+    if (!newDest && IsWaitingForLastMove(MovementPriority::MOVEMENT_NORMAL))
     {
         return false;
     }
@@ -79,6 +81,12 @@ bool NewRpgBaseAction::MoveFarTo(WorldPosition dest)
     // finish. The stuck counter below continues to track real
     // progress toward dest and triggers teleport recovery if the
     // committed paths genuinely aren't closing the gap.
+    //
+    // A changed destination (e.g. the gather state switching to a
+    // live node it passes, or a quest POI change) skips this gate:
+    // letting the old spline finish would keep walking the bot
+    // toward a target it no longer has.
+    if (!newDest)
     {
         LastMovement& lastMove = AI_VALUE(LastMovement&, "last movement");
         if (bot->isMoving() && lastMove.lastMoveToMapId == bot->GetMapId())
@@ -1186,6 +1194,11 @@ bool NewRpgBaseAction::RandomChangeStatus(std::vector<NewRpgStatus> candidateSta
             }
             return false;
         }
+        case RPG_DO_GATHER:
+        {
+            botAI->rpgInfo.ChangeToDoGather();
+            return true;
+        }
         case RPG_IDLE:
         {
             botAI->rpgInfo.ChangeToIdle();
@@ -1255,6 +1268,18 @@ bool NewRpgBaseAction::CheckRpgStatusAvailable(NewRpgStatus status)
                 }
             }
             return false;
+        }
+        case RPG_DO_GATHER:
+        {
+            if (!botAI->HasSkill(SKILL_HERBALISM) && !botAI->HasSkill(SKILL_MINING))
+                return false;
+
+            // No point farming with (nearly) full bags - the loot pipeline
+            // can't store the harvest (see StoreLootAction).
+            if (AI_VALUE(uint8, "bag space") > 80)
+                return false;
+
+            return sGatherNodeMgr.HasUsableNodes(bot);
         }
         case RPG_TRAVEL_FLIGHT:
         {

--- a/src/Ai/World/Rpg/Action/NewRpgDoGather.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgDoGather.cpp
@@ -103,6 +103,15 @@ bool NewRpgDoGatherAction::Execute(Event /*event*/)
         return true;
     }
 
+    // Teleported/summoned away mid-route: drop the target and reselect.
+    // Checked before anything that uses data.nodePos, which holds
+    // coordinates from the old map.
+    if (data.nodeSpawnId && bot->GetMapId() != data.nodePos.GetMapId())
+    {
+        AbandonNode(data);
+        return true;
+    }
+
     bool runPeriodicChecks =
         !data.lastPassiveCheck || GetMSTimeDiffToNow(data.lastPassiveCheck) > passiveCheckInterval;
     if (runPeriodicChecks)
@@ -169,13 +178,6 @@ bool NewRpgDoGatherAction::Execute(Event /*event*/)
         data.nodeSpawnId = node->spawnId;
         data.nodePos = node->pos;
         data.lastReach = 0;
-        return true;
-    }
-
-    if (bot->GetMapId() != data.nodePos.GetMapId())
-    {
-        // teleported/summoned away mid-route - drop the target and reselect
-        AbandonNode(data);
         return true;
     }
 

--- a/src/Ai/World/Rpg/Action/NewRpgDoGather.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgDoGather.cpp
@@ -1,0 +1,272 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license, you may redistribute it
+ * and/or modify it under version 3 of the License, or (at your option), any later version.
+ */
+
+#include "NewRpgDoGather.h"
+
+#include "GameObject.h"
+#include "GatherNodeMgr.h"
+#include "LootObjectStack.h"
+#include "NewRpgInfo.h"
+#include "ObjectDefines.h"
+#include "Player.h"
+#include "PlayerbotAI.h"
+#include "PlayerbotAIConfig.h"
+#include "Playerbots.h"
+#include "SharedDefines.h"
+#include "SpellAuraDefines.h"
+#include "SpellInfo.h"
+#include "SpellMgr.h"
+#include "Timer.h"
+
+// Base-rank gather spells, the same ids OpenLootAction::DoLoot casts.
+enum GatherSpells
+{
+    HERB_GATHERING = 2366,
+    MINING = 2575,
+};
+
+bool StartRpgDoGatherAction::Execute(Event event)
+{
+    Player* owner = event.getOwner();
+    if (!owner)
+        return false;
+
+    if (!botAI->HasSkill(SKILL_HERBALISM) && !botAI->HasSkill(SKILL_MINING))
+    {
+        bot->Whisper("I have neither Herbalism nor Mining, so I can't gather", LANG_UNIVERSAL, owner);
+        return false;
+    }
+
+    if (!botAI->HasStrategy("new rpg", BOT_STATE_NON_COMBAT))
+        bot->Whisper("Note: my 'new rpg' strategy is off - run 'nc +new rpg' or I won't act on this",
+                     LANG_UNIVERSAL, owner);
+
+    botAI->rpgInfo.ChangeToDoGather();
+
+    if (sGatherNodeMgr.HasUsableNodes(bot))
+        bot->Whisper("Starting to gather nodes in this zone", LANG_UNIVERSAL, owner);
+    else
+        bot->Whisper("Starting to gather, but I see no harvestable nodes in this zone right now",
+                     LANG_UNIVERSAL, owner);
+
+    return true;
+}
+
+void NewRpgDoGatherAction::ClearLootTargetForNode(ObjectGuid::LowType spawnId)
+{
+    LootObject lootTarget = AI_VALUE(LootObject, "loot target");
+    if (!lootTarget.guid.IsGameObject())
+        return;
+
+    // GO instance guids are map-generated and do NOT equal spawn ids -
+    // resolve the object and compare its spawn id. An unresolvable target
+    // (despawned) is dead weight either way: release it too.
+    GameObject* go = botAI->GetGameObject(lootTarget.guid);
+    if (go && go->GetSpawnId() != spawnId)
+        return;
+
+    context->GetValue<LootObject>("loot target")->Set(LootObject());
+}
+
+void NewRpgDoGatherAction::AbandonNode(NewRpgInfo::DoGather& data, bool markVisited)
+{
+    ClearLootTargetForNode(data.nodeSpawnId);
+    if (markVisited)
+        data.visited.insert(data.nodeSpawnId);
+    data.nodeSpawnId = 0;
+    data.lastReach = 0;
+}
+
+bool NewRpgDoGatherAction::Execute(Event /*event*/)
+{
+    NewRpgInfo& info = botAI->rpgInfo;
+    auto* dataPtr = std::get_if<NewRpgInfo::DoGather>(&info.data);
+    if (!dataPtr)
+        return false;
+    auto& data = *dataPtr;
+
+    // A dead bot can't interact with nodes: standing on them just burns the
+    // timeout and wrongly writes live nodes into `visited`. Leave the state
+    // untouched and resume after revive.
+    if (!bot->IsAlive())
+        return false;
+
+    // (Nearly) full bags: the loot pipeline refuses to store new items
+    // above this fill level (see StoreLootAction), so every harvest would
+    // open the node, store nothing and stall until the timeout. Stop
+    // farming and let the maintenance logic (sell/destroy) catch up.
+    if (AI_VALUE(uint8, "bag space") > 80)
+    {
+        info.ChangeToIdle();
+        return true;
+    }
+
+    bool runPeriodicChecks =
+        !data.lastPassiveCheck || GetMSTimeDiffToNow(data.lastPassiveCheck) > passiveCheckInterval;
+    if (runPeriodicChecks)
+        data.lastPassiveCheck = getMSTime();
+
+    // Periodically drop a target that is verifiably empty (grid loaded, no
+    // live object) instead of walking all the way to it. Deliberately NOT
+    // added to `visited`: nodes respawn, and a permanently poisoned spawn
+    // point would make the bot run past the herb standing on it later.
+    if (runPeriodicChecks && data.nodeSpawnId &&
+        GatherNodeMgr::IsVerifiablyDown(bot->GetMap(), data.nodePos, data.nodeSpawnId))
+    {
+        AbandonNode(data);
+        return true;
+    }
+
+    // Opportunistic switch (same cadence as the passive check): take a
+    // verifiably live node over the current, possibly unverified target
+    // when it is either meaningfully closer (switchMinGain) or right next
+    // to the path (nodePickupDistance) - without the second clause the
+    // bot runs past herbs whenever its target happens to be at a
+    // comparable distance. Both clauses require the live node to be
+    // strictly closer than the current target. Closeness alone does not
+    // prevent ping-ponging (bot movement flips which node is closer), so
+    // the node last switched away from may not steal the target back
+    // until the current target resolves.
+    if (runPeriodicChecks && data.nodeSpawnId)
+    {
+        float distToTarget = bot->GetExactDist(data.nodePos);
+        GatherNodeSpawn const* live = sGatherNodeMgr.GetNearestLiveNode(bot, data.visited, nodeSwitchDistance);
+        if (live && live->spawnId != data.nodeSpawnId && live->spawnId != data.lastSwitchedFrom)
+        {
+            float distToLive = bot->GetExactDist(live->pos);
+            bool muchCloser = distToLive + switchMinGain < distToTarget;
+            bool passingBy = distToLive < nodePickupDistance && distToLive < distToTarget;
+            if (muchCloser || passingBy)
+            {
+                ClearLootTargetForNode(data.nodeSpawnId);
+                data.lastSwitchedFrom = data.nodeSpawnId;
+                data.nodeSpawnId = live->spawnId;
+                data.nodePos = live->pos;
+                data.lastReach = 0;
+                return true;
+            }
+        }
+    }
+
+    if (!data.nodeSpawnId)
+    {
+        // The previous target was resolved (harvested or written off), so
+        // the node we once switched away from becomes fair game again.
+        data.lastSwitchedFrom = 0;
+
+        // Prefer a node we can already see to be up over an unverified pick.
+        GatherNodeSpawn const* node = sGatherNodeMgr.GetNearestLiveNode(bot, data.visited, nodeSwitchDistance);
+        if (!node)
+            node = sGatherNodeMgr.GetNextNode(bot, data.visited);
+        if (!node)
+        {
+            // nothing (left) to gather in this zone
+            info.ChangeToIdle();
+            return true;
+        }
+        data.nodeSpawnId = node->spawnId;
+        data.nodePos = node->pos;
+        data.lastReach = 0;
+        return true;
+    }
+
+    if (bot->GetMapId() != data.nodePos.GetMapId())
+    {
+        // teleported/summoned away mid-route - drop the target and reselect
+        AbandonNode(data);
+        return true;
+    }
+
+    // 10yd keeps the bot inside lootDistance (default 15) so the loot
+    // pipeline's "loot available" trigger can fire on the node.
+    if (bot->GetExactDist(data.nodePos) > 10.0f)
+        return MoveFarTo(data.nodePos);
+
+    if (!data.lastReach)
+        data.lastReach = getMSTime();
+
+    GameObject* go = GatherNodeMgr::FindLiveNode(bot->GetMap(), data.nodeSpawnId);
+
+    if (!go)
+    {
+        // harvested (by us or someone else) or despawned - move on. NOT
+        // added to `visited`: the spawn point becomes a valid target again
+        // once it respawns.
+        AbandonNode(data);
+        return true;
+    }
+
+    // A harvest cast is already underway - do nothing that could clobber
+    // it (movement cancels the cast).
+    if (bot->GetCurrentSpell(CURRENT_GENERIC_SPELL) || bot->GetCurrentSpell(CURRENT_CHANNELED_SPELL))
+        return false;
+
+    // Write-off cases that do go into `visited` (this bot can't harvest
+    // the node, now or later this session):
+    // - IsEmpty: no access to the loot at all (quest-gated chests and
+    //   anything else the index filter misses). Deliberately only the
+    //   content check - positional/transient failures like the loot
+    //   pipeline's Z-distance check on a slope are left to the timeout,
+    //   so the bot doesn't bounce off harvestable nodes.
+    // - nodeStayTime timeout: the loot pipeline failed to harvest a live
+    //   node in time; without the write-off the bot would re-select it
+    //   forever.
+    LootObject lootObj(bot, go->GetGUID());
+    bool timedOut = GetMSTimeDiffToNow(data.lastReach) > nodeStayTime;
+    if (lootObj.IsEmpty() || timedOut)
+    {
+        AbandonNode(data, /*markVisited*/ true);
+        return true;
+    }
+
+    // Keep the loot pipeline pointed at our node, not a stale previous one:
+    // otherwise its move-to-loot (higher relevance) pulls the bot toward the
+    // old target while our approach pulls toward this one, and they fight.
+    // Don't override a valid target the pipeline is already busy with in loot
+    // range (e.g. a corpse right next to us).
+    LootObject currentTarget = AI_VALUE(LootObject, "loot target");
+    bool keepCurrent = !currentTarget.IsEmpty() && currentTarget.IsLootPossible(bot) &&
+                       AI_VALUE2(float, "distance", "loot target") <= sPlayerbotAIConfig.lootDistance;
+    if (currentTarget.guid != go->GetGUID() && !keepCurrent)
+        context->GetValue<LootObject>("loot target")->Set(LootObject(bot, go->GetGUID()));
+
+    // Drive the close approach ourselves when out of interaction range. The
+    // loot pipeline's own move-to-loot can't: it is gated on IsLootPossible
+    // (whose Z check fails for nodes well above/below the bot - ledges,
+    // underwater kelp), and it approaches via LOS-sampled offset points,
+    // which find nothing when the node sits behind an obstacle (los=false
+    // around a corner). A validated path (exact_waypoint false) climbs,
+    // descends and routes around geometry to the node. This only runs when
+    // the pipeline's higher-relevance approach already failed to move this
+    // tick; a node with no reachable path is retired by the timeout above.
+    if (!lootObj.IsLootPossible(bot) || bot->GetDistance(go) > INTERACTION_DISTANCE - 2.0f)
+    {
+        if (bot->isMoving())
+            return false;
+        return MoveTo(bot->GetMapId(), data.nodePos.GetPositionX(), data.nodePos.GetPositionY(),
+                      data.nodePos.GetPositionZ(), false, false, false, false);
+    }
+
+    // The loot pipeline only dismounts, it never leaves shapeshift form. Drop
+    // the form only when it actually blocks the gather cast (per the spell's
+    // own stance rules: Herb Gathering is explicitly allowed in flight forms,
+    // while e.g. Travel Form blocks it). We're in interaction range here (the
+    // approach branch above returned otherwise), so the bot keeps its form
+    // speed while approaching. No-op for non-druids (FORM_NONE).
+    if (bot->GetShapeshiftForm() != FORM_NONE)
+    {
+        uint32 gatherSpellId = lootObj.skillId == SKILL_MINING ? MINING : HERB_GATHERING;
+        SpellInfo const* gatherSpell = sSpellMgr->GetSpellInfo(gatherSpellId);
+        if (gatherSpell && gatherSpell->CheckShapeshift(bot->GetShapeshiftForm()) != SPELL_CAST_OK)
+        {
+            bot->RemoveAurasByType(SPELL_AURA_MOD_SHAPESHIFT);
+            return true;
+        }
+    }
+
+    // In range with the pipeline pointed at our node: it casts the gather
+    // spell and loots. While it works, Add() returns false and this idles.
+    return AI_VALUE(LootObjectStack*, "available loot")->Add(go->GetGUID());
+}

--- a/src/Ai/World/Rpg/Action/NewRpgDoGather.h
+++ b/src/Ai/World/Rpg/Action/NewRpgDoGather.h
@@ -1,0 +1,53 @@
+#ifndef PLAYERBOT_NEWRPGDOGATHER_H
+#define PLAYERBOT_NEWRPGDOGATHER_H
+
+#include "NewRpgBaseAction.h"
+
+// Chat command "rpg do gather": force the bot into the gathering state in
+// its current zone, mirroring "rpg do quest". Intended for maintainers to
+// test the gather behavior on demand (requires the "new rpg" strategy to be
+// active, e.g. via "nc +new rpg").
+class StartRpgDoGatherAction : public Action
+{
+public:
+    StartRpgDoGatherAction(PlayerbotAI* botAI) : Action(botAI, "start rpg do gather") {}
+
+    bool Execute(Event event) override;
+};
+
+class NewRpgDoGatherAction : public NewRpgBaseAction
+{
+public:
+    NewRpgDoGatherAction(PlayerbotAI* botAI) : NewRpgBaseAction(botAI, "new rpg do gather") {}
+    bool Execute(Event event) override;
+
+protected:
+    // Release the loot pipeline's target if it points at the given spawn.
+    // Called whenever the gather action abandons a node, so a half-done
+    // harvest can't leave a stale loot target behind (which would gate off
+    // loot-target replacement and wedge all subsequent harvesting).
+    void ClearLootTargetForNode(ObjectGuid::LowType spawnId);
+
+    // Drop the current node target (releasing the loot target with it) and
+    // reset the per-node state; markVisited writes the spawn off for this
+    // gather session.
+    void AbandonNode(NewRpgInfo::DoGather& data, bool markVisited = false);
+
+    // Max time waiting at a reached node for the loot pipeline to harvest
+    // it before giving up and moving on.
+    const uint32 nodeStayTime = 30 * IN_MILLISECONDS;
+    // Cadence for the periodic target-liveness and switch checks.
+    const uint32 passiveCheckInterval = 2 * IN_MILLISECONDS;
+    // A live node passed within this range takes priority over the current
+    // (possibly unverified) target.
+    const float nodeSwitchDistance = 80.0f;
+    // Required distance gain before switching to a live node that is not
+    // in immediate pickup range.
+    const float switchMinGain = 20.0f;
+    // A live node this close is always picked up (if strictly closer than
+    // the current target) - the cost of grabbing it is negligible and
+    // skipping it reads as "ran past a herb".
+    const float nodePickupDistance = 30.0f;
+};
+
+#endif

--- a/src/Ai/World/Rpg/NewRpgInfo.cpp
+++ b/src/Ai/World/Rpg/NewRpgInfo.cpp
@@ -60,6 +60,12 @@ void NewRpgInfo::ChangeToOutdoorPvp(ObjectGuid::LowType capturePointSpawnId)
     data = pvp;
 }
 
+void NewRpgInfo::ChangeToDoGather()
+{
+    startT = getMSTime();
+    data = DoGather{};
+}
+
 void NewRpgInfo::ChangeToRest()
 {
     startT = getMSTime();
@@ -118,6 +124,7 @@ NewRpgStatus NewRpgInfo::GetStatus()
         if constexpr (std::is_same_v<T, DoQuest>) return RPG_DO_QUEST;
         if constexpr (std::is_same_v<T, TravelFlight>) return RPG_TRAVEL_FLIGHT;
         if constexpr (std::is_same_v<T, OutdoorPvP>) return RPG_OUTDOOR_PVP;
+        if constexpr (std::is_same_v<T, DoGather>) return RPG_DO_GATHER;
         return RPG_IDLE;
     }, data);
 }
@@ -188,6 +195,15 @@ std::string NewRpgInfo::ToString()
                 out << "\nNo capture point assigned.";
             else
                 out << "\ncapturePointSpawnId: " << arg.capturePointSpawnId;
+        }
+        else if constexpr (std::is_same_v<T, DoGather>)
+        {
+            out << "DO_GATHER";
+            out << "\nnodeSpawnId: " << arg.nodeSpawnId;
+            out << "\nnodePos: " << arg.nodePos.GetMapId() << " " << arg.nodePos.GetPositionX() << " "
+                << arg.nodePos.GetPositionY() << " " << arg.nodePos.GetPositionZ();
+            out << "\nvisited: " << arg.visited.size();
+            out << "\nlastReach: " << (arg.lastReach ? GetMSTimeDiffToNow(arg.lastReach) : 0);
         }
         else
             out << "UNKNOWN";

--- a/src/Ai/World/Rpg/NewRpgInfo.h
+++ b/src/Ai/World/Rpg/NewRpgInfo.h
@@ -7,6 +7,8 @@
 #ifndef PLAYERBOTS_NEWRPGINFO_H
 #define PLAYERBOTS_NEWRPGINFO_H
 
+#include <unordered_set>
+
 #include "Define.h"
 #include "ObjectGuid.h"
 #include "ObjectMgr.h"
@@ -70,6 +72,16 @@ struct NewRpgInfo
     {
         ObjectGuid::LowType capturePointSpawnId{0};
     };
+    // RPG_DO_GATHER
+    struct DoGather
+    {
+        ObjectGuid::LowType nodeSpawnId{0};
+        WorldPosition nodePos{};
+        std::unordered_set<ObjectGuid::LowType> visited;
+        uint32 lastReach{0};
+        uint32 lastPassiveCheck{0};
+        ObjectGuid::LowType lastSwitchedFrom{0};
+    };
     struct Idle
     {
     };
@@ -92,7 +104,8 @@ struct NewRpgInfo
         DoQuest,
         Rest,
         TravelFlight,
-        OutdoorPvP
+        OutdoorPvP,
+        DoGather
     >;
     RpgData data;
 
@@ -106,6 +119,7 @@ struct NewRpgInfo
     void ChangeToDoQuest(uint32 questId, const Quest* quest);
     void ChangeToTravelFlight(uint32 flightMasterEntry, WorldPosition flightMasterPos, std::vector<uint32> path);
     void ChangeToOutdoorPvp(ObjectGuid::LowType capturePointSpawnId = 0);
+    void ChangeToDoGather();
     void ChangeToRest();
     void ChangeToIdle();
     bool CanChangeTo(NewRpgStatus status);

--- a/src/Ai/World/Rpg/NewRpgInfo.h
+++ b/src/Ai/World/Rpg/NewRpgInfo.h
@@ -7,6 +7,8 @@
 #ifndef PLAYERBOTS_NEWRPGINFO_H
 #define PLAYERBOTS_NEWRPGINFO_H
 
+#include <unordered_set>
+
 #include "Define.h"
 #include "ObjectGuid.h"
 #include "ObjectMgr.h"
@@ -70,6 +72,16 @@ struct NewRpgInfo
     {
         ObjectGuid::LowType capturePointSpawnId{0};
     };
+    // RPG_DO_GATHER
+    struct DoGather
+    {
+        ObjectGuid::LowType nodeSpawnId{0};
+        WorldPosition nodePos{};
+        std::unordered_set<ObjectGuid::LowType> visited;
+        uint32 lastReach{0};
+        uint32 lastPassiveCheck{0};
+        ObjectGuid::LowType lastSwitchedFrom{0};
+    };
     struct Idle
     {
     };
@@ -92,7 +104,8 @@ struct NewRpgInfo
         DoQuest,
         Rest,
         TravelFlight,
-        OutdoorPvP
+        OutdoorPvP,
+        DoGather
     >;
     RpgData data;
 
@@ -106,6 +119,7 @@ struct NewRpgInfo
     void ChangeToDoQuest(uint32 questId, Quest const* quest);
     void ChangeToTravelFlight(uint32 flightMasterEntry, WorldPosition flightMasterPos, std::vector<uint32> path);
     void ChangeToOutdoorPvp(ObjectGuid::LowType capturePointSpawnId = 0);
+    void ChangeToDoGather();
     void ChangeToRest();
     void ChangeToIdle();
     bool CanChangeTo(NewRpgStatus status);

--- a/src/Ai/World/Rpg/Strategy/NewRpgStrategy.cpp
+++ b/src/Ai/World/Rpg/Strategy/NewRpgStrategy.cpp
@@ -74,6 +74,14 @@ void NewRpgStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
             }
         )
     );
+    triggers.push_back(
+        new TriggerNode(
+            "do gather status",
+            {
+                NextAction("new rpg do gather", 3.0f)
+            }
+        )
+    );
 }
 
 void NewRpgStrategy::InitMultipliers(std::vector<Multiplier*>&)

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -2876,10 +2876,11 @@ void RandomPlayerbotMgr::PrintStats()
         LOG_INFO("playerbots", "Bots rpg status:");
         LOG_INFO("playerbots",
                  "    Idle: {}, Rest: {}, GoGrind: {}, GoCamp: {}, MoveRandom: {}, MoveNpc: {}, DoQuest: {}, "
-                 "TravelFlight: {}, OutdoorPvP: {}",
+                 "TravelFlight: {}, OutdoorPvP: {}, DoGather: {}",
                  rpgStatusCount[RPG_IDLE], rpgStatusCount[RPG_REST], rpgStatusCount[RPG_GO_GRIND],
                  rpgStatusCount[RPG_GO_CAMP], rpgStatusCount[RPG_WANDER_RANDOM], rpgStatusCount[RPG_WANDER_NPC],
-                 rpgStatusCount[RPG_DO_QUEST], rpgStatusCount[RPG_TRAVEL_FLIGHT], rpgStatusCount[RPG_OUTDOOR_PVP]);
+                 rpgStatusCount[RPG_DO_QUEST], rpgStatusCount[RPG_TRAVEL_FLIGHT], rpgStatusCount[RPG_OUTDOOR_PVP],
+                 rpgStatusCount[RPG_DO_GATHER]);
 
         LOG_INFO("playerbots", "Bots total quests:");
         LOG_INFO("playerbots", "    Accepted: {}, Rewarded: {}, Dropped: {}", rpgStasticTotal.questAccepted,

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -2970,10 +2970,11 @@ void RandomPlayerbotMgr::PrintStats()
         LOG_INFO("playerbots", "Bots rpg status:");
         LOG_INFO("playerbots",
                  "    Idle: {}, Rest: {}, GoGrind: {}, GoCamp: {}, MoveRandom: {}, MoveNpc: {}, DoQuest: {}, "
-                 "TravelFlight: {}, OutdoorPvP: {}",
+                 "TravelFlight: {}, OutdoorPvP: {}, DoGather: {}",
                  rpgStatusCount[RPG_IDLE], rpgStatusCount[RPG_REST], rpgStatusCount[RPG_GO_GRIND],
                  rpgStatusCount[RPG_GO_CAMP], rpgStatusCount[RPG_WANDER_RANDOM], rpgStatusCount[RPG_WANDER_NPC],
-                 rpgStatusCount[RPG_DO_QUEST], rpgStatusCount[RPG_TRAVEL_FLIGHT], rpgStatusCount[RPG_OUTDOOR_PVP]);
+                 rpgStatusCount[RPG_DO_QUEST], rpgStatusCount[RPG_TRAVEL_FLIGHT], rpgStatusCount[RPG_OUTDOOR_PVP],
+                 rpgStatusCount[RPG_DO_GATHER]);
 
         LOG_INFO("playerbots", "Bots total quests:");
         LOG_INFO("playerbots", "    Accepted: {}, Rewarded: {}, Dropped: {}", rpgStasticTotal.questAccepted,

--- a/src/Mgr/GatherNode/GatherNodeMgr.cpp
+++ b/src/Mgr/GatherNode/GatherNodeMgr.cpp
@@ -1,0 +1,256 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license, you may redistribute it
+ * and/or modify it under version 3 of the License, or (at your option), any later version.
+ */
+
+#include "GatherNodeMgr.h"
+
+#include <algorithm>
+
+#include "DBCStores.h"
+#include "DatabaseEnv.h"
+#include "GameObject.h"
+#include "Log.h"
+#include "Map.h"
+#include "MapMgr.h"
+#include "Object.h"
+#include "ObjectMgr.h"
+#include "Player.h"
+#include "PlayerbotAI.h"
+#include "Playerbots.h"
+#include "Random.h"
+#include "SharedDefines.h"
+#include "Timer.h"
+
+namespace
+{
+bool GetGatherSkillFromTemplate(GameObjectTemplate const* goInfo, uint32& skillId, uint32& reqSkillValue)
+{
+    if (!goInfo || goInfo->type != GAMEOBJECT_TYPE_CHEST)
+        return false;
+
+    uint32 lockId = goInfo->GetLockId();
+    if (!lockId)
+        return false;
+
+    LockEntry const* lockInfo = sLockStore.LookupEntry(lockId);
+    if (!lockInfo)
+        return false;
+
+    for (uint8 j = 0; j < 8; ++j)
+    {
+        if (lockInfo->Type[j] != LOCK_KEY_SKILL)
+            continue;
+
+        uint32 skill = SkillByLockType(LockType(lockInfo->Index[j]));
+        if (skill == SKILL_HERBALISM || skill == SKILL_MINING)
+        {
+            skillId = skill;
+            reqSkillValue = std::max(1u, lockInfo->Skill[j]);
+            return true;
+        }
+    }
+
+    return false;
+}
+}
+
+void GatherNodeMgr::Load()
+{
+    uint32 oldMSTime = getMSTime();
+    uint32 count = 0;
+
+    // Loot ids with at least one freely lootable row. Quest-gated
+    // "gathering" chests (Cactus Apple, Serpentbloom, ...) carry a
+    // herbalism/mining lock but ALL their loot rows are QuestRequired, so
+    // bots without the quest can't harvest them - and they never despawn,
+    // which makes them permanent live-node bait. Note that filtering on
+    // gameobject_questitem instead would be wrong: standard herbs carry a
+    // conditional quest item (Root Sample) on top of their normal loot.
+    std::unordered_set<uint32> openLootIds;
+    if (QueryResult result =
+            WorldDatabase.Query("SELECT DISTINCT Entry FROM gameobject_loot_template WHERE QuestRequired = 0"))
+    {
+        do
+        {
+            openLootIds.insert((*result)[0].Get<uint32>());
+        } while (result->NextRow());
+    }
+
+    std::unordered_map<ObjectGuid::LowType, uint32> dbZoneIds;
+    if (QueryResult result = WorldDatabase.Query("SELECT guid, zoneId FROM gameobject WHERE zoneId <> 0"))
+    {
+        do
+        {
+            dbZoneIds[(*result)[0].Get<uint32>()] = (*result)[1].Get<uint32>();
+        } while (result->NextRow());
+    }
+
+    for (auto const& [spawnId, goData] : sObjectMgr->GetAllGOData())
+    {
+        // Instances are excluded: the state targets outdoor zone roaming.
+        MapEntry const* mapEntry = sMapStore.LookupEntry(goData.mapid);
+        if (!mapEntry || !mapEntry->IsContinent())
+            continue;
+
+        GameObjectTemplate const* goInfo = sObjectMgr->GetGameObjectTemplate(goData.id);
+
+        uint32 skillId = 0;
+        uint32 reqSkillValue = 0;
+        if (!GetGatherSkillFromTemplate(goInfo, skillId, reqSkillValue))
+            continue;
+
+        if (!openLootIds.contains(goInfo->GetLootId()))
+            continue;
+
+        GatherNodeSpawn node;
+        node.spawnId = spawnId;
+        node.pos = WorldPosition(goData.mapid, goData.posX, goData.posY, goData.posZ);
+        node.skillId = skillId;
+        node.reqSkillValue = reqSkillValue;
+        auto zoneItr = dbZoneIds.find(spawnId);
+        uint32 zoneId = zoneItr != dbZoneIds.end()
+                            ? zoneItr->second
+                            : sMapMgr->GetZoneId(PHASEMASK_NORMAL, goData.mapid, goData.posX, goData.posY, goData.posZ);
+        _nodes[goData.mapid][zoneId].push_back(std::move(node));
+        ++count;
+    }
+
+    LOG_INFO("playerbots", ">> Loaded {} gather node spawns in {} ms", count, GetMSTimeDiffToNow(oldMSTime));
+}
+
+bool GatherNodeMgr::IsUsable(PlayerbotAI* botAI, Player* bot, GatherNodeSpawn const& node)
+{
+    if (!botAI->HasSkill(SkillType(node.skillId)))
+        return false;
+
+    return bot->GetSkillValue(node.skillId) >= node.reqSkillValue;
+}
+
+std::vector<GatherNodeSpawn> const* GatherNodeMgr::GetZoneNodes(uint32 mapId, uint32 zoneId) const
+{
+    auto mapItr = _nodes.find(mapId);
+    if (mapItr == _nodes.end())
+        return nullptr;
+
+    auto zoneItr = mapItr->second.find(zoneId);
+    return zoneItr != mapItr->second.end() ? &zoneItr->second : nullptr;
+}
+
+bool GatherNodeMgr::HasUsableNodes(Player* bot)
+{
+    std::vector<GatherNodeSpawn> const* nodes = GetZoneNodes(bot->GetMapId(), bot->GetZoneId());
+    if (!nodes)
+        return false;
+
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+    if (!botAI)
+        return false;
+
+    for (GatherNodeSpawn const& node : *nodes)
+        if (IsUsable(botAI, bot, node))
+            return true;
+
+    return false;
+}
+
+GatherNodeSpawn const* GatherNodeMgr::GetNextNode(Player* bot, std::unordered_set<ObjectGuid::LowType> const& visited)
+{
+    std::vector<GatherNodeSpawn> const* nodes = GetZoneNodes(bot->GetMapId(), bot->GetZoneId());
+    if (!nodes)
+        return nullptr;
+
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+    if (!botAI)
+        return nullptr;
+
+    Map* map = bot->GetMap();
+    WorldPosition botPos(bot);
+
+    std::vector<std::pair<float, GatherNodeSpawn const*>> candidates;
+    for (GatherNodeSpawn const& node : *nodes)
+    {
+        if (visited.contains(node.spawnId) || !IsUsable(botAI, bot, node))
+            continue;
+
+        // Don't route to spawn points we can already see to be empty.
+        // Evaluated fresh on every selection so respawns come back into
+        // the pool naturally.
+        if (IsVerifiablyDown(map, node.pos, node.spawnId))
+            continue;
+
+        candidates.push_back({botPos.sqDistance(node.pos), &node});
+    }
+
+    if (candidates.empty())
+        return nullptr;
+
+    uint32 nearestCount = std::min<uint32>(4, candidates.size());
+    std::partial_sort(candidates.begin(), candidates.begin() + nearestCount, candidates.end(),
+                      [](auto const& a, auto const& b) { return a.first < b.first; });
+
+    return candidates[urand(0, nearestCount - 1)].second;
+}
+
+GameObject* GatherNodeMgr::FindLiveNode(Map* map, ObjectGuid::LowType spawnId)
+{
+    auto bounds = map->GetGameObjectBySpawnIdStore().equal_range(spawnId);
+    for (auto it = bounds.first; it != bounds.second; ++it)
+        if (it->second->isSpawned() && it->second->GetGoState() == GO_STATE_READY)
+            return it->second;
+
+    return nullptr;
+}
+
+bool GatherNodeMgr::IsVerifiablyDown(Map* map, WorldPosition const& pos, ObjectGuid::LowType spawnId)
+{
+    // An unloaded grid means "unknown", not "not up".
+    if (!map->IsGridLoaded(pos.GetPositionX(), pos.GetPositionY()))
+        return false;
+
+    return !FindLiveNode(map, spawnId);
+}
+
+GatherNodeSpawn const* GatherNodeMgr::GetNearestLiveNode(Player* bot,
+                                                         std::unordered_set<ObjectGuid::LowType> const& visited,
+                                                         float radius)
+{
+    auto mapItr = _nodes.find(bot->GetMapId());
+    if (mapItr == _nodes.end())
+        return nullptr;
+
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+    if (!botAI)
+        return nullptr;
+
+    Map* map = bot->GetMap();
+    WorldPosition botPos(bot);
+    GatherNodeSpawn const* nearest = nullptr;
+    float nearestDistSq = radius * radius;
+    // All zone buckets of the map: this query is deliberately not
+    // zone-scoped, and a radius this small prunes nearly everything on the
+    // cheap distance check.
+    for (auto const& [zoneId, nodes] : mapItr->second)
+    {
+        for (GatherNodeSpawn const& node : nodes)
+        {
+            float distSq = botPos.sqDistance(node.pos);
+            if (distSq > nearestDistSq)
+                continue;
+
+            if (visited.contains(node.spawnId) || !IsUsable(botAI, bot, node))
+                continue;
+
+            if (!map->IsGridLoaded(node.pos.GetPositionX(), node.pos.GetPositionY()))
+                continue;
+
+            if (!FindLiveNode(map, node.spawnId))
+                continue;
+
+            nearest = &node;
+            nearestDistSq = distSq;
+        }
+    }
+
+    return nearest;
+}

--- a/src/Mgr/GatherNode/GatherNodeMgr.h
+++ b/src/Mgr/GatherNode/GatherNodeMgr.h
@@ -3,8 +3,8 @@
  * and/or modify it under version 3 of the License, or (at your option), any later version.
  */
 
-#ifndef _PLAYERBOT_GATHERNODEMGR_H
-#define _PLAYERBOT_GATHERNODEMGR_H
+#ifndef PLAYERBOT_GATHERNODEMGR_H
+#define PLAYERBOT_GATHERNODEMGR_H
 
 #include <unordered_map>
 #include <unordered_set>

--- a/src/Mgr/GatherNode/GatherNodeMgr.h
+++ b/src/Mgr/GatherNode/GatherNodeMgr.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2016+ AzerothCore <www.azerothcore.org>, released under GNU AGPL v3 license, you may redistribute it
+ * and/or modify it under version 3 of the License, or (at your option), any later version.
+ */
+
+#ifndef _PLAYERBOT_GATHERNODEMGR_H
+#define _PLAYERBOT_GATHERNODEMGR_H
+
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "ObjectGuid.h"
+#include "TravelMgr.h"
+
+class GameObject;
+class Map;
+class Player;
+class PlayerbotAI;
+
+struct GatherNodeSpawn
+{
+    ObjectGuid::LowType spawnId{0};
+    WorldPosition pos{};
+    uint32 skillId{0};  // SKILL_HERBALISM or SKILL_MINING
+    uint32 reqSkillValue{0};
+};
+
+/// Index of gatherable gameobject spawns (herbs/veins) on continent maps,
+/// built once from sObjectMgr spawn data at world init. Immutable afterwards.
+class GatherNodeMgr
+{
+public:
+    static GatherNodeMgr& instance()
+    {
+        static GatherNodeMgr instance;
+        return instance;
+    }
+
+    void Load();
+
+    // Cheap check for CheckRpgStatusAvailable: any node in the bot's current
+    // zone harvestable with its current skills?
+    bool HasUsableNodes(Player* bot);
+
+    // Random pick among the 4 nearest unvisited usable nodes in the bot's
+    // current zone (jitter keeps co-located bots from herding on one route).
+    GatherNodeSpawn const* GetNextNode(Player* bot, std::unordered_set<ObjectGuid::LowType> const& visited);
+
+    // Live (spawned + GO_STATE_READY) object for a spawn point, nullptr if
+    // none. Only meaningful when the grid at the spawn position is loaded.
+    static GameObject* FindLiveNode(Map* map, ObjectGuid::LowType spawnId);
+
+    // True when the spawn point is verifiably empty right now: grid loaded
+    // and no live object. An unloaded grid yields false ("unknown"). Never
+    // record this verdict anywhere - nodes respawn, so liveness must be
+    // re-evaluated at every decision.
+    static bool IsVerifiablyDown(Map* map, WorldPosition const& pos, ObjectGuid::LowType spawnId);
+
+    // Nearest unvisited usable node within `radius` that is verifiably up
+    // right now, or nullptr. Deliberately not zone-filtered: a live node
+    // just across a zone border still counts as "passing by".
+    GatherNodeSpawn const* GetNearestLiveNode(Player* bot, std::unordered_set<ObjectGuid::LowType> const& visited,
+                                              float radius);
+
+private:
+    bool IsUsable(PlayerbotAI* botAI, Player* bot, GatherNodeSpawn const& node);
+
+    std::vector<GatherNodeSpawn> const* GetZoneNodes(uint32 mapId, uint32 zoneId) const;
+
+    // Bucketed per zone so the zone-scoped queries (HasUsableNodes,
+    // GetNextNode) touch only the bot's zone instead of the whole continent.
+    std::unordered_map<uint32 /*mapId*/, std::unordered_map<uint32 /*zoneId*/, std::vector<GatherNodeSpawn>>> _nodes;
+};
+
+#define sGatherNodeMgr GatherNodeMgr::instance()
+
+#endif

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -733,6 +733,7 @@ bool PlayerbotAIConfig::Initialize()
     RpgStatusProbWeight[RPG_TRAVEL_FLIGHT] = sConfigMgr->GetOption<int32>("AiPlayerbot.RpgStatusProbWeight.TravelFlight", 15);
     RpgStatusProbWeight[RPG_REST] = sConfigMgr->GetOption<int32>("AiPlayerbot.RpgStatusProbWeight.Rest", 5);
     RpgStatusProbWeight[RPG_OUTDOOR_PVP] = sConfigMgr->GetOption<int32>("AiPlayerbot.RpgStatusProbWeight.OutdoorPvp", 10);
+    RpgStatusProbWeight[RPG_DO_GATHER] = sConfigMgr->GetOption<int32>("AiPlayerbot.RpgStatusProbWeight.DoGather", 15);
 
     syncLevelWithPlayers = sConfigMgr->GetOption<bool>("AiPlayerbot.SyncLevelWithPlayers", false);
     randomBotGroupNearby = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotGroupNearby", false);

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -735,6 +735,7 @@ bool PlayerbotAIConfig::Initialize()
     RpgStatusProbWeight[RPG_TRAVEL_FLIGHT] = sConfigMgr->GetOption<int32>("AiPlayerbot.RpgStatusProbWeight.TravelFlight", 15);
     RpgStatusProbWeight[RPG_REST] = sConfigMgr->GetOption<int32>("AiPlayerbot.RpgStatusProbWeight.Rest", 5);
     RpgStatusProbWeight[RPG_OUTDOOR_PVP] = sConfigMgr->GetOption<int32>("AiPlayerbot.RpgStatusProbWeight.OutdoorPvp", 10);
+    RpgStatusProbWeight[RPG_DO_GATHER] = sConfigMgr->GetOption<int32>("AiPlayerbot.RpgStatusProbWeight.DoGather", 15);
 
     syncLevelWithPlayers = sConfigMgr->GetOption<bool>("AiPlayerbot.SyncLevelWithPlayers", false);
     randomBotConcentrateInPlayerZone =

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -71,7 +71,9 @@ enum NewRpgStatus : int
     // Taking a break
     RPG_REST = 7,
     RPG_OUTDOOR_PVP = 8,
-    RPG_STATUS_END = 9
+    // Roam the current zone harvesting herb/ore nodes
+    RPG_DO_GATHER = 9,
+    RPG_STATUS_END = 10
 };
 
 #define MAX_SPECNO 20

--- a/src/Script/Playerbots.cpp
+++ b/src/Script/Playerbots.cpp
@@ -10,6 +10,7 @@
 #include "Config.h"
 #include "DatabaseEnv.h"
 #include "DatabaseLoader.h"
+#include "GatherNodeMgr.h"
 #include "GuildTaskMgr.h"
 #include "PlayerScript.h"
 #include "PlayerbotAIConfig.h"
@@ -359,6 +360,9 @@ public:
         LOG_INFO("server.loading", " ");
 
         PlayerbotSpellRepository::Instance().Initialize();
+
+        LOG_INFO("server.loading", "Loading gather node index...");
+        GatherNodeMgr::instance().Load();
 
         LOG_INFO("server.loading", "Playerbots World Thread Processor initialized");
     }

--- a/src/Script/Playerbots.cpp
+++ b/src/Script/Playerbots.cpp
@@ -11,6 +11,7 @@
 #include "Config.h"
 #include "DatabaseEnv.h"
 #include "DatabaseLoader.h"
+#include "GatherNodeMgr.h"
 #include "GuildTaskMgr.h"
 #include "PlayerScript.h"
 #include "PlayerbotAIConfig.h"
@@ -362,6 +363,9 @@ public:
         LOG_INFO("server.loading", " ");
 
         PlayerbotSpellRepository::Instance().Initialize();
+
+        LOG_INFO("server.loading", "Loading gather node index...");
+        GatherNodeMgr::instance().Load();
 
         LOG_INFO("server.loading", "Playerbots World Thread Processor initialized");
     }


### PR DESCRIPTION
## Pull Request Description

This PR adds a dedicated `RPG_DO_GATHER` status to the new RPG system: bots with Herbalism or Mining roam their current zone and systematically harvest herb and ore nodes.

The core of the feature is a gather node index (`GatherNodeMgr`), built once at world init from spawn data. Every gameobject spawn on the four continents whose lock requires Herbalism/Mining goes into the index with its position and required skill, bucketed by zone. Spawns whose loot table has no freely lootable row are excluded, since quest-gated chests like Cactus Apple never despawn and would otherwise sit in the index as permanent bait. Bots in the gather state then tour these known spawn points:

- Node selection is a random pick among the 4 nearest unvisited usable nodes in the zone (the jitter keeps co-located bots from herding onto one route), preferring nodes that are verifiably up right now.
- A spawn point with a loaded grid and no live object is skipped without being blacklisted. Nodes respawn, so liveness is re-evaluated at every decision.
- Drive-by pickups: a verifiably live node passing within range steals the target when it is strictly closer, with anti-ping-pong guards.
- The action drives the close approach itself for nodes the loot pipeline's move-to-loot can't reach (Z-offset ledges, underwater kelp, obstructed LOS) using a validated path.
- Nodes that can't be harvested, either from lack of loot access or a 30s harvest timeout, are marked visited for the session. Nearly-full bags (>80%) end the state so the sell/maintenance logic can catch up.

A nice side effect: many nodes spawn inside caves and mob camps, so gathering routes naturally pull bots into these hostile pockets and spread them across the whole zone instead of clustering around grind spots and quest hubs.

Entry is weighted into the status selection via `AiPlayerbot.RpgStatusProbWeight.DoGather` (default 15), and a `rpg do gather` chat command forces the state for testing.

## Relation to #2246 (Farming RPG Status)

#2246 adds a broader `RPG_FARMING` status that travels to a promising area and farms opportunistically: it selects a farming position from travel destinations, prioritizes mobs that drop cloth/leather via grind-target changes, and gathers nodes the bot happens to encounter once they are already visible and loot-possible.

This PR is narrower and approaches the gathering half from the other direction. Instead of discovering nodes en route, it indexes every gatherable spawn point from the DB and routes to them deliberately, including nodes in unloaded grids the bot can't see yet and respawns of nodes previously found empty. It does not touch mob selection, cloth/leather farming, or grind targeting at all.

The two can coexist: #2246 covers combat-material farming with incidental gathering, while this PR makes profession gathering a deliberate, reliable loop. They wire into the status machine the same way, as separate statuses with separate weights.

## Feature Evaluation

- Describe the **minimum logic** required to achieve the intended behavior.

A status enum entry, state storage in `NewRpgInfo` (current node, visited set, timers), the `NewRpgDoGatherAction` execution loop, trigger/action registration, and a config weight. On top of that sits the node index itself, which is the piece that makes deliberate routing possible at acceptable cost: the alternative, grid-scanning for gameobjects around every gathering bot, is far more expensive per tick.

- Describe the **processing cost** when this logic executes across many bots.

Startup: one pass over gameobject spawn data plus two world-DB queries. Zone ids come from the `gameobject.zoneId` column (populated for ~99% of gather-node spawns); only unpopulated rows fall back to a terrain lookup of one map tile each. Runtime: the index is immutable. Entry checks (`HasUsableNodes`) touch only the bot's per-(map,zone) bucket and run once per status roll. Bots actively gathering run a periodic check every 2s whose radius query prunes on a squared-distance compare before any heavier lookup. No per-tick global processing is added.

## How to Test the Changes

1. Build the module and run `worldserver` with New RPG enabled.
2. Ensure random bots with Herbalism/Mining are active (or whisper a bot `rpg do gather` with the `new rpg` strategy on).
3. Confirm bots route between herb/ore spawn points in their zone and that the harvest ends up in their bags.
4. Watch the interesting cases: nodes on ledges/underwater (bot climbs/dives to them), a node harvested by someone else (bot re-targets without blacklisting the spawn), druid bots (Travel Form is dropped at the node, flight-form herbing is left alone), nearly-full bags (state ends).
5. Verify existing New RPG statuses still transition normally.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

Entry checks are zone-bucket scans on status transitions only. Active gatherers add a 2s-cadence distance-pruned scan of their map's index. The index costs one startup pass and a few MB of memory.

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

The default weight (15) lets gather-skilled bots enter the state out of the box; set `AiPlayerbot.RpgStatusProbWeight.DoGather = 0` to disable.

- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [x] Yes (**explain below**)

One new RPG status with its action/trigger wiring, and one new manager (`GatherNodeMgr`). The logic is localized to the NewRpg system and the new files.

## Messages to Translate

- Does this change add bot messages to translate?
    - - [x] No
    - - [ ] Yes (**list messages in the table**)

| Message key  | Default message |
| --------------- | ------------------ |
| 			 | 			      |
| 			 | 			      |

No `ai_playerbot_texts` entries are added. The `rpg do gather` chat command replies with four plain-English whispers, mirroring the existing raw-whisper pattern of `rpg do quest` ("Start to do quest …" / "Invalid quest …"): maintainer-facing command feedback, not bot social text.

## AI Assistance

- Was AI assistance used while working on this change?
    - - [ ] No
    - - [x] Yes (**explain below**)

AI assistance was used during development and review of the change; the behavior was iterated on and validated in-game.

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).

## Notes for Reviewers

- The `visited` write-off set and node target live in `NewRpgInfo`'s per-status data and reset naturally on status change; nothing is persisted.
