### PR TITLE
[CI/CD] Clear remaining warnings for the upcoming promotion of warnings to errors in #2557

### DIFF
--- a/src/Ai/Base/Actions/MovementActions.h
+++ b/src/Ai/Base/Actions/MovementActions.h
@@ -17,7 +17,7 @@ class Player;
 class PlayerbotAI;
 class Unit;
 class WorldObject;
-class Position;
+struct Position;
 
 #define ANGLE_45_DEG (static_cast<float>(M_PI) / 4.f)
 #define ANGLE_90_DEG M_PI_2

--- a/src/Ai/Base/Actions/MovementActions.h
+++ b/src/Ai/Base/Actions/MovementActions.h
@@ -17,6 +17,7 @@ class Player;
 class PlayerbotAI;
 class Unit;
 class WorldObject;
+
 struct Position;
 
 #define ANGLE_45_DEG (static_cast<float>(M_PI) / 4.f)

--- a/src/Ai/Raid/Mag/MagActions.cpp
+++ b/src/Ai/Raid/Mag/MagActions.cpp
@@ -490,7 +490,7 @@ bool MagtheridonUseManticronCubeAction::FindSafePositionNearCube(
         if (IsPositionInActiveDebris(bot->GetMap()->GetInstanceId(), x, y))
             continue;
 
-        if (IsPositionInActiveConflagration(botAI, bot, x, y))
+        if (IsPositionInActiveConflagration(botAI, x, y))
             continue;
 
         const float moveDistance = bot->GetExactDist2d(x, y);
@@ -562,7 +562,7 @@ bool MagtheridonMoveOutOfDebrisAction::FindSafePosition(Position& outPos)
             if (IsPositionInActiveDebris(instanceId, x, y))
                 continue;
 
-            if (IsPositionInActiveConflagration(botAI, bot, x, y))
+            if (IsPositionInActiveConflagration(botAI, x, y))
                 continue;
 
             float const moveDistance = bot->GetExactDist2d(x, y);

--- a/src/Ai/Raid/Mag/MagActions.cpp
+++ b/src/Ai/Raid/Mag/MagActions.cpp
@@ -292,7 +292,7 @@ bool MagtheridonWarlockCcBurningAbyssalAction::Execute(Event /*event*/)
         }
     }
 
-    if (warlockIndex >= 0 && warlockIndex < abyssals.size())
+    if (warlockIndex >= 0 && warlockIndex < static_cast<int>(abyssals.size()))
     {
         Unit* assignedAbyssal = abyssals[warlockIndex];
         if (!botAI->HasAura("banish", assignedAbyssal) &&

--- a/src/Ai/Raid/Mag/Util/MagHelpers.cpp
+++ b/src/Ai/Raid/Mag/Util/MagHelpers.cpp
@@ -114,7 +114,7 @@ bool IsPositionInActiveDebris(uint32 instanceId, float x, float y, float radius)
     return false;
 }
 
-bool IsPositionInActiveConflagration(PlayerbotAI* botAI, Player* bot, float x, float y)
+bool IsPositionInActiveConflagration(PlayerbotAI* botAI, Player*, float x, float y)
 {
     constexpr float conflagrationHazardRadius = 5.0f;
     GuidVector const& gameObjects =

--- a/src/Ai/Raid/Mag/Util/MagHelpers.cpp
+++ b/src/Ai/Raid/Mag/Util/MagHelpers.cpp
@@ -114,7 +114,7 @@ bool IsPositionInActiveDebris(uint32 instanceId, float x, float y, float radius)
     return false;
 }
 
-bool IsPositionInActiveConflagration(PlayerbotAI* botAI, Player*, float x, float y)
+bool IsPositionInActiveConflagration(PlayerbotAI* botAI, float x, float y)
 {
     constexpr float conflagrationHazardRadius = 5.0f;
     GuidVector const& gameObjects =

--- a/src/Ai/Raid/Mag/Util/MagHelpers.h
+++ b/src/Ai/Raid/Mag/Util/MagHelpers.h
@@ -83,8 +83,7 @@ Creature* GetChanneler(Player* bot, uint32 dbGuid);
 bool IsMagtheridonActive(Unit* magtheridon);
 bool IsCubeClicker(Player* bot);
 bool IsPositionInActiveDebris(uint32 instanceId, float x, float y, float radius = 10.0f);
-bool IsPositionInActiveConflagration(
-    PlayerbotAI* botAI, Player*, float x, float y);
+bool IsPositionInActiveConflagration(PlayerbotAI* botAI, float x, float y);
 
 }
 

--- a/src/Ai/Raid/Mag/Util/MagHelpers.h
+++ b/src/Ai/Raid/Mag/Util/MagHelpers.h
@@ -84,7 +84,7 @@ bool IsMagtheridonActive(Unit* magtheridon);
 bool IsCubeClicker(Player* bot);
 bool IsPositionInActiveDebris(uint32 instanceId, float x, float y, float radius = 10.0f);
 bool IsPositionInActiveConflagration(
-    PlayerbotAI* botAI, Player* bot, float x, float y);
+    PlayerbotAI* botAI, Player*, float x, float y);
 
 }
 

--- a/src/Bot/Engine/Strategy/Strategy.h
+++ b/src/Bot/Engine/Strategy/Strategy.h
@@ -50,19 +50,19 @@ enum StrategyType : uint32
 //     ACTION_EMERGENCY = 90
 // };
 
-static float ACTION_IDLE = 0.0f;
-static float ACTION_BG = 1.0f;
-static float ACTION_DEFAULT = 5.0f;
-static float ACTION_NORMAL = 10.0f;
-static float ACTION_HIGH = 20.0f;
-static float ACTION_MOVE = 30.0f;
-static float ACTION_INTERRUPT = 40.0f;
-static float ACTION_DISPEL = 50.0f;
-static float ACTION_RAID = 60.0f;
-static float ACTION_LIGHT_HEAL = 10.0f;
-static float ACTION_MEDIUM_HEAL = 20.0f;
-static float ACTION_CRITICAL_HEAL = 30.0f;
-static float ACTION_EMERGENCY = 90.0f;
+static constexpr float ACTION_IDLE = 0.0f;
+static constexpr float ACTION_BG = 1.0f;
+static constexpr float ACTION_DEFAULT = 5.0f;
+static constexpr float ACTION_NORMAL = 10.0f;
+static constexpr float ACTION_HIGH = 20.0f;
+static constexpr float ACTION_MOVE = 30.0f;
+static constexpr float ACTION_INTERRUPT = 40.0f;
+static constexpr float ACTION_DISPEL = 50.0f;
+static constexpr float ACTION_RAID = 60.0f;
+static constexpr float ACTION_LIGHT_HEAL = 10.0f;
+static constexpr float ACTION_MEDIUM_HEAL = 20.0f;
+static constexpr float ACTION_CRITICAL_HEAL = 30.0f;
+static constexpr float ACTION_EMERGENCY = 90.0f;
 
 class Strategy : public PlayerbotAIAware
 {


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
A couple warnings about casting and unused `bot` from #2518 is addressed. And with the upcoming change of CI in #2557, may as well address the points it brings up in its own compile.
1. Position in MovementActions.h, should be a struct as the core defines it.
2. All the action weights in Strategy.h should be constexpr.


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.



## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->



## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [x] No
- - [ ] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->



## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note).
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


