### PR TITLE
Mages conjure water for themselves and their party

### DIFF
--- a/src/Ai/Class/Mage/MageActions.cpp
+++ b/src/Ai/Class/Mage/MageActions.cpp
@@ -12,6 +12,67 @@
 #include "ServerFacade.h"
 #include "SharedDefines.h"
 
+namespace
+{
+bool IsKnownConjuredWaterItem(Item const* item, std::vector<Item*> const& waterItems)
+{
+    if (!item)
+        return false;
+
+    for (Item* knownWater : waterItems)
+    {
+        if (knownWater == item)
+            return true;
+    }
+
+    return false;
+}
+
+bool PlaceConjuredWaterInTrade(PlayerbotAI* botAI, std::vector<Item*> const& waterItems)
+{
+    Player* bot = botAI->GetBot();
+    TradeData* tradeData = bot->GetTradeData();
+    if (!tradeData)
+        return false;
+
+    // Already trading conjured water.
+    for (uint8 i = 0; i < TRADE_SLOT_TRADED_COUNT; ++i)
+    {
+        Item* traded = tradeData->GetItem(TradeSlots(i));
+        if (IsKnownConjuredWaterItem(traded, waterItems))
+            return true;
+    }
+
+    int8 freeSlot = -1;
+    for (uint8 i = 0; i < TRADE_SLOT_TRADED_COUNT; ++i)
+    {
+        if (!tradeData->GetItem(TradeSlots(i)))
+        {
+            freeSlot = i;
+            break;
+        }
+    }
+
+    if (freeSlot < 0)
+        return false;
+
+    for (Item* item : waterItems)
+    {
+        if (!item || item->IsInTrade() || !item->CanBeTraded())
+            continue;
+
+        WorldPacket packet(CMSG_SET_TRADE_ITEM, 3);
+        packet << (uint8)freeSlot;
+        packet << (uint8)item->GetBagSlot();
+        packet << (uint8)item->GetSlot();
+        bot->GetSession()->HandleSetTradeItemOpcode(packet);
+        return true;
+    }
+
+    return false;
+}
+}
+
 std::vector<NextAction> CastMoltenArmorAction::getAlternatives()
 {
     if (!botAI->HasSpell("molten armor"))
@@ -156,4 +217,134 @@ bool CastBlinkBackAction::Execute(Event event)
 
     bot->SetOrientation(bot->GetAngle(target) + M_PI);
     return CastSpellAction::Execute(event);
+}
+
+Unit* MageGiveWaterAction::GetTarget()
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+        return nullptr;
+
+    if (Player* trader = bot->GetTrader())
+    {
+        if (trader->IsAlive() && trader->GetMap() == bot->GetMap())
+            return trader;
+    }
+
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member || member == bot || !member->IsAlive() || member->GetMap() != bot->GetMap())
+            continue;
+
+        uint8 cls = member->getClass();
+        if (cls != CLASS_DRUID && cls != CLASS_HUNTER && cls != CLASS_PALADIN && cls != CLASS_PRIEST &&
+            cls != CLASS_SHAMAN && cls != CLASS_WARLOCK)
+        {
+            continue;
+        }
+
+        if (member->GetTrader() && member->GetTrader() != bot)
+            continue;
+
+        PlayerbotAI* memberAi = GET_PLAYERBOT_AI(member);
+        if (!memberAi)
+            continue;
+
+        if (!memberAi->HasStrategy("food", memberAi->GetState()))
+            continue;
+
+        if (memberAi->GetAiObjectContext()->GetValue<uint32>("item count", "conjured water")->Get())
+            continue;
+
+        return member;
+    }
+
+    return nullptr;
+}
+
+bool MageGiveWaterAction::isUseful()
+{
+    Unit* target = GetTarget();
+    Player* receiver = target ? target->ToPlayer() : nullptr;
+    if (!receiver && bot->GetTrader())
+        receiver = bot->GetTrader()->ToPlayer();
+
+    if (!receiver)
+        return false;
+
+    if (bot->GetTrader() && bot->GetTrader() != receiver)
+        return false;
+
+    if (!botAI->HasSpell("conjure water"))
+        return false;
+
+    if (botAI->HasSpell("ritual of refreshment"))
+        return false;
+
+    return true;
+}
+
+bool MageGiveWaterAction::Execute(Event /*event*/)
+{
+    Unit* target = GetTarget();
+    Player* receiver = target ? target->ToPlayer() : nullptr;
+    if (!receiver && bot->GetTrader())
+        receiver = bot->GetTrader()->ToPlayer();
+
+    if (!receiver)
+        return false;
+
+    if (!receiver->IsAlive() || receiver->GetMap() != bot->GetMap())
+        return false;
+
+    if (bot->GetDistance(receiver) > sPlayerbotAIConfig.spellDistance * 2)
+        return false;
+
+    if (!bot->IsWithinLOS(receiver->GetPositionX(), receiver->GetPositionY(), receiver->GetPositionZ()))
+        return false;
+
+    PlayerbotAI* receiverAi = GET_PLAYERBOT_AI(receiver);
+    if (!receiverAi)
+        return false;
+
+    if (receiverAi->GetAiObjectContext()->GetValue<uint32>("item count", "conjured water")->Get())
+        return false;
+
+    // if someone needs water and mage has none, conjure first and do not open trade yet.
+    std::vector<Item*> waterItems =
+        botAI->GetAiObjectContext()->GetValue<std::vector<Item*>>("inventory items", "conjured water")->Get();
+    if (waterItems.empty())
+    {
+        botAI->DoSpecificAction("conjure water", Event(), true);
+        return true;
+    }
+
+    if (bot->GetTrader())
+    {
+
+        if (bot->GetTrader() != receiver)
+            return false;
+
+        if (!bot->GetTradeData() || !receiver->GetTradeData())
+            return false;
+
+        if (!PlaceConjuredWaterInTrade(botAI, waterItems))
+            return false;
+
+        WorldPacket p;
+        uint32 status = 0;
+        p << status;
+        bot->GetSession()->HandleAcceptTradeOpcode(p);
+
+        return true;
+    }
+
+    if (receiver->GetTrader() && receiver->GetTrader() != bot)
+        return false;
+
+    WorldPacket packet(CMSG_INITIATE_TRADE);
+    packet << receiver->GetGUID();
+    bot->GetSession()->HandleInitiateTradeOpcode(packet);
+    return true;
 }

