### PR TITLE
fix: read COUNT(*) as uint64 to silence Field type warning

### DIFF
--- a/src/Bot/Factory/RandomPlayerbotFactory.cpp
+++ b/src/Bot/Factory/RandomPlayerbotFactory.cpp
@@ -353,7 +353,7 @@ uint32 RandomPlayerbotFactory::CalculateTotalAccountCount()
         {
             Field* fields = typeCheck->Fetch();
             uint8 accountType = fields[0].Get<uint8>();
-            uint32 count = fields[1].Get<uint32>();
+            uint32 count = static_cast<uint32>(fields[1].Get<uint64>());
 
             if (accountType == 0) existingUnassignedAccounts = count;
             else if (accountType == 1) existingRndBotAccounts = count;


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

`COUNT(*)` returns a LONGLONG (64-bit) column, but the account type check in `RandomPlayerbotFactory::CalculateTotalAccountCount()` read it with `Get<uint32>()`, causing the core to log a warning on every server startup:

```
Warning: Field::GetData<unsigned int> on LONGLONG field .COUNT(*) (.) at index 1.
> Please use GetData<uint64>()
```

This reads the field as `uint64` as the core asks (matching the identical query pattern already used two lines above, at line 337, in the same file), then narrows to `uint32` for storage in the existing `uint32` counters (`existingUnassignedAccounts`, `existingRndBotAccounts`, `existingAddClassAccounts`) that the rest of the function already uses. No behavioral change — the count of bot accounts of a given type always fits comfortably in 32 bits.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

This is a one-line type-correctness fix, not new logic. It changes how a single already-executing query result is read (`Get<uint64>()` + `static_cast<uint32>` instead of `Get<uint32>()`); the query itself, its frequency, and the surrounding control flow are all unchanged. It runs once at server startup during bot account provisioning (`CalculateTotalAccountCount()`), not per-bot or per-tick, so there is no per-bot/per-tick cost at all.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

1. Start a worldserver with mod-playerbots enabled and `AiPlayerbot.RandomBotAccounts` (or the relevant random-bot-account-creation config) turned on, on a `playerbots_account_type` table that already has rows (i.e. not a fresh empty install).
2. Observe the startup log during "Creating random bot accounts...".
3. **Before the fix:** the log shows `Warning: Field::GetData<unsigned int> on LONGLONG field .COUNT(*) (.) at index 1.` / `> Please use GetData<uint64>()`, once per distinct `account_type` value present in the table.
4. **After the fix:** the warning no longer appears, and account counts (`existingUnassignedAccounts`, `existingRndBotAccounts`, `existingAddClassAccounts`) are unchanged — bot account creation proceeds identically.

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [X] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

- Does this change modify default bot behavior?
    - - [X] No
    - - [ ] Yes (**explain why**)

- Does this change add new decision branches or increase maintenance complexity?
    - - [X] No
    - - [ ] Yes (**explain below**)

## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [X] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

Claude (Anthropic) was used to diagnose the root cause of a startup log warning observed while running a local worldserver, trace it to this specific `Get<uint32>()` call, and propose/apply the one-line fix. The change was reviewed and is fully understood: it is a narrow type-correctness fix consistent with the existing `Get<uint64>()` usage on the neighboring query in the same file.

## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [X] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->

## Final Checklist

- - [X] Stability is not compromised.
- - [X] Performance impact is understood, tested, and acceptable.
- - [X] Added logic complexity is justified and explained.
- - [X] Any new bot dialogue lines are translated. (N/A — no new dialogue)
- - [X] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note). (N/A — no ported code)
- - [X] New source files use the GPLv2 header. (N/A — no new files)
- - [X] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->

Branched from and targeting `test-staging` per the contribution guide.
