### PR TITLE
fix(value): use NPC/GO count for creature objective in ActiveQuestObjectives

### DIFF
--- a/src/Ai/Base/Value/QuestValues.cpp
+++ b/src/Ai/Base/Value/QuestValues.cpp
@@ -278,7 +278,7 @@ std::vector<GuidPosition> ActiveQuestObjectivesValue::Calculate()
 
             if (quest->RequiredNpcOrGoCount[objective])
             {
-                uint32 reqCount = quest->RequiredItemCount[objective];
+                uint32 reqCount = quest->RequiredNpcOrGoCount[objective];
                 uint32 hasCount = statusData.CreatureOrGOCount[objective];
 
                 if (!reqCount || hasCount >= reqCount)


### PR DESCRIPTION
## Pull Request Description

`ActiveQuestObjectivesValue::Calculate()` read the required count for a
creature/GO objective from `RequiredItemCount` instead of `RequiredNpcOrGoCount`.
Kill/interact objectives were compared against the item array, so their
completion was mis-judged. One-line fix; the item branch above was already correct.

## Feature Evaluation
<!-- Minimal wrong-ID fix, no logic added. -->

## How to Test the Changes

Give a bot a quest with a creature/GO objective (e.g. any "kill N" quest).
Before: objective progress/completion evaluated against the wrong counts.
After: bot treats the objective as complete only when `CreatureOrGOCount` meets
`RequiredNpcOrGoCount`.

## Impact Assessment
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all

- Does this change modify default bot behavior?
    - - [x] Yes: corrects when creature/GO quest objectives count as complete (was reading the wrong field).

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No

## AI Assistance
- - [x] Yes

## Code Provenance / Attribution
- - [x] No, all code in this PR is original

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated. (N/A)
- - [x] Any code ported/adapted from another project is attributed. (N/A)
- - [x] New source files use the GPLv2 header. (N/A)
- - [x] Documentation updated if needed. (N/A)
- - [x] New and modified files do not introduce new compiler warnings.
