### PR TITLE
Fix WithinAreaTrigger box check using trigger coords as box extents

### DIFF
--- a/src/Ai/Base/Trigger/WithinAreaTrigger.cpp
+++ b/src/Ai/Base/Trigger/WithinAreaTrigger.cpp
@@ -62,8 +62,8 @@ bool WithinAreaTrigger::IsPointInAreaTriggerZone(AreaTrigger const* atEntry, uin
         float dz = z - atEntry->z;
         float dx = rotPlayerX - atEntry->x;
         float dy = rotPlayerY - atEntry->y;
-        if ((fabs(dx) > atEntry->x / 2 + delta) || (fabs(dy) > atEntry->y / 2 + delta) ||
-            (fabs(dz) > atEntry->z / 2 + delta))
+        if ((fabs(dx) > atEntry->length / 2 + delta) || (fabs(dy) > atEntry->width / 2 + delta) ||
+            (fabs(dz) > atEntry->height / 2 + delta))
         {
             return false;
         }


### PR DESCRIPTION
## Pull Request Description

Bots following their master into a dungeon would run to the entrance, say "Wait for me" and never teleport in. The `AreaTriggerAction` replay never fired because `WithinAreaTrigger::IsPointInAreaTriggerZone` never reported the bot inside the trigger.

In the box branch (radius == 0), the check compares against the trigger's **position** instead of the box **extents**:

```cpp
if ((fabs(dx) > atEntry->x / 2 + delta) || ...
```

For any trigger with a negative coordinate this can never pass — e.g. the Ragefire Chasm entrance (trigger 2230, AreaTrigger.dbc: x=1818.4, y=-4427.26, z=-10.45, box 21.69×11.83×21.22): `y/2 + delta` is about -2213, and `fabs(dy) > -2213` is always true, so the trigger is dead anywhere on the map. Positive-coordinate triggers get arbitrary boxes instead of the DBC ones.

The fix reads `length/width/height / 2`, matching the core's `Player::IsInAreaTriggerRadius`, which does `IsWithinBox(center, length/2, width/2, height/2)`.

## Feature Evaluation

- **Minimum logic required**: none added. The comparison already existed; it reads the three box extents of the DBC entry instead of the three coordinates of its centre. Two lines, same branch, same number of comparisons.
- **Processing cost across many bots**: unchanged. No allocation, no lookup, no new call — the same `fabs` comparisons on different struct members of an entry that was already dereferenced. The only observable difference is that a trigger that could never match now can, which is the intended behaviour of the existing code path.

## How to Test the Changes

1. Any realm, one player and one bot invited to the group, no special configuration.
2. Take the bot to the Ragefire Chasm entrance in Orgrimmar (trigger 2230), master enters the instance.
3. Before the fix: the bot runs to the entrance, says "Wait for me" and stays outside indefinitely.
4. After the fix: the bot teleports in with its master.

Any instance entrance works; a trigger with a negative coordinate makes the difference obvious, since those never matched at all before.

The values above were also checked standalone against the real DBC entry, master versus fixed:

```
trigger center      master=0 fixed=1 expected=1
2m inside box       master=0 fixed=1 expected=1
30m away (outside)  master=0 fixed=0 expected=0
```

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all

    Same code path, same number of operations. Bots that used to loop at an entrance now stop retrying, so if anything the change removes work.

- Does this change modify default bot behavior?
    - - [x] Yes (**explain why**)

    Only by making an existing behaviour work: bots that were meant to follow their master through an area trigger, and could not, now do. No new behaviour, no new configuration.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No

## AI Assistance

Was AI assistance used while working on this change?
- - [x] Yes (**explain below**)

Used for the investigation and for drafting this description. The root cause was found by reading `WithinAreaTrigger.cpp` against `AreaTrigger.dbc` values and the core's `Player::IsInAreaTriggerRadius`, then confirmed with the standalone check above and on a live realm. The change itself is two operands in an existing condition; I have read, tested and own it.

## Code Provenance / Attribution

Was any code in this PR copied or adapted from a sister / upstream project?
- - [x] No, all code in this PR is original

The corrected expression follows the semantics of the core's `Player::IsInAreaTriggerRadius`, but no code was copied from it.

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated. *(none added)*
- - [x] Any code ported/adapted from another project is attributed. *(none)*
- - [x] New source files use the GPLv2 header. *(no new files)*
- - [x] Documentation updated if needed. *(no configuration or command change)*
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers

The PR targets `test-staging`. Tested on a four-shard cluster running mod-playerbots, where the symptom was first observed: bots stuck at instance entrances with their master already inside.
