### PR TITLE
Fix channel chat crashes and scoped public-channel command dispatch

### DIFF
--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -73,6 +73,28 @@ std::string& trim(std::string& s);
 
 std::set<std::string> PlayerbotAI::unsecuredCommands;
 
+namespace
+{
+    std::mutex s_channelSayMutex;
+}
+
+void PlayerbotAI::EnsureUnsecuredCommands()
+{
+    if (!unsecuredCommands.empty())
+        return;
+
+    unsecuredCommands.insert("who");
+    unsecuredCommands.insert("wts");
+    unsecuredCommands.insert("sendmail");
+    unsecuredCommands.insert("invite");
+    unsecuredCommands.insert("leave");
+    unsecuredCommands.insert("ready for invite");
+    unsecuredCommands.insert("drop group");
+    unsecuredCommands.insert("lfg");
+    unsecuredCommands.insert("pvp stats");
+    unsecuredCommands.insert("rpg status");
+}
+
 PlayerbotChatHandler::PlayerbotChatHandler(Player* pMasterPlayer) : ChatHandler(pMasterPlayer->GetSession()) {}
 
 uint32 PlayerbotChatHandler::extractQuestId(std::string const str)
@@ -574,6 +596,13 @@ void PlayerbotAI::HandleCommands()
             continue;
         }
 
+        owner = ObjectAccessor::FindPlayer(owner->GetGUID());
+        if (!owner)
+        {
+            it = chatCommands.erase(it);
+            continue;
+        }
+
         const std::string& command = it->GetCommand();
         if (command.empty())
         {
@@ -919,26 +948,133 @@ void PlayerbotAI::LeaveOrDisbandGroup()
     bot->GetSession()->QueuePacket(packet);
 }
 
