### PR TITLE
MC Improvements

### DIFF
--- a/src/Ai/Raid/MC/MCActionContext.h
+++ b/src/Ai/Raid/MC/MCActionContext.h
@@ -33,6 +33,9 @@ public:
         creators["mc majordomo shadow resistance"] = &RaidMcActionContext::majordomo_shadow_resistance;
         creators["mc ragnaros fire resistance"] = &RaidMcActionContext::ragnaros_fire_resistance;
         creators["mc core hound mark"] = &RaidMcActionContext::core_hound_mark;
+        creators["mc move from lava"] = &RaidMcActionContext::move_from_lava;
+        creators["mc golemagg back off"] = &RaidMcActionContext::golemagg_back_off;
+        creators["mc golemagg healer position"] = &RaidMcActionContext::golemagg_healer_position;
     }
 
 private:
@@ -52,6 +55,9 @@ private:
     static Action* majordomo_shadow_resistance(PlayerbotAI* botAI) { return new BossShadowResistanceAction(botAI, "majordomo executus"); }
     static Action* ragnaros_fire_resistance(PlayerbotAI* botAI) { return new BossFireResistanceAction(botAI, "ragnaros"); }
     static Action* core_hound_mark(PlayerbotAI* botAI) { return new McCoreHoundMarkAction(botAI); }
+    static Action* move_from_lava(PlayerbotAI* botAI) { return new McMoveFromLavaAction(botAI); }
+    static Action* golemagg_back_off(PlayerbotAI* botAI) { return new McGolemaggBackOffAction(botAI); }
+    static Action* golemagg_healer_position(PlayerbotAI* botAI) { return new McGolemaggHealerPositionAction(botAI); }
 };
 
 #endif

--- a/src/Ai/Raid/MC/MCActions.cpp
+++ b/src/Ai/Raid/MC/MCActions.cpp
@@ -9,15 +9,18 @@
 #include "Playerbots.h"
 #include "RtiTargetValue.h"
 
+#include <algorithm>
+
 static constexpr float LIVING_BOMB_DISTANCE = 20.0f;
 static constexpr float INFERNO_DISTANCE = 20.0f;
-
-// don't get hit by Arcane Explosion but still be in casting range
-static constexpr float ARCANE_EXPLOSION_DISTANCE = 26.0f;
 
 // dedicated tank positions; prevents assist tanks from positioning Core Ragers on steep walls on pull
 static const Position GOLEMAGG_TANK_POSITION{795.7308, -994.8848, -207.18661};
 static const Position CORE_RAGER_TANK_POSITION{846.6453, -1019.0639, -198.9819};
+
+// Midpoint of the two tank camps (56y apart): healers standing here reach both
+static const Position GOLEMAGG_HEALER_POSITION{821.2f, -1007.0f, -203.0f};
+static constexpr float HEALER_POSITION_TOLERANCE = 8.0f;
 
 static constexpr float GOLEMAGGS_TRUST_DISTANCE = 30.0f;
 static constexpr float CORE_RAGER_STEP_DISTANCE = 5.0f;
@@ -55,6 +58,75 @@ bool McShazzrahMoveAwayAction::Execute(Event /*event*/)
             return MoveAway(boss, distToTravel);
     }
     return false;
