### PR TITLE
fix(loot): let bots loot quest objects again

### DIFF
--- a/src/Ai/Base/Actions/LootAction.cpp
+++ b/src/Ai/Base/Actions/LootAction.cpp
@@ -140,8 +140,9 @@ bool OpenLootAction::DoLoot(LootObject& lootObject)
     if (go && (go->GetGoState() != GO_STATE_READY))
         return false;
 
-    // This prevents dungeon chests like Tribunal Chest (Halls of Stone) from being ninja'd by the bots
-    if (go && go->HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_INTERACT_COND))
+    // This prevents dungeon chests like Tribunal Chest (Halls of Stone) from being ninja'd by the bots.
+    // Quest objects carry the same flag but are gated on quest state, which ActivateToQuest answers.
+    if (go && go->HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_INTERACT_COND) && !go->ActivateToQuest(bot))
         return false;
 
     // This prevents raid chests like Gunship Armory (ICC) from being ninja'd by the bots

--- a/src/Mgr/Item/LootObjectStack.cpp
+++ b/src/Mgr/Item/LootObjectStack.cpp
@@ -308,7 +308,12 @@ bool LootObject::IsLootPossible(Player* bot)
     // Prevent bot from running to chests that are unlootable (e.g. Gunship Armory before completing the event) or on
     // respawn time
     GameObject* go = botAI->GetGameObject(guid);
-    if (go && (go->HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_INTERACT_COND | GO_FLAG_NOT_SELECTABLE) || !go->isSpawned()))
+    if (go && (go->HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE) || !go->isSpawned()))
+        return false;
+
+    // Conditional objects (quest chests, goobers, ...) are gated client-side on quest state.
+    // A bot has no client, so make the same call the server makes for one.
+    if (go && go->HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_INTERACT_COND) && !go->ActivateToQuest(bot))
         return false;
 
     if (skillId == SKILL_NONE)


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

Bots cannot loot **any** quest chest, and haven't been able to since #1280.

Example: a bot on *Filthy Paws* (quest 307) walks to a Miners' League Crate and stands on it:

```
chest 271: added false canLoot false empty false possible false
           skill 0 reqItem 0 dz 0.0 dist 0.0 goflags 4 heldFor 44757ms
→ wrote off quest target ... Entry: 271
```

Spawned, `GO_STATE_READY`, no skill and no key required, distance 0. The loot pipeline
refuses it every tick.

**Cause.** `GO_FLAG_INTERACT_COND` (goflags 4 above) means *interaction is conditional*. The
server never checks the flag because the **client** evaluates the condition, and for these objects the
condition is quest state. That is why the flag sits on quest objects generally:

| type | objects carrying the flag | condition |
|------|--------------------------|-----------|
| chest | 788 (764 with quest items) | quest loot / `chest.questId` |
| questgiver | 429 | quest dialog status |
| goober | 257 | `goober.questId` |
| spell focus / generic / … | ~50 | `questID` |

Two guards read the flag as "never touch": `LootObject::IsLootPossible()`, so `"can loot"`
never goes true, and `OpenLootAction::DoLoot()`, so the object is never opened. A bot has no
client and therefore never gets the exemption a player gets.

**Where the guards came from.** 97f582b9 (#1280) added both for excluding three chests, but only one of
them carries the flag:

| chest | addon flags | actually guarded by |
|-------|-------------|--------------------|
| Gunship Armory (×8) | 16 `NOT_SELECTABLE` | the next guard, already present |
| Deathbringer's Cache (×4) | 16 / 50 | the next guard, already present |
| Tribunal Chest (×2) | **4 `INTERACT_COND`** | this guard |

So the check was doing exactly one job (keeping bots out of the Tribunal Chest), and every
quest object in the game was collateral.

**Fix.** A bot has to make the call its client would, so ask the function the server uses to
make it: `GameObject::ActivateToQuest()` is what `BuildValuesUpdate` calls to set
`GO_DYNFLAG_LO_ACTIVATE` / `GO_DYNFLAG_LO_SPARKLE`, i.e. whether a player's client lights the
object up. It covers every type in the table above and goes false again once the objective is
satisfied.

`GO_FLAG_NOT_SELECTABLE` and the `isSpawned()` checks are untouched, so #1162 (Gunship Armory)
is unaffected: that chest is gated by `NOT_SELECTABLE`, which the ICC script removes when the
gunship event ends.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

**Minimum logic:** one condition on each of the two guards that already test the flag:
`&& !go->ActivateToQuest(bot)`. No new helper, no new state, no new lookup path.

**Processing cost:** only objects carrying `GO_FLAG_INTERACT_COND` reach the call; everything
else short-circuits on the flag test exactly as before. For those, `ActivateToQuest()` is the
quest-log scan the server already performs per player per gameobject update in
`BuildValuesUpdate`. It adds one such call per loot evaluation of a conditional object in
loot range, which for a typical bot is none, occasionally one.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

**A quest chest can be looted again.** Quest 307 has no kill objective, so it isolates the
chest path:

1. Put a level 15+ bot in Loch Modan at ~(-4936, -2967, 318), with the `loot` strategy.
2. Give it quest 307 *Filthy Paws*: 4x Chewed Bone from Miners' League Crates (GO 271; 10
   crates, unpooled, in a small cluster).
