### PR TITLE
Force rebuff on ready check

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -509,6 +509,22 @@ AiPlayerbot.TellWhenMissingBuffReagents = 1
 # Default: 300 (5 minutes)
 AiPlayerbot.MissingBuffReagentMessageCooldown = 300
 
+# When a ready check is issued out of combat, bots refresh missing/short buffs before reporting ready.
+# A bot that still has buff work it can perform stays not-ready until the ready check ends; this
+# includes missing reagents (the cast is attempted and fails). Uses the always-on "force rebuff"
+# strategy: bots with strategy sets saved before this feature keep their saved set - reset their
+# strategies or use "nc +force rebuff" to opt them in. The "rebuff" chat command starts the same
+# buff pass without a ready check and works regardless of this setting.
+# Default: 0 (disabled)
+AiPlayerbot.ForceRebuffOnReadyCheck = 0
+
+# During a force-rebuff pass (ready check or the "rebuff" command), a buff is topped off (recast)
+# once it drops more than this many seconds below its full duration, so buffs are refreshed toward
+# maximum remaining time to last the fight. The effective margin never drops below the time the
+# pass has already run, so small values are safe.
+# Default: 60
+AiPlayerbot.ForceRebuffMarginSecs = 60
+
 # Bots can flee from enemies
 AiPlayerbot.FleeingEnabled = 1
 

--- a/src/Ai/Base/Actions/GenericSpellActions.cpp
+++ b/src/Ai/Base/Actions/GenericSpellActions.cpp
@@ -20,6 +20,7 @@
 #include <ctime>
 #include <unordered_set>
 
+using ai::buff::BuffBelowRefreshTarget;
 using ai::buff::MakeAuraQualifierForBuff;
 using ai::spell::HasSpellOrCategoryCooldown;
 
@@ -268,10 +269,7 @@ bool CastAuraSpellAction::isUseful()
         return false;
 
     Aura* aura = botAI->GetAura(spell, GetTarget(), isOwner, checkDuration);
-    if (!aura || (beforeDuration && uint32(aura->GetDuration()) < beforeDuration))
-        return true;
-
-    return false;
+    return BuffBelowRefreshTarget(botAI, aura, beforeDuration);
 }
 
 bool CastBuffSpellAction::isUseful()
@@ -281,11 +279,13 @@ bool CastBuffSpellAction::isUseful()
         return false;
 
     Aura* aura = botAI->GetAura(spell, target, isOwner, checkDuration);
-    return !aura || (beforeDuration && uint32(aura->GetDuration()) < beforeDuration);
+    return BuffBelowRefreshTarget(botAI, aura, beforeDuration);
 }
 
 bool CastBuffSpellAction::Execute(Event /*event*/)
 {
+    botAI->forceRebuff.NoteBuffWork();
+
     return botAI->CastSpell(spell, GetTarget());
 }
 
@@ -298,19 +298,19 @@ bool GroupBuffSpellAction::isUseful()
     if (ai::buff::IsGroupVariantEnabled(bot, spell))
     {
         std::string const groupVariant = ai::buff::GroupVariantFor(spell);
-        if (!groupVariant.empty() && botAI->HasAura(groupVariant, target, false, isOwner, -1, checkDuration))
+        if (!groupVariant.empty() && !BuffBelowRefreshTarget(
+                botAI, botAI->GetAura(groupVariant, target, isOwner, checkDuration), beforeDuration))
             return false;
     }
 
     Aura* aura = botAI->GetAura(spell, target, isOwner, checkDuration);
-    if (!aura || (beforeDuration && uint32(aura->GetDuration()) < beforeDuration))
-        return true;
-
-    return false;
+    return BuffBelowRefreshTarget(botAI, aura, beforeDuration);
 }
 
 bool GroupBuffSpellAction::Execute(Event /*event*/)
 {
+    botAI->forceRebuff.NoteBuffWork();
+
     std::string missingReagentGroupName;
     std::string const castName = ai::buff::UpgradeToGroupIfAppropriate(
         bot, botAI, spell, &missingReagentGroupName);

--- a/src/Ai/Base/Actions/ReadyCheckAction.cpp
+++ b/src/Ai/Base/Actions/ReadyCheckAction.cpp
@@ -11,6 +11,14 @@
 #include <mutex>
 #include <vector>
 
+static void SendReadyConfirm(Player* bot)
+{
+    WorldPacket packet(MSG_RAID_READY_CHECK);
+    packet << bot->GetGUID();
+    packet << uint8(1);
+    bot->GetSession()->HandleRaidReadyCheckOpcode(packet);
+}
+
 std::string const formatPercent(std::string const name, uint8 value, float percent)
 {
     std::ostringstream out;
@@ -159,12 +167,21 @@ bool ReadyCheckAction::Execute(Event event)
         p >> player;
         if (player == bot->GetGUID())
             return false;
+
+        // Defer the ready reply until buffs are topped off.
+        if (sPlayerbotAIConfig.forceRebuffOnReadyCheck && !bot->IsInCombat() &&
+            botAI->HasStrategy("force rebuff", BOT_STATE_NON_COMBAT))
+        {
+            ReportReadinessToMaster();
+            botAI->forceRebuff.Begin(true);
+            return true;
+        }
     }
 
     return ReadyCheck();
 }
 
