### PR TITLE
[CI/CD] Changed way to get git diff to mark label with translation

### DIFF
--- a/.github/workflows/label_translation-pr.yml
+++ b/.github/workflows/label_translation-pr.yml
@@ -12,13 +12,16 @@ jobs:
   label-translation:
     runs-on: ubuntu-latest
     steps:
-      - name: Fetch PR diff
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Checkout base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+
+      - name: Fetch PR head and generate diff
         run: |
-          gh api \
-            repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} \
-            --header "Accept: application/vnd.github.v3.diff" > pr.diff
+          git fetch origin refs/pull/${{ github.event.pull_request.number }}/head
+          git diff ${{ github.event.pull_request.base.sha }}...FETCH_HEAD > pr.diff
 
       - name: Detect ai_playerbot_texts inserts
         id: detect


### PR DESCRIPTION
Maintenance PR

Test:
<img width="790" height="679" alt="obraz" src="https://github.com/user-attachments/assets/cf475221-2406-4353-ace4-c733c1eb464a" />
