### PR TITLE
Fix addclass bot init issues: spells not learned and talents not rand…

### DIFF
--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -611,7 +611,7 @@ void PlayerbotFactory::Randomize(bool incremental)
     LOG_DEBUG("playerbots", "Resetting player...");
     PerfMonitorOperation* pmo = sPerfMonitor.start(PERF_MON_RNDBOT, "PlayerbotFactory_Reset");
 
-    if (!sPlayerbotAIConfig.equipAndSpecPersistence ||
+    if (!incremental || !sPlayerbotAIConfig.equipAndSpecPersistence ||
         level < uint32(sPlayerbotAIConfig.equipAndSpecPersistenceLevel))
     {
         bot->resetTalents(true);
@@ -3352,6 +3352,30 @@ void PlayerbotFactory::InitSpecialSpells()
     if (bot->getClass() == CLASS_DEATH_KNIGHT)
     {
         bot->learnSpell(50977, false);
+    }
+    // Force-learn spells from allocated talents.
+    // Some DBC versions cause sSpellMgr->GetSpellInfo() to return null
+    // for talent spell IDs, making LearnTalent() skip learnSpell().
+    {
+        uint32 classMask = bot->getClassMask();
+        for (uint32 i = 0; i < sTalentStore.GetNumRows(); ++i)
+        {
+            TalentEntry const* talentInfo = sTalentStore.LookupEntry(i);
+            if (!talentInfo) continue;
+            TalentTabEntry const* tabInfo = sTalentTabStore.LookupEntry(talentInfo->TalentTab);
+            if (!tabInfo || !(classMask & tabInfo->ClassMask)) continue;
+
+            for (uint8 rank = 0; rank < MAX_TALENT_RANK; ++rank)
+            {
+                uint32 spellId = talentInfo->RankID[rank];
+                if (!spellId) continue;
+                if (bot->HasTalent(spellId, bot->GetActiveSpec()))
+                {
+                    if (!bot->HasSpell(spellId))
+                        bot->learnSpell(spellId, false);
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
…omized

After running the init command, addclass bots were not learning any active or passive spells from allocated talents, leaving them unable to use their class abilities. Additionally, init would not randomize the talent specialization, always keeping the same spec.

Root cause: sSpellMgr->GetSpellInfo() returns null for many talent spell IDs on servers with DBC locale mismatches, causing LearnTalent() to skip learnSpell(). Also, equipAndSpecPersistence was preventing talent reset during incremental init.

Changes:
- Force-learn every spell from every allocated talent in InitSpecialSpells
- Always reset talents when init is called (non-incremental)

<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

Pull Request Description
When init command resets an addclass bot, two bugs occur:

Spells not learned: allocated talent points don't result in the corresponding spells being added to the spellbook, leaving bots unable to use talent-granted abilities (e.g. Blessing of Sanctuary, Avenger's Shield, Hammer of the Righteous)
Talents not randomized: equipAndSpecPersistence config prevents resetTalents(true) during init, causing LearnTalent() to fail because GetFreeTalentPoints() returns 0 — the bot keeps the same spec every time
Root cause: sSpellMgr->GetSpellInfo() returns null for many talent spell IDs on servers with DBC issues (locale mismatches, etc.), causing LearnTalent() to skip learnSpell(). Additionally, equipAndSpecPersistence was incorrectly gating the talent reset during non-incremental init.

Feature Evaluation
Minimum logic required: A single post-talent pass in InitSpecialSpells() that iterates allocated talents and calls learnSpell() for any missing talent spell. One additional condition (!incremental) to ensure resetTalents always runs during init.
Processing cost: The spell check iterates all talent entries for the bot's class — approximately 50-70 entries with up to 5 ranks each, totaling ~300 HasTalent/HasSpell checks. This runs only once during bot initialization (not per tick). Total cost is negligible relative to the rest of the init process.
How to Test the Changes
Create or select an addclass bot, e.g. .playerbots bot addclass paladin
Use .playerbots bot info to note the bot's current spec
Run .playerbots bot init=auto 3-5 times and verify the spec changes randomly
Check the bot's spellbook — all talent-granted abilities (especially Protection tree: Avenger's Shield, Hammer of the Righteous, Holy Shield, Blessing of Sanctuary) should be present and usable
Test in combat to confirm abilities actually cast
Impact Assessment
Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
 No, not at all (only runs during bot init, not per-tick)
Does this change modify default bot behavior?
 Yes — fixes broken behavior; bots will now properly learn all talent spells and randomize specs on init, which is the expected/intended behavior
Does this change add new decision branches or increase maintenance complexity?
 No
AI Assistance
Was AI assistance used while working on this change?

 Yes — AI assisted with code analysis, debugging, and code generation. All code was thoroughly reviewed, tested, and understood by the contributor.
Code Provenance / Attribution
Was any code in this PR copied or adapted from a sister / upstream project?

 No, all code in this PR is original
Final Checklist
 Stability is not compromised.
 Performance impact is understood, tested, and acceptable.
 Added logic complexity is justified and explained.
 Any new bot dialogue lines are translated. (N/A — no new dialogue)
 Any code ported/adapted from another project is attributed. (N/A)
 New source files use the GPLv2 header. (N/A — no new files)
 Documentation updated if needed. (N/A)
 New and modified files do not introduce new compiler warnings.
Notes for Reviewers
Only one file changed: src/Bot/Factory/PlayerbotFactory.cpp. Two small changes:

resetTalents condition: added !incremental so init always resets talents before re-allocation
InitSpecialSpells(): added a post-talent loop that force-learns any missing talent-granted spells using learnSpell(spellId, false), bypassing GetSpellInfo() which may return null due to DBC environment mismatches

