### PR TITLE
feat(gb): trade-goods categories (herb/ore/materials/...) and skip gray junk

### DIFF
--- a/src/Ai/Base/Actions/InventoryAction.cpp
+++ b/src/Ai/Base/Actions/InventoryAction.cpp
@@ -15,7 +15,7 @@ namespace
 {
 bool isReservedQualifier(std::string const& text)
 {
-    static std::array<std::string_view, 13> const exactQualifiers = {
+    static std::array<std::string_view, 14> const exactQualifiers = {
         "ammo",
         "conjured drink",
         "conjured food",
@@ -23,6 +23,7 @@ bool isReservedQualifier(std::string const& text)
         "drink",
         "food",
         "healing potion",
+        "materials",
         "mount",
         "mana potion",
         "pet",
@@ -308,6 +309,13 @@ std::vector<Item*> InventoryAction::parseItems(std::string const text, IterateIt
     {
         FindQuestItemVisitor visitor(bot);
         IterateItems(&visitor, ITERATE_ITEMS_IN_BAGS);
+        found.insert(visitor.GetResult().begin(), visitor.GetResult().end());
+    }
+
+    if (text == "materials")
+    {
+        FindTradeMaterialsVisitor visitor(count);
+        IterateItems(&visitor, mask);
         found.insert(visitor.GetResult().begin(), visitor.GetResult().end());
     }
 

--- a/src/Bot/Cmd/ChatHelper.cpp
+++ b/src/Bot/Cmd/ChatHelper.cpp
@@ -65,19 +65,18 @@ ChatHelper::ChatHelper(PlayerbotAI* botAI) : PlayerbotAIAware(botAI)
     projectileSubClasses["arrows"] = ITEM_SUBCLASS_ARROW;
     projectileSubClasses["bullets"] = ITEM_SUBCLASS_BULLET;
 
-    // tradeSubClasses["cloth"] = ITEM_SUBCLASS_CLOTH;
-    // tradeSubClasses["leather"] = ITEM_SUBCLASS_LEATHER;
-    // tradeSubClasses["metal"] = ITEM_SUBCLASS_METAL_STONE;
-    // tradeSubClasses["stone"] = ITEM_SUBCLASS_METAL_STONE;
-    // tradeSubClasses["ore"] = ITEM_SUBCLASS_METAL_STONE;
-    // tradeSubClasses["meat"] = ITEM_SUBCLASS_MEAT;
-    // tradeSubClasses["herb"] = ITEM_SUBCLASS_HERB;
-    // tradeSubClasses["elemental"] = ITEM_SUBCLASS_ELEMENTAL;
-    // tradeSubClasses["disenchants"] = ITEM_SUBCLASS_ENCHANTING;
-    // tradeSubClasses["enchanting"] = ITEM_SUBCLASS_ENCHANTING;
-    // tradeSubClasses["gems"] = ITEM_SUBCLASS_JEWELCRAFTING;
-    // tradeSubClasses["jewels"] = ITEM_SUBCLASS_JEWELCRAFTING;
-    // tradeSubClasses["jewelcrafting"] = ITEM_SUBCLASS_JEWELCRAFTING;
+    tradeSubClasses["cloth"] = ITEM_SUBCLASS_CLOTH;
+    tradeSubClasses["leather"] = ITEM_SUBCLASS_LEATHER;
+    tradeSubClasses["metal"] = ITEM_SUBCLASS_METAL_STONE;
+    tradeSubClasses["stone"] = ITEM_SUBCLASS_METAL_STONE;
+    tradeSubClasses["ore"] = ITEM_SUBCLASS_METAL_STONE;
+    tradeSubClasses["meat"] = ITEM_SUBCLASS_MEAT;
+    tradeSubClasses["herb"] = ITEM_SUBCLASS_HERB;
+    tradeSubClasses["elemental"] = ITEM_SUBCLASS_ELEMENTAL;
+    tradeSubClasses["disenchants"] = ITEM_SUBCLASS_ENCHANTING;
+    tradeSubClasses["enchanting"] = ITEM_SUBCLASS_ENCHANTING;
+    // Note: gems/jewels are ITEM_CLASS_GEM, not a trade-goods subclass, so they are not
+    // mapped here (a JEWELCRAFTING trade-goods match would miss actual gems).
 
     slots["head"] = EQUIPMENT_SLOT_HEAD;
     slots["neck"] = EQUIPMENT_SLOT_NECK;

--- a/src/Mgr/Item/ItemVisitors.h
+++ b/src/Mgr/Item/ItemVisitors.h
@@ -141,6 +141,11 @@ public:
         if (item->IsSoulBound())
             return true;
 
+        // Some gray junk (e.g. "NPC Equip", deprecated items) is flagged as trade goods in
+        // Blizzard data; a category match should not pick it up. Use "gray" for those instead.
+        if (item->GetTemplate()->Quality == ITEM_QUALITY_POOR)
+            return true;
+
         if (item->GetTemplate()->Class != itemClass || item->GetTemplate()->SubClass != itemSubClass)
             return true;
 
@@ -156,6 +161,52 @@ public:
 private:
     uint32 itemClass;
     uint32 itemSubClass;
+    uint32 count;
+    std::vector<Item*> result;
+};
+
+// "materials" aggregates the gatherable/craftable trade-goods subclasses that have dedicated
+// keywords (cloth, leather, metal/stone, meat, herb, elemental, enchanting). It deliberately
+// excludes parts/explosives/devices/jewelcrafting and enchant vellums, and skips gray junk,
+// so it maps to what a player means by "crafting materials".
+class FindTradeMaterialsVisitor : public IterateItemsVisitor
+{
+public:
+    FindTradeMaterialsVisitor(uint32 count) : IterateItemsVisitor(), count(count) {}
+
+    bool Visit(Item* item) override
+    {
+        if (item->IsSoulBound())
+            return true;
+
+        ItemTemplate const* proto = item->GetTemplate();
+        if (proto->Class != ITEM_CLASS_TRADE_GOODS || proto->Quality == ITEM_QUALITY_POOR)
+            return true;
+
+        switch (proto->SubClass)
+        {
+            case ITEM_SUBCLASS_CLOTH:
+            case ITEM_SUBCLASS_LEATHER:
+            case ITEM_SUBCLASS_METAL_STONE:
+            case ITEM_SUBCLASS_MEAT:
+            case ITEM_SUBCLASS_HERB:
+            case ITEM_SUBCLASS_ELEMENTAL:
+            case ITEM_SUBCLASS_ENCHANTING:
+                break;
+            default:
+                return true;
+        }
+
+        if (result.size() >= (size_t)count)
+            return false;
+
+        result.push_back(item);
+        return true;
+    }
+
+    std::vector<Item*>& GetResult() { return result; }
+
+private:
     uint32 count;
     std::vector<Item*> result;
 };


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
Adds item-category keywords for a bot's trade goods, used by `gb`, `bank`, and trades:

1. Enable the trade-goods category keywords already present but commented out in ChatHelper:
   `cloth`, `leather`, `metal`/`stone`/`ore`, `meat`, `herb`, `elemental`,
   `enchanting`/`disenchants`. Lets a player sort a bot's crafting mats by type
   (e.g. `gb herb`, `gb ore`) instead of link-by-link.

2. Add a `materials` keyword (new `FindTradeMaterialsVisitor`) that aggregates exactly
   those gatherable/craftable trade-goods subclasses. It deliberately excludes
   parts/explosives/devices/jewelcrafting and enchant vellums, so it matches what a
   player means by "crafting materials" rather than the entire item class.

3. Fix category matching picking up gray junk: Blizzard flags some poor-quality items
   ("NPC Equip", deprecated ores) as trade goods, so a category match wrongly included
   them. Category matching now skips `ITEM_QUALITY_POOR` (use `gray` for those).

Note: `gems`/`jewels` are intentionally not mapped — actual gems are `ITEM_CLASS_GEM`,
not a trade-goods subclass, so a JEWELCRAFTING trade-goods match would miss them.



## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Minimum logic: uncomment the existing `tradeSubClasses` entries; add a `ITEM_QUALITY_POOR`
  early-out to the existing class-match visitor; add `FindTradeMaterialsVisitor` (a fixed
  subclass whitelist) and register the `materials` keyword.
- Processing cost: runs only on an explicit command (whisper / trade / gb), iterating the
  bot's own bags once. No per-tick or per-bot background cost.



## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
1. Give a bot mixed crafting mats (herbs, ore, cloth) plus a gray "trade goods" junk item.
2. Open a trade / guild bank: `gb herb` / `gb ore` move that type; `gb materials` moves all
   crafting mats at once.
3. The gray junk is not picked up by category or `materials` (use `gb gray` for it).



## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)

Claude (Anthropic) assisted with mapping the trade-goods subclasses, spotting that gems are
a separate item class, the gray trade-goods data quirk, and drafting the whitelist visitor.
Reviewed, understood, and tested on a live server before submitting.
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->



## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [ ] Any new bot dialogue lines are translated.
- - [ ] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note).
- - [ ] New source files use the GPLv2 header.
- - [ ] Documentation updated if needed (Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