--- a/src/Ai/Class/Mage/MageActions.h
+++ b/src/Ai/Class/Mage/MageActions.h
@@ -7,6 +7,7 @@
 #ifndef PLAYERBOTS_MAGEACTIONS_H
 #define PLAYERBOTS_MAGEACTIONS_H
 
+#include "GiveItemAction.h"
 #include "GenericSpellActions.h"
 #include "SharedDefines.h"
 #include "UseItemAction.h"
@@ -174,6 +175,16 @@ class CastConjureWaterAction : public CastBuffSpellAction
 {
 public:
     CastConjureWaterAction(PlayerbotAI* botAI) : CastBuffSpellAction(botAI, "conjure water") {}
+};
+
+class MageGiveWaterAction : public GiveWaterAction
+{
+public:
+    MageGiveWaterAction(PlayerbotAI* botAI) : GiveWaterAction(botAI) {}
+
+    Unit* GetTarget() override;
+    bool Execute(Event event) override;
+    bool isUseful() override;
 };
 
 class UseManaSapphireAction : public UseItemAction

--- a/src/Ai/Class/Mage/MageAiObjectContext.cpp
+++ b/src/Ai/Class/Mage/MageAiObjectContext.cpp
@@ -126,6 +126,8 @@ public:
         creators["no firestarter strategy"] = &MageTriggerFactoryInternal::no_firestarter_strategy;
         creators["enemy is close and no firestarter strategy"] = &MageTriggerFactoryInternal::enemy_is_close_and_no_firestarter_strategy;
         creators["enemy too close for spell and no firestarter strategy"] = &MageTriggerFactoryInternal::enemy_too_close_for_spell_and_no_firestarter_strategy;
+        creators["conjure water"] = &MageTriggerFactoryInternal::conjure_water;
+        creators["give water"] = &MageTriggerFactoryInternal::give_water;
     }
 
 private:
@@ -176,6 +178,8 @@ private:
     static Trigger* no_firestarter_strategy(PlayerbotAI* botAI) { return new NoFirestarterStrategyTrigger(botAI); }
     static Trigger* enemy_is_close_and_no_firestarter_strategy(PlayerbotAI* botAI) { return new EnemyIsCloseAndNoFirestarterStrategyTrigger(botAI); }
     static Trigger* enemy_too_close_for_spell_and_no_firestarter_strategy(PlayerbotAI* botAI) { return new EnemyTooCloseForSpellAndNoFirestarterStrategyTrigger(botAI); }
+    static Trigger* conjure_water(PlayerbotAI* botAI) { return new ConjureWaterTrigger(botAI); }
+    static Trigger* give_water(PlayerbotAI* botAI) { return new MageGiveWaterTrigger(botAI); }
 };
 
 class MageAiObjectContextInternal : public NamedObjectContext<Action>
@@ -234,6 +238,7 @@ public:
         creators["mirror image"] = &MageAiObjectContextInternal::mirror_image;
         creators["focus magic on party"] = &MageAiObjectContextInternal::focus_magic_on_party;
         creators["blink back"] = &MageAiObjectContextInternal::blink_back;
