### PR TITLE
fix(value): keep global PlayerbotAI alive for cached values

### DIFF
--- a/src/Ai/Base/SharedValueContext.h
+++ b/src/Ai/Base/SharedValueContext.h
@@ -26,14 +26,11 @@ public:
     template <class T>
     Value<T>* getGlobalValue(std::string const name)
     {
-        // should never reach here
         SharedNamedObjectContextList<UntypedValue> sValueContexts;
         sValueContexts.Add(this);
         NamedObjectContextList<UntypedValue> valueContexts(sValueContexts);
-        PlayerbotAI* botAI = new PlayerbotAI();
 
-        UntypedValue* value = valueContexts.GetContextObject(name, botAI);
-        delete botAI;
+        UntypedValue* value = valueContexts.GetContextObject(name, globalAI());
         return dynamic_cast<Value<T>*>(value);
     }
 
@@ -52,6 +49,13 @@ public:
     }
 
 private:
+    // Cached values hold this pointer after the call returns, so it must not be a local temporary.
+    static PlayerbotAI* globalAI()
+    {
+        static PlayerbotAI* ai = new PlayerbotAI();
+        return ai;
+    }
+
     SharedValueContext() : NamedObjectContext(true)
     {
         creators["bg masters"] = &SharedValueContext::bg_masters;


### PR DESCRIPTION
## Pull Request Description

`SharedValueContext::getGlobalValue()` created a temporary `PlayerbotAI`, passed it
to `GetContextObject`, then `delete`d it before returning. The returned `Value` (and
the context) keep a reference to that AI, so every global value ended up holding a
dangling `botAI` pointer -> used-after-free on the next access. Replace the
per-call temporary with a single process-lifetime instance (`globalAI()`).

## Feature Evaluation
<!-- Lifetime fix, no logic added. One shared instance instead of a per-call new/delete. -->

## How to Test the Changes

Access any global value routed through `getGlobalValue` (e.g. drop map / item drop
list lookups). Before: the value's stored `PlayerbotAI*` points at freed memory
(crash / UB under ASan). After: the pointer stays valid for the process lifetime.

## Impact Assessment
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all (removes a per-call `new`/`delete`)

- Does this change modify default bot behavior?
    - - [x] No

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No

## AI Assistance
- - [x] Yes, used to trace the dangling pointer to the premature delete; fix reviewed and understood.

## Code Provenance / Attribution
- - [x] No, all code in this PR is original

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated. (N/A)
- - [x] Any code ported/adapted from another project is attributed. (N/A)
- - [x] New source files use the GPLv2 header. (N/A)
- - [x] Documentation updated if needed. (N/A)
- - [x] New and modified files do not introduce new compiler warnings.
