### PR TITLE
fix(RandomPlayerbotMgr): stop recomputing activity in PrintStats

### DIFF
--- a/src/Bot/PlayerbotAI.h
+++ b/src/Bot/PlayerbotAI.h
@@ -554,6 +554,7 @@ public:
     bool HasPlayerNearby(float range = sPlayerbotAIConfig.reactDistance);
     bool AllowActive(ActivityType activityType);
     bool AllowActivity(ActivityType activityType = ALL_ACTIVITY, bool checkNow = false);
+    bool IsActivityAllowedCached() const { return allowActive[ALL_ACTIVITY]; }
     uint32 AutoScaleActivity(uint32 mod);
 
     // Check if player is safe to use.

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -2743,7 +2743,7 @@ void RandomPlayerbotMgr::PrintStats()
             continue;
         }
 
-        if (botAI->AllowActivity())
+        if (botAI->IsActivityAllowedCached())
             ++active;
         /* TODO: Review statistics on rpg merge
         if (botAI->GetAiObjectContext()->GetValue<bool>("random bot update")->Get())
@@ -2792,10 +2792,10 @@ void RandomPlayerbotMgr::PrintStats()
         else
             ++engine_dead;
 
-        if (botAI->IsHeal(bot, true))
+        if (botAI->IsHeal(bot, false))
             ++heal;
 
-        else if (botAI->IsTank(bot, true))
+        else if (botAI->IsTank(bot, false))
             ++tank;
 
         else


### PR DESCRIPTION
## Pull Request Description

`RandomPlayerbotMgr::PrintStats()` runs on the world thread every 5 minutes when random-bot autologin is enabled. For each online bot it calls `AllowActivity()`, which recomputes `AllowActive()` whenever the per-bot cache has expired (about 5 seconds).

With 500+ bots online, each stats dump re-runs the full activity decision for every bot. That includes real-player proximity, friend-list, group, and LFG checks. It also runs two talent-map scans per bot for heal/tank role counts (`IsHeal`/`IsTank` with `bySpec=true`). In my homelab (520 bots, 14 real players) this blocked the world thread for about 1 to 1.4 seconds every 5 minutes. Not terrible, but still noticeable.

This change reads the activity flag already cached during normal AI ticks (`IsActivityAllowedCached()`) and uses strategy-based role classification for stats (`bySpec=false`). The log output is the same. Only the per-bot work inside `PrintStats()` is reduced.

## Feature Evaluation

- **Minimum logic:** Read the existing `allowActive[ALL_ACTIVITY]` cache instead of calling `AllowActivity()`. Use `IsHeal`/`IsTank` with `bySpec=false` (strategy lookup) for role tallies.
- **Processing cost:** `PrintStats()` drops from O(bots x AllowActive cost) to O(bots x cheap field reads) on each dump. This should not add any per-tick or per-trigger cost.

## How to Test the Changes

1. Build worldserver with this branch on the Playerbot AC fork.
2. Configure about 500 random bots with autologin enabled (default `printStatsTimer + 300` path in `UpdateAIInternal`).
3. Let the server reach steady state (all bots online, for me, it was about 10 minutes uptime).
4. Log in with at least one real player and play for around 30 minutes.
5. **Before:** In my homelab, I ran `kubectl logs` (or worldserver log) and it showed `Random Bots Stats:` immediately followed by `Update time diff: 1000-2000ms with 1 players online` on a 5-10 minute cadence.
6. **After:** The stats block still appears. The following `Update time diff` lines should stay near normal tick values (tens of ms).
7. Optional: `.server info` during or after a stats dump. The update diff should not spike.
8. Manual: `.playerbot rndbot stats` should still print the summary without any noticeable freeze.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - [x] No, not at all
    - [ ] Minimal impact (**explain below**)
    - [ ] Moderate impact (**explain below**)

- Does this change modify default bot behavior?
    - [x] No
    - [ ] Yes (**explain why**)

- Does this change add new decision branches or increase maintenance complexity?
    - [x] No
    - [ ] Yes (**explain below**)

## AI Assistance

Was AI assistance used while working on this change?
- [ ] No
- [x] Yes (**explain below**)

Root cause came from worldserver logs on a 520-bot homelab. I pulled 11 hours of logs with `kubectl logs`, stripped any ANSI, and counted `Update time diff` spikes with some real players online. An `awk` pass over the log stream flagged spikes that landed immediately after a `Random Bots Stats:` block (97 of 99 slow ticks). I then saw `RandomPlayerbotMgr::PrintStats()` in mod-playerbots and traced the per-bot loop to `AllowActivity()` and `IsHeal`/`IsTank` with `bySpec=true`. I then used ai to audit and verify my root cause analysis and make sure I wasn't missing anything else in my original analysis.

## Code Provenance / Attribution

Was any code in this PR copied or adapted from a sister / upstream project?
- [x] No, all code in this PR is original
- [ ] Yes (**name the project and the original author(s) below**)

## Final Checklist

- [x] Stability is not compromised.
- [x] Performance impact is understood, tested, and acceptable.
- [x] Added logic complexity is justified and explained.
- [x] Any new bot dialogue lines are translated. (N/A)
- [x] Any code ported/adapted from another project is attributed. (N/A)
- [x] New source files use the GPLv2 header. (N/A, no new files)
- [x] Documentation updated if needed. (N/A, no config surface change)
- [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers

- `activatePrintStatsThread()` stays commented out. Unless I am mistaken, off-thread `PrintStats` would race map-thread `Player` access.
- The `Active:` count in logs may differ slightly from a fresh `AllowActivity()` recompute. It uses the cache refreshed during normal AI ticks, which is fine for periodic diagnostics I think. If its not, though, then I'll need to find a different way to improve the PrintStats calls.
- Heal/tank role counts now use strategy assignment instead of talent-tab inference. That should match how bots actually behave more accurately, I think.