### PR TITLE
Fix Swipe (Bear) and other naming issues

### DIFF
--- a/src/Ai/Class/Druid/Action/DruidBearActions.h
+++ b/src/Ai/Class/Druid/Action/DruidBearActions.h
@@ -44,12 +44,6 @@ public:
     CastBashAction(PlayerbotAI* botAI) : CastMeleeSpellAction(botAI, "bash") {}
 };
 
-class CastSwipeAction : public CastMeleeSpellAction
-{
-public:
-    CastSwipeAction(PlayerbotAI* botAI) : CastMeleeSpellAction(botAI, "swipe") {}
-};
-
 class CastDemoralizingRoarAction : public CastMeleeDebuffSpellAction
 {
 public:

--- a/src/Ai/Class/Druid/DruidAiObjectContext.cpp
+++ b/src/Ai/Class/Druid/DruidAiObjectContext.cpp
@@ -218,7 +218,6 @@ public:
         creators["mangle (bear)"] = &DruidAiObjectContextInternal::mangle_bear;
         creators["maul"] = &DruidAiObjectContextInternal::maul;
         creators["bash"] = &DruidAiObjectContextInternal::bash;
-        creators["swipe"] = &DruidAiObjectContextInternal::swipe;
         creators["growl"] = &DruidAiObjectContextInternal::growl;
         creators["challenging roar"] = &DruidAiObjectContextInternal::challenging_roar;
         creators["demoralizing roar"] = &DruidAiObjectContextInternal::demoralizing_roar;
@@ -316,7 +315,6 @@ private:
     static Action* mangle_bear(PlayerbotAI* botAI) { return new CastMangleBearAction(botAI); }
     static Action* maul(PlayerbotAI* botAI) { return new CastMaulAction(botAI); }
     static Action* bash(PlayerbotAI* botAI) { return new CastBashAction(botAI); }
-    static Action* swipe(PlayerbotAI* botAI) { return new CastSwipeAction(botAI); }
     static Action* growl(PlayerbotAI* botAI) { return new CastGrowlAction(botAI); }
     static Action* challenging_roar(PlayerbotAI* botAI) { return new CastChallengingRoarAction(botAI); }
     static Action* demoralizing_roar(PlayerbotAI* botAI) { return new CastDemoralizingRoarAction(botAI); }

--- a/src/Ai/Class/Druid/Strategy/BearDruidStrategy.cpp
+++ b/src/Ai/Class/Druid/Strategy/BearDruidStrategy.cpp
@@ -17,7 +17,7 @@ public:
         creators["dire bear form"] = &dire_bear_form;
         creators["maul"] = &maul;
         creators["bash"] = &bash;
-        creators["swipe"] = &swipe;
+        creators["swipe (bear)"] = &swipe_bear;
         creators["lacerate"] = &lacerate;
     }
 
@@ -62,10 +62,10 @@ private:
         );
     }
 