+}
+
+bool McMoveFromLavaAction::Execute(Event /*event*/)
+{
+    // Escape to the nearest raid member on dry ground: raids fight on the
+    // rock shelves, so a dry teammate marks the closest safe floor.
+    Unit* dryTarget = nullptr;
+    float bestDist = 100.0f;
+
+    if (Group* group = bot->GetGroup())
+    {
+        for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+        {
+            Player* member = ref->GetSource();
+            if (!member || member == bot || !member->IsAlive() || member->GetMapId() != bot->GetMapId())
+                continue;
+
+            if (member->GetLiquidData().Flags & MAP_LIQUID_TYPE_MAGMA)
+                continue;
+
+            float dist = bot->GetDistance(member);
+            if (dist < bestDist)
+            {
+                bestDist = dist;
+                dryTarget = member;
+            }
+        }
+    }
+
+    // No dry raid member in range: stay put and let the in-lava trigger fire
+    // again — any other destination (the current target included) can path
+    // straight back into the pool.
+    if (!dryTarget)
+        return false;
+
+    botAI->InterruptSpell();
+
+    if (!MoveTo(dryTarget->GetMapId(), dryTarget->GetPositionX(), dryTarget->GetPositionY(),
+                dryTarget->GetPositionZ(), false, false, false, true, MovementPriority::MOVEMENT_FORCED))
+        return false;
+
+    // Hold the AI so rotation/facing actions can't cancel the escape spline
+    // mid-lava. Capped at 2s on purpose: the in-lava trigger refires and
+    // re-issues the escape while the bot is still swimming.
+    constexpr uint32 MAX_ESCAPE_HOLD_MS = 2000;
+    constexpr float MIN_ESCAPE_SPEED = 0.1f;
+
+    float const speed = bot->GetSpeed(MOVE_RUN);
+    if (speed > MIN_ESCAPE_SPEED)
+        botAI->SetNextCheckDelay(std::min(MAX_ESCAPE_HOLD_MS, uint32(1000.0f * bot->GetDistance(dryTarget) / speed)));
+
+    return true;
+}
+
+bool McGolemaggBackOffAction::Execute(Event /*event*/)
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", "golemagg the incinerator");
+    if (!boss)
+        return false;
+
+    // Out of swing range the stack stops growing and expires 30s after
+    // the last application; the multiplier blocks re-engaging until then.
+    botAI->InterruptSpell();
+
+    float distToTravel = MAGMA_SPLASH_BACK_OFF_DISTANCE - bot->GetDistance2d(boss);
+    if (distToTravel <= 0.0f)
+        return true;
+
+    return MoveAway(boss, distToTravel);
 }
 
 bool McGolemaggMarkBossAction::Execute(Event /*event*/)
@@ -134,6 +206,16 @@ bool McGolemaggMainTankAttackGolemaggAction::Execute(Event /*event*/)
             return MoveUnitToPosition(boss, GOLEMAGG_TANK_POSITION, boss->GetCombatReach());
     }
     return false;
+}
+
+bool McGolemaggHealerPositionAction::Execute(Event /*event*/)
+{
+    if (bot->GetExactDist2d(GOLEMAGG_HEALER_POSITION) <= HEALER_POSITION_TOLERANCE)
+        return false;
+
+    return MoveTo(bot->GetMapId(), GOLEMAGG_HEALER_POSITION.GetPositionX(), GOLEMAGG_HEALER_POSITION.GetPositionY(),
+                  GOLEMAGG_HEALER_POSITION.GetPositionZ(), false, false, false, false,
+                  MovementPriority::MOVEMENT_COMBAT, true, false);
 }
 
 bool McGolemaggAssistTankAttackCoreRagerAction::Execute(Event event)

--- a/src/Ai/Raid/MC/MCActions.h
+++ b/src/Ai/Raid/MC/MCActions.h
@@ -36,6 +36,22 @@ public:
     bool Execute(Event event) override;
 };
 
+class McMoveFromLavaAction : public MovementAction
+{
+public:
+    McMoveFromLavaAction(PlayerbotAI* botAI, std::string const name = "mc move from lava")
+        : MovementAction(botAI, name) {}
+    bool Execute(Event event) override;
+};
+
+class McGolemaggBackOffAction : public MovementAction
+{
+public:
+    McGolemaggBackOffAction(PlayerbotAI* botAI, std::string const name = "mc golemagg back off")
+        : MovementAction(botAI, name) {}
+    bool Execute(Event event) override;
+};
+
 class McGolemaggMarkBossAction : public Action
 {
 public:
@@ -67,6 +83,14 @@ class McGolemaggAssistTankAttackCoreRagerAction : public McGolemaggTankAction
 public:
     McGolemaggAssistTankAttackCoreRagerAction(PlayerbotAI* botAI, std::string const name = "mc golemagg assist tank attack core rager")
         : McGolemaggTankAction(botAI, name) {};
+    bool Execute(Event event) override;
+};
+
+class McGolemaggHealerPositionAction : public MovementAction
+{
+public:
+    McGolemaggHealerPositionAction(PlayerbotAI* botAI, std::string const name = "mc golemagg healer position")
+        : MovementAction(botAI, name) {}
     bool Execute(Event event) override;
 };
 

