### PR TITLE
fix(travel): set spawnId on GameObject GuidPosition

### DIFF
--- a/src/Mgr/Travel/TravelMgr.cpp
+++ b/src/Mgr/Travel/TravelMgr.cpp
@@ -1068,7 +1068,7 @@ GuidPosition::GuidPosition(CreatureData const& creData)
 }
 
 GuidPosition::GuidPosition(GameObjectData const& goData)
-    : ObjectGuid(HighGuid::GameObject, goData.id),
+    : ObjectGuid(HighGuid::GameObject, goData.id, goData.spawnId),
       WorldPosition(goData.mapid, goData.posX, goData.posY, goData.posZ, goData.orientation)
 {
     loadedFromDB = true;


### PR DESCRIPTION
## Pull Request Description

`GuidPosition(GameObjectData const&)` built the guid from the entry id only,
omitting the spawnId counter. Every spawn of the same GO entry collapsed to a
single guid, so anything keyed on the guid (travel write-off sets, map lookups)
could not tell two spawns of the same object apart. The creature ctor already
passes its spawnId; this makes the GO ctor match.

## Feature Evaluation
<!-- Passes an already-available field to the base ctor; no logic added. -->

## How to Test the Changes

Place two spawns of the same GameObject entry (e.g. a quest chest) in one area.
Before: both resolve to one `GuidPosition`; a bot that writes one off (or looks it
up on the map) affects/confuses the other.
After: each spawn has a distinct guid and is tracked independently.

## Impact Assessment
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all

- Does this change modify default bot behavior?
    - - [x] Yes: GO GuidPositions are now per-spawn unique, so guid-keyed travel/lookup logic distinguishes spawns that previously aliased.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No

## AI Assistance
- - [x] Yes

## Code Provenance / Attribution
- - [x] No, all code in this PR is original

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated. (N/A)
- - [x] Any code ported/adapted from another project is attributed. (N/A)
- - [x] New source files use the GPLv2 header. (N/A)
- - [x] Documentation updated if needed. (N/A)
- - [x] New and modified files do not introduce new compiler warnings.
