### PR TITLE
feat(gb): add "recipe all" keyword to move every recipe in bulk

### DIFF
--- a/src/Ai/Base/Actions/InventoryAction.cpp
+++ b/src/Ai/Base/Actions/InventoryAction.cpp
@@ -304,6 +304,15 @@ std::vector<Item*> InventoryAction::parseItems(std::string const text, IterateIt
         found.insert(visitor.GetResult().begin(), visitor.GetResult().end());
     }
 
+    // "recipe" keeps the usable-only filter (used by the bot's own recipe-learning);
+    // "recipe all" matches every recipe in the bags, for moving/trading them in bulk.
+    if (text == "recipe all")
+    {
+        FindAnyRecipeVisitor visitor;
+        IterateItems(&visitor, ITERATE_ITEMS_IN_BAGS);
+        found.insert(visitor.GetResult().begin(), visitor.GetResult().end());
+    }
+
     if (text == "quest")
     {
         FindQuestItemVisitor visitor(bot);

--- a/src/Mgr/Item/ItemVisitors.h
+++ b/src/Mgr/Item/ItemVisitors.h
@@ -427,6 +427,18 @@ private:
     SkillType skill;
 };
 
+// Matches any recipe in the bags regardless of whether the bot can learn it.
+// FindRecipeVisitor filters through CanUseItem (FindUsableItemVisitor), so it only
+// returns recipes for the bot's own professions/skill level. This variant matches
+// every recipe, which is what "recipe" trades/deposits are expected to move.
+class FindAnyRecipeVisitor : public FindItemVisitor
+{
+public:
+    FindAnyRecipeVisitor() : FindItemVisitor() {}
+
+    bool Accept(ItemTemplate const* proto) override { return proto->Class == ITEM_CLASS_RECIPE; }
+};
+
 class FindItemUsageVisitor : public FindUsableItemVisitor
 {
 public:


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
Adds a `recipe all` keyword that moves every recipe in a bot's bags, for trading /
guild-bank / bank deposits.

The existing `recipe` keyword filters through `FindRecipeVisitor` (which gates items via
`CanUseItem`). That is intentional and must stay: `UseRandomRecipe` uses the `recipe`
qualifier so a bot only auto-learns recipes it can actually use. But the same filter makes
it impossible to bulk-move recipes of other professions off a companion/alt bot.

`recipe all` is backed by a new `FindAnyRecipeVisitor` that matches every recipe regardless
of usability. `recipe` and bot auto-learning are left completely unchanged.



## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Minimum logic: a new `FindAnyRecipeVisitor` (matches `ITEM_CLASS_RECIPE`, no usability
  gate) and a new `recipe all` branch in `parseItems`. The existing `recipe` path is untouched.
- Processing cost: runs only on an explicit command (whisper / trade / gb), iterating the
  bot's own bags once. No per-tick or per-bot background cost.



## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
1. Have a bot hold recipes for a profession it cannot learn.
2. Open a trade / guild bank: `recipe` moves only its own-profession recipes (unchanged);
   `recipe all` moves every recipe in the bags.
3. Verify bot auto-learning (`UseRandomRecipe`) still only picks usable recipes.



## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)

Claude (Anthropic) assisted with tracing that the `recipe` filter is load-bearing for
UseRandomRecipe, and with adding a separate keyword instead of changing `recipe`. Reviewed,
understood, and tested on a live server before submitting.
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->



## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [ ] Any new bot dialogue lines are translated.
- - [ ] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note).
- - [ ] New source files use the GPLv2 header.
- - [ ] Documentation updated if needed (Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