--- a/src/Ai/Raid/MC/MCHelpers.h
+++ b/src/Ai/Raid/MC/MCHelpers.h
@@ -14,6 +14,9 @@ enum MoltenCoreNPCs
     // Golemagg
     NPC_CORE_RAGER = 11672,
 
+    // Majordomo Executus
+    NPC_MAJORDOMO_EXECUTUS = 12018,
+
     // Core Hound (trash)
     NPC_CORE_HOUND = 11671,
 };
@@ -25,7 +28,14 @@ enum MoltenCoreSpells
 
     // Golemagg
     SPELL_GOLEMAGGS_TRUST = 20553,
+    SPELL_MAGMA_SPLASH = 13880,
 };
+
+constexpr uint32 MAGMA_SPLASH_BACK_OFF_STACKS = 20;
+constexpr float MAGMA_SPLASH_BACK_OFF_DISTANCE = 12.0f;
+
+// Shazzrah's Arcane Explosion radius
+constexpr float ARCANE_EXPLOSION_DISTANCE = 26.0f;
 }
 
 #endif

--- a/src/Ai/Raid/MC/MCMultipliers.cpp
+++ b/src/Ai/Raid/MC/MCMultipliers.cpp
@@ -5,16 +5,21 @@
  */
 
 #include "MCMultipliers.h"
+#include "AttackAction.h"
 #include "ChooseTargetActions.h"
 #include "DKActions.h"
 #include "DruidActions.h"
+#include "GenericActions.h"
 #include "GenericSpellActions.h"
 #include "HunterActions.h"
 #include "MCActions.h"
 #include "MCHelpers.h"
+#include "MovementActions.h"
 #include "PaladinActions.h"
 #include "Playerbots.h"
+#include "ReachTargetActions.h"
 #include "ShamanActions.h"
+#include "SpellAuras.h"
 #include "WarriorActions.h"
 
 using namespace MoltenCoreHelpers;