-    static ActionNode* swipe([[maybe_unused]] PlayerbotAI* botAI)
+    static ActionNode* swipe_bear([[maybe_unused]] PlayerbotAI* botAI)
     {
         return new ActionNode(
-            "swipe",
+            "swipe (bear)",
             /*P*/ {},
             /*A*/ { NextAction("melee") },
             /*C*/ {}

--- a/src/Ai/Class/Priest/PriestActions.h
+++ b/src/Ai/Class/Priest/PriestActions.h
@@ -118,8 +118,8 @@ public:
 SPELL_ACTION(CastShadowWordDeathAction, "shadow word: death");
 
 // shadow
-DEBUFF_CHECKISOWNER_ACTION(CastPowerWordPainAction, "shadow word: pain");
-DEBUFF_ENEMY_ACTION(CastPowerWordPainOnAttackerAction, "shadow word: pain");
+DEBUFF_CHECKISOWNER_ACTION(CastShadowWordPainAction, "shadow word: pain");
+DEBUFF_ENEMY_ACTION(CastShadowWordPainOnAttackerAction, "shadow word: pain");
 SPELL_ACTION(CastMindBlastAction, "mind blast");
 SPELL_ACTION(CastPsychicScreamAction, "psychic scream");
 DEBUFF_ACTION(CastMindSootheAction, "mind soothe");

--- a/src/Ai/Class/Priest/PriestAiObjectContext.cpp
+++ b/src/Ai/Class/Priest/PriestAiObjectContext.cpp
@@ -113,10 +113,10 @@ private:
     static Trigger* vampiric_touch(PlayerbotAI* botAI) { return new VampiricTouchTrigger(botAI); }
     static Trigger* vampiric_touch_on_attacker(PlayerbotAI* botAI) { return new VampiricTouchOnAttackerTrigger(botAI); }
     static Trigger* devouring_plague(PlayerbotAI* botAI) { return new DevouringPlagueTrigger(botAI); }
-    static Trigger* shadow_word_pain(PlayerbotAI* botAI) { return new PowerWordPainTrigger(botAI); }
+    static Trigger* shadow_word_pain(PlayerbotAI* botAI) { return new ShadowWordPainTrigger(botAI); }
     static Trigger* shadow_word_pain_on_attacker(PlayerbotAI* botAI)
     {
-        return new PowerWordPainOnAttackerTrigger(botAI);
+        return new ShadowWordPainOnAttackerTrigger(botAI);
     }
     static Trigger* dispel_magic(PlayerbotAI* botAI) { return new DispelMagicTrigger(botAI); }
     static Trigger* dispel_magic_party_member(PlayerbotAI* botAI) { return new DispelMagicPartyMemberTrigger(botAI); }
@@ -256,10 +256,10 @@ private:
     static Action* psychic_scream(PlayerbotAI* botAI) { return new CastPsychicScreamAction(botAI); }
     static Action* circle_of_healing(PlayerbotAI* botAI) { return new CastCircleOfHealingAction(botAI); }
     static Action* resurrection(PlayerbotAI* botAI) { return new CastResurrectionAction(botAI); }
-    static Action* shadow_word_pain(PlayerbotAI* botAI) { return new CastPowerWordPainAction(botAI); }
+    static Action* shadow_word_pain(PlayerbotAI* botAI) { return new CastShadowWordPainAction(botAI); }
     static Action* shadow_word_pain_on_attacker(PlayerbotAI* botAI)
     {
-        return new CastPowerWordPainOnAttackerAction(botAI);
+        return new CastShadowWordPainOnAttackerAction(botAI);
     }
     static Action* devouring_plague(PlayerbotAI* botAI) { return new CastDevouringPlagueAction(botAI); }
     static Action* mind_flay(PlayerbotAI* botAI) { return new CastMindFlayAction(botAI); }

--- a/src/Ai/Class/Priest/PriestTriggers.h
+++ b/src/Ai/Class/Priest/PriestTriggers.h
@@ -15,8 +15,8 @@
 class PlayerbotAI;
 
 DEBUFF_CHECKISOWNER_TRIGGER(HolyFireTrigger, "holy fire");
-DEBUFF_CHECKISOWNER_TRIGGER(PowerWordPainTrigger, "shadow word: pain");
-DEBUFF_ENEMY_TRIGGER(PowerWordPainOnAttackerTrigger, "shadow word: pain");
+DEBUFF_CHECKISOWNER_TRIGGER(ShadowWordPainTrigger, "shadow word: pain");
+DEBUFF_ENEMY_TRIGGER(ShadowWordPainOnAttackerTrigger, "shadow word: pain");
 DEBUFF_CHECKISOWNER_TRIGGER(VampiricTouchTrigger, "vampiric touch");
 DEBUFF_ENEMY_TRIGGER(VampiricTouchOnAttackerTrigger, "vampiric touch on attacker");
 BUFF_TRIGGER(VampiricEmbraceTrigger, "vampiric embrace");

--- a/src/Ai/Class/Shaman/ShamanAiObjectContext.cpp
+++ b/src/Ai/Class/Shaman/ShamanAiObjectContext.cpp
@@ -64,14 +64,14 @@ public:
     ShamanEarthTotemStrategyFactoryInternal() : NamedObjectContext<Strategy>(false, true)
     {
         creators["strength of earth"] = &ShamanEarthTotemStrategyFactoryInternal::strength_of_earth_totem;
-        creators["stoneskin"] = &ShamanEarthTotemStrategyFactoryInternal::stoneclaw_totem;
+        creators["stoneskin"] = &ShamanEarthTotemStrategyFactoryInternal::stoneskin_totem;
         creators["tremor"] = &ShamanEarthTotemStrategyFactoryInternal::earth_totem;
         creators["earthbind"] = &ShamanEarthTotemStrategyFactoryInternal::earthbind_totem;
     }
 
 private:
     static Strategy* strength_of_earth_totem(PlayerbotAI* botAI) { return new StrengthOfEarthTotemStrategy(botAI); }
-    static Strategy* stoneclaw_totem(PlayerbotAI* botAI) { return new StoneclawTotemStrategy(botAI); }
+    static Strategy* stoneskin_totem(PlayerbotAI* botAI) { return new StoneskinTotemStrategy(botAI); }
     static Strategy* earth_totem(PlayerbotAI* botAI) { return new EarthTotemStrategy(botAI); }
     static Strategy* earthbind_totem(PlayerbotAI* botAI) { return new EarthbindTotemStrategy(botAI); }
 };

--- a/src/Ai/Class/Shaman/Strategy/TotemsShamanStrategy.cpp
+++ b/src/Ai/Class/Shaman/Strategy/TotemsShamanStrategy.cpp
@@ -31,8 +31,8 @@ void StrengthOfEarthTotemStrategy::InitTriggers(std::vector<TriggerNode*>& trigg
     triggers.push_back(new TriggerNode("no earth totem", { NextAction("strength of earth totem", 55.0f) }));
 }
 
-StoneclawTotemStrategy::StoneclawTotemStrategy(PlayerbotAI* botAI) : GenericShamanStrategy(botAI) {}
-void StoneclawTotemStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+StoneskinTotemStrategy::StoneskinTotemStrategy(PlayerbotAI* botAI) : GenericShamanStrategy(botAI) {}
+void StoneskinTotemStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
     GenericShamanStrategy::InitTriggers(triggers);
     triggers.push_back(new TriggerNode("set stoneskin totem", { NextAction("set stoneskin totem", 60.0f) }));

--- a/src/Ai/Class/Shaman/Strategy/TotemsShamanStrategy.h
+++ b/src/Ai/Class/Shaman/Strategy/TotemsShamanStrategy.h
@@ -230,10 +230,10 @@ public:
     std::string const getName() override { return "strength of earth"; }
 };
 