-bool ReadyCheckAction::ReadyCheck()
+void ReadyCheckAction::ReportReadinessToMaster()
 {
     std::call_once(
         ReadyChecker::initFlag,
@@ -214,11 +231,15 @@ bool ReadyCheckAction::ReadyCheck()
     }
 
     botAI->TellMaster(out);
+}
 
-    WorldPacket packet(MSG_RAID_READY_CHECK);
-    packet << bot->GetGUID();
-    packet << uint8(1);
-    bot->GetSession()->HandleRaidReadyCheckOpcode(packet);
+bool ReadyCheckAction::ReadyCheck()
+{
+    ReportReadinessToMaster();
+
+    SendReadyConfirm(bot);
+
+    botAI->forceRebuff.End();
 
     botAI->ChangeStrategy("-ready check", BOT_STATE_NON_COMBAT);
 
@@ -226,3 +247,30 @@ bool ReadyCheckAction::ReadyCheck()
 }
 
 bool FinishReadyCheckAction::Execute(Event /*event*/) { return ReadyCheck(); }
+
+// Manual "rebuff" command: opens a rebuff window with no ready check to answer.
+bool ForceRebuffAction::Execute(Event /*event*/)
+{
+    if (bot->IsInCombat() || !botAI->HasStrategy("force rebuff", BOT_STATE_NON_COMBAT))
+        return false;
+
+    botAI->forceRebuff.Begin(false);
+    return true;
+}
+
+bool ReadyReplyAction::isUseful()
+{
+    ForceRebuffState const& rebuff = botAI->forceRebuff;
+    return rebuff.IsPending() && !rebuff.IsOnGlobalCooldown() &&
+           !bot->GetCurrentSpell(CURRENT_GENERIC_SPELL) && !bot->GetCurrentSpell(CURRENT_CHANNELED_SPELL) &&
+           !rebuff.IsBuffPendingThisCycle();
+}
+
+bool ReadyReplyAction::Execute(Event /*event*/)
+{
+    if (botAI->forceRebuff.ShouldReplyToReadyCheck())
+        SendReadyConfirm(bot);
+
+    botAI->forceRebuff.End();
+    return true;
+}

--- a/src/Ai/Base/Actions/ReadyCheckAction.h
+++ b/src/Ai/Base/Actions/ReadyCheckAction.h
@@ -20,6 +20,7 @@ public:
 
 protected:
     bool ReadyCheck();
+    void ReportReadinessToMaster();
 };
 
 class FinishReadyCheckAction : public ReadyCheckAction
@@ -27,6 +28,23 @@ class FinishReadyCheckAction : public ReadyCheckAction
 public:
     FinishReadyCheckAction(PlayerbotAI* botAI) : ReadyCheckAction(botAI, "finish ready check") {}
 
+    bool Execute(Event event) override;
+};
+
+class ForceRebuffAction : public Action
+{
+public:
+    ForceRebuffAction(PlayerbotAI* botAI) : Action(botAI, "force rebuff") {}
+
+    bool Execute(Event event) override;
+};
+
+class ReadyReplyAction : public Action
+{
+public:
+    ReadyReplyAction(PlayerbotAI* botAI) : Action(botAI, "ready reply") {}
+
+    bool isUseful() override;
     bool Execute(Event event) override;
 };
 

--- a/src/Ai/Base/ChatTriggerContext.h
+++ b/src/Ai/Base/ChatTriggerContext.h
@@ -122,6 +122,7 @@ public:
         creators["outfit"] = &ChatTriggerContext::outfit;
         creators["go"] = &ChatTriggerContext::go;
         creators["ready"] = &ChatTriggerContext::ready_check;
+        creators["rebuff"] = &ChatTriggerContext::rebuff;
         creators["debug"] = &ChatTriggerContext::debug;
         creators["cdebug"] = &ChatTriggerContext::cdebug;
         creators["cs"] = &ChatTriggerContext::cs;
@@ -262,6 +263,7 @@ private:
     static Trigger* reset_ai(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "reset botAI"); }
     static Trigger* spell(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "spell"); }
     static Trigger* ready_check(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "ready check"); }
+    static Trigger* rebuff(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "rebuff"); }
     static Trigger* give_leader(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "give leader"); }
     static Trigger* cheat(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "cheat"); }
     static Trigger* ginvite(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "ginvite"); }

--- a/src/Ai/Base/Strategy/ChatCommandHandlerStrategy.cpp
+++ b/src/Ai/Base/Strategy/ChatCommandHandlerStrategy.cpp
@@ -71,6 +71,7 @@ void ChatCommandHandlerStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
     triggers.push_back(new TriggerNode("pull back", { NextAction("pull my target", relevance) }));
     triggers.push_back(new TriggerNode("pull rti", { NextAction("pull rti target", relevance) }));
     triggers.push_back(new TriggerNode("ready", { NextAction("ready check", relevance) }));