@@ -100,8 +105,11 @@ static bool IsSingleLivingTankInGroup(Player* bot)
 
 float GolemaggMultiplier::GetValue(Action* action)
 {
-    if (AI_VALUE2(Unit*, "find target", "golemagg the incinerator"))
+    if (Unit* golemagg = AI_VALUE2(Unit*, "find target", "golemagg the incinerator"))
     {
+        // Below 10% (soft enrage: Earthquake + converging Core Ragers) the
+        // fight is a burn race, everyone dps, no splash management.
+        bool burnPhase = golemagg->GetHealthPct() <= 10.0f;
         if (PlayerbotAI::IsTank(bot) && IsSingleLivingTankInGroup(bot))
         {
             // Only one tank => Pick up Golemagg and the two Core Ragers
@@ -116,6 +124,21 @@ float GolemaggMultiplier::GetValue(Action* action)
                 return 0.0f;
         }
         if (IsDpsBotWithAoeAction(bot, action))
+            return 0.0f;
+
+        // Golemagg's Magma Splash stacks an uncapped 30s dot on anyone striking
+        // him in melee. This blocks the default "melee when out of mana / in dead zone" fallback
+        // that walks casters and hunters onto the boss.
+        if (!burnPhase && PlayerbotAI::IsRanged(bot) && dynamic_cast<MeleeAction*>(action))
+            return 0.0f;
+
+        // Backed-off melee stay out until their whole Magma Splash stack expires (30s after the last application).
+        Aura* splash = bot->GetAura(SPELL_MAGMA_SPLASH);
+        bool backedOff = splash && splash->GetStackAmount() >= MAGMA_SPLASH_BACK_OFF_STACKS;
+        bool engagesBoss = !dynamic_cast<McGolemaggBackOffAction*>(action) &&
+                           (dynamic_cast<AttackAction*>(action) || dynamic_cast<MeleeAction*>(action) ||
+                            dynamic_cast<CastReachTargetSpellAction*>(action));
+        if (!burnPhase && !PlayerbotAI::IsTank(bot) && backedOff && engagesBoss)
             return 0.0f;
     }
     return 1.0f;

--- a/src/Ai/Raid/MC/MCStrategy.cpp
+++ b/src/Ai/Raid/MC/MCStrategy.cpp
@@ -5,8 +5,12 @@
  */
 
 #include "MCStrategy.h"
+#include "MCHelpers.h"
 #include "MCMultipliers.h"
+#include "Playerbots.h"
 #include "Strategy.h"
+
+using namespace MoltenCoreHelpers;
 
 void RaidMcStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
@@ -66,6 +70,12 @@ void RaidMcStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(
         new TriggerNode("mc golemagg is assist tank",
                         { NextAction("mc golemagg assist tank attack core rager", ACTION_RAID) }));
+    triggers.push_back(
+        new TriggerNode("mc golemagg magma splash",
+                        { NextAction("mc golemagg back off", ACTION_RAID + 1) }));
+    triggers.push_back(
+        new TriggerNode("mc golemagg is healer",
+                        { NextAction("mc golemagg healer position", ACTION_RAID) }));
 
     // Majordomo Executus
     triggers.push_back(
@@ -81,6 +91,11 @@ void RaidMcStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(
         new TriggerNode("mc core hound mark",
                         { NextAction("mc core hound mark", ACTION_RAID) }));
+
+    // Anywhere in MC: escaping a lava pool outranks everything else.
+    triggers.push_back(
+        new TriggerNode("mc in lava",
+                        { NextAction("mc move from lava", ACTION_RAID + 1) }));
 }
 
 void RaidMcStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
@@ -88,4 +103,26 @@ void RaidMcStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
     multipliers.push_back(new GarrDisableDpsAoeMultiplier(botAI));
     multipliers.push_back(new BaronGeddonAbilityMultiplier(botAI));
     multipliers.push_back(new GolemaggMultiplier(botAI));
+}
+
+void RaidMcStrategy::AppendTargetExclusions(GuidSet& exclusions, TargetValueExclusionType type)
+{
+    if (type != TargetValueExclusionType::Dps && type != TargetValueExclusionType::Attacker)
+        return;
+
+    // Damage into these is wasted: Core Ragers are unkillable while Golemagg
+    // lives (full heal at 50%), and Majordomo reflects and cannot die; his
+    // encounter ends when the eight adds are dead. Tanks still pick them up
+    // through their own target selection.
+    AiObjectContext* context = botAI->GetAiObjectContext();
+    bool const golemaggAlive = AI_VALUE2(Unit*, "find target", "golemagg the incinerator") != nullptr;
+    for (ObjectGuid const guid : AI_VALUE(GuidVector, "attackers"))
+    {
+        Unit* unit = botAI->GetUnit(guid);
+        if (!unit)
+            continue;
+
+        if ((golemaggAlive && unit->GetEntry() == NPC_CORE_RAGER) || unit->GetEntry() == NPC_MAJORDOMO_EXECUTUS)
+            exclusions.insert(guid);
+    }
 }

--- a/src/Ai/Raid/MC/MCStrategy.h
+++ b/src/Ai/Raid/MC/MCStrategy.h
@@ -16,6 +16,8 @@ public:
     std::string const getName() override { return "moltencore"; }
     void InitTriggers(std::vector<TriggerNode*>& triggers) override;
     void InitMultipliers(std::vector<Multiplier*> &multipliers) override;
+    void AppendTargetExclusions(GuidSet& exclusions, TargetValueExclusionType type) override;
+    bool HasTargetExclusions() const override { return true; }
 };
 
 #endif

