### PR TITLE
Revise general boss helpers

### DIFF
--- a/src/Ai/Raid/BT/BTActions.cpp
+++ b/src/Ai/Raid/BT/BTActions.cpp
@@ -158,7 +158,7 @@ bool HighWarlordNajentusDisperseRangedAction::Execute(Event /*event*/)
     }
 
     constexpr float safeDistFromPlayer = 7.0f;
-    if (Unit* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistFromPlayer))
+    if (Player* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistFromPlayer))
         return FleePosition(nearestPlayer->GetPosition(), safeDistFromPlayer, minInterval);
 
     return false;
@@ -325,7 +325,7 @@ bool SupremusDisperseRangedAction::Execute(Event /*event*/)
 {
     constexpr float safeDistance = 8.0f;
     constexpr uint32 minInterval = 1000;
-    if (Unit* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance))
+    if (Player* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance))
         return FleePosition(nearestPlayer->GetPosition(), safeDistance, minInterval);
 
     return false;
@@ -1652,7 +1652,7 @@ bool IllidariCouncilDisperseRangedAction::Execute(Event /*event*/)
 {
     constexpr float safeDistance = 4.0f;
     constexpr uint32 minInterval = 1000;
-    if (Unit* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance))
+    if (Player* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance))
         return FleePosition(nearestPlayer->GetPosition(), safeDistance, minInterval);
 
     return false;
@@ -2089,7 +2089,7 @@ bool IllidanStormrageIsolateBotWithParasiteAction::Execute(Event /*event*/)
     if (phase == 1)
     {
         constexpr float safeDistance = 15.0f;
-        if (Unit* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance))
+        if (Player* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance))
         {
             const float currentDistance = bot->GetExactDist2d(nearestPlayer);
             if (currentDistance < safeDistance)
@@ -2622,7 +2622,7 @@ bool IllidanStormrageDisperseRangedAction::SpreadInCircleInDemonPhase(
 
         constexpr float safeDistFromPlayer = 6.0f;
         constexpr uint32 minInterval = 1000;
-        if (Unit* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistFromPlayer))
+        if (Player* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistFromPlayer))
             return FleePosition(nearestPlayer->GetPosition(), safeDistFromPlayer, minInterval);
 
         return false;
@@ -2733,7 +2733,7 @@ bool IllidanStormrageMeleeGoSomewhereToNotDieAction::Execute(Event /*event*/)
     }
 
     constexpr float safeDistFromPlayer = 6.0f;
-    if (Unit* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistFromPlayer))
+    if (Player* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistFromPlayer))
         MoveAway(nearestPlayer, safeDistFromPlayer - bot->GetDistance2d(nearestPlayer));
 
     return true;

--- a/src/Ai/Raid/BT/BTActions.cpp
+++ b/src/Ai/Raid/BT/BTActions.cpp
@@ -526,7 +526,8 @@ bool ShadeOfAkamaMeleeDpsPrioritizeChannelersAction::Execute(Event /*event*/)
 
     Creature* const channeler = channelers.front();
 
-    MarkTargetWithSkull(bot, channeler);
+    if (MarkTargetWithSkull(bot, channeler))
+        return true;
 
     if (AI_VALUE(Unit*, "current target") != channeler)
         return Attack(channeler);
@@ -564,7 +565,8 @@ bool TeronGorefiendTanksPositionBossAction::Execute(Event /*event*/)
     if (!gorefiend)
         return false;
 
-    MarkTargetWithSkull(bot, gorefiend);
+    if (MarkTargetWithSkull(bot, gorefiend))
+        return true;
 
     if (AI_VALUE(Unit*, "current target") != gorefiend)
         return Attack(gorefiend);
@@ -1428,7 +1430,9 @@ bool IllidariCouncilMainTankPositionGathiosAction::Execute(Event /*event*/)
                         gathios->GetPositionZ(), bot->GetOrientation());
     }
 
-    MarkTargetWithSquare(bot, gathios);
+    if (MarkTargetWithSquare(bot, gathios))
+        return true;
+
     SetRtiTarget(botAI, "square", gathios);
 
     if (AI_VALUE(Unit*, "current target") != gathios)
@@ -1499,7 +1503,9 @@ bool IllidariCouncilFirstAssistTankFocusMalandeAction::Execute(Event /*event*/)
                         malande->GetPositionZ(), bot->GetOrientation());
     }
 
-    MarkTargetWithStar(bot, malande);
+    if (MarkTargetWithStar(bot, malande))
+        return true;
+
     SetRtiTarget(botAI, "star", malande);
 
     if (AI_VALUE(Unit*, "current target") != malande)
@@ -1521,7 +1527,9 @@ bool IllidariCouncilSecondAssistTankPositionDarkshadowAction::Execute(Event /*ev
                         darkshadow->GetPositionZ(), bot->GetOrientation());
     }
 
-    MarkTargetWithCircle(bot, darkshadow);
+    if (MarkTargetWithCircle(bot, darkshadow))
+        return true;
+
     SetRtiTarget(botAI, "circle", darkshadow);
 
     if (AI_VALUE(Unit*, "current target") != darkshadow)
@@ -1564,7 +1572,9 @@ bool IllidariCouncilMageTankPositionZerevorAction::Execute(Event /*event*/)
         return botAI->CastSpell("spellsteal", zerevor);
     }
 
-    MarkTargetWithTriangle(bot, zerevor);
+    if (MarkTargetWithTriangle(bot, zerevor))
+        return true;
+
     SetRtiTarget(botAI, "triangle", zerevor);
 
     if (AI_VALUE(Unit*, "current target") != zerevor)

--- a/src/Ai/Raid/BT/BTTriggers.cpp
+++ b/src/Ai/Raid/BT/BTTriggers.cpp
@@ -19,7 +19,8 @@ using namespace BlackTempleHelpers;
 
 bool BlackTempleBotIsNotInCombatTrigger::IsActive()
 {
-    return !bot->IsInCombat() && bot->GetMapId() == BLACK_TEMPLE_MAP_ID;
+    return bot->GetMapId() == BLACK_TEMPLE_MAP_ID &&
+           !AI_VALUE2(bool, "combat", "self target");
 }
 
 // High Warlord Naj'entus
@@ -160,13 +161,8 @@ bool SupremusVolcanoIsNearbyTrigger::IsActive()
 
 bool SupremusNeedToManagePhaseTimerTrigger::IsActive()
 {
-    if (!botAI->IsDps(bot))
-        return false;
-
-    if (!AI_VALUE2(Unit*, "find target", "supremus"))
-        return false;
-
-    return IsMechanicTrackerBot(botAI, bot, BLACK_TEMPLE_MAP_ID);
+    return IsMechanicTrackerBot(bot, BLACK_TEMPLE_MAP_ID) &&
+           AI_VALUE2(Unit*, "find target", "supremus");
 }
 
 // Shade of Akama
@@ -333,8 +329,8 @@ bool GurtoggBloodboilBotHasFelRageTrigger::IsActive()
 
 bool GurtoggBloodboilNeedToManagePhaseTimerTrigger::IsActive()
 {
-    return AI_VALUE2(Unit*, "find target", "gurtogg bloodboil") &&
-           IsMechanicTrackerBot(botAI, bot, BLACK_TEMPLE_MAP_ID);
+    return IsMechanicTrackerBot(bot, BLACK_TEMPLE_MAP_ID) &&
+           AI_VALUE2(Unit*, "find target", "gurtogg bloodboil");
 }
 
 // Reliquary of Souls
@@ -568,14 +564,8 @@ bool IllidariCouncilDeterminingDpsAssignmentsTrigger::IsActive()
 
 bool IllidariCouncilNeedToManageDpsTimerTrigger::IsActive()
 {
-    if (!botAI->IsDps(bot))
-        return false;
-
-    if (!AI_VALUE2(Unit*, "find target", "gathios the shatterer"))
-        return false;
-
-    return IsMechanicTrackerBot(
-        botAI, bot, BLACK_TEMPLE_MAP_ID, GetZerevorMageTank(bot));
+    return IsMechanicTrackerBot(bot, BLACK_TEMPLE_MAP_ID) &&
+           AI_VALUE2(Unit*, "find target", "gathios the shatterer");
 }
 
 // Illidan Stormrage <The Betrayer>
@@ -820,22 +810,18 @@ bool IllidanStormrageMaievPlacedShadowTrapTrigger::IsActive()
 
 bool IllidanStormrageNeedToManageDpsTimerAndRtiTrigger::IsActive()
 {
-    if (!botAI->IsDps(bot))
+    if (!IsMechanicTrackerBot(bot, BLACK_TEMPLE_MAP_ID))
         return false;
 
     Unit* illidan = AI_VALUE2(Unit*, "find target", "illidan stormrage");
-    if (!illidan || illidan->GetHealth() == 1)
-        return false;
-
-    return IsMechanicTrackerBot(
-        botAI, bot, BLACK_TEMPLE_MAP_ID, GetIllidanWarlockTank(bot));
+    return illidan && illidan->GetHealth() > 1;
 }
 
 // Destroying hazards behind phases is not gated behind CheatMask
 // The strategy simply cannot work without doing this
 bool IllidanStormrageNeedToClearHazardsBetweenPhasesTrigger::IsActive()
 {
-    if (!botAI->IsDps(bot))
+    if (!IsMechanicTrackerBot(bot, BLACK_TEMPLE_MAP_ID))
         return false;
 
     Unit* illidan = AI_VALUE2(Unit*, "find target", "illidan stormrage");
@@ -843,11 +829,7 @@ bool IllidanStormrageNeedToClearHazardsBetweenPhasesTrigger::IsActive()
         return false;
 
     int phase = GetIllidanPhase(illidan);
-    if (phase != 0 && phase != 2 && phase != 4)
-        return false;
-
-    return IsMechanicTrackerBot(
-        botAI, bot, BLACK_TEMPLE_MAP_ID, GetIllidanWarlockTank(bot));
+    return phase == 0 || phase == 2 || phase == 4;
 }
 
 bool IllidanStormrageCheatTrigger::IsActive()

--- a/src/Ai/Raid/BWL/BWLActions.cpp
+++ b/src/Ai/Raid/BWL/BWLActions.cpp
@@ -109,7 +109,9 @@ bool BwlRazorgoreMarkBossAction::Execute(Event /*event*/)
     {
         if (IsRazorgoreOffTank(bot))
         {
-            MarkTargetWithMoon(bot, boss);
+            if (MarkTargetWithMoon(bot, boss))
+                return true;
+
             SetRtiTarget(botAI, "moon", boss);
 
             if (AI_VALUE(Unit*, "current target") != boss)

--- a/src/Ai/Raid/Gruul/GruulActions.cpp
+++ b/src/Ai/Raid/Gruul/GruulActions.cpp
@@ -596,7 +596,7 @@ bool GruulTheDragonkillerShatterSpreadAction::Execute(Event /*event*/)
 {
     constexpr float safeDistance = 10.0f;
     constexpr uint32 minInterval = 0;
-    if (Unit* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance))
+    if (Player* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance))
         return FleePosition(nearestPlayer->GetPosition(), safeDistance, minInterval);
 
     return false;

--- a/src/Ai/Raid/Gruul/GruulActions.cpp
+++ b/src/Ai/Raid/Gruul/GruulActions.cpp
@@ -16,7 +16,9 @@ bool HighKingMaulgarMainTankAttackMaulgarAction::Execute(Event /*event*/)
     if (!maulgar)
         return false;
 
-    MarkTargetWithSquare(bot, maulgar);
+    if (MarkTargetWithSquare(bot, maulgar))
+        return true;
+
     SetRtiTarget(botAI, "square", maulgar);
 
     if (AI_VALUE(Unit*, "current target") != maulgar)
@@ -51,7 +53,9 @@ bool HighKingMaulgarFirstAssistTankAttackOlmAction::Execute(Event /*event*/)
     if (!olm)
         return false;
 
-    MarkTargetWithCircle(bot, olm);
+    if (MarkTargetWithCircle(bot, olm))
+        return true;
+
     SetRtiTarget(botAI, "circle", olm);
 
     if (AI_VALUE(Unit*, "current target") != olm)
@@ -86,7 +90,9 @@ bool HighKingMaulgarSecondAssistTankAttackBlindeyeAction::Execute(Event /*event*
     if (!blindeye)
         return false;
 
-    MarkTargetWithStar(bot, blindeye);
+    if (MarkTargetWithStar(bot, blindeye))
+        return true;
+
     SetRtiTarget(botAI, "star", blindeye);
 
     if (AI_VALUE(Unit*, "current target") != blindeye)
@@ -121,7 +127,9 @@ bool HighKingMaulgarMageTankAttackKroshAction::Execute(Event /*event*/)
     if (!krosh)
         return false;
 
-    MarkTargetWithTriangle(bot, krosh);
+    if (MarkTargetWithTriangle(bot, krosh))
+        return true;
+
     SetRtiTarget(botAI, "triangle", krosh);
 
     if (krosh->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_SPELL_SHIELD)) &&
@@ -177,7 +185,9 @@ bool HighKingMaulgarMoonkinTankAttackKigglerAction::Execute(Event /*event*/)
     if (!kiggler)
         return false;
 
-    MarkTargetWithDiamond(bot, kiggler);
+    if (MarkTargetWithDiamond(bot, kiggler))
+        return true;
+
     SetRtiTarget(botAI, "diamond", kiggler);
 
     if (AI_VALUE(Unit*, "current target") != kiggler)
