### PR TITLE
Honor EnableGreet at all native greeting call sites

### DIFF
--- a/src/Ai/Base/Actions/AcceptInvitationAction.cpp
+++ b/src/Ai/Base/Actions/AcceptInvitationAction.cpp
@@ -57,7 +57,10 @@ bool AcceptInvitationAction::Execute(Event event)
     botAI->ChangeStrategy("+follow,-lfg,-bg", BOT_STATE_NON_COMBAT);
     botAI->Reset();
 
-    botAI->TellMaster(PlayerbotTextMgr::instance().GetBotTextOrDefault("hello", "Hello", {}));
+    if (sPlayerbotAIConfig.enableGreet)
+    {
+        botAI->TellMaster(PlayerbotTextMgr::instance().GetBotTextOrDefault("hello", "Hello", {}));
+    }
 
     if (sPlayerbotAIConfig.summonWhenGroup && bot->GetDistance(inviter) > sPlayerbotAIConfig.sightDistance)
     {

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -449,12 +449,15 @@ void PlayerbotAI::UpdateAIGroupMaster()
             {
                 botAI->ChangeStrategy("+follow", BOT_STATE_NON_COMBAT);
 
-                if (botAI->GetMaster() == botAI->GetGroupLeader())
-                    botAI->TellMaster(PlayerbotTextMgr::instance().GetBotTextOrDefault(
-                        "hello_follow", "Hello, I follow you!", {}));
-                else
-                    botAI->TellMaster(PlayerbotTextMgr::instance().GetBotTextOrDefault(
-                        "hello", "Hello!", {}));
+                if (sPlayerbotAIConfig.enableGreet)
+                {
+                    if (botAI->GetMaster() == botAI->GetGroupLeader())
+                        botAI->TellMaster(PlayerbotTextMgr::instance().GetBotTextOrDefault(
+                            "hello_follow", "Hello, I follow you!", {}));
+                    else
+                        botAI->TellMaster(PlayerbotTextMgr::instance().GetBotTextOrDefault(
+                            "hello", "Hello!", {}));
+                }
             }
             else
             {

--- a/src/Bot/PlayerbotMgr.cpp
+++ b/src/Bot/PlayerbotMgr.cpp
@@ -547,8 +547,11 @@ void PlayerbotHolder::OnBotLogin(Player* const bot)
     // set delay on login
     botAI->SetNextCheckDelay(urand(2000, 4000));
 
-    botAI->TellMaster(PlayerbotTextMgr::instance().GetBotTextOrDefault(
-        "hello", "Hello!", {}), PLAYERBOT_SECURITY_TALK);
+    if (sPlayerbotAIConfig.enableGreet)
+    {
+        botAI->TellMaster(PlayerbotTextMgr::instance().GetBotTextOrDefault(
+            "hello", "Hello!", {}), PLAYERBOT_SECURITY_TALK);
+    }
 
     // Queue group operations for world thread
     if (master && master->GetGroup() && !group)

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -2591,8 +2591,11 @@ void RandomPlayerbotMgr::OnPlayerLogin(Player* player)
                 {
                     botAI->SetMaster(player);
                     botAI->ResetStrategies();
-                    botAI->TellMaster(PlayerbotTextMgr::instance().GetBotTextOrDefault(
-                        "hello", "Hello", {}));
+                    if (sPlayerbotAIConfig.enableGreet)
+                    {
+                        botAI->TellMaster(PlayerbotTextMgr::instance().GetBotTextOrDefault(
+                            "hello", "Hello", {}));
+                    }
                 }
 
                 break;


### PR DESCRIPTION
## What changed

Guard the four native Playerbots greeting call sites with the existing `AiPlayerbot.EnableGreet` configuration value.

## Why

The option is already exposed to administrators, but these login, invitation, and group-master paths emitted a greeting even when it was disabled. That creates duplicate/private greetings for modules that provide their own party greeting and makes the setting inconsistent.

## Impact

Default behavior is unchanged because `AiPlayerbot.EnableGreet` defaults to enabled. Servers that set it to `0` now suppress all four native greeting paths consistently.

## Validation

- Built AzerothCore `worldserver` successfully on Windows x64, RelWithDebInfo, static modules.
- Changes are limited to the four greeting call sites.