--- a/src/Ai/Raid/MC/MCTriggerContext.h
+++ b/src/Ai/Raid/MC/MCTriggerContext.h
@@ -32,6 +32,9 @@ public:
         creators["mc majordomo shadow resistance"] = &RaidMcTriggerContext::majordomo_shadow_resistance;
         creators["mc ragnaros fire resistance"] = &RaidMcTriggerContext::ragnaros_fire_resistance;
         creators["mc core hound mark"] = &RaidMcTriggerContext::core_hound_mark;
+        creators["mc in lava"] = &RaidMcTriggerContext::in_lava;
+        creators["mc golemagg magma splash"] = &RaidMcTriggerContext::golemagg_magma_splash;
+        creators["mc golemagg is healer"] = &RaidMcTriggerContext::golemagg_is_healer;
     }
 
 private:
@@ -51,6 +54,9 @@ private:
     static Trigger* majordomo_shadow_resistance(PlayerbotAI* botAI) { return new BossShadowResistanceTrigger(botAI, "majordomo executus"); }
     static Trigger* ragnaros_fire_resistance(PlayerbotAI* botAI) { return new BossFireResistanceTrigger(botAI, "ragnaros"); }
     static Trigger* core_hound_mark(PlayerbotAI* botAI) { return new McCoreHoundMarkTrigger(botAI); }
+    static Trigger* in_lava(PlayerbotAI* botAI) { return new McInLavaTrigger(botAI); }
+    static Trigger* golemagg_magma_splash(PlayerbotAI* botAI) { return new McGolemaggMagmaSplashTrigger(botAI); }
+    static Trigger* golemagg_is_healer(PlayerbotAI* botAI) { return new McGolemaggIsHealerTrigger(botAI); }
 };
 
 #endif

--- a/src/Ai/Raid/MC/MCTriggers.cpp
+++ b/src/Ai/Raid/MC/MCTriggers.cpp
@@ -7,6 +7,7 @@
 #include "MCTriggers.h"
 #include "MCHelpers.h"
 #include "SharedDefines.h"
+#include "SpellAuras.h"
 
 using namespace MoltenCoreHelpers;
 
@@ -25,23 +26,65 @@ bool McBaronGeddonInfernoTrigger::IsActive()
 
 bool McShazzrahRangedTrigger::IsActive()
 {
-    return AI_VALUE2(Unit*, "find target", "shazzrah") && PlayerbotAI::IsRanged(bot);
+    // Only fire inside Arcane Explosion range. The move-away action no-ops
+    // beyond it, so an unconditional trigger makes every already-safe ranged
+    // bot attempt a failing move each tick.
+    if (!PlayerbotAI::IsRanged(bot))
+        return false;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "shazzrah");
+    return boss && bot->GetDistance2d(boss) < ARCANE_EXPLOSION_DISTANCE;
+}
+
+bool McInLavaTrigger::IsActive()
+{
+    LiquidData const& liquid = bot->GetLiquidData();
+    return (liquid.Flags & MAP_LIQUID_TYPE_MAGMA) &&
+           (liquid.Status & (LIQUID_MAP_WATER_WALK | LIQUID_MAP_IN_WATER | LIQUID_MAP_UNDER_WATER));
+}
+
+bool McGolemaggMagmaSplashTrigger::IsActive()
+{
+    if (PlayerbotAI::IsTank(bot))
+        return false;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "golemagg the incinerator");
+    if (!boss)
+        return false;
+
+    // Below 10% the fight is a burn race (Earthquake pulses, Core Ragers
+    // converge): stack management stops mattering, melee return to dps.
+    if (boss->GetHealthPct() <= 10.0f)
+        return false;
+
+    Aura* splash = bot->GetAura(SPELL_MAGMA_SPLASH);
+    if (!splash || splash->GetStackAmount() < MAGMA_SPLASH_BACK_OFF_STACKS)
+        return false;
+
+    // Only fire while still inside swing range; once the bot has backed off,
+    // the multiplier keeps it from re-engaging until the stack expires.
+    return bot->GetDistance2d(boss) < MAGMA_SPLASH_BACK_OFF_DISTANCE;
 }
 
 bool McGolemaggMarkBossTrigger::IsActive()
 {
     // any tank may mark the boss
-    return AI_VALUE2(Unit*, "find target", "golemagg the incinerator") && PlayerbotAI::IsTank(bot);
+    return PlayerbotAI::IsTank(bot) && AI_VALUE2(Unit*, "find target", "golemagg the incinerator");
 }
 
 bool McGolemaggIsMainTankTrigger::IsActive()
 {
-    return AI_VALUE2(Unit*, "find target", "golemagg the incinerator") && PlayerbotAI::IsMainTank(bot);
+    return PlayerbotAI::IsMainTank(bot) && AI_VALUE2(Unit*, "find target", "golemagg the incinerator");
 }
 
 bool McGolemaggIsAssistTankTrigger::IsActive()
 {
-    return AI_VALUE2(Unit*, "find target", "golemagg the incinerator") && PlayerbotAI::IsAssistTank(bot);
+    return PlayerbotAI::IsAssistTank(bot) && AI_VALUE2(Unit*, "find target", "golemagg the incinerator");
+}
+
+bool McGolemaggIsHealerTrigger::IsActive()
+{
+    return PlayerbotAI::IsHeal(bot) && AI_VALUE2(Unit*, "find target", "golemagg the incinerator");
 }
 
 bool McCoreHoundMarkTrigger::IsActive()