3. Before: the bot walks onto a crate and never opens it, 0/4 indefinitely. After: it opens
   them and completes the objective in a few minutes.

**The Tribunal Chest is still refused** (#1200 regression check):

1. Put a bot in Halls of Stone at the chest, ~(880, 345, 204).
2. Test twice: with no quest, and while holding *Ancient Relics* (12870, repeatable, wants the
   Relic of Ulduar that is in that chest's loot table).
3. Expected both times: `ActivateToQuest` false, `can loot` false, the chest never opens, no
   matter how long the bot stands there, and regardless of the Tribunal of Ages event state.

Measured with a bot parked at the object for 10 minutes, sampled every 30s:

| build | quest | activate | can loot | times looted | relics |
|-------|-------|----------|----------|--------------|--------|
| this PR | none | false | false | **0** | 0 |
| this PR | Ancient Relics | false | false | **0** | 0 |
| **guard removed entirely** (control) | none | n/a | n/a | **4** | **3** |

The control row is the point: remove the `INTERACT_COND` check and #1200 is back within 30
seconds. The chest is consumable with a 180s respawn, so a bot farms it roughly every 150s
with no quest at all. The guard is load-bearing; this PR keeps it and fixes only its condition.

The Tribunal Chest never activates because its Relic of Ulduar is **ordinary** loot
(`QuestRequired=0`), so `HaveQuestLootForPlayer()` is false even for a bot on the relic quest,
the same reason a player's client never lights that chest up. Quest chest items are
`QuestRequired=1`, so those activate for a bot on the quest, and stop activating once it has
enough.

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

Gated behind the existing `GO_FLAG_INTERACT_COND` test, so it only runs for conditional objects
in loot range, so for the vast majority of loot evaluations nothing changes at all. When it does
run, it is a single `ActivateToQuest()` call, the same one the core already makes per player
per gameobject update.

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

Bots can loot quest chests again, which is the point of the PR; they could before #1280. They
now touch exactly the conditional objects a player's client would offer them, and stop once the
objective is satisfied.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)

The same two guards, with one condition added to each. The combined
`INTERACT_COND | NOT_SELECTABLE` test in `IsLootPossible()` is split so the two flags can be
answered separately, which is why that hunk looks bigger than it is.

## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

Used for the investigation and for drafting this description: reproducing the failure, tracing
it to the flag, checking how the core uses `GO_FLAG_INTERACT_COND` and `ActivateToQuest()`,
surveying which objects carry the flag, and running the before/after and control measurements
above. The change itself is two conditions and was reviewed and verified by me.

## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->

<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated. <!-- none added -->
- - [x] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note). <!-- nothing ported -->
- - [x] New source files use the GPLv2 header. <!-- no new files -->
- - [x] Documentation updated if needed (Conf comments, WiKi commands). <!-- no config or command changes -->
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->

- Not addressed here, but worth knowing while reviewing the control row: the Tribunal Chest is
  a plain DB spawn with a 180s respawn, no `chest.questId`, no `eventId`, no `conditions` rows
  and no instance-script handling, so nothing server-side gates it on the Tribunal of Ages
  event, and forcing the event to DONE changes nothing. Only the client-side condition keeps
  players out of it, which is why bots needed a guard in the first place. That looks like an
  AzerothCore data issue rather than a mod-playerbots one, and I have not touched it.