+bool PlayerbotAI::CommandTextEqualsOrStartsWith(std::string const& text, std::string const& cmd)
+{
+    if (text == cmd)
+        return true;
+
+    if (text.size() <= cmd.size() || text[cmd.size()] != ' ')
+        return false;
+
+    return text.compare(0, cmd.size(), cmd) == 0;
+}
+
+std::string PlayerbotAI::NormalizeChatCommandText(std::string const& text)
+{
+    std::string filtered = trim(text);
+    if (filtered.empty())
+        return filtered;
+
+    if (!sPlayerbotAIConfig.commandPrefix.empty() &&
+        filtered.find(sPlayerbotAIConfig.commandPrefix) == 0)
+        filtered = filtered.substr(sPlayerbotAIConfig.commandPrefix.size());
+
+    return trim(filtered);
+}
+
+bool PlayerbotAI::IsPublicChannelChat(uint32 type)
+{
+    return type == CHAT_MSG_CHANNEL;
+}
+
+namespace
+{
+bool MatchesAnyPublicChannelCommand(std::string const& text, std::initializer_list<char const*> commands)
+{
+    for (char const* cmd : commands)
+    {
+        if (PlayerbotAI::CommandTextEqualsOrStartsWith(text, cmd))
+            return true;
+    }
+
+    return false;
+}
+}  // namespace
+
+PublicChannelDispatchMode PlayerbotAI::GetPublicChannelDispatchMode(std::string const& text)
+{
+    std::string const filtered = NormalizeChatCommandText(text);
+    if (filtered.empty())
+        return PublicChannelDispatchMode::Blocked;
+
+    if (filtered[0] == '@')
+        return PublicChannelDispatchMode::Nearby;
+
+    // Master-only or group-context commands — never broadcast on General/Trade to random bots.
+    if (MatchesAnyPublicChannelCommand(filtered, {
+            "leave", "drop group", "ready for invite", "logout", "logout cancel",
+            "reset", "reset botAI", "follow", "stay", "flee", "runaway", "warning",
+            "debug", "cdebug", "cs", "cheat", "teleport", "summon", "home",
+            "give leader", "ginvite", "guild promote", "guild demote", "guild remove", "guild leave",
+            "wipe", "tame", "glyph equip", "remove glyph", "pet attack", "formation", "stance",
+            "cancel tree form", "cancel travel form", "cancel bear form", "cancel dire bear form",
+            "cancel cat form", "cancel moonkin form", "cancel aquatic form",
+            "max dps", "pull", "pull back", "pull rti", "attack", "grind", "cast", "castnc",
+            "accept", "add all loot", "enter vehicle", "leave vehicle", "revive", "disperse",
+            "focus heal", "naxx", "bwl", "ready", "rtsc", "rti", "open items", "unlock items",
+            "unlock traded item", "wait for attack time", "move from group", "tank attack",
+            "equip upgrade", "autogear", "autogear bis", "maintenance", "trainer", "destroy",
+            "drop", "share", "ll", "ss", "release", "spells", "spell", "buff", "emote",
+            "save mana", "flag", "ra", "go", "mail", "outfit", "craft", "hire", "bank", "gb",
+            "roll", "calc", "drink", "glyphs", "pet", "talk", "u", "e", "ue", "t", "nt", "s", "b", "r",
+            "co", "nc", "de", "q", "rep", "reputation", "log", "chat", "aura", "emblems", "talents",
+            "rpg do quest", "dps", "qi", "items", "inv", "c", "los", "guard",
+            "do accept invitation", "react", "reset strats", "nc ?", "co ?", "de ?", "dead ?",
+            "all ?", "talents list", "talents auto", "join", "repair",
+            "tell estimated dps", "tell attackers", "tell target", "tell pvp stats",
+            "follow target", "focus heal", "cast ", "accept [", "e [", "destroy [", "go zone"
+        }))
+        return PublicChannelDispatchMode::Blocked;
+
+    // Recruiting commands — one nearby responder on public channels to avoid mass-invite spam.
+    if (MatchesAnyPublicChannelCommand(filtered, { "invite", "lfg" }))
+        return PublicChannelDispatchMode::SingleNearest;
+
+    // Info / query commands — one nearby responder.
+    if (MatchesAnyPublicChannelCommand(filtered, {
+            "who", "wts", "help", "stats", "pvp stats", "rpg status", "sendmail", "position",
+            "quests", "reputation", "attackers", "target", "range", "spells", "talents", "outfit"
+        }))
+        return PublicChannelDispatchMode::SingleNearest;
+
+    return PublicChannelDispatchMode::Blocked;
+}
+
 bool PlayerbotAI::IsAllowedCommand(std::string const text)
 {
-    if (unsecuredCommands.empty())
-    {
-        unsecuredCommands.insert("who");
-        unsecuredCommands.insert("wts");
-        unsecuredCommands.insert("sendmail");
-        unsecuredCommands.insert("invite");
-        unsecuredCommands.insert("leave");
-        unsecuredCommands.insert("lfg");
-        unsecuredCommands.insert("pvp stats");
-        unsecuredCommands.insert("rpg status");
-    }
+    EnsureUnsecuredCommands();
 
     for (std::set<std::string>::iterator i = unsecuredCommands.begin(); i != unsecuredCommands.end(); ++i)
     {
-        if (text.find(*i) == 0)
-        {
+        if (CommandTextEqualsOrStartsWith(text, *i))
             return true;
-        }
+    }
+
+    return false;
+}
+
+bool PlayerbotAI::LooksLikeChatCommand(std::string const& text)
+{
+    if (text.empty())
+        return false;
+
+    if (!sPlayerbotAIConfig.commandPrefix.empty() &&
+        trim(text).find(sPlayerbotAIConfig.commandPrefix) == 0)
+        return true;
+
+    std::string const filtered = NormalizeChatCommandText(text);
+    if (filtered.empty())
+        return false;
+
+    if (filtered[0] == '@')
+        return true;
+
+    EnsureUnsecuredCommands();
+
+    for (std::string const& cmd : unsecuredCommands)
+    {
+        if (CommandTextEqualsOrStartsWith(filtered, cmd))
+            return true;
     }
 
     return false;
@@ -1088,7 +1224,7 @@ void PlayerbotAI::HandleCommand(uint32 type, std::string const text, Player* fro
         {
             std::string message = PlayerbotTextMgr::instance().GetBotTextOrDefault(
                 "bot_rndbot_no_logout", "You can't command me to logout!", {});
-            TellMaster(message);
+            bot->Whisper(message, LANG_UNIVERSAL, fromPlayer);
         }
     }
     else if (filtered == "logout cancel")
@@ -1237,8 +1373,12 @@ void PlayerbotAI::HandleBotOutgoingPacket(WorldPacket const& packet)
                     if (bot->InBattleground() && !(isMentioned || (msgtype != CHAT_MSG_CHANNEL && !isFromFreeBot)))
                         return;
 
-                    if (HasRealPlayerMaster() && guid1 != GetMaster()->GetGUID())
-                        return;
+                    if (HasRealPlayerMaster())
+                    {
+                        Player* const botMaster = GetMaster();
+                        if (!botMaster || !botMaster->IsInWorld() || guid1 != botMaster->GetGUID())
+                            return;
+                    }
 
                     auto itemIds = GetChatHelper()->ExtractAllItemIds(message);
                     if (message.starts_with(sPlayerbotAIConfig.toxicLinksPrefix) &&
@@ -2841,8 +2981,7 @@ bool PlayerbotAI::SayToChannel(const std::string& msg, const ChatChannelId& chan
 
     const auto current_str_zone = GetLocalizedAreaName(current_zone);
 
-    std::mutex socialMutex;
-    std::lock_guard<std::mutex> lock(socialMutex);  // Blocking for thread safety when accessing SocialMgr
+    std::lock_guard<std::mutex> lock(s_channelSayMutex);
 
     for (auto const& [key, channel] : cMgr->GetChannels())
     {

--- a/src/Bot/PlayerbotAI.h
+++ b/src/Bot/PlayerbotAI.h
@@ -379,6 +379,15 @@ private:
     time_t time;
 };
 
+class Player;
+
+enum class PublicChannelDispatchMode : uint8
+{
+    Blocked,        // Do not fan out on General/Trade (use whisper/party/guild instead)
+    SingleNearest,  // One nearby bot responds (info queries)
+    Nearby          // All nearby bots may respond (invite/lfg/@role)
+};
+
 class PlayerbotAI : public PlayerbotAIBase
 {
 public:
@@ -528,6 +537,11 @@ public:
     static uint32 GetMixedGearScore(Player* player, bool withBags, bool withBank, uint32 topN = 0);
     bool HasSkill(SkillType skill);
     bool IsAllowedCommand(std::string const text);
+    static bool LooksLikeChatCommand(std::string const& text);
+    static bool CommandTextEqualsOrStartsWith(std::string const& text, std::string const& cmd);
+    static std::string NormalizeChatCommandText(std::string const& text);
+    static bool IsPublicChannelChat(uint32 type);
+    static PublicChannelDispatchMode GetPublicChannelDispatchMode(std::string const& text);
     float GetRange(std::string const type);
 
     Player* GetBot() { return bot; }
@@ -644,6 +658,7 @@ protected:
     std::map<std::string, time_t> whispers;
     std::pair<ChatMsg, time_t> currentChat;
     static std::set<std::string> unsecuredCommands;
+    static void EnsureUnsecuredCommands();
     bool allowActive[MAX_ACTIVITY_TYPE];
     time_t allowActiveCheckTimer[MAX_ACTIVITY_TYPE];
     bool inCombat = false;

--- a/src/Bot/PlayerbotMgr.cpp
+++ b/src/Bot/PlayerbotMgr.cpp
@@ -1516,6 +1516,47 @@ void PlayerbotMgr::HandleCommand(uint32 type, std::string const text)
         return;
     }
 
+    if (PlayerbotAI::IsPublicChannelChat(type) || type == CHAT_MSG_GUILD)
+    {
+        switch (PlayerbotAI::GetPublicChannelDispatchMode(text))
+        {
+            case PublicChannelDispatchMode::Blocked:
+                return;
+            case PublicChannelDispatchMode::SingleNearest:
+                for (PlayerBotMap::const_iterator it = GetPlayerBotsBegin(); it != GetPlayerBotsEnd(); ++it)
+                {
+                    Player* const bot = it->second;
+                    if (!bot || !bot->IsInWorld())
+                        continue;
+
+                    if (PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot))
+                    {
+                        botAI->HandleCommand(type, text, master);
+                        return;
+                    }
+                }
+
+                for (PlayerBotMap::const_iterator it = sRandomPlayerbotMgr.GetPlayerBotsBegin();
+                     it != sRandomPlayerbotMgr.GetPlayerBotsEnd(); ++it)
+                {
+                    Player* const bot = it->second;
+                    if (!bot || !bot->IsInWorld())
+                        continue;
+
+                    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+                    if (botAI && botAI->GetMaster() == master)
+                    {
+                        botAI->HandleCommand(type, text, master);
+                        return;
+                    }
+                }
+
+                return;
+            case PublicChannelDispatchMode::Nearby:
+                break;
+        }
+    }
+
     for (PlayerBotMap::const_iterator it = GetPlayerBotsBegin(); it != GetPlayerBotsEnd(); ++it)
     {
         Player* const bot = it->second;

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -2485,25 +2485,110 @@ bool RandomPlayerbotMgr::HandlePlayerbotConsoleCommand(ChatHandler* /*handler*/,
     return true;
 }
 
+namespace
+{
+bool IsBotNearPlayerForChannelCommand(Player* bot, Player* fromPlayer)
+{
+    if (!bot || !fromPlayer || !bot->IsInWorld() || !fromPlayer->IsInWorld())
+        return false;
+
+    if (bot->GetMapId() != fromPlayer->GetMapId())
+        return false;
+
+    return bot->GetExactDist(fromPlayer) <= sPlayerbotAIConfig.reactDistance;
+}
+
+bool BotIsInChannel(Player* bot, std::string const& channelName)
+{
+    if (channelName.empty())
+        return true;
+
+    ChannelMgr* cMgr = ChannelMgr::forTeam(bot->GetTeamId());
+    if (!cMgr)
+        return false;
+
+    return cMgr->GetChannel(channelName, bot) != nullptr;
+}
+
+Player* FindNearestChannelCommandBot(RandomPlayerbotMgr& mgr, Player* fromPlayer, std::string const& channelName)
+{
+    Player* nearestBot = nullptr;
+    float nearestDist = sPlayerbotAIConfig.reactDistance;
+
+    for (PlayerBotMap::const_iterator it = mgr.GetPlayerBotsBegin(); it != mgr.GetPlayerBotsEnd(); ++it)
+    {
+        Player* const bot = it->second;
+        if (!bot || !bot->IsInWorld())
+            continue;
+
+        if (!BotIsInChannel(bot, channelName))
+            continue;
+
+        if (!IsBotNearPlayerForChannelCommand(bot, fromPlayer))
+            continue;
+
+        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+        if (!botAI)
+            continue;
+
+        float const dist = bot->GetExactDist(fromPlayer);
+        if (dist > nearestDist)
+            continue;
+
+        nearestDist = dist;
+        nearestBot = bot;
+    }
+
+    return nearestBot;
+}
+}  // namespace
+
 void RandomPlayerbotMgr::HandleCommand(uint32 type, std::string const text, Player* fromPlayer, std::string channelName)
 {
+    if (!fromPlayer)
+        return;
+
+    bool const publicChannel = PlayerbotAI::IsPublicChannelChat(type);
+
+    if (publicChannel)
+    {
+        switch (PlayerbotAI::GetPublicChannelDispatchMode(text))
+        {
+            case PublicChannelDispatchMode::Blocked:
+                return;
+            case PublicChannelDispatchMode::SingleNearest:
+            {
+                Player* const bot = FindNearestChannelCommandBot(*this, fromPlayer, channelName);
+                if (!bot)
+                    return;
+
+                if (PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot))
+                    botAI->HandleCommand(type, text, fromPlayer);
+
+                return;
+            }
+            case PublicChannelDispatchMode::Nearby:
+                break;
+        }
+    }
+
     for (PlayerBotMap::const_iterator it = GetPlayerBotsBegin(); it != GetPlayerBotsEnd(); ++it)
     {
         Player* const bot = it->second;
-        if (!bot)
+        if (!bot || !bot->IsInWorld())
             continue;
 
-        if (!channelName.empty())
-        {
-            if (ChannelMgr* cMgr = ChannelMgr::forTeam(bot->GetTeamId()))
-            {
-                Channel* chn = cMgr->GetChannel(channelName, bot);
-                if (!chn)
-                    continue;
-            }
-        }
+        if (!BotIsInChannel(bot, channelName))
+            continue;
 
-        GET_PLAYERBOT_AI(bot)->HandleCommand(type, text, fromPlayer);
+        if (publicChannel && !IsBotNearPlayerForChannelCommand(bot, fromPlayer))
+            continue;
+
+        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+        if (!botAI)
+            continue;
+
+        botAI->HandleCommand(type, text, fromPlayer);
     }
 }
 

--- a/src/Script/Playerbots.cpp
+++ b/src/Script/Playerbots.cpp
@@ -197,10 +197,9 @@ public:
 
         botAI->HandleCommand(type, msg, player);
 
-        // hotfix; otherwise the server will crash when whispering logout
-        // https://github.com/mod-playerbots/mod-playerbots/pull/1838
-        // TODO: find the root cause and solve it. (does not happen in party chat)
-        if (msg == "logout")
+        // Block core chat handling for bot logout whispers — prevents re-entrant crash (#1838).
+        std::string const logoutCmd = PlayerbotAI::NormalizeChatCommandText(msg);
+        if (logoutCmd == "logout" || logoutCmd == "logout cancel")
             return false;
 
         return true;
@@ -231,6 +230,9 @@ public:
         if (type != CHAT_MSG_GUILD)
             return true;
 
+        if (!PlayerbotAI::LooksLikeChatCommand(msg))
+            return true;
+
         PlayerbotMgr* playerbotMgr = PlayerbotsMgr::instance().GetPlayerbotMgr(player);
 
         if (playerbotMgr == nullptr)
@@ -246,7 +248,11 @@ public:
             if (bot->GetGuildId() != player->GetGuildId())
                 continue;
 
-            PlayerbotsMgr::instance().GetPlayerbotAI(bot)->HandleCommand(type, msg, player);
+            PlayerbotAI* botAI = PlayerbotsMgr::instance().GetPlayerbotAI(bot);
+            if (!botAI)
+                continue;
+
+            botAI->HandleCommand(type, msg, player);
         }
 
         return true;
@@ -254,12 +260,19 @@ public:
 
     bool OnPlayerCanUseChat(Player* player, uint32 type, uint32 /*lang*/, std::string& msg, Channel* channel) override
     {
+        if (!channel)
+            return true;
+
         PlayerbotMgr* const playerbotMgr = PlayerbotsMgr::instance().GetPlayerbotMgr(player);
+
+        // Normal general/trade chat must not iterate every bot; only whitelisted commands.
+        if (PlayerbotAI::GetPublicChannelDispatchMode(msg) == PublicChannelDispatchMode::Blocked)
+            return true;
 
         if (playerbotMgr != nullptr && channel->GetFlags() & 0x18)
             playerbotMgr->HandleCommand(type, msg);
 
-        sRandomPlayerbotMgr.HandleCommand(type, msg, player);
+        sRandomPlayerbotMgr.HandleCommand(type, msg, player, channel->GetName());
 
         return true;
     }


### PR DESCRIPTION
## Summary

- Replace broken per-call mutex in `SayToChannel` with a process-wide `s_channelSayMutex` (fixes ineffective locking from #666).
- Stop treating every General/Trade message as a bot command — gate channel chat and dispatch by explicit command classification instead of fanning out to all random bots.
- Add `PublicChannelDispatchMode` (Blocked / SingleNearest / Nearby) with word-boundary command matching to prevent false positives (e.g. `"invited"` matching `"invite"`).
- Harden logout whisper handling and null guards in chat command paths.

## Related issues

- Complements/fixes gaps left by #666 / #756 (SayToChannel mutex)
- Hardens #1870 / #1874 (whisper logout crash)
- Addresses channel fan-out regression after #1838 OnPlayerCanUseChat migration

## Files changed (5)

- `src/Bot/PlayerbotAI.cpp` / `.h`
- `src/Bot/RandomPlayerbotMgr.cpp`
- `src/Bot/PlayerbotMgr.cpp`
- `src/Script/Playerbots.cpp`

## Test plan

- [ ] Type normal text in General/Trade — no bot reactions, no CPU spike
- [ ] Type `who` in Trade near one bot — one nearby bot responds
- [ ] Type `invite` in Trade — one nearby bot responds (not mass invite spam)
- [ ] Whisper `logout` / `logout cancel` to a bot (with/without command prefix) — no crash
- [ ] Multiple bots `SayToChannel` concurrently — no crash
- [ ] Party/guild/whisper commands still work for owned bots