--- a/src/Ai/Raid/MC/MCTriggers.h
+++ b/src/Ai/Raid/MC/MCTriggers.h
@@ -53,10 +53,32 @@ public:
     bool IsActive() override;
 };
 
+class McGolemaggIsHealerTrigger : public Trigger
+{
+public:
+    McGolemaggIsHealerTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mc golemagg is healer") {}
+    bool IsActive() override;
+};
+
 class McCoreHoundMarkTrigger : public Trigger
 {
 public:
     McCoreHoundMarkTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mc core hound mark") {}
+    bool IsActive() override;
+};
+
+// Standing/swimming in magma (knocked into a lava pool by Ragnaros' Wrath or an Eruption)
+class McInLavaTrigger : public Trigger
+{
+public:
+    McInLavaTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mc in lava") {}
+    bool IsActive() override;
+};
+
+class McGolemaggMagmaSplashTrigger : public Trigger
+{
+public:
+    McGolemaggMagmaSplashTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mc golemagg magma splash") {}
     bool IsActive() override;
 };
 


### PR DESCRIPTION
## Pull Request Description

Molten Core strategy improvements, measured with a bot-only raid (27 bots, one per talent tree, no real player) at individual-progression vanilla tuning (0.5 power / 0.5 healing). Every change was benchmarked with 10 runs per configuration.