-class StoneclawTotemStrategy : public GenericShamanStrategy
+class StoneskinTotemStrategy : public GenericShamanStrategy
 {
 public:
-    StoneclawTotemStrategy(PlayerbotAI* botAI);
+    StoneskinTotemStrategy(PlayerbotAI* botAI);
     void InitTriggers(std::vector<TriggerNode*>& triggers) override;
     std::string const getName() override { return "stoneskin"; }
 };

--- a/src/Ai/Raid/BT/BTMultipliers.cpp
+++ b/src/Ai/Raid/BT/BTMultipliers.cpp
@@ -403,7 +403,8 @@ float IllidariCouncilDisableTankActionsMultiplier::GetValue(Action* action)
         dynamic_cast<CastShockwaveAction*>(action) ||
         dynamic_cast<CastCleaveAction*>(action) ||
         dynamic_cast<CastGrowlAction*>(action) ||
-        dynamic_cast<CastSwipeAction*>(action) ||
+        dynamic_cast<CastSwipeBearAction*>(action) ||
+        dynamic_cast<CastChallengingRoarAction*>(action) ||
         dynamic_cast<CastHandOfReckoningAction*>(action) ||
         dynamic_cast<CastRighteousDefenseAction*>(action) ||
         dynamic_cast<CastDarkCommandAction*>(action) ||

--- a/src/Ai/Raid/SSC/SSCMultipliers.cpp
+++ b/src/Ai/Raid/SSC/SSCMultipliers.cpp
@@ -427,7 +427,8 @@ float FathomLordKarathressDisableTankActionsMultiplier::GetValue(Action* action)
         dynamic_cast<CastShockwaveAction*>(action) ||
         dynamic_cast<CastCleaveAction*>(action) ||
         dynamic_cast<CastGrowlAction*>(action) ||