+    triggers.push_back(new TriggerNode("rebuff", { NextAction("force rebuff", relevance) }));
     triggers.push_back(new TriggerNode("naxx", {NextAction("naxx chat shortcut", relevance) }));
     triggers.push_back(new TriggerNode("bwl", { NextAction("bwl chat shortcut", relevance) }));
     triggers.push_back(new TriggerNode("dps", { NextAction("tell estimated dps", relevance) }));

--- a/src/Ai/Base/Strategy/WorldPacketHandlerStrategy.cpp
+++ b/src/Ai/Base/Strategy/WorldPacketHandlerStrategy.cpp
@@ -44,7 +44,7 @@ void WorldPacketHandlerStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
                                                                                 NextAction("equip upgrades packet action", relevance) }));
     triggers.push_back(new TriggerNode("item push result", { NextAction("quest item push result", relevance) }));
     triggers.push_back(new TriggerNode("loot roll won", { NextAction("equip upgrades packet action", relevance) }));
-    triggers.push_back(new TriggerNode("ready check finished", { NextAction("finish ready check", relevance) }));
+    triggers.push_back(new TriggerNode("ready check finished", { NextAction("ready check finished", relevance) }));
     // triggers.push_back(new TriggerNode("often", { NextAction("security check", relevance), NextAction("check mail", relevance) }));
     triggers.push_back(new TriggerNode("guild invite", { NextAction("guild accept", relevance) }));
     triggers.push_back(new TriggerNode("petition offer", { NextAction("petition sign", relevance) }));

--- a/src/Ai/Base/StrategyContext.h
+++ b/src/Ai/Base/StrategyContext.h
@@ -23,6 +23,7 @@
 #include "FleeStrategy.h"
 #include "FocusTargetStrategy.h"
 #include "FollowMasterStrategy.h"
+#include "ForceRebuff.h"
 #include "GrindingStrategy.h"
 #include "GroupStrategy.h"
 #include "GuardStrategy.h"
@@ -72,6 +73,7 @@ public:
         creators["chat"] = &StrategyContext::chat;
         creators["default"] = &StrategyContext::world_packet;
         creators["ready check"] = &StrategyContext::ready_check;
+        creators["force rebuff"] = &StrategyContext::force_rebuff;
         creators["dead"] = &StrategyContext::dead;
         creators["flee"] = &StrategyContext::flee;
         creators["duel"] = &StrategyContext::duel;
@@ -160,6 +162,7 @@ private:
     static Strategy* chat(PlayerbotAI* botAI) { return new ChatCommandHandlerStrategy(botAI); }
     static Strategy* world_packet(PlayerbotAI* botAI) { return new WorldPacketHandlerStrategy(botAI); }
     static Strategy* ready_check(PlayerbotAI* botAI) { return new ReadyCheckStrategy(botAI); }
+    static Strategy* force_rebuff(PlayerbotAI* botAI) { return new ForceRebuffStrategy(botAI); }
     static Strategy* pvp(PlayerbotAI* botAI) { return new AttackEnemyPlayersStrategy(botAI); }
     static Strategy* _return(PlayerbotAI* botAI) { return new ReturnStrategy(botAI); }
     static Strategy* lfg(PlayerbotAI* botAI) { return new LfgStrategy(botAI); }

--- a/src/Ai/Base/Trigger/GenericTriggers.cpp
+++ b/src/Ai/Base/Trigger/GenericTriggers.cpp
@@ -163,10 +163,7 @@ bool BuffTrigger::IsActive()
         return false;
 
     Aura* aura = botAI->GetAura(spell, target, checkIsOwner, checkDuration);
-    if (!aura || (beforeDuration && uint32(aura->GetDuration()) < beforeDuration))
-        return true;
-
-    return false;
+    return ai::buff::BuffBelowRefreshTarget(botAI, aura, beforeDuration);
 }
 
 Value<Unit*>* BuffOnPartyTrigger::GetTargetValue()
@@ -749,4 +746,9 @@ bool NewPetTrigger::IsActive()
     }
 
     return false;
+}
+
+bool ForceRebuffPendingTrigger::IsActive()
+{
+    return botAI->forceRebuff.IsPending();
 }

--- a/src/Ai/Base/Trigger/GenericTriggers.h
+++ b/src/Ai/Base/Trigger/GenericTriggers.h
@@ -321,6 +321,7 @@ public:
 
 public:
     std::string const GetTargetName() override { return "self target"; }
+    bool IsBuffTrigger() override { return true; }
     bool IsActive() override;
 
 protected:
@@ -389,6 +390,7 @@ public:
         : BuffTrigger(botAI, spell, checkInterval, checkIsOwner, false, beforeDuration), needLifeTime(needLifeTime) {}
 
     std::string const GetTargetName() override { return "current target"; }
+    bool IsDebuffTrigger() override { return true; }
     bool IsActive() override;
 
 protected:
@@ -969,6 +971,14 @@ public:
 private:
     ObjectGuid lastPetGuid;
     bool triggered;