@@ -201,10 +211,11 @@ bool HighKingMaulgarMoonkinTankAttackKigglerAction::Execute(Event /*event*/)
 bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
 {
     // Target priority 1: Blindeye
-    Unit* blindeye = AI_VALUE2(Unit*, "find target", "blindeye the seer");
-    if (blindeye)
+    if (Unit* blindeye = AI_VALUE2(Unit*, "find target", "blindeye the seer"))
     {
-        MarkTargetWithStar(bot, blindeye);
+        if (MarkTargetWithStar(bot, blindeye))
+            return true;
+
         SetRtiTarget(botAI, "star", blindeye);
 
         if (AI_VALUE(Unit*, "current target") != blindeye)
@@ -214,10 +225,11 @@ bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
     }
 
     // Target priority 2: Olm
-    Unit* olm = AI_VALUE2(Unit*, "find target", "olm the summoner");
-    if (olm)
+    if (Unit* olm = AI_VALUE2(Unit*, "find target", "olm the summoner"))
     {
-        MarkTargetWithCircle(bot, olm);
+        if (MarkTargetWithCircle(bot, olm))
+            return true;
+
         SetRtiTarget(botAI, "circle", olm);
 
         if (AI_VALUE(Unit*, "current target") != olm)
@@ -227,10 +239,12 @@ bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
     }
 
     // Target priority 3a: Krosh (ranged only)
-    Unit* krosh = AI_VALUE2(Unit*, "find target", "krosh firehand");
-    if (krosh && botAI->IsRanged(bot))
+    if (Unit* krosh = AI_VALUE2(Unit*, "find target", "krosh firehand");
+        krosh && botAI->IsRanged(bot))
     {
-        MarkTargetWithTriangle(bot, krosh);
+        if (MarkTargetWithTriangle(bot, krosh))
+            return true;
+
         SetRtiTarget(botAI, "triangle", krosh);
 
         if (AI_VALUE(Unit*, "current target") != krosh)
@@ -240,10 +254,11 @@ bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
     }
 
     // Target priority 3b: Kiggler
-    Unit* kiggler = AI_VALUE2(Unit*, "find target", "kiggler the crazed");
-    if (kiggler)
+    if (Unit* kiggler = AI_VALUE2(Unit*, "find target", "kiggler the crazed"))
     {
-        MarkTargetWithDiamond(bot, kiggler);
+        if (MarkTargetWithDiamond(bot, kiggler))
+            return true;
+
         SetRtiTarget(botAI, "diamond", kiggler);
 
         if (AI_VALUE(Unit*, "current target") != kiggler)
@@ -253,10 +268,11 @@ bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
     }
 
     // Target priority 4: Maulgar
-    Unit* maulgar = AI_VALUE2(Unit*, "find target", "high king maulgar");
-    if (maulgar)
+    if (Unit* maulgar = AI_VALUE2(Unit*, "find target", "high king maulgar"))
     {
-        MarkTargetWithSquare(bot, maulgar);
+        if (MarkTargetWithSquare(bot, maulgar))
+            return true;
+
         SetRtiTarget(botAI, "square", maulgar);
 
         if (AI_VALUE(Unit*, "current target") != maulgar)

--- a/src/Ai/Raid/Hyjal/HyjalActions.cpp
+++ b/src/Ai/Raid/Hyjal/HyjalActions.cpp
@@ -263,7 +263,9 @@ bool AnetheronMainTankPositionBossAction::Execute(Event /*event*/)
     if (!anetheron)
         return false;
 
-    MarkTargetWithSquare(bot, anetheron);
+    if (MarkTargetWithSquare(bot, anetheron))
+        return true;
+
     SetRtiTarget(botAI, "square", anetheron);
 
     if (AI_VALUE(Unit*, "current target") != anetheron)
@@ -393,7 +395,9 @@ bool AnetheronFirstAssistTankPickUpInfernalsAction::Execute(Event /*event*/)
     if (!infernal)
         return false;
 
-    MarkTargetWithDiamond(bot, infernal);
+    if (MarkTargetWithDiamond(bot, infernal))
+        return true;
+
     SetRtiTarget(botAI, "diamond", infernal);
 
     if (AI_VALUE(Unit*, "current target") != infernal)
@@ -732,7 +736,9 @@ bool AzgalorMainTankPositionBossAction::Execute(Event /*event*/)
     if (!azgalor)
         return false;
 
-    MarkTargetWithStar(bot, azgalor);
+    if (MarkTargetWithStar(bot, azgalor))
+        return true;
+
     SetRtiTarget(botAI, "star", azgalor);
 
     if (AI_VALUE(Unit*, "current target") != azgalor)
@@ -910,7 +916,9 @@ bool AzgalorFirstAssistTankPositionDoomguardAction::Execute(Event /*event*/)
 
     if (Unit* doomguard = AI_VALUE2(Unit*, "find target", "lesser doomguard"))
     {
-        MarkTargetWithCircle(bot, doomguard);
+        if (MarkTargetWithCircle(bot, doomguard))
+            return true;
+
         SetRtiTarget(botAI, "circle", doomguard);
 
         if (AI_VALUE(Unit*, "current target") != doomguard)

--- a/src/Ai/Raid/Hyjal/HyjalActions.cpp
+++ b/src/Ai/Raid/Hyjal/HyjalActions.cpp
@@ -340,7 +340,7 @@ bool AnetheronSpreadRangedInCircleAction::Execute(Event /*event*/)
     {
         constexpr float safeDistFromPlayer = 6.0f;
         constexpr uint32 minInterval = 2000;
-        if (Unit* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistFromPlayer))
+        if (Player* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistFromPlayer))
             return FleePosition(nearestPlayer->GetPosition(), safeDistFromPlayer, minInterval);
     }
 
@@ -671,7 +671,7 @@ bool KazrogalLowManaBotTakeDefensiveMeasuresAction::Execute(Event /*event*/)
 
     constexpr float safeDistance = 16.0f;
 
-    Unit* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance);
+    Player* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance);
     if (!nearestPlayer)
         return false;
 
@@ -810,7 +810,7 @@ bool AzgalorDisperseRangedAction::Execute(Event /*event*/)
     }
     else if (!doomguard || AI_VALUE(Unit*, "current target") != doomguard)
     {
-        Unit* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistFromPlayer);
+        Player* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistFromPlayer);
         if (nearestPlayer)
             return FleePosition(nearestPlayer->GetPosition(), safeDistFromPlayer);
     }
@@ -1118,7 +1118,7 @@ bool ArchimondeSpreadToAvoidAirBurstAction::Execute(Event /*event*/)
 
     if (botAI->IsRanged(bot))
     {
-        Unit* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistFromPlayer);
+        Player* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistFromPlayer);
         if (nearestPlayer &&
             FleePosition(nearestPlayer->GetPosition(), safeDistFromPlayer, minInterval))
         {

--- a/src/Ai/Raid/Hyjal/HyjalTriggers.cpp
+++ b/src/Ai/Raid/Hyjal/HyjalTriggers.cpp
@@ -17,7 +17,8 @@ using namespace HyjalSummitHelpers;
 
 bool HyjalSummitBotIsNotInCombatTrigger::IsActive()
 {
-    return !bot->IsInCombat() && bot->GetMapId() == HYJAL_SUMMIT_MAP_ID;
+    return bot->GetMapId() == HYJAL_SUMMIT_MAP_ID &&
+           !AI_VALUE2(bool, "combat", "self target");
 }
 
 // Rage Winterchill

--- a/src/Ai/Raid/Kara/KaraActions.cpp
+++ b/src/Ai/Raid/Kara/KaraActions.cpp
@@ -98,7 +98,7 @@ bool AttumenTheHuntsmanSplitBossesAction::Execute(Event /*event*/)
     if (attumen->GetVictim() == bot && midnight->GetVictim() != bot)
     {
         const float safeDistance = 6.0f;
-        Unit* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance);
+        Player* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance);
         if (nearestPlayer && attumen->GetExactDist2d(nearestPlayer) < safeDistance)
             return MoveFromGroup(safeDistance + 2.0f);
     }