**Golemagg**
- Core Ragers are excluded from dps target selection while Golemagg lives (target-exclusion framework from #2494): they auto-heal to full at 50% and cannot die before he does, so any dps sent there is wasted.
- Healers hold the midpoint between the boss camp and the Core Rager tank camp. Heal target selection drops anyone beyond 40y or out of LOS; with healers parked at one camp, the other camp's tank died unhealed.
- The default "melee when out of mana / in dead zone" fallback is blocked for non-melee on this fight (Magma Splash makes walking into melee stupid for casters), and melee now back off once their Magma Splash stack reaches 20, returning after it expires (threshold swept below).

**Majordomo Executus**
- Excluded from dps target selection entirely: he alternates Magic/Damage Reflection and cannot die; the encounter ends when his eight adds are dead, so attacks on him are reflected damage for nothing.

**Lava escape (MC-wide, mainly Ragnaros)**
- A bot standing or swimming in magma (knocked into a lava pool by Wrath of Ragnaros or an Eruption) runs to the nearest raid member on dry ground; without this, bots swim in place and burn to death.

**Shazzrah**
- The ranged-spread trigger gates on Arcane Explosion range instead of firing unconditionally (every already-safe ranged bot attempted a failing move each tick).

### Back-Off Threshold Sweep

Without a back-off (current behavior) melee die to Golemagg's stacking dot. The sweep looked for the highest threshold that still prevents the deaths; each row is 10 runs.

| Back-off | Kill avg (blues) | Deaths avg (blues) | Kill avg (BiS 76) | Deaths avg (BiS 76) |
|---|---|---|---|---|
| none (current) | 108s | 3.4 | 112s | 5.2 |
| at 5 stacks | 139s | 0.3 | 146s | 0.7 |
| at 10 stacks | 126s | 0.2 | 133s | 0.5 |
| **at 20 stacks (chosen)** | **118s** | **0.3** | **121s** | **0.7** |

### Full Clear Results

Pre-raid blues, 10 runs per boss.

| Encounter | Pass | Kill avg | Deaths avg |
|---|---|---|---|
| Lucifron | 10/10 | 53s | 1.0 |
| Magmadar | 10/10 | 94s | 0.0 |
| Gehennas | 10/10 | 59s | 0.1 |
| Garr | 10/10 | 83s | 1.2 |
| Baron Geddon | 10/10 | 72s | 0.1 |
| Shazzrah | 10/10 | 49s | 0.2 |
| Sulfuron Harbinger | 10/10 | 64s | 0.0 |
| Golemagg | 10/10 | 121s | 0.3 |
| Majordomo Executus | 10/10 | 75s | 4.5 |
| Ragnaros | 10/10 | 106s | 0.2 |

Before the Golemagg changes the same comp went 0/10 on him at this tuning; with them he is a stable 10/10. The Majordomo deaths are the add burst at pre-raid gear.

## Feature Evaluation

- **Minimum logic:** two entries in the MC strategy's target-exclusion set (a guid lookup during dps target selection, only while the MC raid strategy is active); one healer position action gated by a distance check; one aura-stack read in the Golemagg multiplier; a liquid-flag check for the lava trigger; a range gate on the Shazzrah trigger. No new polling loops, no per-tick scans.
- **Processing cost:** all logic lives behind the MC raid strategy, so bots outside Molten Core pay nothing. Inside MC the additions are constant-time checks (aura stack amount, 2D distance, liquid flags) evaluated on the normal trigger cadence. The Shazzrah change is a net reduction: it removes thousands of failing move attempts per fight.

## How to Test the Changes

1. Enable instance strategies (`AiPlayerbot.ApplyInstanceStrategies = 1`) and raid Molten Core with a bot raid (tested with 27 bots at individual-progression 0.5 tuning, pre-raid gear).
2. Golemagg: melee leave the boss around 20 Magma Splash stacks and return after the stack expires; healers stand between the two tank camps; no bot attacks a Core Rager while Golemagg lives; below 10% everyone burns the boss.
3. Majordomo: bots kill the eight adds and never target Majordomo himself.
4. Ragnaros: a bot knocked into a lava pool runs to the nearest dry raid member instead of swimming in place until it dies.
5. Shazzrah: ranged bots reposition only when actually inside Arcane Explosion range.

The tables above come from an automated raid harness (10 runs per configuration on a dedicated test server); the harness itself is a separate branch/PR.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] Minimal impact (**explain below**)

Constant-time checks on the MC strategy's trigger cadence; bots outside Molten Core are untouched.

- Does this change modify default bot behavior?
    - - [x] Yes (**explain why**)

Only inside Molten Core with the MC raid strategy active (the changes described above); behavior elsewhere is unchanged.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] Yes (**explain below**)

Encounter-specific triggers/actions following the established MC strategy pattern, each gated to its boss.

## AI Assistance

Was AI assistance used while working on this change?
- - [x] Yes (**explain below**)

Used for the benchmark automation and for drafting. I reviewed and tested all strategy code myself; the tables above are those test runs.

## Code Provenance / Attribution

Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots, MaNGOS, another module)?
- - [x] No, all code in this PR is original

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated. (no new dialogue)
- - [x] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note). (nothing ported)
- - [x] New source files use the GPLv2 header. (no new files)
- - [x] Documentation updated if needed (Conf comments, WiKi commands). (no config changes)
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers

- All numbers were produced at individual-progression 0.5 vanilla tuning, which is harsher than stock; stock-tuning results should only be better.