+};
+
+class ForceRebuffPendingTrigger : public Trigger
+{
+public:
+    ForceRebuffPendingTrigger(PlayerbotAI* botAI) : Trigger(botAI, "force rebuff pending") {}
+
+    bool IsActive() override;
 };
 
 #endif

--- a/src/Ai/Base/TriggerContext.h
+++ b/src/Ai/Base/TriggerContext.h
@@ -45,6 +45,8 @@ public:
         creators["often"] = &TriggerContext::often;
         creators["very often"] = &TriggerContext::very_often;
 
+        creators["force rebuff pending"] = &TriggerContext::force_rebuff_pending;
+
         creators["target critical health"] = &TriggerContext::TargetCriticalHealth;
 
         creators["critical health"] = &TriggerContext::CriticalHealth;
@@ -335,6 +337,7 @@ private:
     static Trigger* TankAssist(PlayerbotAI* botAI) { return new TankAssistTrigger(botAI); }
     static Trigger* Timer(PlayerbotAI* botAI) { return new TimerTrigger(botAI); }
     static Trigger* TimerBG(PlayerbotAI* botAI) { return new TimerBGTrigger(botAI); }
+    static Trigger* force_rebuff_pending(PlayerbotAI* botAI) { return new ForceRebuffPendingTrigger(botAI); }
     static Trigger* NoTarget(PlayerbotAI* botAI) { return new NoTargetTrigger(botAI); }
     static Trigger* TargetInSight(PlayerbotAI* botAI) { return new TargetInSightTrigger(botAI); }
     static Trigger* not_dps_target_active(PlayerbotAI* botAI) { return new NotDpsTargetActiveTrigger(botAI); }

--- a/src/Ai/Base/Util/GenericBuffUtils.cpp
+++ b/src/Ai/Base/Util/GenericBuffUtils.cpp
@@ -11,6 +11,7 @@
 #include "Player.h"
 #include "PlayerbotAI.h"
 #include "PlayerbotAIConfig.h"
+#include "SpellAuras.h"
 #include "SpellMgr.h"
 #include "Unit.h"
 #include "Value.h"
@@ -32,6 +33,15 @@ namespace ai::buff
         }
     }
 
+    bool BuffBelowRefreshTarget(PlayerbotAI* botAI, Aura* aura, uint32 baseBeforeDuration)
+    {
+        if (!aura)
+            return true;
+
+        return botAI->forceRebuff.BuffBelowRefreshTarget(
+            aura->GetDuration(), aura->GetMaxDuration(), baseBeforeDuration);
+    }
+
     static bool HasEnoughSameMapMissingPlayersForGroupVariant(
         Player* bot, PlayerbotAI* botAI, std::string const& baseName,
         std::string const& groupName, uint32 requiredCount = 3)
@@ -50,7 +60,8 @@ namespace ai::buff
                 continue;
             }
 
-            if (botAI->HasAura(baseName, member) || botAI->HasAura(groupName, member))
+            if (!BuffBelowRefreshTarget(botAI, botAI->GetAura(baseName, member), 0) ||
+                !BuffBelowRefreshTarget(botAI, botAI->GetAura(groupName, member), 0))
                 continue;
 
             if (++missingCount >= requiredCount)

--- a/src/Ai/Base/Util/GenericBuffUtils.h
+++ b/src/Ai/Base/Util/GenericBuffUtils.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <unordered_map>
 
+class Aura;
 class Player;
 class PlayerbotAI;
 class Unit;