-        dynamic_cast<CastSwipeAction*>(action) ||
+        dynamic_cast<CastSwipeBearAction*>(action) ||
+        dynamic_cast<CastChallengingRoarAction*>(action) ||
         dynamic_cast<CastHandOfReckoningAction*>(action) ||
         dynamic_cast<CastAvengersShieldAction*>(action) ||
         dynamic_cast<CastConsecrationAction*>(action) ||

--- a/src/Ai/Raid/TK/TKMultipliers.cpp
+++ b/src/Ai/Raid/TK/TKMultipliers.cpp
@@ -316,7 +316,8 @@ float KaelthasSunstriderManageWeaponTankingMultiplier::GetValue(Action* action)
          dynamic_cast<CastShockwaveAction*>(action) ||
          dynamic_cast<CastCleaveAction*>(action) ||
          dynamic_cast<CastGrowlAction*>(action) ||
-         dynamic_cast<CastSwipeAction*>(action) ||
+         dynamic_cast<CastSwipeBearAction*>(action) ||
+         dynamic_cast<CastChallengingRoarAction*>(action) ||
          dynamic_cast<CastHandOfReckoningAction*>(action) ||
          dynamic_cast<CastAvengersShieldAction*>(action) ||
          dynamic_cast<CastConsecrationAction*>(action) ||

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -6720,7 +6720,7 @@ float PlayerbotAI::GetItemScoreMultiplier(ItemQualities quality)
     return 1.0f;
 }
 
-bool PlayerbotAI::IsHealingSpell(uint32 spellFamilyName, flag96 spellFalimyFlags)
+bool PlayerbotAI::IsHealingSpell(uint32 spellFamilyName, flag96 spellFamilyFlags)
 {
     if (!spellFamilyName)
         return false;
@@ -6765,7 +6765,7 @@ bool PlayerbotAI::IsHealingSpell(uint32 spellFamilyName, flag96 spellFalimyFlags
         default:
             break;
     }
-    return spellFalimyFlags & healingFlags;
+    return spellFamilyFlags & healingFlags;
 }
 
 SpellFamilyNames PlayerbotAI::Class2SpellFamilyName(uint8 cls)

--- a/src/Bot/PlayerbotAI.h
+++ b/src/Bot/PlayerbotAI.h
@@ -601,7 +601,7 @@ public:
     std::set<uint32> GetCurrentIncompleteQuestIds();
     void PetFollow();
     static float GetItemScoreMultiplier(ItemQualities quality);
-    static bool IsHealingSpell(uint32 spellFamilyName, flag96 spelFalimyFlags);
+    static bool IsHealingSpell(uint32 spellFamilyName, flag96 spellFamilyFlags);
     static SpellFamilyNames Class2SpellFamilyName(uint8 cls);
     NewRpgInfo rpgInfo;
     NewRpgStatistic rpgStatistic;


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

Currently, the code contains three Swipe-related classes, CastSwipeAction, CastSwipeBearAction, and CastSwipeCatAction. There is no Druid ability that is just named "swipe." This PR removes CastSwipeAction and changes where it is used to CastSwipeBearAction. 

The only place in the Druid code where CastSwipeAction was actually used was for a bear ActionNode with an alternative to melee. I fixed it, but any benefit is completely marginal since bears will call melee anyway (just lower priority) and also Maul and Bash already have melee as alternatives.

This PR also adds CastChallengingRoarAction to the raid multipliers that disable CastSwipeBearAction (at the time of the strategies, Challenging Roar had not yet been implemented).

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.



## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

Play with a bear bot and verify no noticeable changes in behavior. Fight Fathom-Lord Karathress, Kael'thas (weapon phase), and/or Illidari Council and confirm bear bots do not use Swipe or Challenging Roar (check playerbots log and confirm attempted use is made useless by the applicable multiplier).

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [x] No
- - [ ] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->



## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note).
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