@@ -456,7 +456,7 @@ bool TheCuratorPositionBossAction::Execute(Event /*event*/)
 bool TheCuratorSpreadRangedAction::Execute(Event /*event*/)
 {
     const float minDistance = 5.0f;
-    Unit* nearestPlayer = GetNearestPlayerInRadius(bot, minDistance);
+    Player* nearestPlayer = GetNearestPlayerInRadius(bot, minDistance);
 
     if (nearestPlayer)
     {

--- a/src/Ai/Raid/Kara/KaraActions.cpp
+++ b/src/Ai/Raid/Kara/KaraActions.cpp
@@ -377,14 +377,13 @@ bool RomuloAndJulianneMarkTargetAction::Execute(Event /*event*/)
 // Mark targets with skull in the recommended kill order
 bool WizardOfOzMarkTargetAction::Execute(Event /*event*/)
 {
-    static const std::array<const char*, 6> ozTargets =
+    static const std::array<const char*, 5> ozTargets =
     {
         "dorothee",
         "tito",
         "roar",
         "strawman",
         "tinhead",
-        "the crone"
     };
 
     for (const char* name : ozTargets)

--- a/src/Ai/Raid/Kara/KaraActions.cpp
+++ b/src/Ai/Raid/Kara/KaraActions.cpp
@@ -23,7 +23,6 @@ bool ManaWarpStunCreatureBeforeWarpBreachAction::Execute(Event /*event*/)
         "hammer of justice",
         "kidney shot",
         "maim",
-        "revenge stun",
         "shadowfury",
         "shockwave"
     };
@@ -45,8 +44,11 @@ bool AttumenTheHuntsmanMarkTargetAction::Execute(Event /*event*/)
     Unit* attumenMounted = GetFirstAliveUnitByEntry(botAI, NPC_ATTUMEN_THE_HUNTSMAN_MOUNTED);
     if (attumenMounted)
     {
-        if (IsMechanicTrackerBot(botAI, bot, KARAZHAN_MAP_ID, nullptr))
-            MarkTargetWithStar(bot, attumenMounted);
+        if (IsMechanicTrackerBot(bot, KARAZHAN_MAP_ID) &&
+            MarkTargetWithStar(bot, attumenMounted))
+        {
+            return true;
+        }
 
         SetRtiTarget(botAI, "star", attumenMounted);
 
@@ -56,8 +58,11 @@ bool AttumenTheHuntsmanMarkTargetAction::Execute(Event /*event*/)
     }
     else if (Unit* midnight = AI_VALUE2(Unit*, "find target", "midnight"))
     {
-        if (IsMechanicTrackerBot(botAI, bot, KARAZHAN_MAP_ID, nullptr))
-            MarkTargetWithStar(bot, midnight);
+        if (IsMechanicTrackerBot(bot, KARAZHAN_MAP_ID) &&
+            MarkTargetWithStar(bot, midnight))
+        {
+            return true;
+        }
 
         if (!botAI->IsAssistTankOfIndex(bot, 0))
         {
@@ -82,7 +87,9 @@ bool AttumenTheHuntsmanSplitBossesAction::Execute(Event /*event*/)
     if (!attumen)
         return false;
 
-    MarkTargetWithSquare(bot, attumen);
+    if (MarkTargetWithSquare(bot, attumen))
+        return true;
+
     SetRtiTarget(botAI, "square", attumen);
 
     if (AI_VALUE(Unit*, "current target") != attumen)
@@ -154,7 +161,9 @@ bool MoroesMainTankAttackBossAction::Execute(Event /*event*/)
     if (!moroes)
         return false;
 
-    MarkTargetWithCircle(bot, moroes);
+    if (MarkTargetWithCircle(bot, moroes))
+        return true;
+
     SetRtiTarget(botAI, "circle", moroes);
 
     if (AI_VALUE(Unit*, "current target") != moroes)
@@ -166,20 +175,20 @@ bool MoroesMainTankAttackBossAction::Execute(Event /*event*/)
 // Mark targets with skull in the recommended kill order
 bool MoroesMarkTargetAction::Execute(Event /*event*/)
 {
-    Unit* dorothea = AI_VALUE2(Unit*, "find target", "baroness dorothea millstipe");
-    Unit* catriona = AI_VALUE2(Unit*, "find target", "lady catriona von'indi");
-    Unit* keira = AI_VALUE2(Unit*, "find target", "lady keira berrybuck");
-    Unit* rafe = AI_VALUE2(Unit*, "find target", "baron rafe dreuger");
-    Unit* robin = AI_VALUE2(Unit*, "find target", "lord robin daris");
-    Unit* crispin = AI_VALUE2(Unit*, "find target", "lord crispin ference");
-    Unit* target = GetFirstAliveUnit({dorothea, catriona, keira, rafe, robin, crispin});
-
-    if (target)
+    static const std::array<const char*, 6> moroesGuests =
     {
-        if (IsMechanicTrackerBot(botAI, bot, KARAZHAN_MAP_ID, nullptr))
-            MarkTargetWithSkull(bot, target);
+        "baroness dorothea millstipe",
+        "lady catriona von'indi",
+        "lady keira berrybuck",
+        "baron rafe dreuger",
+        "lord robin daris",
+        "lord crispin ference"
+    };
 
-        SetRtiTarget(botAI, "skull", target);
+    for (const char* name : moroesGuests)
+    {
+        if (Unit* guest = AI_VALUE2(Unit*, "find target", name))
+            return MarkTargetWithSkull(bot, guest);
     }
 
     return false;
@@ -358,7 +367,7 @@ bool RomuloAndJulianneMarkTargetAction::Execute(Event /*event*/)
         target = (romulo->GetHealthPct() >= julianne->GetHealthPct()) ? romulo : julianne;
 
     if (target)
-        MarkTargetWithSkull(bot, target);
+        return MarkTargetWithSkull(bot, target);
 
     return false;
 }
@@ -368,16 +377,21 @@ bool RomuloAndJulianneMarkTargetAction::Execute(Event /*event*/)
 // Mark targets with skull in the recommended kill order
 bool WizardOfOzMarkTargetAction::Execute(Event /*event*/)
 {
-    Unit* dorothee = AI_VALUE2(Unit*, "find target", "dorothee");
-    Unit* tito = AI_VALUE2(Unit*, "find target", "tito");
-    Unit* roar = AI_VALUE2(Unit*, "find target", "roar");
-    Unit* strawman = AI_VALUE2(Unit*, "find target", "strawman");
-    Unit* tinhead = AI_VALUE2(Unit*, "find target", "tinhead");
-    Unit* crone = AI_VALUE2(Unit*, "find target", "the crone");
-    Unit* target = GetFirstAliveUnit({dorothee, tito, roar, strawman, tinhead, crone});
+    static const std::array<const char*, 6> ozTargets =
+    {
+        "dorothee",
+        "tito",
+        "roar",
+        "strawman",
+        "tinhead",
+        "the crone"
+    };
 
-    if (target)
-        MarkTargetWithSkull(bot, target);
+    for (const char* name : ozTargets)
+    {
+        if (Unit* target = AI_VALUE2(Unit*, "find target", name))
+            return MarkTargetWithSkull(bot, target);
+    }
 
     return false;
 }
@@ -394,17 +408,10 @@ bool WizardOfOzScorchStrawmanAction::Execute(Event /*event*/)
 
 // The Curator
 
-// Prioritize destroying Astral Flares
 bool TheCuratorMarkAstralFlareAction::Execute(Event /*event*/)
 {
-    Unit* flare = AI_VALUE2(Unit*, "find target", "astral flare");
-    if (!flare)
-        return false;
-
-    if (IsMechanicTrackerBot(botAI, bot, KARAZHAN_MAP_ID, nullptr))
-        MarkTargetWithSkull(bot, flare);
-
-    SetRtiTarget(botAI, "skull", flare);
+    if (Unit* flare = AI_VALUE2(Unit*, "find target", "astral flare"))
+        return MarkTargetWithSkull(bot, flare);
 
     return false;
 }
@@ -417,7 +424,9 @@ bool TheCuratorPositionBossAction::Execute(Event /*event*/)
     if (!curator)
         return false;
 
-    MarkTargetWithCircle(bot, curator);
+    if (MarkTargetWithCircle(bot, curator))
+        return true;
+
     SetRtiTarget(botAI, "circle", curator);
 
     if (AI_VALUE(Unit*, "current target") != curator)
@@ -465,13 +474,18 @@ bool TheCuratorSpreadRangedAction::Execute(Event /*event*/)
 // Prioritize (1) Demon Chains, (2) Kil'rek, (3) Illhoof
 bool TerestianIllhoofMarkTargetAction::Execute(Event /*event*/)
 {
-    Unit* demonChains = GetFirstAliveUnitByEntry(botAI, NPC_DEMON_CHAINS);
-    Unit* kilrek = GetFirstAliveUnitByEntry(botAI, NPC_KILREK);
-    Unit* illhoof = AI_VALUE2(Unit*, "find target", "terestian illhoof");
+    static const std::array<const char*, 3> illhoofTargets =
+    {
+        "demon chains",
+        "kil'rek",
+        "terestian illhoof"
+    };
 
-    Unit* target = GetFirstAliveUnit({demonChains, kilrek, illhoof});
-    if (target)
-        MarkTargetWithSkull(bot, target);
+    for (const char* name : illhoofTargets)
+    {
+        if (Unit* target = AI_VALUE2(Unit*, "find target", name))
+            return MarkTargetWithSkull(bot, target);
+    }
 
     return false;
 }
@@ -515,10 +529,8 @@ bool ShadeOfAranStopMovingDuringFlameWreathAction::Execute(Event /*event*/)
 // Mark Conjured Elementals with skull so DPS can burn them down
 bool ShadeOfAranMarkConjuredElementalAction::Execute(Event /*event*/)
 {
-    Unit* elemental = GetFirstAliveUnitByEntry(botAI, NPC_CONJURED_ELEMENTAL);
-
-    if (elemental)
-        MarkTargetWithSkull(bot, elemental);
+    if (Unit* elemental = GetFirstAliveUnitByEntry(botAI, NPC_CONJURED_ELEMENTAL))
+        return MarkTargetWithSkull(bot, elemental);
 
     return false;
 }
@@ -1002,7 +1014,7 @@ bool NetherspiteManageTimersAndTrackersAction::Execute(Event /*event*/)
     if (netherspite->GetHealth() == netherspite->GetMaxHealth() &&
         !netherspite->HasAura(SPELL_GREEN_BEAM_HEAL))
     {
-        if (IsMechanicTrackerBot(botAI, bot, KARAZHAN_MAP_ID, nullptr))
+        if (IsMechanicTrackerBot(bot, KARAZHAN_MAP_ID))
             netherspiteDpsWaitTimer.insert_or_assign(instanceId, now);
 
         if (botAI->IsTank(bot) && !bot->HasAura(SPELL_RED_BEAM_DEBUFF))
@@ -1013,7 +1025,7 @@ bool NetherspiteManageTimersAndTrackersAction::Execute(Event /*event*/)
     }
     else if (netherspite->HasAura(SPELL_NETHERSPITE_BANISHED))
     {
-        if (IsMechanicTrackerBot(botAI, bot, KARAZHAN_MAP_ID, nullptr))
+        if (IsMechanicTrackerBot(bot, KARAZHAN_MAP_ID))
             netherspiteDpsWaitTimer.erase(instanceId);
 
         if (botAI->IsTank(bot))
@@ -1024,7 +1036,7 @@ bool NetherspiteManageTimersAndTrackersAction::Execute(Event /*event*/)
     }
     else if (!netherspite->HasAura(SPELL_NETHERSPITE_BANISHED))
     {
-        if (IsMechanicTrackerBot(botAI, bot, KARAZHAN_MAP_ID, nullptr))
+        if (IsMechanicTrackerBot(bot, KARAZHAN_MAP_ID))
             netherspiteDpsWaitTimer.try_emplace(instanceId, now);
 
         if (botAI->IsTank(bot) && bot->HasAura(SPELL_RED_BEAM_DEBUFF))
@@ -1254,7 +1266,8 @@ bool NightbaneGroundPhasePositionBossAction::Execute(Event /*event*/)
     if (!nightbane)
         return false;
 
-    MarkTargetWithSkull(bot, nightbane);
+    if (MarkTargetWithSkull(bot, nightbane))
+        return true;
 
     if (AI_VALUE(Unit*, "current target") != nightbane)
         return Attack(nightbane);
@@ -1393,7 +1406,8 @@ bool NightbaneFlightPhaseMovementAction::Execute(Event /*event*/)
     if (!nightbane || nightbane->GetPositionZ() <= NIGHTBANE_FLIGHT_Z)
         return false;
 
-    MarkTargetWithMoon(bot, nightbane);
+    if (MarkTargetWithMoon(bot, nightbane))
+        return true;
 
     if (AI_VALUE(Unit*, "current target") == nightbane)
     {
@@ -1451,7 +1465,7 @@ bool NightbaneManageTimersAndTrackersAction::Execute(Event /*event*/)
         if (botAI->IsRanged(bot))
             nightbaneRangedStep.erase(botGuid);
 
-        if (IsMechanicTrackerBot(botAI, bot, KARAZHAN_MAP_ID, nullptr))
+        if (IsMechanicTrackerBot(bot, KARAZHAN_MAP_ID))
             nightbaneDpsWaitTimer.erase(instanceId);
     }
     // Erase flight phase timer and Rain of Bones tracker on ground phase and start DPS wait timer
@@ -1459,7 +1473,7 @@ bool NightbaneManageTimersAndTrackersAction::Execute(Event /*event*/)
     {
         nightbaneRainOfBonesHit.erase(botGuid);
 
-        if (IsMechanicTrackerBot(botAI, bot, KARAZHAN_MAP_ID, nullptr))
+        if (IsMechanicTrackerBot(bot, KARAZHAN_MAP_ID))
         {
             nightbaneFlightPhaseStartTimer.erase(instanceId);
             nightbaneDpsWaitTimer.try_emplace(instanceId, now);
@@ -1475,7 +1489,7 @@ bool NightbaneManageTimersAndTrackersAction::Execute(Event /*event*/)
         if (botAI->IsRanged(bot))
             nightbaneRangedStep.erase(botGuid);
 
-        if (IsMechanicTrackerBot(botAI, bot, KARAZHAN_MAP_ID, nullptr))
+        if (IsMechanicTrackerBot(bot, KARAZHAN_MAP_ID))
         {
             nightbaneDpsWaitTimer.erase(instanceId);
             nightbaneFlightPhaseStartTimer.try_emplace(instanceId, now);

--- a/src/Ai/Raid/Kara/KaraActions.cpp
+++ b/src/Ai/Raid/Kara/KaraActions.cpp
@@ -377,16 +377,7 @@ bool RomuloAndJulianneMarkTargetAction::Execute(Event /*event*/)
 // Mark targets with skull in the recommended kill order
 bool WizardOfOzMarkTargetAction::Execute(Event /*event*/)
 {
-    static const std::array<const char*, 5> ozTargets =
-    {
-        "dorothee",
-        "tito",
-        "roar",
-        "strawman",
-        "tinhead",
-    };
-
-    for (const char* name : ozTargets)
+    for (const char* name : GetOzTargets())
     {
         if (Unit* target = AI_VALUE2(Unit*, "find target", name))
             return MarkTargetWithSkull(bot, target);

--- a/src/Ai/Raid/Kara/KaraActions.cpp
+++ b/src/Ai/Raid/Kara/KaraActions.cpp
@@ -16,7 +16,7 @@ bool ManaWarpStunCreatureBeforeWarpBreachAction::Execute(Event /*event*/)
     if (!manaWarp)
         return false;
 
-    static const std::array<const char*, 8> spells =
+    static const std::array<const char*, 7> spells =
     {
         "bash",
         "concussion blow",

--- a/src/Ai/Raid/Kara/KaraHelpers.cpp
+++ b/src/Ai/Raid/Kara/KaraHelpers.cpp
@@ -50,17 +50,6 @@ namespace KarazhanHelpers
     const Position NIGHTBANE_FLIGHT_STACK_POSITION = { -11159.555f, -1893.526f, 91.473f }; // Broken Barrel
     const Position NIGHTBANE_RAIN_OF_BONES_POSITION = { -11165.233f, -1911.123f, 91.473f };
 
-    Unit* GetFirstAliveUnit(const std::vector<Unit*>& units)
-    {
-        for (Unit* unit : units)
-        {
-            if (unit && unit->IsAlive())
-                return unit;
-        }
-
-        return nullptr;
-    }
-
     bool IsFlameWreathActive(PlayerbotAI* botAI, Player* bot)
     {
         Unit* aran = botAI->GetAiObjectContext()->GetValue<Unit*>("find target", "shade of aran")->Get();

--- a/src/Ai/Raid/Kara/KaraHelpers.cpp
+++ b/src/Ai/Raid/Kara/KaraHelpers.cpp
@@ -50,6 +50,22 @@ namespace KarazhanHelpers
     const Position NIGHTBANE_FLIGHT_STACK_POSITION = { -11159.555f, -1893.526f, 91.473f }; // Broken Barrel
     const Position NIGHTBANE_RAIN_OF_BONES_POSITION = { -11165.233f, -1911.123f, 91.473f };
 
+    // Wizard of Oz
+
+    std::array<const char*, 5> const& GetOzTargets()
+    {
+        static std::array<const char*, 5> const targets =
+        {
+            "dorothee",
+            "tito",
+            "roar",
+            "strawman",
+            "tinhead",
+        };
+
+        return targets;
+    }
+
     bool IsFlameWreathActive(PlayerbotAI* botAI, Player* bot)
     {
         Unit* aran = botAI->GetAiObjectContext()->GetValue<Unit*>("find target", "shade of aran")->Get();

--- a/src/Ai/Raid/Kara/KaraHelpers.h
+++ b/src/Ai/Raid/Kara/KaraHelpers.h
@@ -62,6 +62,7 @@ namespace KarazhanHelpers
         NPC_ATTUMEN_THE_HUNTSMAN_MOUNTED = 16152,
 
         // Terestian Illhoof
+        NPC_TERESTIAN_ILLHOOF            = 15688,
         NPC_DEMON_CHAINS                 = 17248,
         NPC_KILREK                       = 17229,
 
@@ -109,7 +110,6 @@ namespace KarazhanHelpers
     extern const Position NIGHTBANE_FLIGHT_STACK_POSITION;
     extern const Position NIGHTBANE_RAIN_OF_BONES_POSITION;
 
-    Unit* GetFirstAliveUnit(const std::vector<Unit*>& units);
     bool IsFlameWreathActive(PlayerbotAI* botAI, Player* bot);
     std::vector<Player*> GetRedBlockers(PlayerbotAI* botAI, Player* bot);
     std::vector<Player*> GetBlueBlockers(PlayerbotAI* botAI, Player* bot);

--- a/src/Ai/Raid/Kara/KaraHelpers.h
+++ b/src/Ai/Raid/Kara/KaraHelpers.h
@@ -1,6 +1,7 @@
 #ifndef PLAYERBOTS_KARAHELPERS_H
 #define PLAYERBOTS_KARAHELPERS_H
 
+#include <array>
 #include <ctime>
 #include <unordered_map>
 
@@ -110,6 +111,7 @@ namespace KarazhanHelpers
     extern const Position NIGHTBANE_FLIGHT_STACK_POSITION;
     extern const Position NIGHTBANE_RAIN_OF_BONES_POSITION;
 
+    std::array<const char*, 5> const& GetOzTargets();
     bool IsFlameWreathActive(PlayerbotAI* botAI, Player* bot);
     std::vector<Player*> GetRedBlockers(PlayerbotAI* botAI, Player* bot);
     std::vector<Player*> GetBlueBlockers(PlayerbotAI* botAI, Player* bot);

--- a/src/Ai/Raid/Kara/KaraTriggers.cpp
+++ b/src/Ai/Raid/Kara/KaraTriggers.cpp
@@ -110,8 +110,25 @@ bool RomuloAndJulianneBothBossesRevivedTrigger::IsActive()
 
 bool WizardOfOzNeedTargetPriorityTrigger::IsActive()
 {
-    return IsMechanicTrackerBot(bot, KARAZHAN_MAP_ID) &&
-           AI_VALUE2(Unit*, "find target", "moroes");
+    if (!IsMechanicTrackerBot(bot, KARAZHAN_MAP_ID))
+        return false;
+
+    static const std::array<const char*, 5> ozTargets =
+    {
+        "dorothee",
+        "tito",
+        "roar",
+        "strawman",
+        "tinhead",
+    };
+
+    for (const char* name : ozTargets)
+    {
+        if (AI_VALUE2(Unit*, "find target", name))
+            return true;
+    }
+
+    return false;
 }
 
 bool WizardOfOzStrawmanIsVulnerableToFireTrigger::IsActive()

--- a/src/Ai/Raid/Kara/KaraTriggers.cpp
+++ b/src/Ai/Raid/Kara/KaraTriggers.cpp
@@ -14,11 +14,7 @@ bool ManaWarpIsAboutToExplodeTrigger::IsActive()
 
 bool AttumenTheHuntsmanNeedTargetPriorityTrigger::IsActive()
 {
-    if (botAI->IsHeal(bot))
-        return false;
-
-    Unit* midnight = AI_VALUE2(Unit*, "find target", "midnight");
-    return midnight != nullptr;
+    return AI_VALUE2(Unit*, "find target", "midnight");
 }
 
 bool AttumenTheHuntsmanAttumenSpawnedTrigger::IsActive()
@@ -41,11 +37,8 @@ bool AttumenTheHuntsmanAttumenIsMountedTrigger::IsActive()
 
 bool AttumenTheHuntsmanBossWipesAggroWhenMountingTrigger::IsActive()
 {
-    if (!IsMechanicTrackerBot(botAI, bot, KARAZHAN_MAP_ID, nullptr))
-        return false;
-
-    Unit* midnight = AI_VALUE2(Unit*, "find target", "midnight");
-    return midnight != nullptr;
+    return IsMechanicTrackerBot(bot, KARAZHAN_MAP_ID) &&
+           AI_VALUE2(Unit*, "find target", "midnight");
 }
 
 bool MoroesBossEngagedByMainTankTrigger::IsActive()
@@ -59,18 +52,8 @@ bool MoroesBossEngagedByMainTankTrigger::IsActive()
 
 bool MoroesNeedTargetPriorityTrigger::IsActive()
 {
-    if (!botAI->IsDps(bot))
-        return false;
-
-    Unit* dorothea = AI_VALUE2(Unit*, "find target", "baroness dorothea millstipe");
-    Unit* catriona = AI_VALUE2(Unit*, "find target", "lady catriona von'indi");
-    Unit* keira = AI_VALUE2(Unit*, "find target", "lady keira berrybuck");
-    Unit* rafe = AI_VALUE2(Unit*, "find target", "baron rafe dreuger");
-    Unit* robin = AI_VALUE2(Unit*, "find target", "lord robin daris");
-    Unit* crispin = AI_VALUE2(Unit*, "find target", "lord crispin ference");
-
-    Unit* target = GetFirstAliveUnit({ dorothea, catriona, keira, rafe, robin, crispin });
-    return target != nullptr;
+    return IsMechanicTrackerBot(bot, KARAZHAN_MAP_ID) &&
+           AI_VALUE2(Unit*, "find target", "moroes");
 }
 
 bool MaidenOfVirtueHealersAreStunnedByRepentanceTrigger::IsActive()
@@ -111,7 +94,7 @@ bool BigBadWolfBossIsChasingLittleRedRidingHoodTrigger::IsActive()
 
 bool RomuloAndJulianneBothBossesRevivedTrigger::IsActive()
 {
-    if (!IsMechanicTrackerBot(botAI, bot, KARAZHAN_MAP_ID, nullptr))
+    if (!IsMechanicTrackerBot(bot, KARAZHAN_MAP_ID))
         return false;
 
     Unit* romulo = AI_VALUE2(Unit*, "find target", "romulo");
@@ -127,18 +110,8 @@ bool RomuloAndJulianneBothBossesRevivedTrigger::IsActive()
 
 bool WizardOfOzNeedTargetPriorityTrigger::IsActive()
 {
-    if (!IsMechanicTrackerBot(botAI, bot, KARAZHAN_MAP_ID, nullptr))
-        return false;
-
-    Unit* dorothee = AI_VALUE2(Unit*, "find target", "dorothee");
-    Unit* tito = AI_VALUE2(Unit*, "find target", "tito");
-    Unit* roar = AI_VALUE2(Unit*, "find target", "roar");
-    Unit* strawman = AI_VALUE2(Unit*, "find target", "strawman");
-    Unit* tinhead = AI_VALUE2(Unit*, "find target", "tinhead");
-    Unit* crone = AI_VALUE2(Unit*, "find target", "the crone");
-
-    Unit* target = GetFirstAliveUnit({ dorothee, tito, roar, strawman, tinhead, crone });
-    return target != nullptr;
+    return IsMechanicTrackerBot(bot, KARAZHAN_MAP_ID) &&
+           AI_VALUE2(Unit*, "find target", "moroes");
 }
 
 bool WizardOfOzStrawmanIsVulnerableToFireTrigger::IsActive()
@@ -152,11 +125,8 @@ bool WizardOfOzStrawmanIsVulnerableToFireTrigger::IsActive()
 
 bool TheCuratorAstralFlareSpawnedTrigger::IsActive()
 {
-    if (!botAI->IsDps(bot))
-        return false;
-
-    Unit* flare = AI_VALUE2(Unit*, "find target", "astral flare");
-    return flare != nullptr;
+    return IsMechanicTrackerBot(bot, KARAZHAN_MAP_ID) &&
+           AI_VALUE2(Unit*, "find target", "astral flare");
 }
 
 bool TheCuratorBossEngagedByTanksTrigger::IsActive()
@@ -179,7 +149,7 @@ bool TheCuratorBossAstralFlaresCastArcingSearTrigger::IsActive()
 
 bool TerestianIllhoofNeedTargetPriorityTrigger::IsActive()
 {
-    if (!IsMechanicTrackerBot(botAI, bot, KARAZHAN_MAP_ID, nullptr))
+    if (!IsMechanicTrackerBot(bot, KARAZHAN_MAP_ID))
         return false;
 
     Unit* illhoof = AI_VALUE2(Unit*, "find target", "terestian illhoof");
@@ -203,7 +173,7 @@ bool ShadeOfAranFlameWreathIsActiveTrigger::IsActive()
 // Exclusion of Banish is so the player may Banish elementals if they wish
 bool ShadeOfAranConjuredElementalsSummonedTrigger::IsActive()
 {
-    if (!IsMechanicTrackerBot(botAI, bot, KARAZHAN_MAP_ID, nullptr))
+    if (!IsMechanicTrackerBot(bot, KARAZHAN_MAP_ID))
         return false;
 
     Unit* elemental = AI_VALUE2(Unit*, "find target", "conjured elemental");
@@ -280,7 +250,7 @@ bool NetherspiteBossIsBanishedTrigger::IsActive()
 
 bool NetherspiteNeedToManageTimersAndTrackersTrigger::IsActive()
 {
-    if (!botAI->IsTank(bot) && !IsMechanicTrackerBot(botAI, bot, KARAZHAN_MAP_ID, nullptr))
+    if (!botAI->IsTank(bot) && !IsMechanicTrackerBot(bot, KARAZHAN_MAP_ID))
         return false;
 
     Unit* netherspite = AI_VALUE2(Unit*, "find target", "netherspite");

--- a/src/Ai/Raid/Kara/KaraTriggers.cpp
+++ b/src/Ai/Raid/Kara/KaraTriggers.cpp
@@ -113,16 +113,7 @@ bool WizardOfOzNeedTargetPriorityTrigger::IsActive()
     if (!IsMechanicTrackerBot(bot, KARAZHAN_MAP_ID))
         return false;
 
-    static const std::array<const char*, 5> ozTargets =
-    {
-        "dorothee",
-        "tito",
-        "roar",
-        "strawman",
-        "tinhead",
-    };
-
-    for (const char* name : ozTargets)
+    for (const char* name : GetOzTargets())
     {
         if (AI_VALUE2(Unit*, "find target", name))
             return true;

--- a/src/Ai/Raid/Mag/MagActions.cpp
+++ b/src/Ai/Raid/Mag/MagActions.cpp
@@ -20,19 +20,25 @@ bool MagtheridonMainTankAttackFirstThreeChannelersAction::Execute(Event /*event*
     if (Creature* channelerSquare = GetChanneler(bot, SOUTH_CHANNELER))
     {
         channelerTarget = channelerSquare;
-        MarkTargetWithSquare(bot, channelerSquare);
+        if (MarkTargetWithSquare(bot, channelerSquare))
+            return true;
+
         SetRtiTarget(botAI, "square", channelerSquare);
     }
     else if (Creature* channelerStar = GetChanneler(bot, WEST_CHANNELER))
     {
         channelerTarget = channelerStar;
-        MarkTargetWithStar(bot, channelerStar);
+        if (MarkTargetWithStar(bot, channelerStar))
+            return true;
+
         SetRtiTarget(botAI, "star", channelerStar);
     }
     else if (Creature* channelerCircle = GetChanneler(bot, EAST_CHANNELER))
     {
         channelerTarget = channelerCircle;
-        MarkTargetWithCircle(bot, channelerCircle);
+        if (MarkTargetWithCircle(bot, channelerCircle))
+            return true;
+
         SetRtiTarget(botAI, "circle", channelerCircle);
     }
 
@@ -63,7 +69,9 @@ bool MagtheridonFirstAssistTankAttackNWChannelerAction::Execute(Event /*event*/)
     if (!channelerDiamond)
         return false;
 
-    MarkTargetWithDiamond(bot, channelerDiamond);
+    if (MarkTargetWithDiamond(bot, channelerDiamond))
+        return true;
+
     SetRtiTarget(botAI, "diamond", channelerDiamond);
 
     if (AI_VALUE(Unit*, "current target") != channelerDiamond)
@@ -97,7 +105,9 @@ bool MagtheridonSecondAssistTankAttackNEChannelerAction::Execute(Event /*event*/
     if (!channelerTriangle)
         return false;
 
-    MarkTargetWithTriangle(bot, channelerTriangle);
+    if (MarkTargetWithTriangle(bot, channelerTriangle))
+        return true;
+
     SetRtiTarget(botAI, "triangle", channelerTriangle);
 
     if (AI_VALUE(Unit*, "current target") != channelerTriangle)
@@ -181,7 +191,9 @@ bool MagtheridonAssignDpsPriorityAction::Execute(Event /*event*/)
     // Listed in order of priority
     if (Creature* channelerSquare   = GetChanneler(bot, SOUTH_CHANNELER))
     {
-        MarkTargetWithSquare(bot, channelerSquare);
+        if (MarkTargetWithSquare(bot, channelerSquare))
+            return true;
+
         SetRtiTarget(botAI, "square", channelerSquare);
 
         if (AI_VALUE(Unit*, "current target") != channelerSquare)
@@ -189,7 +201,9 @@ bool MagtheridonAssignDpsPriorityAction::Execute(Event /*event*/)
     }
     else if (Creature* channelerStar = GetChanneler(bot, WEST_CHANNELER))
     {
-        MarkTargetWithStar(bot, channelerStar);
+        if (MarkTargetWithStar(bot, channelerStar))
+            return true;
+
         SetRtiTarget(botAI, "star", channelerStar);
 
         if (AI_VALUE(Unit*, "current target") != channelerStar)
@@ -197,7 +211,9 @@ bool MagtheridonAssignDpsPriorityAction::Execute(Event /*event*/)
     }
     else if (Creature* channelerCircle = GetChanneler(bot, EAST_CHANNELER))
     {
-        MarkTargetWithCircle(bot, channelerCircle);
+        if (MarkTargetWithCircle(bot, channelerCircle))
+            return true;
+
         SetRtiTarget(botAI, "circle", channelerCircle);
 
         if (AI_VALUE(Unit*, "current target") != channelerCircle)
@@ -205,7 +221,9 @@ bool MagtheridonAssignDpsPriorityAction::Execute(Event /*event*/)
     }
     else if (Creature* channelerDiamond = GetChanneler(bot, NORTHWEST_CHANNELER))
     {
-        MarkTargetWithDiamond(bot, channelerDiamond);
+        if (MarkTargetWithDiamond(bot, channelerDiamond))
+            return true;
+
         SetRtiTarget(botAI, "diamond", channelerDiamond);
 
         if (AI_VALUE(Unit*, "current target") != channelerDiamond)
@@ -213,7 +231,9 @@ bool MagtheridonAssignDpsPriorityAction::Execute(Event /*event*/)
     }
     else if (Creature* channelerTriangle = GetChanneler(bot, NORTHEAST_CHANNELER))
     {
-        MarkTargetWithTriangle(bot, channelerTriangle);
+        if (MarkTargetWithTriangle(bot, channelerTriangle))
+            return true;
+
         SetRtiTarget(botAI, "triangle", channelerTriangle);
 
         if (AI_VALUE(Unit*, "current target") != channelerTriangle)
@@ -303,7 +323,9 @@ bool MagtheridonMainTankPositionBossAction::Execute(Event /*event*/)
     if (!magtheridon)
         return false;
 
-    MarkTargetWithCross(bot, magtheridon);
+    if (MarkTargetWithCross(bot, magtheridon))
+        return true;
+
     SetRtiTarget(botAI, "cross", magtheridon);
 
     if (AI_VALUE(Unit*, "current target") != magtheridon)

--- a/src/Ai/Raid/Mag/MagActions.cpp
+++ b/src/Ai/Raid/Mag/MagActions.cpp
@@ -378,7 +378,7 @@ bool MagtheridonSpreadRangedAction::Execute(Event /*event*/)
 
     constexpr float safeDistFromPlayer = 6.0f;
     constexpr uint32 minInterval = 1000;
-    if (Unit* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistFromPlayer))
+    if (Player* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistFromPlayer))
         return FleePosition(nearestPlayer->GetPosition(), safeDistFromPlayer, minInterval);
 
     return false;

--- a/src/Ai/Raid/Mag/MagTriggers.cpp
+++ b/src/Ai/Raid/Mag/MagTriggers.cpp
@@ -115,13 +115,14 @@ bool MagtheridonIncomingBlastNovaTrigger::IsActive()
 
 bool MagtheridonNeedToManageTimersAndAssignmentsTrigger::IsActive()
 {
-    return IsMechanicTrackerBot(botAI, bot, MAGTHERIDON_MAP_ID, nullptr) &&
+    return IsMechanicTrackerBot(bot, MAGTHERIDON_MAP_ID) &&
            AI_VALUE2(Unit*, "find target", "magtheridon");
 }
 
 bool MagtheridonBotIsNotInCombatTrigger::IsActive()
 {
-    return !bot->IsInCombat() && bot->GetMapId() == MAGTHERIDON_MAP_ID &&
+    return bot->GetMapId() == MAGTHERIDON_MAP_ID &&
+           !AI_VALUE2(bool, "combat", "self target") &&
            !AI_VALUE2(Unit*, "find target", "magtheridon") &&
            !AI_VALUE2(Unit*, "find target", "hellfire channeler");
 }

--- a/src/Ai/Raid/RaidBossHelpers.cpp
+++ b/src/Ai/Raid/RaidBossHelpers.cpp
@@ -199,7 +199,9 @@ Unit* GetFirstAliveUnitByEntry(PlayerbotAI* botAI, uint32 entry)
 }
 
 // Return the nearest alive player (human or bot) within the specified radius
-// Distance is measured by GetDistance2d(), which takes into account hitboxes (1.5y)
+// Distance is measured by GetExactDist2d(), which does not take into account 
+// player hitboxes (1.5y). Exact measurement is required due to this function
+// often being used to gate FleePosition(), which uses exact distances.
 Unit* GetNearestPlayerInRadius(Player* bot, float radius)
 {
     Unit* nearestPlayer = nullptr;
@@ -213,7 +215,7 @@ Unit* GetNearestPlayerInRadius(Player* bot, float radius)
             if (!member || !member->IsAlive() || member == bot)
                 continue;
 
-            float distance = bot->GetDistance2d(member);
+            float distance = bot->GetExactDist2d(member);
             if (distance < nearestDistance)
             {
                 nearestDistance = distance;

--- a/src/Ai/Raid/RaidBossHelpers.cpp
+++ b/src/Ai/Raid/RaidBossHelpers.cpp
@@ -199,7 +199,7 @@ Unit* GetFirstAliveUnitByEntry(PlayerbotAI* botAI, uint32 entry)
 }
 
 // Return the nearest alive player (human or bot) within the specified radius
-// Distance is measured by GetExactDist2d(), which does not take into account 
+// Distance is measured by GetExactDist2d(), which does not take into account
 // player hitboxes (1.5y). Exact measurement is required due to this function
 // often being used to gate FleePosition(), which uses exact distances.
 Unit* GetNearestPlayerInRadius(Player* bot, float radius)

--- a/src/Ai/Raid/RaidBossHelpers.cpp
+++ b/src/Ai/Raid/RaidBossHelpers.cpp
@@ -201,29 +201,28 @@ Unit* GetFirstAliveUnitByEntry(PlayerbotAI* botAI, uint32 entry)
     return nullptr;
 }
 
-// Return the nearest alive player (human or bot) within the specified radius
-// Distance is measured by GetExactDist2d(), which does not take into account
-// player hitboxes (1.5y). Exact measurement is required due to this function
-// often being used to gate FleePosition(), which uses exact distances.
-Unit* GetNearestPlayerInRadius(Player* bot, float radius)
+// Return the nearest alive player (human or bot) within the specified radius. Distance is
+// measured by GetExactDist2d(), which does not take into account player hitboxes (1.5y).
+Player* GetNearestPlayerInRadius(Player* bot, float radius)
 {
-    Unit* nearestPlayer = nullptr;
+    Group* group = bot->GetGroup();
+    if (!group)
+        return nullptr;
+
+    Player* nearestPlayer = nullptr;
     float nearestDistance = radius;
 
-    if (Group* group = bot->GetGroup())
+    for (GroupReference* ref = group->GetFirstMember(); ref != nullptr; ref = ref->next())
     {
-        for (GroupReference* ref = group->GetFirstMember(); ref != nullptr; ref = ref->next())
-        {
-            Player* member = ref->GetSource();
-            if (!member || !member->IsAlive() || member == bot)
-                continue;
+        Player* member = ref->GetSource();
+        if (!member || !member->IsAlive() || member == bot)
+            continue;
 
-            float distance = bot->GetExactDist2d(member);
-            if (distance < nearestDistance)
-            {
-                nearestDistance = distance;
-                nearestPlayer = member;
-            }
+        float distance = bot->GetExactDist2d(member);
+        if (distance < nearestDistance)
+        {
+            nearestDistance = distance;
+            nearestPlayer = member;
         }
     }
 

--- a/src/Ai/Raid/RaidBossHelpers.cpp
+++ b/src/Ai/Raid/RaidBossHelpers.cpp
@@ -1,4 +1,7 @@
 #include "RaidBossHelpers.h"
+#include "CellImpl.h"
+#include "GridNotifiers.h"
+#include "GridNotifiersImpl.h"
 #include "Playerbots.h"
 #include "RtiTargetValue.h"
 
@@ -225,4 +228,30 @@ Unit* GetNearestPlayerInRadius(Player* bot, float radius)
     }
 
     return nearestPlayer;
+}
+
+// Grid search for dynamic objects for methods to avoid dynobj-based AoE hazards
+std::vector<Position> GetDynamicObjectPositions(Player* bot, float searchRadius, uint32 spellId)
+{
+    std::list<WorldObject*> objs;
+    Acore::AllWorldObjectsInRange check(bot, searchRadius);
+    Acore::WorldObjectListSearcher<Acore::AllWorldObjectsInRange> searcher(
+        bot, objs, check, GRID_MAP_TYPE_MASK_DYNAMICOBJECT);
+    Cell::VisitObjects(bot, searcher, searchRadius);
+
+    std::vector<Position> dynObjs;
+    for (WorldObject* obj : objs)
+    {
+        if (obj->GetTypeId() != TYPEID_DYNAMICOBJECT)
+            continue;
+
+        DynamicObject* dynObj = static_cast<DynamicObject*>(obj);
+        if (dynObj->GetSpellId() == spellId)
+        {
+            dynObjs.emplace_back(
+                dynObj->GetPositionX(), dynObj->GetPositionY(), dynObj->GetPositionZ());
+        }
+    }
+
+    return dynObjs;
 }

--- a/src/Ai/Raid/RaidBossHelpers.cpp
+++ b/src/Ai/Raid/RaidBossHelpers.cpp
@@ -4,67 +4,79 @@
 
 // Functions to mark targets with raid target icons
 // Note that these functions do not allow the player to change the icon during the encounter
-void MarkTargetWithIcon(Player* bot, Unit* target, uint8 iconId)
+bool MarkTargetWithIcon(Player* bot, Unit* target, uint8 iconId)
 {
     if (!target)
-        return;
+        return false;
 
-    if (Group* group = bot->GetGroup())
+    Group* group = bot->GetGroup();
+    if (!group)
+        return false;
+
+    ObjectGuid currentGuid = group->GetTargetIcon(iconId);
+    if (currentGuid != target->GetGUID())
     {
-        ObjectGuid currentGuid = group->GetTargetIcon(iconId);
-        if (currentGuid != target->GetGUID())
-            group->SetTargetIcon(iconId, bot->GetGUID(), target->GetGUID());
+        group->SetTargetIcon(iconId, bot->GetGUID(), target->GetGUID());
+        return true;
     }
+
+    return false;
 }
 
-void MarkTargetWithSkull(Player* bot, Unit* target)
+bool MarkTargetWithSkull(Player* bot, Unit* target)
 {
-    MarkTargetWithIcon(bot, target, RtiTargetValue::skullIndex);
+    return MarkTargetWithIcon(bot, target, RtiTargetValue::skullIndex);
 }
 
-void MarkTargetWithSquare(Player* bot, Unit* target)
+bool MarkTargetWithSquare(Player* bot, Unit* target)
 {
-    MarkTargetWithIcon(bot, target, RtiTargetValue::squareIndex);
+    return MarkTargetWithIcon(bot, target, RtiTargetValue::squareIndex);
 }
 
-void MarkTargetWithStar(Player* bot, Unit* target)
+bool MarkTargetWithStar(Player* bot, Unit* target)
 {
-    MarkTargetWithIcon(bot, target, RtiTargetValue::starIndex);
+    return MarkTargetWithIcon(bot, target, RtiTargetValue::starIndex);
 }
 
-void MarkTargetWithCircle(Player* bot, Unit* target)
+bool MarkTargetWithCircle(Player* bot, Unit* target)
 {
-    MarkTargetWithIcon(bot, target, RtiTargetValue::circleIndex);
+    return MarkTargetWithIcon(bot, target, RtiTargetValue::circleIndex);
 }
 
-void MarkTargetWithDiamond(Player* bot, Unit* target)
+bool MarkTargetWithDiamond(Player* bot, Unit* target)
 {
-    MarkTargetWithIcon(bot, target, RtiTargetValue::diamondIndex);
+    return MarkTargetWithIcon(bot, target, RtiTargetValue::diamondIndex);
 }
 
-void MarkTargetWithTriangle(Player* bot, Unit* target)
+bool MarkTargetWithTriangle(Player* bot, Unit* target)
 {
-    MarkTargetWithIcon(bot, target, RtiTargetValue::triangleIndex);
+    return MarkTargetWithIcon(bot, target, RtiTargetValue::triangleIndex);
 }
 
-void MarkTargetWithCross(Player* bot, Unit* target)
+bool MarkTargetWithCross(Player* bot, Unit* target)
 {
-    MarkTargetWithIcon(bot, target, RtiTargetValue::crossIndex);
+    return MarkTargetWithIcon(bot, target, RtiTargetValue::crossIndex);
 }
 
-void MarkTargetWithMoon(Player* bot, Unit* target)
+bool MarkTargetWithMoon(Player* bot, Unit* target)
 {
-    MarkTargetWithIcon(bot, target, RtiTargetValue::moonIndex);
+    return MarkTargetWithIcon(bot, target, RtiTargetValue::moonIndex);
 }
 
-void ClearTargetIcon(Player* bot, uint8 iconId)
+bool ClearTargetIcon(Player* bot, uint8 iconId)
 {
-    if (Group* group = bot->GetGroup())
+    Group* group = bot->GetGroup();
+    if (!group)
+        return false;
+
+    ObjectGuid currentGuid = group->GetTargetIcon(iconId);
+    if (currentGuid != ObjectGuid::Empty)
     {
-        ObjectGuid currentGuid = group->GetTargetIcon(iconId);
-        if (currentGuid != ObjectGuid::Empty)
-            group->SetTargetIcon(iconId, bot->GetGUID(), ObjectGuid::Empty);
+        group->SetTargetIcon(iconId, bot->GetGUID(), ObjectGuid::Empty);
+        return true;
     }
+
+    return false;
 }
 
 // For bots to set their raid target icon to the specified icon on the specified target
@@ -83,13 +95,10 @@ void SetRtiTarget(PlayerbotAI* botAI, const std::string& rtiName, Unit* target)
     }
 }
 
-// Return the first alive DPS bot in the specified instance map, excluding any specified bot
-// Intended for purposes of storing and erasing timers and trackers in associative containers
-bool IsMechanicTrackerBot(PlayerbotAI* botAI, Player* bot, uint32 mapId, Player* exclude)
+// Return the first alive bot in the specified instance map for purposes of assigning
+// a single bot to manage associative containers, mark targets, etc.
+bool IsMechanicTrackerBot(Player* bot, uint32 mapId)
 {
-    if (!botAI->IsDps(bot) || !bot->IsAlive() || bot->GetMapId() != mapId)
-        return false;
-
     Group* group = bot->GetGroup();
     if (!group)
         return false;
@@ -97,12 +106,11 @@ bool IsMechanicTrackerBot(PlayerbotAI* botAI, Player* bot, uint32 mapId, Player*
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
         Player* member = ref->GetSource();
-        if (!member || !member->IsAlive() || member->GetMapId() != mapId || member == exclude)
+        if (!member || !member->IsAlive() || member->GetMapId() != mapId ||
+            !GET_PLAYERBOT_AI(member))
+        {
             continue;
-
-        PlayerbotAI* memberAI = GET_PLAYERBOT_AI(member);
-        if (!memberAI || !memberAI->IsDps(member))
-            continue;
+        }
 
         return member == bot;
     }
@@ -111,7 +119,6 @@ bool IsMechanicTrackerBot(PlayerbotAI* botAI, Player* bot, uint32 mapId, Player*
 }
 
 // Requires the main tank to be alive
-// Note that IsMainTank() will return the player with the main tank flag, even if dead
 Player* GetGroupMainTank(PlayerbotAI* botAI, Player* bot)
 {
     Group* group = bot->GetGroup();
@@ -133,7 +140,6 @@ Player* GetGroupMainTank(PlayerbotAI* botAI, Player* bot)
 }
 
 // Returns the alive assist tank of the specified index (0 = first, 1 = second, etc.)
-// Priority: Assistants first, then Non-Assistants.
 Player* GetGroupAssistTank(PlayerbotAI* botAI, Player* bot, uint8 index)
 {
     Group* group = bot->GetGroup();
@@ -169,7 +175,6 @@ Player* GetGroupAssistTank(PlayerbotAI* botAI, Player* bot, uint8 index)
         }
     }
 
-    // If the index wasn't found among assistants, check the non-assistants that were saved
     uint8 nonAssistantIndex = index - assistantCount;
     if (nonAssistantIndex < nonAssistantTanks.size())
         return nonAssistantTanks[nonAssistantIndex];
@@ -178,13 +183,14 @@ Player* GetGroupAssistTank(PlayerbotAI* botAI, Player* bot, uint8 index)
 }
 
 // Return the first matching alive unit from PossibleTargetsValue within sightDistance from config
+// Note that PossibleTargetsValue picks up only hostile units
 Unit* GetFirstAliveUnitByEntry(PlayerbotAI* botAI, uint32 entry)
 {
-    auto const& npcs =
+    auto const& units =
         botAI->GetAiObjectContext()->GetValue<GuidVector>("possible targets no los")->Get();
-    for (auto const& npcGuid : npcs)
+    for (auto const& unitGuid : units)
     {
-        Unit* unit = botAI->GetUnit(npcGuid);
+        Unit* unit = botAI->GetUnit(unitGuid);
         if (unit && unit->IsAlive() && unit->GetEntry() == entry)
             return unit;
     }
@@ -193,6 +199,7 @@ Unit* GetFirstAliveUnitByEntry(PlayerbotAI* botAI, uint32 entry)
 }
 
 // Return the nearest alive player (human or bot) within the specified radius
+// Distance is measured by GetDistance2d(), which takes into account hitboxes (1.5y)
 Unit* GetNearestPlayerInRadius(Player* bot, float radius)
 {
     Unit* nearestPlayer = nullptr;
@@ -206,7 +213,7 @@ Unit* GetNearestPlayerInRadius(Player* bot, float radius)
             if (!member || !member->IsAlive() || member == bot)
                 continue;
 
-            float distance = bot->GetExactDist2d(member);
+            float distance = bot->GetDistance2d(member);
             if (distance < nearestDistance)
             {
                 nearestDistance = distance;

--- a/src/Ai/Raid/RaidBossHelpers.h
+++ b/src/Ai/Raid/RaidBossHelpers.h
@@ -19,7 +19,7 @@ bool IsMechanicTrackerBot(Player* bot, uint32 mapId);
 Player* GetGroupMainTank(PlayerbotAI* botAI, Player* bot);
 Player* GetGroupAssistTank(PlayerbotAI* botAI, Player* bot, uint8 index);
 Unit* GetFirstAliveUnitByEntry(PlayerbotAI* botAI, uint32 entry);
-Unit* GetNearestPlayerInRadius(Player* bot, float radius);
+Player* GetNearestPlayerInRadius(Player* bot, float radius);
 std::vector<Position> GetDynamicObjectPositions(Player* bot, float searchRadius, uint32 spellId);
 
 #endif

--- a/src/Ai/Raid/RaidBossHelpers.h
+++ b/src/Ai/Raid/RaidBossHelpers.h
@@ -20,5 +20,6 @@ Player* GetGroupMainTank(PlayerbotAI* botAI, Player* bot);
 Player* GetGroupAssistTank(PlayerbotAI* botAI, Player* bot, uint8 index);
 Unit* GetFirstAliveUnitByEntry(PlayerbotAI* botAI, uint32 entry);
 Unit* GetNearestPlayerInRadius(Player* bot, float radius);
+std::vector<Position> GetDynamicObjectPositions(Player* bot, float searchRadius, uint32 spellId);
 
 #endif

--- a/src/Ai/Raid/RaidBossHelpers.h
+++ b/src/Ai/Raid/RaidBossHelpers.h
@@ -4,22 +4,21 @@
 #include "AiObject.h"
 #include "Unit.h"
 
-void MarkTargetWithIcon(Player* bot, Unit* target, uint8 iconId);
-void MarkTargetWithSkull(Player* bot, Unit* target);
-void MarkTargetWithSquare(Player* bot, Unit* target);
-void MarkTargetWithStar(Player* bot, Unit* target);
-void MarkTargetWithCircle(Player* bot, Unit* target);
-void MarkTargetWithDiamond(Player* bot, Unit* target);
-void MarkTargetWithTriangle(Player* bot, Unit* target);
-void MarkTargetWithCross(Player* bot, Unit* target);
-void MarkTargetWithMoon(Player* bot, Unit* target);
-void ClearTargetIcon(Player* bot, uint8 iconId);
+bool MarkTargetWithIcon(Player* bot, Unit* target, uint8 iconId);
+bool MarkTargetWithSkull(Player* bot, Unit* target);
+bool MarkTargetWithSquare(Player* bot, Unit* target);
+bool MarkTargetWithStar(Player* bot, Unit* target);
+bool MarkTargetWithCircle(Player* bot, Unit* target);
+bool MarkTargetWithDiamond(Player* bot, Unit* target);
+bool MarkTargetWithTriangle(Player* bot, Unit* target);
+bool MarkTargetWithCross(Player* bot, Unit* target);
+bool MarkTargetWithMoon(Player* bot, Unit* target);
+bool ClearTargetIcon(Player* bot, uint8 iconId);
 void SetRtiTarget(PlayerbotAI* botAI, const std::string& rtiName, Unit* target);
-bool IsMechanicTrackerBot(PlayerbotAI* botAI, Player* bot, uint32 mapId, Player* exclude = nullptr);
+bool IsMechanicTrackerBot(Player* bot, uint32 mapId);
 Player* GetGroupMainTank(PlayerbotAI* botAI, Player* bot);
 Player* GetGroupAssistTank(PlayerbotAI* botAI, Player* bot, uint8 index);
-Unit* GetFirstAliveUnitByEntry(
-    PlayerbotAI* botAI, uint32 entry);
+Unit* GetFirstAliveUnitByEntry(PlayerbotAI* botAI, uint32 entry);
 Unit* GetNearestPlayerInRadius(Player* bot, float radius);
 
 #endif

--- a/src/Ai/Raid/SSC/SSCActions.cpp
+++ b/src/Ai/Raid/SSC/SSCActions.cpp
@@ -132,10 +132,8 @@ bool UnderbogColossusEscapeToxicPoolAction::Execute(Event /*event*/)
 
 bool GreyheartTidecallerMarkWaterElementalTotemAction::Execute(Event /*event*/)
 {
-    if (Unit* totem = GetFirstAliveUnitByEntry(botAI, NPC_WATER_ELEMENTAL_TOTEM))
-        MarkTargetWithSkull(bot, totem);
-
-    return false;
+    Unit* totem = GetFirstAliveUnitByEntry(botAI, NPC_WATER_ELEMENTAL_TOTEM);
+    return totem && MarkTargetWithSkull(bot, totem);
 }
 
 // Hydross the Unstable <Duke of Currents>
@@ -151,7 +149,9 @@ bool HydrossTheUnstablePositionFrostTankAction::Execute(Event /*event*/)
 
     if (!hydross->HasAura(SPELL_CORRUPTION) && !HasMarkOfHydrossAt100Percent(bot))
     {
-        MarkTargetWithSquare(bot, hydross);
+        if (MarkTargetWithSquare(bot, hydross))
+            return true;
+
         SetRtiTarget(botAI, "square", hydross);
 
         if (AI_VALUE(Unit*, "current target") != hydross)
@@ -231,7 +231,9 @@ bool HydrossTheUnstablePositionNatureTankAction::Execute(Event /*event*/)
 
     if (hydross->HasAura(SPELL_CORRUPTION) && !HasMarkOfCorruptionAt100Percent(bot))
     {
-        MarkTargetWithTriangle(bot, hydross);
+        if (MarkTargetWithTriangle(bot, hydross))
+            return true;
+
         SetRtiTarget(botAI, "triangle", hydross);
 
         if (AI_VALUE(Unit*, "current target") != hydross)
@@ -304,8 +306,8 @@ bool HydrossTheUnstablePrioritizeElementalAddsAction::Execute(Event /*event*/)
 {
     if (Unit* waterElemental = GetFirstAliveUnitByEntry(botAI, NPC_PURE_SPAWN_OF_HYDROSS))
     {
-        if (IsMechanicTrackerBot(botAI, bot, SSC_MAP_ID, nullptr))
-            MarkTargetWithSkull(bot, waterElemental);
+        if (MarkTargetWithSkull(bot, waterElemental))
+            return true;
 
         SetRtiTarget(botAI, "skull", waterElemental);
 
@@ -314,8 +316,8 @@ bool HydrossTheUnstablePrioritizeElementalAddsAction::Execute(Event /*event*/)
     }
     else if (Unit* natureElemental = GetFirstAliveUnitByEntry(botAI, NPC_TAINTED_SPAWN_OF_HYDROSS))
     {
-        if (IsMechanicTrackerBot(botAI, bot, SSC_MAP_ID, nullptr))
-            MarkTargetWithSkull(bot, natureElemental);
+        if (MarkTargetWithSkull(bot, natureElemental))
+            return true;
 
         SetRtiTarget(botAI, "skull", natureElemental);
 
@@ -637,7 +639,9 @@ bool TheLurkerBelowTanksPickUpAddsAction::Execute(Event /*event*/)
         Unit* guardian = guardians[i];
         if (bot == tank)
         {
-            MarkTargetWithIcon(bot, guardian, rtiIndices[i]);
+            if (MarkTargetWithIcon(bot, guardian, rtiIndices[i]))
+                return true;
+
             SetRtiTarget(botAI, rtiNames[i], guardian);
 
             if (AI_VALUE(Unit*, "current target") != guardian)
@@ -681,8 +685,9 @@ bool TheLurkerBelowManageSpoutTimerAction::Execute(Event /*event*/)
 
 bool LeotherasTheBlindTargetSpellbindersAction::Execute(Event /*event*/)
 {
-    if (Unit* spellbinder = GetFirstAliveUnitByEntry(botAI, NPC_GREYHEART_SPELLBINDER))
-        MarkTargetWithSkull(bot, spellbinder);
+    Unit* spellbinder = GetFirstAliveUnitByEntry(botAI, NPC_GREYHEART_SPELLBINDER);
+    if (spellbinder && MarkTargetWithSkull(bot, spellbinder))
+        return true;
 
     return false;
 }
@@ -712,7 +717,9 @@ bool LeotherasTheBlindDemonFormTankAttackBossAction::Execute(Event /*event*/)
 
     if (Unit* leotherasDemon = GetActiveLeotherasDemon(bot))
     {
-        MarkTargetWithSquare(bot, leotherasDemon);
+        if (MarkTargetWithSquare(bot, leotherasDemon))
+            return true;
+
         SetRtiTarget(botAI, "square", leotherasDemon);
 
         if (botAI->CanCastSpell("searing pain", leotherasDemon))
@@ -976,7 +983,9 @@ bool LeotherasTheBlindFinalPhaseAssignDpsPriorityAction::Execute(Event /*event*/
     if (!leotherasHuman)
         return false;
 
-    MarkTargetWithStar(bot, leotherasHuman);
+    if (MarkTargetWithStar(bot, leotherasHuman))
+        return true;
+
     SetRtiTarget(botAI, "star", leotherasHuman);
 
     if (AI_VALUE(Unit*, "current target") != leotherasHuman)
@@ -1090,7 +1099,9 @@ bool FathomLordKarathressMainTankPositionBossAction::Execute(Event /*event*/)
     if (!karathress)
         return false;
 
-    MarkTargetWithTriangle(bot, karathress);
+    if (MarkTargetWithTriangle(bot, karathress))
+        return true;
+
     SetRtiTarget(botAI, "triangle", karathress);
 
     if (AI_VALUE(Unit*, "current target") != karathress)
@@ -1126,7 +1137,9 @@ bool FathomLordKarathressFirstAssistTankPositionCaribdisAction::Execute(Event /*
     if (!caribdis)
         return false;
 
-    MarkTargetWithDiamond(bot, caribdis);
+    if (MarkTargetWithDiamond(bot, caribdis))
+        return true;
+
     SetRtiTarget(botAI, "diamond", caribdis);
 
     if (AI_VALUE(Unit*, "current target") != caribdis)
@@ -1161,7 +1174,9 @@ bool FathomLordKarathressSecondAssistTankPositionSharkkisAction::Execute(Event /
     if (!sharkkis)
         return false;
 
-    MarkTargetWithStar(bot, sharkkis);
+    if (MarkTargetWithStar(bot, sharkkis))
+        return true;
+
     SetRtiTarget(botAI, "star", sharkkis);
 
     if (AI_VALUE(Unit*, "current target") != sharkkis)
@@ -1196,7 +1211,9 @@ bool FathomLordKarathressThirdAssistTankPositionTidalvessAction::Execute(Event /
     if (!tidalvess)
         return false;
 
-    MarkTargetWithCircle(bot, tidalvess);
+    if (MarkTargetWithCircle(bot, tidalvess))
+        return true;
+
     SetRtiTarget(botAI, "circle", tidalvess);
 
     if (AI_VALUE(Unit*, "current target") != tidalvess)
@@ -1320,7 +1337,9 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
     Unit* totem = GetFirstAliveUnitByEntry(botAI, NPC_SPITFIRE_TOTEM);
     if (totem && botAI->IsMelee(bot) && botAI->IsDps(bot))
     {
-        MarkTargetWithSkull(bot, totem);
+        if (MarkTargetWithSkull(bot, totem))
+            return true;
+
         SetRtiTarget(botAI, "skull", totem);
 
         if (AI_VALUE(Unit*, "current target") != totem)
@@ -1341,7 +1360,9 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
     Unit* tidalvess = AI_VALUE2(Unit*, "find target", "fathom-guard tidalvess");
     if (tidalvess)
     {
-        MarkTargetWithCircle(bot, tidalvess);
+        if (MarkTargetWithCircle(bot, tidalvess))
+            return true;
+
         SetRtiTarget(botAI, "circle", tidalvess);
 
         if (AI_VALUE(Unit*, "current target") != tidalvess)
@@ -1354,7 +1375,9 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
     Unit* caribdis = AI_VALUE2(Unit*, "find target", "fathom-guard caribdis");
     if (botAI->IsRangedDps(bot) && caribdis)
     {
-        MarkTargetWithDiamond(bot, caribdis);
+        if (MarkTargetWithDiamond(bot, caribdis))
+            return true;
+
         SetRtiTarget(botAI, "diamond", caribdis);
 
         const Position& position = CARIBDIS_RANGED_DPS_POSITION;
@@ -1374,7 +1397,9 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
     Unit* sharkkis = AI_VALUE2(Unit*, "find target", "fathom-guard sharkkis");
     if (sharkkis)
     {
-        MarkTargetWithStar(bot, sharkkis);
+        if (MarkTargetWithStar(bot, sharkkis))
+            return true;
+
         SetRtiTarget(botAI, "star", sharkkis);
 
         if (AI_VALUE(Unit*, "current target") != sharkkis)
@@ -1387,7 +1412,9 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
     Unit* fathomSporebat = AI_VALUE2(Unit*, "find target", "fathom sporebat");
     if (fathomSporebat && botAI->IsMelee(bot))
     {
-        MarkTargetWithCross(bot, fathomSporebat);
+        if (MarkTargetWithCross(bot, fathomSporebat))
+            return true;
+
         SetRtiTarget(botAI, "cross", fathomSporebat);
 
         if (AI_VALUE(Unit*, "current target") != fathomSporebat)
@@ -1399,7 +1426,9 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
     Unit* fathomLurker = AI_VALUE2(Unit*, "find target", "fathom lurker");
     if (fathomLurker && botAI->IsMelee(bot))
     {
-        MarkTargetWithSquare(bot, fathomLurker);
+        if (MarkTargetWithSquare(bot, fathomLurker))
+            return true;
+
         SetRtiTarget(botAI, "square", fathomLurker);
 
         if (AI_VALUE(Unit*, "current target") != fathomLurker)
@@ -1412,7 +1441,9 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
     Unit* karathress = AI_VALUE2(Unit*, "find target", "fathom-lord karathress");
     if (karathress)
     {
-        MarkTargetWithTriangle(bot, karathress);
+        if (MarkTargetWithTriangle(bot, karathress))
+            return true;
+
         SetRtiTarget(botAI, "triangle", karathress);
 
         if (AI_VALUE(Unit*, "current target") != karathress)
@@ -1883,7 +1914,9 @@ bool LadyVashjAssignPhase2AndPhase3DpsPriorityAction::Execute(Event /*event*/)
         {
             if (botAI->IsMainTank(bot))
             {
-                MarkTargetWithDiamond(bot, vashj);
+                if (MarkTargetWithDiamond(bot, vashj))
+                    return true;
+
                 SetRtiTarget(botAI, "diamond", vashj);
                 targets = { vashj };
             }
@@ -2045,7 +2078,9 @@ bool LadyVashjTeleportToTaintedElementalAction::Execute(Event /*event*/)
 
     if (AI_VALUE(Unit*, "current target") != tainted)
     {
-        MarkTargetWithStar(bot, tainted);
+        if (MarkTargetWithStar(bot, tainted))
+            return true;
+
         SetRtiTarget(botAI, "star", tainted);
         return Attack(tainted);
     }

--- a/src/Ai/Raid/SSC/SSCActions.cpp
+++ b/src/Ai/Raid/SSC/SSCActions.cpp
@@ -336,7 +336,7 @@ bool HydrossTheUnstableFrostPhaseSpreadOutAction::Execute(Event /*event*/)
 
     constexpr float safeDistance = 6.0f;
     constexpr uint32 minInterval = 1000;
-    if (Unit* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance))
+    if (Player* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance))
         return FleePosition(nearestPlayer->GetPosition(), safeDistance, minInterval);
 
     return false;

--- a/src/Ai/Raid/SSC/SSCTriggers.cpp
+++ b/src/Ai/Raid/SSC/SSCTriggers.cpp
@@ -19,7 +19,7 @@ using namespace SerpentShrineCavernHelpers;
 // General
 bool SerpentShrineCavernBotIsNotInCombatTrigger::IsActive()
 {
-    return !bot->IsInCombat();
+    return bot->GetMapId() == SSC_MAP_ID && !AI_VALUE2(bool, "combat", "self target");
 }
 
 // Trash Mobs
@@ -90,7 +90,7 @@ bool HydrossTheUnstableAggroResetsUponPhaseChangeTrigger::IsActive()
 
 bool HydrossTheUnstableNeedToManageTimersTrigger::IsActive()
 {
-    return IsMechanicTrackerBot(botAI, bot, SSC_MAP_ID) &&
+    return IsMechanicTrackerBot(bot, SSC_MAP_ID) &&
            AI_VALUE2(Unit*, "find target", "hydross the unstable");
 }
 
@@ -162,7 +162,7 @@ bool TheLurkerBelowBossIsSubmergedTrigger::IsActive()
 
 bool TheLurkerBelowNeedToPrepareTimerForSpoutTrigger::IsActive()
 {
-    return IsMechanicTrackerBot(botAI, bot, SSC_MAP_ID) &&
+    return IsMechanicTrackerBot(bot, SSC_MAP_ID) &&
            AI_VALUE2(Unit*, "find target", "the lurker below");
 }
 
@@ -170,7 +170,7 @@ bool TheLurkerBelowNeedToPrepareTimerForSpoutTrigger::IsActive()
 
 bool LeotherasTheBlindBossIsInactiveTrigger::IsActive()
 {
-    return IsMechanicTrackerBot(botAI, bot, SSC_MAP_ID) &&
+    return IsMechanicTrackerBot(bot, SSC_MAP_ID) &&
            AI_VALUE2(Unit*, "find target", "greyheart spellbinder");
 }
 
@@ -295,7 +295,7 @@ bool LeotherasTheBlindDemonFormTankNeedsAggro::IsActive()
 
 bool LeotherasTheBlindBossWipesAggroUponPhaseChangeTrigger::IsActive()
 {
-    return IsMechanicTrackerBot(botAI, bot, SSC_MAP_ID) &&
+    return IsMechanicTrackerBot(bot, SSC_MAP_ID) &&
            AI_VALUE2(Unit*, "find target", "leotheras the blind");
 }
 
@@ -362,7 +362,7 @@ bool FathomLordKarathressDeterminingKillOrderTrigger::IsActive()
 
 bool FathomLordKarathressTanksNeedToEstablishAggroTrigger::IsActive()
 {
-    return IsMechanicTrackerBot(botAI, bot, SSC_MAP_ID) &&
+    return IsMechanicTrackerBot(bot, SSC_MAP_ID) &&
            AI_VALUE2(Unit*, "find target", "fathom-lord karathress");
 }
 

--- a/src/Ai/Raid/TK/TKActions.cpp
+++ b/src/Ai/Raid/TK/TKActions.cpp
@@ -61,7 +61,9 @@ bool AlarBossTanksMoveBetweenPlatformsAction::Execute(Event /*event*/)
     if (!alar)
         return false;
 
-    MarkTargetWithStar(bot, alar);
+    if (MarkTargetWithStar(bot, alar))
+        return true;
+
     SetRtiTarget(botAI, "star", alar);
 
     int8 locationIndex = GetAlarCurrentLocationIndex(alar);
@@ -224,7 +226,9 @@ bool AlarAssistTanksPickUpEmbersAction::HandlePhase1Embers(Unit* alar)
 
     if (Unit* ember = AI_VALUE2(Unit*, "find target", "ember of al'ar"))
     {
-        MarkTargetWithSquare(bot, ember);
+        if (MarkTargetWithSquare(bot, ember))
+            return true;
+
         SetRtiTarget(botAI, "square", ember);
 
         if (AI_VALUE(Unit*, "current target") != ember)
@@ -281,7 +285,9 @@ bool AlarAssistTanksPickUpEmbersAction::HandlePhase2Embers()
 
     if (botAI->IsAssistTankOfIndex(bot, 1, true) && firstEmber)
     {
-        MarkTargetWithSquare(bot, firstEmber);
+        if (MarkTargetWithSquare(bot, firstEmber))
+            return true;
+
         SetRtiTarget(botAI, "square", firstEmber);
 
         if (firstEmber->GetVictim() != bot)
@@ -300,7 +306,9 @@ bool AlarAssistTanksPickUpEmbersAction::HandlePhase2Embers()
     }
     else if (GetSecondEmberTank(botAI) == bot && secondEmber)
     {
-        MarkTargetWithCircle(bot, secondEmber);
+        if (MarkTargetWithCircle(bot, secondEmber))
+            return true;
+
         SetRtiTarget(botAI, "circle", secondEmber);
 
         if (secondEmber->GetVictim() != bot)
@@ -878,12 +886,16 @@ bool HighAstromancerSolarianTargetSolariumPriestsAction::Execute(Event /*event*/
 
     if (targetPriest == priestsPair.first)
     {
-        MarkTargetWithSquare(bot, targetPriest);
+        if (MarkTargetWithSquare(bot, targetPriest))
+            return true;
+
         SetRtiTarget(botAI, "square", targetPriest);
     }
     else
     {
-        MarkTargetWithStar(bot, targetPriest);
+        if (MarkTargetWithStar(bot, targetPriest))
+            return true;
+
         SetRtiTarget(botAI, "star", targetPriest);
     }
 
@@ -1044,7 +1056,9 @@ bool KaelthasSunstriderMainTankPositionSanguinarAction::Execute(Event /*event*/)
     if (!sanguinar)
         return false;
 
-    MarkTargetWithStar(bot, sanguinar);
+    if (MarkTargetWithStar(bot, sanguinar))
+        return true;
+
     SetRtiTarget(botAI, "star", sanguinar);
 
     if (AI_VALUE(Unit*, "current target") != sanguinar)
@@ -1087,7 +1101,9 @@ bool KaelthasSunstriderWarlockTankPositionCapernianAction::Execute(Event /*event
     if (!capernian)
         return false;
 
-    MarkTargetWithCircle(bot, capernian);
+    if (MarkTargetWithCircle(bot, capernian))
+        return true;
+
     SetRtiTarget(botAI, "circle", capernian);
 
     if (AI_VALUE(Unit*, "current target") != capernian &&
@@ -1248,7 +1264,9 @@ bool KaelthasSunstriderFirstAssistTankPositionTelonicusAction::Execute(Event /*e
     if (!telonicus)
         return false;
 
-    MarkTargetWithTriangle(bot, telonicus);
+    if (MarkTargetWithTriangle(bot, telonicus))
+        return true;
+
     SetRtiTarget(botAI, "triangle", telonicus);
 
     if (AI_VALUE(Unit*, "current target") != telonicus)
@@ -1328,7 +1346,9 @@ bool KaelthasSunstriderAssignAdvisorDpsPriorityAction::Execute(Event /*event*/)
         thaladred && !thaladred->HasUnitFlag(UNIT_FLAG_NON_ATTACKABLE) &&
         !thaladred->HasAura(SPELL_PERMANENT_FEIGN_DEATH))
     {
-        MarkTargetWithSquare(bot, thaladred);
+        if (MarkTargetWithSquare(bot, thaladred))
+            return true;
+
         SetRtiTarget(botAI, "square", thaladred);
 
         if (AI_VALUE(Unit*, "current target") != thaladred)
@@ -1458,7 +1478,9 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
         // Priority 1: Staff of Disintegration (Skull)
         if (Unit* staff = AI_VALUE2(Unit*, "find target", "staff of disintegration"))
         {
-            MarkTargetWithSkull(bot, staff);
+            if (MarkTargetWithSkull(bot, staff))
+                return true;
+
             SetRtiTarget(botAI, "skull", staff);
 
             if (AI_VALUE(Unit*, "current target") != staff)
@@ -1467,7 +1489,9 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
         // Priority 2: Cosmic Infuser (Skull)
         else if (mace)
         {
-            MarkTargetWithSkull(bot, mace);
+            if (MarkTargetWithSkull(bot, mace))
+                return true;
+
             SetRtiTarget(botAI, "skull", mace);
 
             if (AI_VALUE(Unit*, "current target") != mace)
@@ -1476,7 +1500,9 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
         // Priority 3: Warp Slicer (Skull)
         else if (sword)
         {
-            MarkTargetWithSkull(bot, sword);
+            if (MarkTargetWithSkull(bot, sword))
+                return true;
+
             SetRtiTarget(botAI, "skull", sword);
 
             if (AI_VALUE(Unit*, "current target") != sword)
@@ -1485,7 +1511,9 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
         // Priority 4: Infinity Blades (Skull)
         else if (dagger)
         {
-            MarkTargetWithSkull(bot, dagger);
+            if (MarkTargetWithSkull(bot, dagger))
+                return true;
+
             SetRtiTarget(botAI, "skull", dagger);
 
             if (AI_VALUE(Unit*, "current target") != dagger)
@@ -1502,7 +1530,9 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
         // Priority 6: Netherstrand Longbow (Skull)
         else if (Unit* longbow = AI_VALUE2(Unit*, "find target", "netherstrand longbow"))
         {
-            MarkTargetWithSkull(bot, longbow);
+            if (MarkTargetWithSkull(bot, longbow))
+                return true;
+
             SetRtiTarget(botAI, "skull", longbow);
 
             if (AI_VALUE(Unit*, "current target") != longbow)
@@ -1511,7 +1541,9 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
         // Priority 7: Phaseshift Bulwark (Skull)
         else if (Unit* shield = AI_VALUE2(Unit*, "find target", "phaseshift bulwark"))
         {
-            MarkTargetWithSkull(bot, shield);
+            if (MarkTargetWithSkull(bot, shield))
+                return true;
+
             SetRtiTarget(botAI, "skull", shield);
 
             if (AI_VALUE(Unit*, "current target") != shield)
@@ -1528,7 +1560,9 @@ bool KaelthasSunstriderMoveDevastationAwayAction::Execute(Event /*event*/)
     if (!axe)
         return false;
 
-    MarkTargetWithDiamond(bot, axe);
+    if (MarkTargetWithDiamond(bot, axe))
+        return true;
+
     SetRtiTarget(botAI, "diamond", axe);
 
     if (AI_VALUE(Unit*, "current target") != axe)
@@ -1761,7 +1795,9 @@ bool KaelthasSunstriderMainTankPositionBossAction::Execute(Event /*event*/)
     if (!kaelthas)
         return false;
 
-    MarkTargetWithStar(bot, kaelthas);
+    if (MarkTargetWithStar(bot, kaelthas))
+        return true;
+
     SetRtiTarget(botAI, "star", kaelthas);
 
     if (AI_VALUE(Unit*, "current target") != kaelthas)
@@ -1849,13 +1885,19 @@ bool KaelthasSunstriderHandlePhoenixesAndEggsAction::AssistTanksPickUpPhoenixes(
     if (botAI->IsAssistTankOfIndex(bot, 0, true))
     {
         targetPhoenix = phoenixes[0];
-        MarkTargetWithSquare(bot, targetPhoenix);
+
+        if (MarkTargetWithSquare(bot, targetPhoenix))
+            return true;
+
         SetRtiTarget(botAI, "square", targetPhoenix);
     }
     else if (botAI->IsAssistTankOfIndex(bot, 1, true) && phoenixes.size() >= 2)
     {
         targetPhoenix = phoenixes[1];
-        MarkTargetWithCircle(bot, targetPhoenix);
+
+        if (MarkTargetWithCircle(bot, targetPhoenix))
+            return true;
+
         SetRtiTarget(botAI, "circle", targetPhoenix);
     }
 
@@ -1883,7 +1925,9 @@ bool KaelthasSunstriderHandlePhoenixesAndEggsAction::NonTanksDestroyEggsAndAvoid
     {
         if (Unit* phoenixEgg = GetFirstAliveUnitByEntry(botAI, NPC_PHOENIX_EGG))
         {
-            MarkTargetWithDiamond(bot, phoenixEgg);
+            if (MarkTargetWithDiamond(bot, phoenixEgg))
+                return true;
+
             SetRtiTarget(botAI, "diamond", phoenixEgg);
 
             if (AI_VALUE(Unit*, "current target") != phoenixEgg)

--- a/src/Ai/Raid/TK/TKActions.cpp
+++ b/src/Ai/Raid/TK/TKActions.cpp
@@ -550,7 +550,7 @@ bool AlarAvoidFlamePatchesAndDiveBombsAction::HandleDiveBomb(Unit* alar)
         {
             constexpr float safeDistance = 10.0f;
             constexpr uint32 minInterval = 0;
-            if (Unit* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance))
+            if (Player* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance))
                 return FleePosition(nearestPlayer->GetPosition(), safeDistance, minInterval);
         }
     }
@@ -1225,7 +1225,7 @@ bool KaelthasSunstriderSpreadAndMoveAwayFromCapernianAction::RangedBotsDisperse(
 
         const float safeDistance = 6.0f;
         constexpr uint32 minInterval = 1000;
-        if (Unit* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance))
+        if (Player* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance))
             return FleePosition(nearestPlayer->GetPosition(), safeDistance, minInterval);
     }
 

--- a/src/Ai/Raid/TK/TKTriggers.cpp
+++ b/src/Ai/Raid/TK/TKTriggers.cpp
@@ -107,7 +107,7 @@ bool AlarPhase2EncounterIsAtRoomCenterTrigger::IsActive()
 
 bool AlarStrategyChangesBetweenPhasesTrigger::IsActive()
 {
-    return botAI->IsDps(bot) && IsMechanicTrackerBot(botAI, bot, TEMPEST_KEEP_MAP_ID) &&
+    return IsMechanicTrackerBot(bot, TEMPEST_KEEP_MAP_ID) &&
            AI_VALUE2(Unit*, "find target", "al'ar");
 }
 
@@ -176,7 +176,9 @@ bool VoidReaverArcaneOrbIsIncomingTrigger::IsActive()
 
 bool VoidReaverBotIsNotInCombatTrigger::IsActive()
 {
-    return !bot->IsInCombat();
+    return bot->GetMapId() == TEMPEST_KEEP_MAP_ID &&
+           !AI_VALUE2(bool, "combat", "self target") &&
+           !AI_VALUE2(Unit*, "find target", "void reaver");
 }
 
 // High Astromancer Solarian
@@ -364,7 +366,7 @@ bool KaelthasSunstriderDeterminingAdvisorKillOrderTrigger::IsActive()
 
 bool KaelthasSunstriderWaitingForTanksToGetAggroOnAdvisorsTrigger::IsActive()
 {
-    if (!botAI->IsDps(bot))
+    if (!IsMechanicTrackerBot(bot, TEMPEST_KEEP_MAP_ID))
         return false;
 
     Unit* kaelthas = AI_VALUE2(Unit*, "find target", "kael'thas sunstrider");
@@ -372,10 +374,7 @@ bool KaelthasSunstriderWaitingForTanksToGetAggroOnAdvisorsTrigger::IsActive()
         return false;
 
     boss_kaelthas* kaelAI = dynamic_cast<boss_kaelthas*>(kaelthas->GetAI());
-    if (!kaelAI || kaelAI->GetPhase() != PHASE_SINGLE_ADVISOR)
-        return false;
-
-    return IsMechanicTrackerBot(botAI, bot, TEMPEST_KEEP_MAP_ID, GetCapernianTank(bot));
+    return kaelAI && kaelAI->GetPhase() == PHASE_SINGLE_ADVISOR;
 }
 
 bool KaelthasSunstriderLegendaryWeaponsAreAliveTrigger::IsActive()

--- a/src/Ai/Raid/TK/Util/TKHelpers.cpp
+++ b/src/Ai/Raid/TK/Util/TKHelpers.cpp
@@ -10,7 +10,7 @@ namespace TempestKeepHelpers
 
     Unit* GetNearestNonTankPlayerInRadius(PlayerbotAI* botAI, Player* bot, float radius)
     {
-        Unit* nearestPlayer = nullptr;
+        Player* nearestPlayer = nullptr;
         float nearestDistance = radius;
 
         Group* group = bot->GetGroup();

--- a/src/Ai/Raid/ZA/ZAActions.cpp
+++ b/src/Ai/Raid/ZA/ZAActions.cpp
@@ -18,12 +18,13 @@ bool AmanishiMedicineManMarkWardAction::Execute(Event /*event*/)
     if (Unit* protectiveWard = GetFirstAliveUnitByEntry(
             botAI, static_cast<uint32>(ZulAmanNPCs::NPC_AMANI_PROTECTIVE_WARD)))
     {
-        MarkTargetWithSkull(bot, protectiveWard);
+        return MarkTargetWithSkull(bot, protectiveWard);
     }
-    else if (Unit* healingWard = GetFirstAliveUnitByEntry(
-                botAI, static_cast<uint32>(ZulAmanNPCs::NPC_AMANI_HEALING_WARD)))
+
+    if (Unit* healingWard = GetFirstAliveUnitByEntry(
+            botAI, static_cast<uint32>(ZulAmanNPCs::NPC_AMANI_HEALING_WARD)))
     {
-        MarkTargetWithSkull(bot, healingWard);
+        return MarkTargetWithSkull(bot, healingWard);
     }
 
     return false;
@@ -371,9 +372,8 @@ bool JanalaiMarkAmanishiHatchersAction::Execute(Event /*event*/)
 
     if (hatcherLow && hatcherHigh && hatcherHigh != hatcherLow)
     {
-        MarkTargetWithSkull(bot, hatcherLow);
-        MarkTargetWithMoon(bot, hatcherHigh);
-        SetRtiTarget(botAI, "skull", hatcherLow);
+        return MarkTargetWithMoon(bot, hatcherHigh) ||
+               MarkTargetWithSkull(bot, hatcherLow);
     }
 
     return false;
@@ -407,7 +407,9 @@ bool HalazziMainTankPositionBossAction::Execute(Event /*event*/)
     if (!halazzi)
         return false;
 
-    MarkTargetWithStar(bot, halazzi);
+    if (MarkTargetWithStar(bot, halazzi))
+        return true;
+
     SetRtiTarget(botAI, "star", halazzi);
 
     if (AI_VALUE(Unit*, "current target") != halazzi)
@@ -441,7 +443,9 @@ bool HalazziFirstAssistTankAttackSpiritLynxAction::Execute(Event /*event*/)
 
     if (Unit* lynx = AI_VALUE2(Unit*, "find target", "spirit of the lynx"))
     {
-        MarkTargetWithCircle(bot, lynx);
+        if (MarkTargetWithCircle(bot, lynx))
+            return true;
+
         SetRtiTarget(botAI, "circle", lynx);
 
         if (AI_VALUE(Unit*, "current target") != lynx)
@@ -490,7 +494,9 @@ bool HalazziAssignDpsPriorityAction::Execute(Event /*event*/)
     if (Unit* totem = GetFirstAliveUnitByEntry(
             botAI, static_cast<uint32>(ZulAmanNPCs::NPC_CORRUPTED_LIGHTNING_TOTEM)))
     {
-        MarkTargetWithSkull(bot, totem);
+        if (MarkTargetWithSkull(bot, totem))
+            return true;
+
         SetRtiTarget(botAI, "skull", totem);
 
         if (AI_VALUE(Unit*, "current target") != totem)
@@ -572,7 +578,9 @@ bool HexLordMalacrassAssignDpsPriorityAction::Execute(Event /*event*/)
 
     if (priorityTarget)
     {
-        MarkTargetWithSkull(bot, priorityTarget);
+        if (MarkTargetWithSkull(bot, priorityTarget))
+            return true;
+
         SetRtiTarget(botAI, "skull", priorityTarget);
     }
 

--- a/src/Ai/Raid/ZA/ZAActions.cpp
+++ b/src/Ai/Raid/ZA/ZAActions.cpp
@@ -87,7 +87,7 @@ bool AkilzonSpreadRangedAction::Execute(Event /*event*/)
 {
     constexpr float minDistance = 13.0f;
     constexpr uint32 minInterval = 1000;
-    if (Unit* nearestPlayer = GetNearestPlayerInRadius(bot, minDistance))
+    if (Player* nearestPlayer = GetNearestPlayerInRadius(bot, minDistance))
         return FleePosition(nearestPlayer->GetPosition(), minDistance, minInterval);
 
     return false;
@@ -230,7 +230,7 @@ bool NalorakkSpreadRangedAction::Execute(Event /*event*/)
 {
     constexpr float minDistance = 11.0f;
     constexpr uint32 minInterval = 1000;
-    if (Unit* nearestPlayer = GetNearestPlayerInRadius(bot, minDistance))
+    if (Player* nearestPlayer = GetNearestPlayerInRadius(bot, minDistance))
         return FleePosition(nearestPlayer->GetPosition(), minDistance, minInterval);
 
     return false;
@@ -747,7 +747,7 @@ bool ZuljinSpreadRangedAction::Execute(Event /*event*/)
 {
     constexpr float minDistance = 6.0f;
     constexpr uint32 minInterval = 1000;
-    if (Unit* nearestPlayer = GetNearestPlayerInRadius(bot, minDistance))
+    if (Player* nearestPlayer = GetNearestPlayerInRadius(bot, minDistance))
         return FleePosition(nearestPlayer->GetPosition(), minDistance, minInterval);
 
     return false;

--- a/src/Ai/Raid/ZA/ZATriggers.cpp
+++ b/src/Ai/Raid/ZA/ZATriggers.cpp
@@ -66,7 +66,7 @@ bool AkilzonElectricalStormIncomingTrigger::IsActive()
 
 bool AkilzonBotsNeedToPrepareForElectricalStormTrigger::IsActive()
 {
-    return IsMechanicTrackerBot(botAI, bot, ZULAMAN_MAP_ID);
+    return IsMechanicTrackerBot(bot, ZULAMAN_MAP_ID);
 }
 
 // Nalorakk <Bear Avatar>


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

I've become aware of various issues that need to be addressed in raid strategies so I'm hoping to revisit older ones like Karazhan and TK to make some changes and general code updates (like moving to enum class).

Before I do so, I'm going to correct a few things I should have done in the first place, which affect many raid strategies.
1. Change the generic boss marking helper from a void to a bool so methods that do nothing but mark can actually return true. Note I'm actually moving away from using RTI in strategies as I think it's problematic and largely unnecessary in light of workarounds. But until/unless I get to addressing them all, it's better for this to be a bool.
2. Remove exceptions from IsMechanicTrackerBot for healers, tanks, and specific bots. I limited this helper a lot at first because I was worried about making more important roles have to run separate actions just to manage containers. But now that I can consolidate erasing into a single out-of-combat action that can erase everything in the instance in one tick, it's not really a problem. Plus, I didn't appreciate that AI ticks were just 100ms apart so losing a tick here or there even in combat is hardly relevant. Better to make sure there is always a bot available to perform these tasks.
3. For out-of-combat container erasure methods, use a 3-layer guard of (1) bot is in the instance, (2) bot is not in combat and neither are nearby raid members in combat, and (3) bot doesn't have the applicable boss on its threat list. Bots being in/out of combat is very different from players since it's driven by their own code, and bots often end up in their non-combat engines in certain phases of fights. What exists is mostly fine, but having all of these checks helps prevent timers and such being reset or erased at the wrong time in the middle of a fight, so this is the unified approach I'm going with now.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

Update RaidBossHelpers to change void functions to bool functions, remove role checks from IsMechanicTrackerBot and update signatures and callsites, update triggers for standalone container management functions.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

Run TBC instances with raid strategies and check for bots locking up and not responding to any input, or not properly responding to timed mechanics in encounters.


## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

Tiny, tiny bit from IsMechanicTracker not being limited to dps bots only.

- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [x] No
- - [ ] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->



## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note).
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