@@ -19,6 +20,10 @@ namespace ai::buff
 {
 
 typedef std::unordered_map<std::string, uint32> MissingBuffReagentNoticeMap;
+
+// True when the buff should be (re)cast: topped off toward full duration during an
+// out-of-combat force-rebuff, below baseBeforeDuration ms remaining otherwise.
+bool BuffBelowRefreshTarget(PlayerbotAI* botAI, Aura* aura, uint32 baseBeforeDuration);
 
 bool IsGroupVariantEnabled(Player* bot, std::string const& name);
 

--- a/src/Ai/Base/Value/PartyMemberWithoutAuraValue.cpp
+++ b/src/Ai/Base/Value/PartyMemberWithoutAuraValue.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "PartyMemberWithoutAuraValue.h"
+#include "GenericBuffUtils.h"
 #include "Playerbots.h"
 
 extern std::vector<std::string> split(std::string const s, char delim);
@@ -25,7 +26,7 @@ public:
 
         for (std::vector<std::string>::iterator i = auras.begin(); i != auras.end(); ++i)
         {
-            if (botAI->HasAura(*i, unit))
+            if (!ai::buff::BuffBelowRefreshTarget(botAI, botAI->GetAura(*i, unit), 0))
                 return false;
         }
 

--- a/src/Ai/Base/WorldPacketActionContext.h
+++ b/src/Ai/Base/WorldPacketActionContext.h
@@ -95,6 +95,8 @@ public:
         creators["accept duel"] = &WorldPacketActionContext::accept_duel;
         creators["ready check"] = &WorldPacketActionContext::ready_check;
         creators["ready check finished"] = &WorldPacketActionContext::ready_check_finished;
+        creators["force rebuff"] = &WorldPacketActionContext::force_rebuff;
+        creators["ready reply"] = &WorldPacketActionContext::ready_reply;
         creators["uninvite"] = &WorldPacketActionContext::uninvite;
         creators["security check"] = &WorldPacketActionContext::security_check;
         creators["guild accept"] = &WorldPacketActionContext::guild_accept;
@@ -124,6 +126,8 @@ private:
     static Action* ready_check(PlayerbotAI* botAI) { return new ReadyCheckAction(botAI); }
     static Action* accept_duel(PlayerbotAI* botAI) { return new AcceptDuelAction(botAI); }
     static Action* tell_cast_failed(PlayerbotAI* botAI) { return new TellCastFailedAction(botAI); }
+    static Action* force_rebuff(PlayerbotAI* botAI) { return new ForceRebuffAction(botAI); }
+    static Action* ready_reply(PlayerbotAI* botAI) { return new ReadyReplyAction(botAI); }
     static Action* party_command(PlayerbotAI* botAI) { return new PartyCommandAction(botAI); }
     static Action* store_loot(PlayerbotAI* botAI) { return new StoreLootAction(botAI); }
     static Action* accept_trade(PlayerbotAI* botAI) { return new TradeStatusAction(botAI); }

--- a/src/Bot/Engine/Engine.cpp
+++ b/src/Bot/Engine/Engine.cpp
@@ -151,6 +151,9 @@ bool Engine::DoNextAction(Unit* /*unit*/, uint32 /*depth*/, bool minimal)
     ActionBasket* basket = nullptr;
     time_t currentTime = time(nullptr);
 
+    if (!minimal)
+        botAI->forceRebuff.RollBuffPendingCycle();
+
     // Update triggers and push default actions
     ProcessTriggers(minimal);
     PushDefaultActions();
@@ -472,6 +475,9 @@ void Engine::ProcessTriggers(bool minimal)
 
             if (!event)
                 continue;
+
+            if (trigger->IsBuffTrigger() && !trigger->IsDebuffTrigger())
+                botAI->forceRebuff.NoteBuffProposed();
 
             fires[trigger] = event;
             LogAction("T:%s", trigger->getName().c_str());

--- a/src/Bot/Engine/Trigger/Trigger.cpp
+++ b/src/Bot/Engine/Trigger/Trigger.cpp
@@ -7,6 +7,7 @@
 #include "Trigger.h"
 #include "AiObjectContext.h"
 #include "Event.h"
+#include "PlayerbotAI.h"
 
 Trigger::Trigger(PlayerbotAI* botAI, std::string const name, int32 checkInterval)
     : AiNamedObject(botAI, name),
@@ -33,6 +34,10 @@ Unit* Trigger::GetTarget() { return GetTargetValue()->Get(); }
 
 bool Trigger::needCheck(uint32 now)
 {
+    // During an out-of-combat force-rebuff, evaluate every buff trigger each tick
+    if (IsBuffTrigger() && !IsDebuffTrigger() && botAI->forceRebuff.IsPending() && !bot->IsInCombat())
+        return true;
+
     if (checkInterval < 2)
         return true;
 

--- a/src/Bot/Engine/Trigger/Trigger.h
+++ b/src/Bot/Engine/Trigger/Trigger.h
@@ -27,6 +27,8 @@ public:
     virtual void ExternalEvent([[maybe_unused]] std::string const param, [[maybe_unused]] Player* owner = nullptr) {}
     virtual void ExternalEvent([[maybe_unused]] WorldPacket& packet, [[maybe_unused]] Player* owner = nullptr) {}
     virtual bool IsActive() { return false; }
+    virtual bool IsBuffTrigger() { return false; }
+    virtual bool IsDebuffTrigger() { return false; }
     virtual std::vector<NextAction> getHandlers() { return {}; }
     void Update() {}
     virtual void Reset() {}

--- a/src/Bot/Factory/AiFactory.cpp
+++ b/src/Bot/Factory/AiFactory.cpp
@@ -581,7 +581,7 @@ void AiFactory::AddDefaultNonCombatStrategies(Player* player, PlayerbotAI* const
 
     if (!player->InBattleground())
     {
-        nonCombatEngine->addStrategiesNoInit("nc", "food", "chat", "follow", "default", "quest", "loot",
+        nonCombatEngine->addStrategiesNoInit("nc", "food", "chat", "follow", "default", "force rebuff", "quest", "loot",
                                             "gather", "duel", "pvp", "buff", "mount", "emote", nullptr);
     }
 
@@ -673,8 +673,8 @@ void AiFactory::AddDefaultNonCombatStrategies(Player* player, PlayerbotAI* const
     // Battleground switch
     if (player->InBattleground() && player->GetBattleground())
     {
-        nonCombatEngine->addStrategiesNoInit("nc", "chat", "default", "buff", "food", "mount", "pvp", "dps assist",
-                                       "attack tagged", "emote", nullptr);
+        nonCombatEngine->addStrategiesNoInit("nc", "chat", "default", "force rebuff", "buff", "food", "mount", "pvp",
+                                       "dps assist", "attack tagged", "emote", nullptr);
         nonCombatEngine->removeStrategy("custom::say", false);
         nonCombatEngine->removeStrategy("travel", false);
         nonCombatEngine->removeStrategy("rpg", false);

--- a/src/Bot/ForceRebuff.cpp
+++ b/src/Bot/ForceRebuff.cpp
@@ -1,0 +1,96 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+#include "ForceRebuff.h"
+#include "Common.h"
+#include "GenericSpellActions.h"
+#include "Player.h"
+#include "PlayerbotAI.h"
+#include "PlayerbotAIConfig.h"
+#include "Timer.h"
+#include <algorithm>
+
+static constexpr uint32 REBUFF_WINDOW_TIMEOUT_MS = 2 * MINUTE * IN_MILLISECONDS;
+
+void ForceRebuffState::Begin(bool reply)
+{
+    replyToReadyCheck = reply || (IsPending() && replyToReadyCheck);
+    pending = true;
+    buffPendingThisCycle = true;
+    beginMs = getMSTime();
+}
+
+bool ForceRebuffState::IsOnGlobalCooldown() const
+{
+    return bot && lastGcdSpell && bot->GetGlobalCooldownMgr().HasGlobalCooldown(lastGcdSpell);
+}
+
+bool ForceRebuffState::IsPending() const
+{
+    return pending && getMSTimeDiff(beginMs, getMSTime()) < REBUFF_WINDOW_TIMEOUT_MS;
+}
+
+void ForceRebuffState::NoteBuffWork()
+{
+    if (!bot || !IsPending() || bot->IsInCombat())
+        return;
+
+    buffPendingThisCycle = true;
+}
+
+void ForceRebuffState::NoteBuffProposed()
+{
+    if (!bot || !IsPending() || bot->IsInCombat())
+        return;
+
+    buffProposedThisCycle = true;
+}
+
+bool ForceRebuffState::BuffBelowRefreshTarget(int32 remaining, int32 maxDuration, uint32 baseBeforeDuration) const
+{
+    if (bot && IsPending() && !bot->IsInCombat())
+    {
+        if (remaining <= 0 || maxDuration <= 0)
+            return false;
+
+        // Anything refreshed after the rebuff began counts as topped off
+        uint32 const marginMs = std::max(sPlayerbotAIConfig.forceRebuffMarginSecs * IN_MILLISECONDS,
+                                         getMSTimeDiff(beginMs, getMSTime()) + 5000);
+        return uint32(remaining) + marginMs < uint32(maxDuration);
+    }
+
+    return baseBeforeDuration && uint32(remaining) < baseBeforeDuration;
+}
+
+// During a force-rebuff, healing yields to buffing: heals are suppressed while
+// buff work is proposed or the last cast's GCD runs, so the pass is not stretched
+// by interleaved heals.
+class ForceRebuffBuffFirstMultiplier : public Multiplier
+{
+public:
+    ForceRebuffBuffFirstMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "force rebuff buff first") {}
+
+    float GetValue(Action* action) override
+    {
+        ForceRebuffState const& rebuff = botAI->forceRebuff;
+        if (!action || !rebuff.IsPending() || botAI->GetBot()->IsInCombat())
+            return 1.0f;
+
+        if (!dynamic_cast<CastHealingSpellAction*>(action))
+            return 1.0f;
+
+        return rebuff.IsBuffProposedThisCycle() || rebuff.IsOnGlobalCooldown() ? 0.0f : 1.0f;
+    }
+};
+
+void ForceRebuffStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+{
+    triggers.push_back(new TriggerNode("force rebuff pending", { NextAction("ready reply", 6.0f) }));
+}
+
+void ForceRebuffStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
+{
+    multipliers.push_back(new ForceRebuffBuffFirstMultiplier(botAI));
+}

--- a/src/Bot/ForceRebuff.h
+++ b/src/Bot/ForceRebuff.h
@@ -1,0 +1,62 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+#ifndef PLAYERBOTS_FORCEREBUFF_H
+#define PLAYERBOTS_FORCEREBUFF_H
+
+#include "Define.h"
+#include "Strategy.h"
+#include <string>
+#include <vector>
+
+class Player;
+class PlayerbotAI;
+class SpellInfo;
+
+class ForceRebuffState
+{
+public:
+    explicit ForceRebuffState(Player* owner = nullptr) : bot(owner) {}
+
+    ForceRebuffState(ForceRebuffState const&) = delete;
+    ForceRebuffState& operator=(ForceRebuffState const&) = delete;
+
+    void Begin(bool reply);
+    void End() { pending = false; }
+    bool IsPending() const;
+    bool ShouldReplyToReadyCheck() const { return replyToReadyCheck; }
+
+    void NoteBuffWork();
+    void NoteBuffProposed();
+    void RollBuffPendingCycle() { buffPendingThisCycle = false; buffProposedThisCycle = false; }
+    bool IsBuffPendingThisCycle() const { return buffPendingThisCycle; }
+    bool IsBuffProposedThisCycle() const { return buffProposedThisCycle; }
+
+    void NoteCast(SpellInfo const* spellInfo) { lastGcdSpell = spellInfo; }
+    bool IsOnGlobalCooldown() const;
+
+    bool BuffBelowRefreshTarget(int32 remaining, int32 maxDuration, uint32 baseBeforeDuration) const;
+
+private:
+    Player* bot;
+    bool pending = false;
+    bool replyToReadyCheck = false;
+    bool buffPendingThisCycle = false;
+    bool buffProposedThisCycle = false;
+    SpellInfo const* lastGcdSpell = nullptr;
+    uint32 beginMs = 0;
+};
+
+class ForceRebuffStrategy : public Strategy
+{
+public:
+    ForceRebuffStrategy(PlayerbotAI* botAI) : Strategy(botAI) {}
+
+    std::string const getName() override { return "force rebuff"; }
+    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
+    void InitMultipliers(std::vector<Multiplier*>& multipliers) override;
+};
+
+#endif

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -128,6 +128,7 @@ PlayerbotAI::PlayerbotAI()
 
 PlayerbotAI::PlayerbotAI(Player* bot)
     : PlayerbotAIBase(true),
+      forceRebuff(bot),
       bot(bot),
       master(nullptr),
       chatHelper(this),
@@ -3814,6 +3815,8 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
         out << "Casting " << ChatHelper::FormatSpell(spellInfo);
         TellMasterNoFacing(out);
     }
+
+    forceRebuff.NoteCast(spellInfo);
 
     return true;
 }

--- a/src/Bot/PlayerbotAI.h
+++ b/src/Bot/PlayerbotAI.h
@@ -11,6 +11,7 @@
 #include "ChatHelper.h"
 #include "CreatureData.h"
 #include "Event.h"
+#include "ForceRebuff.h"
 #include "Item.h"
 #include "NewRpgInfo.h"
 #include "NewRpgStrategy.h"
@@ -604,6 +605,7 @@ public:
     NewRpgStatistic rpgStatistic;
     std::unordered_set<uint32> lowPriorityQuest;
     time_t bgReleaseAttemptTime = 0;
+    ForceRebuffState forceRebuff;
 
     // Schedules a callback to run once after <delayMs> milliseconds.
     void AddTimedEvent(std::function<void()> callback, uint32 delayMs);

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -161,6 +161,8 @@ bool PlayerbotAIConfig::Initialize()
     tellWhenMissingBuffReagents = sConfigMgr->GetOption<bool>("AiPlayerbot.TellWhenMissingBuffReagents", true);
     missingBuffReagentMessageCooldown = sConfigMgr->GetOption<uint32>(
         "AiPlayerbot.MissingBuffReagentMessageCooldown", 300);
+    forceRebuffOnReadyCheck = sConfigMgr->GetOption<bool>("AiPlayerbot.ForceRebuffOnReadyCheck", false);
+    forceRebuffMarginSecs = std::min(sConfigMgr->GetOption<uint32>("AiPlayerbot.ForceRebuffMarginSecs", 60), 3600u);
     autoAvoidAoe = sConfigMgr->GetOption<bool>("AiPlayerbot.AutoAvoidAoe", true);
     maxAoeAvoidRadius = sConfigMgr->GetOption<float>("AiPlayerbot.MaxAoeAvoidRadius", 15.0f);
     LoadSet<std::set<uint32>>(sConfigMgr->GetOption<std::string>("AiPlayerbot.AoeAvoidSpellWhitelist", "50759,57491,13810,29946"),

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -121,6 +121,8 @@ public:
     AutoPartyBuffMode autoPartyBuffs;
     bool tellWhenMissingBuffReagents;
     uint32 missingBuffReagentMessageCooldown;
+    bool forceRebuffOnReadyCheck;
+    uint32 forceRebuffMarginSecs;
     bool autoAvoidAoe;
     float maxAoeAvoidRadius;
     std::set<uint32> aoeAvoidSpellWhitelist;


### PR DESCRIPTION
## Pull Request Description

Allows refreshing buffs semi-manually: bots don't refresh buffs in combat, so buffs can drop mid-combat on boss fights.
When a ready check arrives out of combat, bots whisper their readiness to the master and start topping off missing or short buffs. The confirm goes out only once nothing is left to do. A bot that still has buff work it can perform stays not-ready until the check ends; that includes a bot out of reagents, whose casts are attempted and fail. Whoever shows not-ready has a reason. The `rebuff` chat command starts the same buff pass without a ready check.

The automatic ready-check behavior is gated behind `AiPlayerbot.ForceRebuffOnReadyCheck` (**off by default**); the manual `rebuff` command works regardless of the config.

How it works:
- `ForceRebuffState` (new `src/Bot/ForceRebuff.h/.cpp`) tracks one rebuff window per bot. While a window is open, buff triggers re-evaluate every tick and the ready reply waits on three gates: a buff action the engine executed this cycle (stamped at the top of the buff `Execute`s; a failed cast is retried, which is how missing reagents keep a bot not-ready), the global cooldown of the last cast (the GCD hides the next round of work from the triggers), and any cast still in progress. Work the bot can never perform does not block, because a wrong-spec talent buff or another caster's stronger aura would otherwise hold the reply forever.
- Buffs are topped off toward full duration by a shared refresh predicate with an adaptive margin, so a raid-sized pass converges instead of re-staling its own first targets. The same predicate now serves every aura-staleness check in the generic buff code.
- An always-on `ForceRebuffStrategy` hosts the reply trigger and a multiplier that suppresses heals while buff work is proposed or the last cast's GCD runs. Bots buff first, heal second, report ready last.
- A two-minute ceiling closes a window that can never finish (a manual rebuff has no ready-check expiry to end it).

**Known limitation:** paladin blessings (including greater blessings) do not participate in the pass. The blessing triggers and actions are not rebuff-aware: blessings are not topped off and do not defer the ready reply, so a paladin can report ready with blessings unrefreshed. Blessing support is planned as a follow-up PR on top of #2530.

## Feature Evaluation

- **Minimum logic:** one small state object per bot (5 fields plus the bot pointer). When no window is open, which is the normal case, the added per-tick cost is a handful of boolean short-circuits: in `Trigger::needCheck` for buff triggers, in the heal multiplier, inside the shared refresh predicate, and at the top of each buff `Execute`, plus one flag reset per engine cycle and one pointer store per successful cast. All constant-time. Opening a window requires an explicit ready check (config-gated) or an explicit chat command.
- **Processing cost across many bots:** idle cost is effectively zero for all bots at all times. During a window, buff triggers evaluate per tick instead of on their throttle interval. That is bounded by the window's lifetime (a ready check's ~30 s, hard-capped at 2 min) and applies only to bots in the group being ready-checked. Bots outside a ready-checked group never open windows.

## How to Test the Changes

Setup: `AiPlayerbot.ForceRebuffOnReadyCheck = 1`, a party or raid with bots (priest/mage/druid buffers make it easy to observe), out of combat.

1. Let buffs age (or dispel a few), then issue a ready check. Expected: each bot whispers its readiness stats immediately, re-casts its missing/short buffs, and its ready confirm arrives only after its casts stop.
2. Repeat with a 25-player raid: the pass completes and every bot reports ready, with no re-cast loop on the first targets.
3. Take a priest bot's candles and ready check: it falls back to single-target Fortitude where possible; if buff work remains that it cannot finish, it stays not-ready until the check expires.
4. Set `ForceRebuffOnReadyCheck = 0` and say `rebuff`: same buff pass, no ready-check reply. During an open ready check, `rebuff` must not eat the pending ready confirm.
5. Ready check while in combat: unchanged legacy behavior (immediate reply).
6. Bots restored from strategy sets saved before this feature answer instantly (legacy behavior); opt one in with a strategy reset or `nc +force rebuff` and verify it then runs the pass.
7. Paladin blessings are expected NOT to refresh during the pass (see known limitation above).

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] Minimal impact (**explain below**)

    Idle: one boolean short-circuit per buff-trigger `needCheck` and per multiplier evaluation. Full evaluation happens only inside an explicitly opened, time-bounded window, for the checked group only.

- Does this change modify default bot behavior?
    - - [x] Yes (**explain why**)

    With the config off, two things change: (1) the `rebuff` chat command exists (explicit master command, same trust gate as other commands); (2) the consolidated refresh predicate makes `GroupBuffSpellAction` re-cast a group buff whose group-wide aura is about to expire instead of treating it as covered, a small correctness improvement to existing behavior.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] Yes (**explain below**)

    One new state class + strategy + trigger + two actions, deliberately kept in one file pair (`src/Bot/ForceRebuff.h/.cpp`) plus standard context registrations. The ready-reply decision is four conditions in one place (`ReadyReplyAction::isUseful`).

## AI Assistance

Was AI assistance used while working on this change?
- - [x] Yes (**explain below**)

Used for design exploration and code generation across the change (Claude Code). All code was reviewed line by line and tested in-game by the contributor. The design decisions are the contributor's, from what counts as blocking work to the heal suppression and the timeout ceiling.

## Code Provenance / Attribution

- - [x] No, all code in this PR is original

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated. *(no new dialogue lines; the readiness report reuses existing output)*
- - [x] Any code ported/adapted from another project is attributed. *(nothing ported)*
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Conf comments, WiKi commands). *(conf.dist documents both settings and the `rebuff` command)*
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers

- The not-ready signal counts only executed buff work plus the last cast's GCD and in-flight casts. Reagent starvation still blocks, since those casts are attempted and fail. The 2-minute ceiling covers the manual command's window.
- Bots keep saved strategy sets (the playerbots DB store restores them on login), so existing bots do not pick up the new always-on "force rebuff" strategy automatically. It felt wrong to migrate those, so AltBots will need a reset.
- I am not sure how to edit the wiki to add the new command — pointers welcome.