+        creators["give water"] = &MageAiObjectContextInternal::give_water;
         creators["use mana sapphire"] = &MageAiObjectContextInternal::use_mana_sapphire;
         creators["use mana emerald"] = &MageAiObjectContextInternal::use_mana_emerald;
         creators["use mana ruby"] = &MageAiObjectContextInternal::use_mana_ruby;
@@ -295,6 +300,7 @@ private:
     static Action* mirror_image(PlayerbotAI* botAI) { return new CastMirrorImageAction(botAI); }
     static Action* focus_magic_on_party(PlayerbotAI* botAI) { return new CastFocusMagicOnPartyAction(botAI); }
     static Action* blink_back(PlayerbotAI* botAI) { return new CastBlinkBackAction(botAI); }
+    static Action* give_water(PlayerbotAI* botAI) { return new MageGiveWaterAction(botAI); }
     static Action* use_mana_sapphire(PlayerbotAI* botAI) { return new UseManaSapphireAction(botAI); }
     static Action* use_mana_emerald(PlayerbotAI* botAI) { return new UseManaEmeraldAction(botAI); }
     static Action* use_mana_ruby(PlayerbotAI* botAI) { return new UseManaRubyAction(botAI); }

--- a/src/Ai/Class/Mage/MageTriggers.cpp
+++ b/src/Ai/Class/Mage/MageTriggers.cpp
@@ -13,6 +13,40 @@
 #include "SpellAuraEffects.h"
 #include "ServerFacade.h"
 
+bool ConjureWaterTrigger::IsActive()
+{
+    if (bot->IsInCombat())
+        return false;
+
+    if (!botAI->HasStrategy("food", botAI->GetState()))
+        return false;
+
+    if (!botAI->HasSpell("conjure water"))
+        return false;
+
+    return AI_VALUE2(std::vector<Item*>, "inventory items", "conjured water").empty();
+}
+
+bool MageGiveWaterTrigger::IsActive()
+{
+    if (bot->IsInCombat())
+        return false;
+
+    if (!bot->GetGroup())
+        return false;
+
+    if (!botAI->HasSpell("conjure water"))
+        return false;
+
+    if (botAI->HasSpell("ritual of refreshment"))
+        return false;
+
+    if (!AI_VALUE(Unit*, "party member without water"))
+        return false;
+
+    return true;
+}
+
 bool NoManaGemTrigger::IsActive()
 {
     static const std::vector<uint32> gemIds = {

--- a/src/Ai/Class/Mage/MageTriggers.h
+++ b/src/Ai/Class/Mage/MageTriggers.h
@@ -16,6 +16,20 @@
 
 // Buff and Out of Combat Triggers
 
+class ConjureWaterTrigger : public Trigger
+{
+public:
+    ConjureWaterTrigger(PlayerbotAI* botAI) : Trigger(botAI, "conjure water") {}
+    bool IsActive() override;
+};
+
+class MageGiveWaterTrigger : public GiveWaterTrigger
+{
+public:
+    MageGiveWaterTrigger(PlayerbotAI* botAI) : GiveWaterTrigger(botAI) {}
+    bool IsActive() override;
+};
+
 class ArcaneIntellectOnPartyTrigger : public BuffOnPartyTrigger
 {
 public:

--- a/src/Ai/Class/Mage/Strategy/GenericMageNonCombatStrategy.cpp
+++ b/src/Ai/Class/Mage/Strategy/GenericMageNonCombatStrategy.cpp
@@ -35,6 +35,8 @@ void GenericMageNonCombatStrategy::InitTriggers(std::vector<TriggerNode*>& trigg
 {
     NonCombatStrategy::InitTriggers(triggers);
 
+    triggers.push_back(new TriggerNode("conjure water", { NextAction("conjure water", 23.0f) }));
+    triggers.push_back(new TriggerNode("give water", { NextAction("give water", 22.0f) }));
     triggers.push_back(new TriggerNode("arcane intellect", { NextAction("arcane intellect", 21.0f) }));
     triggers.push_back(new TriggerNode("no focus magic", { NextAction("focus magic on party", 19.0f) }));
     triggers.push_back(new TriggerNode("often", { NextAction("apply oil", 1.0f) }));


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
Mages with the food strategy will now conjure water if they have none.
Mages who do not have refresh table yet will conjure water and trade it to any party member in their group that has mana, needs water, and has the food strategy 


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.
Adds two noncombat triggers for mages that check if mage is missing water or a party member is missing water.


## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
Conjure water for self test:
Give a mage bot the "food" strategy. If they have no water in inventory they should conjure one stack.

Conjure water for party test:
Make a group with a mage bot and another mana having bot. If the mana having bot has no water, the mage should conjure and trade a stack of water.


## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->
Copilot was used for initial code generation, then code was reviewed and improved manually.


## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note).
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


