### PR TITLE
feat(test): integration-test framework and generic scenarios

### DIFF
--- a/apps/integration-tests/README.md
+++ b/apps/integration-tests/README.md
@@ -1,0 +1,67 @@
+# mod-playerbots integration tests
+
+Compiled only with `-DPLAYERBOTS_INTEGRATION_TESTS=ON` (CMake). Stock worldserver is the
+test runner; environment variables override any config key (module confs would override a
+`-c` conf file, env vars beat everything).
+
+## One-time setup
+
+Create isolated test databases (auth/characters/playerbots; the world DB is shared with
+dev and never written):
+
+    CREATE DATABASE acore_test_auth;
+    CREATE DATABASE acore_test_characters;
+    CREATE DATABASE acore_test_playerbots;
+    GRANT ALL PRIVILEGES ON acore_test_auth.* TO 'acore'@'localhost';
+    GRANT ALL PRIVILEGES ON acore_test_characters.* TO 'acore'@'localhost';
+    GRANT ALL PRIVILEGES ON acore_test_playerbots.* TO 'acore'@'localhost';
+
+Fastest way to get a working bot pool: clone your dev databases into them once —
+
+    mysqldump --single-transaction acore_auth       | mysql acore_test_auth
+    mysqldump --single-transaction acore_characters | mysql acore_test_characters
+    mysqldump --single-transaction acore_playerbots | mysql acore_test_playerbots
+
+(Alternative: leave them empty — the DB updater creates the schema and the first boot
+creates the bot account pool, which takes several minutes once.)
+
+## Run
+
+The build drops `run_test.py` and `test_env.example` into an `integration-tests/`
+folder beside the built worldserver binary. There, once — copy `test_env.example` to
+`test_env` and edit in the test DB credentials:
+
+    cd bin/<config>/integration-tests
+    cp test_env.example test_env        # Windows: copy test_env.example test_env
+
+Then run one or more scenarios (space- or comma-separated):
+
+    python run_test.py "self_test bot_smoke ready_check"
+
+The wrapper loads `test_env`, points the server at the test databases, disables the
+console, runs the scenarios from the binary directory and exits with the server's code
+(`WORLDSERVER_EXIT_CODE=0` means all passed). Everything else (random bots off, full
+activity, react delay, autogear, RPG status) is enforced in code by
+`IntegrationTestMgr::OnWorldStartup`, so results never depend on local config.
+
+Results: `test_results.json` next to the binary, plus a console summary.
+Optional debug detail: set `AC_LOGGER_PLAYERBOTS=5,Playerbots` in `test_env` — level 5
+is DEBUG (3 is WARN and shows nothing from `LOG_DEBUG`), and the `Playerbots` appender
+writes `Playerbots.log` next to the binary.
+
+## Scheduling
+
+Scenarios in one run execute **in parallel**, each with its own raid. Repeating a name runs
+it multiple times concurrently (results are labeled `name#1`, `name#2`, ...); batch
+wall-clock is the slowest scenario. Mind the bot pool: concurrent raids draw disjoint
+characters from the AddClass pool.
+
+Instancing is per *map*, not per scenario, so **two copies of a continent scenario share the
+world** and contend for one set of spawns — a contention test, not a repeat. The runner
+refuses those: a duplicate name whose scenario reports `SharesWorldWithCopies()` (its map is
+not instanceable) fails the run, and a `name*N` bench of one runs serially. **To repeat a
+continent case, boot once per repetition.** Instanced scenarios are unaffected: each run
+gets a real instance, so they still run `BENCH_CONCURRENCY` at a time.
+
+Interactive use against a normal dev server: `.pbtest list`, `.pbtest run <name>`
+(in-game GM chat or the worldserver console). No shutdown, results logged + JSON written.

--- a/apps/integration-tests/run_test.py
+++ b/apps/integration-tests/run_test.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+# information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+# or (at your option) any later version.
+
+"""Integration-test run wrapper, sitting in an integration-tests/ folder beside
+the worldserver binary.
+
+    python run_test.py "self_test bot_smoke ready_check"   (or set SCENARIOS)
+
+Machine-specific settings (test DB credentials) live in a `test_env` file next to
+this script - copy `test_env.example` and adjust. Test-semantic bot config is
+enforced by IntegrationTestMgr::OnWorldStartup.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+BIN_DIR = HERE.parent
+WORLDSERVER = "worldserver.exe" if os.name == "nt" else "worldserver"
+
+
+def load_env(path):
+    """Parse a KEY=VALUE file (blank lines and #-comments ignored)."""
+    env = {}
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, _, value = line.partition("=")
+        env[key.strip()] = value.strip()
+    return env
+
+
+def worldserver_running():
+    if os.name == "nt":
+        out = subprocess.run(["tasklist", "/FI", f"IMAGENAME eq {WORLDSERVER}"],
+                             capture_output=True, text=True).stdout
+        return WORLDSERVER.lower() in out.lower()
+    return subprocess.run(["pgrep", "-x", WORLDSERVER], capture_output=True).returncode == 0
+
+
+def main():
+    env_file = HERE / "test_env"
+    if not env_file.exists():
+        sys.exit(f"ERROR: {env_file} not found - copy test_env.example and adjust it.")
+
+    env = os.environ.copy()
+    env.update(load_env(env_file))
+    if not env.get("AC_LOGIN_DATABASE_INFO"):
+        sys.exit("ERROR: test_env did not set AC_LOGIN_DATABASE_INFO.")
+
+    binary = BIN_DIR / WORLDSERVER
+    if not binary.exists():
+        sys.exit(f"ERROR: {WORLDSERVER} not found in {BIN_DIR}.")
+
+    # Two servers would share the test DBs and ports, contaminating both result sets.
+    if worldserver_running():
+        sys.exit("ERROR: a worldserver is already running - refusing to start a second one.")
+
+    # Scenarios from the command line (or SCENARIOS), space- or comma-separated,
+    # normalised to the CSV the config expects.
+    scenarios = " ".join(sys.argv[1:]) or env.get("SCENARIOS", "")
+    tokens = scenarios.replace(",", " ").split()
+    if not tokens:
+        sys.exit("No scenarios given (arg or SCENARIOS env).")
+    env["AC_AI_PLAYERBOT_INTEGRATION_TEST_RUN"] = ",".join(tokens)
+
+    # Disable the CLI console so an EOF on stdin can't shut the server down at boot.
+    env["AC_CONSOLE_ENABLE"] = "0"
+
+    # Run from the binary directory so the server finds its config and data.
+    result = subprocess.run([str(binary)], cwd=str(BIN_DIR), env=env, stdin=subprocess.DEVNULL)
+    print(f"WORLDSERVER_EXIT_CODE={result.returncode}")
+    sys.exit(result.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/integration-tests/test_env.example
+++ b/apps/integration-tests/test_env.example
@@ -1,0 +1,13 @@
+# Machine-specific integration-test environment. Copy to `test_env` (kept out of
+# git) and adjust for your setup. Consumed by run_test.py; these AC_* variables
+# override the worldserver config.
+
+# Dedicated test databases - NEVER point these at a live server's databases:
+# the harness creates/logs out characters and applies schema updates.
+AC_LOGIN_DATABASE_INFO=127.0.0.1;3306;acore;acore;acore_test_auth
+AC_CHARACTER_DATABASE_INFO=127.0.0.1;3306;acore;acore;acore_test_characters
+AC_PLAYERBOTS_DATABASE_INFO=127.0.0.1;3306;acore;acore;acore_test_playerbots
+
+# World database stays shared with dev (read-mostly); bit 4 (world schema updates)
+# is disabled so it is never written. 3 = login + characters.
+AC_UPDATES_ENABLE_DATABASES=3

--- a/mod-playerbots.cmake
+++ b/mod-playerbots.cmake
@@ -1,0 +1,24 @@
+# This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+# information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+# or (at your option) any later version.
+
+#
+# Optional integration-test build for mod-playerbots.
+# Included by modules/CMakeLists.txt after add_library(modules ...).
+#
+option(PLAYERBOTS_INTEGRATION_TESTS "Compile mod-playerbots integration test scenarios" OFF)
+
+if(PLAYERBOTS_INTEGRATION_TESTS)
+  target_compile_definitions(modules PRIVATE PLAYERBOTS_INTEGRATION_TESTS)
+  message(STATUS "mod-playerbots: integration tests ENABLED")
+
+  # Copy the whole integration-tests/ helper folder next to the worldserver binary
+  # (copy scheme from the config-merger tool in src/server/apps/CMakeLists.txt).
+  if(WIN32 AND "${CMAKE_MAKE_PROGRAM}" MATCHES "MSBuild")
+    foreach(cfg IN ITEMS Debug Release RelWithDebInfo MinSizeRel)
+      file(COPY "${CMAKE_CURRENT_LIST_DIR}/apps/integration-tests" DESTINATION "${CMAKE_BINARY_DIR}/bin/${cfg}")
+    endforeach()
+  else()
+    file(COPY "${CMAKE_CURRENT_LIST_DIR}/apps/integration-tests" DESTINATION "${CMAKE_BINARY_DIR}/bin")
+  endif()
+endif()

--- a/src/Script/Playerbots.cpp
+++ b/src/Script/Playerbots.cpp
@@ -518,6 +518,10 @@ void AddSC_IcecrownBotScripts();
 void AddSC_RubySanctumBotScripts();
 void AddSC_randombot_level_mgr();
 
+#ifdef PLAYERBOTS_INTEGRATION_TESTS
+void AddPlayerbotsIntegrationTestScripts();
+#endif
+
 void AddPlayerbotsScripts()
 {
     new PlayerbotsBattlefieldScript();
@@ -537,4 +541,7 @@ void AddPlayerbotsScripts()
     AddSC_IcecrownBotScripts();
     AddSC_RubySanctumBotScripts();
     AddSC_randombot_level_mgr();
+#ifdef PLAYERBOTS_INTEGRATION_TESTS
+    AddPlayerbotsIntegrationTestScripts();
+#endif
 }

--- a/src/Script/Playerbots.cpp
+++ b/src/Script/Playerbots.cpp
@@ -521,6 +521,10 @@ void AddSC_IcecrownBotScripts();
 void AddSC_RubySanctumBotScripts();
 void AddSC_randombot_level_mgr();
 
+#ifdef PLAYERBOTS_INTEGRATION_TESTS
+void AddPlayerbotsIntegrationTestScripts();
+#endif
+
 void AddPlayerbotsScripts()
 {
     new PlayerbotsBattlefieldScript();
@@ -541,4 +545,7 @@ void AddPlayerbotsScripts()
     AddSC_IcecrownBotScripts();
     AddSC_RubySanctumBotScripts();
     AddSC_randombot_level_mgr();
+#ifdef PLAYERBOTS_INTEGRATION_TESTS
+    AddPlayerbotsIntegrationTestScripts();
+#endif
 }

--- a/src/Test/CombatRecorder.cpp
+++ b/src/Test/CombatRecorder.cpp
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifdef PLAYERBOTS_INTEGRATION_TESTS
+
+#include "ScriptMgr.h"
+#include "SpellInfo.h"
+#include "StringFormat.h"
+#include "TestRunner.h"
+#include "Unit.h"
+
+// Thin forwarder: all routing/state lives in IntegrationTestMgr, which maps
+// participants (bots, watched bosses) to their owning run.
+class TestCombatRecorder : public UnitScript
+{
+public:
+    TestCombatRecorder() : UnitScript("TestCombatRecorder", true, { UNITHOOK_ON_DAMAGE, UNITHOOK_MODIFY_PERIODIC_DAMAGE_AURAS_TICK }) { }
+
+    void OnDamage(Unit* attacker, Unit* victim, uint32& damage) override
+    {
+        IntegrationTestMgr::instance().RecordDamage(attacker, victim,
+            attacker ? attacker->GetName() : "environment", damage);
+    }
+
+    // Periodic aura ticks (DoTs, slime/lava zone auras) bypass OnDamage — without
+    // this hook they are invisible in death recaps.
+    void ModifyPeriodicDamageAurasTick(Unit* target, Unit* attacker, uint32& damage, SpellInfo const* spellInfo) override
+    {
+        // The hook also sees positive periodics (HoT ticks) — recording those as
+        // damage pollutes death recaps.
+        if (spellInfo && spellInfo->IsPositive())
+            return;
+
+        std::string source = attacker ? attacker->GetName() : "aura";
+        if (spellInfo)
+            source += Acore::StringFormat(" [dot {}]", spellInfo->Id);
+        IntegrationTestMgr::instance().RecordDamage(attacker, target, std::move(source), damage);
+    }
+};
+
+void AddPlayerbotsTestCombatRecorder()
+{
+    new TestCombatRecorder();
+}
+
+#endif  // PLAYERBOTS_INTEGRATION_TESTS

--- a/src/Test/Scenarios/GenericRegistrations.cpp
+++ b/src/Test/Scenarios/GenericRegistrations.cpp
@@ -1,0 +1,19 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifdef PLAYERBOTS_INTEGRATION_TESTS
+
+#include "GenericScenarios.h"
+#include "TestRunner.h"
+
+void RegisterGenericScenarios(IntegrationTestMgr& mgr)
+{
+    mgr.RegisterScenario(MakeSelfTestScenario());
+    mgr.RegisterScenario(MakeBotSmokeScenario());
+    mgr.RegisterScenario(MakeReadyCheckScenario());
+}
+
+#endif  // PLAYERBOTS_INTEGRATION_TESTS

--- a/src/Test/Scenarios/GenericScenarios.cpp
+++ b/src/Test/Scenarios/GenericScenarios.cpp
@@ -1,0 +1,123 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifdef PLAYERBOTS_INTEGRATION_TESTS
+
+#include "GenericScenarios.h"
+
+#include "RaidComps.h"
+
+#include "Player.h"
+#include "SharedDefines.h"
+#include "StringFormat.h"
+
+#include <memory>
+
+namespace
+{
+    // Goldshire: an ordinary open-world destination for the pipeline smoke test.
+    Position const BOT_SMOKE_DESTINATION = { -9459.34f, 42.08f, 56.5f, 0.0f };
+    constexpr uint32 BOT_SMOKE_LEVEL = 60;
+
+    // Molten Core entrance: a raid-sized staging area far from any boss — a
+    // neutral spot to buff up and run the ready-check debugging scenario.
+    constexpr uint32 READY_CHECK_MAP = 409;
+    Position const READY_CHECK_STAGING = { 1091.89f, -466.99f, -105.08f, 3.14f };
+}
+
+// Harness self-check: steps, metrics and timing without any bots.
+class SelfTestScenario : public TestScenario
+{
+public:
+    std::string GetName() const override { return "self_test"; }
+
+    void Setup(TestContext& ctx) override
+    {
+        ctx.Do("set a metric", [](TestContext& ctx)
+        {
+            ctx.SetMetric("answer", 42.0);
+            return true;
+        });
+        ctx.WaitUntil("wait 3 seconds", 10000, [](TestContext& ctx)
+        {
+            return ctx.elapsedMs >= 3000;
+        });
+        ctx.Assert("metric survived", [](TestContext& ctx)
+        {
+            return ctx.metrics.count("answer") && ctx.metrics["answer"] == 42.0;
+        });
+    }
+};
+
+// Single-bot lifecycle smoke test: spawn, gear, teleport, teardown.
+class BotSmokeScenario : public TestScenario
+{
+public:
+    std::string GetName() const override { return "bot_smoke"; }
+
+    void Setup(TestContext& ctx) override
+    {
+        ctx.SpawnBots(BOT_SMOKE_LEVEL, { { CLASS_WARRIOR, "" } }, ITEM_QUALITY_UNCOMMON);
+        ctx.TeleportTo(0, BOT_SMOKE_DESTINATION);
+        ctx.Assert("bot alive at destination", [](TestContext& ctx)
+        {
+            Player* bot = ctx.GetBot(0);
+            return bot && bot->IsAlive() && bot->GetMapId() == 0 && bot->GetLevel() == BOT_SMOKE_LEVEL;
+        });
+    }
+};
+
+// All-specs raid runs a ready check; fails on any coverage gap (blessings,
+// mana potions, weapon imbues, warlock soulstone).
+class ReadyCheckScenario : public TestScenario
+{
+public:
+    std::string GetName() const override { return "ready_check"; }
+
+    void Setup(TestContext& ctx) override
+    {
+        ctx.SpawnBots(60, AllSpecsComp(), ITEM_QUALITY_RARE);
+        ctx.SetProgression(PROGRESSION_VANILLA_START);
+        ctx.FormGroup(true);
+        ctx.TeleportTo(READY_CHECK_MAP, READY_CHECK_STAGING);
+
+        ctx.Do("readiness before", [](TestContext& ctx)
+        {
+            ctx.NoteReadiness("before");
+            return true;
+        });
+
+        ctx.ReadyCheck();
+
+        ctx.Assert("raid fully buffed and stocked", [](TestContext& ctx)
+        {
+            TestContext::ReadinessSummary summary = ctx.NoteReadiness("after");
+            ctx.SetMetric("unblessed", summary.unblessed);
+            ctx.SetMetric("unstocked_mana_users", summary.unstockedManaUsers);
+            ctx.SetMetric("unimbued_weapons", summary.unimbuedWeapons);
+            ctx.SetMetric("missing_soulstones", summary.missingSoulstones);
+
+            if (summary.unblessed || summary.unstockedManaUsers ||
+                summary.unimbuedWeapons || summary.missingSoulstones)
+            {
+                ctx.AddNote(Acore::StringFormat(
+                    "coverage gaps after ready check: {} unblessed, {} mana users without potions, "
+                    "{} unimbued weapons, {} warlocks without a soulstone out",
+                    summary.unblessed, summary.unstockedManaUsers,
+                    summary.unimbuedWeapons, summary.missingSoulstones));
+                return false;
+            }
+
+            return true;
+        });
+    }
+};
+
+std::unique_ptr<TestScenario> MakeSelfTestScenario() { return std::make_unique<SelfTestScenario>(); }
+std::unique_ptr<TestScenario> MakeBotSmokeScenario() { return std::make_unique<BotSmokeScenario>(); }
+std::unique_ptr<TestScenario> MakeReadyCheckScenario() { return std::make_unique<ReadyCheckScenario>(); }
+
+#endif  // PLAYERBOTS_INTEGRATION_TESTS

--- a/src/Test/Scenarios/GenericScenarios.h
+++ b/src/Test/Scenarios/GenericScenarios.h
@@ -1,0 +1,20 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifdef PLAYERBOTS_INTEGRATION_TESTS
+#ifndef _PLAYERBOT_GENERICSCENARIOS_H
+#define _PLAYERBOT_GENERICSCENARIOS_H
+
+#include "TestScenario.h"
+
+#include <memory>
+
+std::unique_ptr<TestScenario> MakeSelfTestScenario();
+std::unique_ptr<TestScenario> MakeBotSmokeScenario();
+std::unique_ptr<TestScenario> MakeReadyCheckScenario();
+
+#endif
+#endif  // PLAYERBOTS_INTEGRATION_TESTS

--- a/src/Test/Scenarios/RaidComps.h
+++ b/src/Test/Scenarios/RaidComps.h
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifdef PLAYERBOTS_INTEGRATION_TESTS
+#ifndef _PLAYERBOT_RAIDCOMPS_H
+#define _PLAYERBOT_RAIDCOMPS_H
+
+#include "SharedDefines.h"
+#include "TestScenario.h"
+
+// Raid comps for test scenarios. Comps with DKs are level-80 only.
+
+inline std::vector<BotDef> AllSpecsComp()
+{
+    // One bot per talent tree — 9 classes x 3, no DK (27).
+    return {
+        // group 1: tanks + warriors
+        { CLASS_WARRIOR, "prot pve" },    // MT
+        { CLASS_PALADIN, "prot pve" },    // OT
+        { CLASS_WARRIOR, "arms pve" },
+        { CLASS_WARRIOR, "fury pve" },
+        { CLASS_PALADIN, "holy pve" },
+        // group 2: healers
+        { CLASS_PRIEST, "disc pve" },
+        { CLASS_PRIEST, "holy pve" },
+        { CLASS_DRUID, "resto pve" },
+        { CLASS_SHAMAN, "resto pve" },
+        { CLASS_PRIEST, "shadow pve" },
+        // group 3: casters
+        { CLASS_DRUID, "balance pve" },
+        { CLASS_SHAMAN, "ele pve" },
+        { CLASS_MAGE, "arcane pve" },
+        { CLASS_MAGE, "fire pve" },
+        { CLASS_MAGE, "frost pve" },
+        // group 4: locks + hunters
+        { CLASS_WARLOCK, "affli pve" },
+        { CLASS_WARLOCK, "demo pve" },
+        { CLASS_WARLOCK, "destro pve" },
+        { CLASS_HUNTER, "bm pve" },
+        { CLASS_HUNTER, "mm pve" },
+        // group 5: melee
+        { CLASS_PALADIN, "ret pve" },
+        { CLASS_SHAMAN, "enh pve" },
+        { CLASS_DRUID, "cat pve" },
+        { CLASS_ROGUE, "as pve" },
+        { CLASS_ROGUE, "combat pve" },
+        // group 6: overflow
+        { CLASS_ROGUE, "subtlety pve" },
+        { CLASS_HUNTER, "surv pve" },
+    };
+}
+
+#endif
+#endif  // PLAYERBOTS_INTEGRATION_TESTS

--- a/src/Test/TestReporting.cpp
+++ b/src/Test/TestReporting.cpp
@@ -1,0 +1,355 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifdef PLAYERBOTS_INTEGRATION_TESTS
+
+// Result side of the test runner: damage/death recording, per-run result
+// assembly, bench statistics and the JSON results file. Run lifecycle lives in
+// TestRunner.cpp.
+
+#include "TestRunner.h"
+
+#include "Item.h"
+#include "Log.h"
+#include "ObjectAccessor.h"
+#include "Player.h"
+#include "StringFormat.h"
+#include "Unit.h"
+
+#include <algorithm>
+#include <fstream>
+
+namespace
+{
+    constexpr size_t LAST_HITS_RING_SIZE = 10;
+}
+
+void IntegrationTestMgr::RecordDamage(Unit* attacker, Unit* victim, std::string attackerName, uint32 damage)
+{
+    if (!victim)
+        return;
+
+    std::lock_guard<std::mutex> guard(_participantLock);
+    if (_participants.empty())
+        return;
+
+    // Damage a bot (or its pet) deals to a hostile counts toward that bot's run.
+    if (attacker && victim->ToCreature())
+    {
+        ObjectGuid dealer = attacker->GetGUID();
+        if (!dealer.IsPlayer())
+            dealer = attacker->GetCharmerOrOwnerGUID();
+
+        auto dealerIt = _participants.find(dealer);
+        if (dealerIt != _participants.end())
+        {
+            RunCombatData& combat = dealerIt->second->combat;
+            combat.damageDealt[dealer] += damage;
+            if (Unit* owner = attacker->GetCharmerOrOwner())
+                combat.attackerNames[dealer] = owner->GetName();
+            else
+                combat.attackerNames[dealer] = attacker->GetName();
+        }
+    }
+
+    // Victim-side tracking: ring buffer + death recap for the owning run's bots
+    // and watched boss.
+    auto victimIt = _participants.find(victim->GetGUID());
+    if (victimIt == _participants.end())
+        return;
+
+    TestRun& run = *victimIt->second;
+    bool victimIsBot = victim->IsPlayer();
+
+    // Attacker distance at hit time: separates AoE-radius wipes from room-wide mechanics.
+    if (attacker && attacker != victim && attacker->IsInWorld() && victim->IsInWorld() &&
+        attacker->GetMapId() == victim->GetMapId())
+        attackerName += Acore::StringFormat("@{:.0f}y", attacker->GetDistance2d(victim));
+
+    auto& ring = run.combat.lastHits[victim->GetGUID()];
+    ring.push_back(RecordedHit{
+        run.ctx.elapsedMs,
+        std::move(attackerName),
+        damage,
+        victim->GetHealth() > damage ? uint32(victim->GetHealth() - damage) : 0u });
+    if (ring.size() > LAST_HITS_RING_SIZE)
+        ring.pop_front();
+
+    // Bot death: flush a recap line (once per bot; pre-hook fires again on hits landing after death).
+    if (victimIsBot && damage >= victim->GetHealth() && run.combat.reportedDeaths.insert(victim->GetGUID()).second)
+    {
+        ++run.combat.deaths;
+        std::string recap = Acore::StringFormat("[{}s] {} died. Last hits:", run.ctx.elapsedMs / 1000, victim->GetName());
+        for (RecordedHit const& hit : ring)
+            recap += Acore::StringFormat(" | {}s {} {} (hp->{})", hit.atMs / 1000, hit.attacker, hit.amount, hit.healthAfter);
+        run.combat.recapLines.push_back(recap);
+    }
+}
+
+void IntegrationTestMgr::FinishRun(TestRun& run, bool passed, std::string const& failedStep)
+{
+    ScenarioResult result;
+    result.name = run.label;
+    result.passed = passed;
+    result.failedStep = failedStep;
+    result.elapsedMs = run.ctx.elapsedMs;
+    result.metrics = run.ctx.metrics;
+    result.notes = run.ctx.notes;
+    result.timeline = std::move(run.timeline);
+
+    {
+        std::lock_guard<std::mutex> guard(_participantLock);
+
+        result.metrics["bot_deaths"] = run.combat.deaths;
+        for (std::string const& line : run.combat.recapLines)
+            result.notes.push_back(line);
+
+        if (!passed)
+        {
+            if (!result.timeline.empty())
+            {
+                auto const& last = result.timeline.back();
+                result.notes.push_back(Acore::StringFormat("fail state: [{:.0f}s] boss {:.0f}% alive {:.0f}",
+                    last[0], last[1], last[2]));
+            }
+
+            auto bossHits = run.combat.lastHits.find(run.syncedBoss);
+            if (bossHits != run.combat.lastHits.end() && !bossHits->second.empty())
+            {
+                std::string line = "boss last hits:";
+                for (RecordedHit const& hit : bossHits->second)
+                    line += Acore::StringFormat(" | {}s {} {} (hp->{})",
+                        hit.atMs / 1000, hit.attacker, hit.amount, hit.healthAfter);
+                result.notes.push_back(line);
+            }
+        }
+
+        uint32 fightMs = run.ctx.elapsedMs;
+        auto engageIt = run.ctx.metrics.find("engage_at_ms");
+        if (engageIt != run.ctx.metrics.end() && run.ctx.elapsedMs > uint32(engageIt->second))
+            fightMs = run.ctx.elapsedMs - uint32(engageIt->second);
+
+        HarvestBenchStats(run, passed, fightMs);
+
+        // Damage per raid member, highest first.
+        if (!run.combat.damageDealt.empty())
+        {
+            std::vector<std::pair<uint64, ObjectGuid>> sorted;
+            uint64 total = 0;
+            for (auto const& [guid, dmg] : run.combat.damageDealt)
+            {
+                sorted.push_back({ dmg, guid });
+                total += dmg;
+            }
+            std::sort(sorted.rbegin(), sorted.rend());
+
+            std::map<ObjectGuid, std::string const*> specOf;
+            for (size_t i = 0; i < run.ctx.botGuids.size() && i < run.ctx.botSpecs.size(); ++i)
+                specOf[run.ctx.botGuids[i]] = &run.ctx.botSpecs[i];
+
+            for (auto const& [dmg, guid] : sorted)
+            {
+                auto specIt = specOf.find(guid);
+                result.notes.push_back(Acore::StringFormat("dmg: {} [{}] {} (dps {})",
+                    run.combat.attackerNames[guid], specIt != specOf.end() ? *specIt->second : "?",
+                    dmg, fightMs >= 1000 ? dmg / (fightMs / 1000) : dmg));
+            }
+            result.notes.push_back(Acore::StringFormat("dmg total: {} (raid dps {})",
+                total, fightMs >= 1000 ? total / (fightMs / 1000) : total));
+        }
+
+        // Drop this run's participants from the routing index.
+        for (ObjectGuid const& guid : run.ctx.botGuids)
+            _participants.erase(guid);
+        if (!run.syncedBoss.IsEmpty())
+            _participants.erase(run.syncedBoss);
+    }
+
+    _results.push_back(std::move(result));
+
+    if (!passed)
+        _anyFailed = true;
+
+    LOG_INFO("playerbots", "IntegrationTest: === {} {} ({} ms) ===",
+        run.label, passed ? "PASSED" : "FAILED", run.ctx.elapsedMs);
+
+    Teardown(run);
+    run.scenario = nullptr;  // marks the run for removal in Update()
+    WriteResults();
+
+    // Bench slot advance: each finished run frees a slot; the summary lands
+    // once the whole series is done.
+    if (BenchState* bench = run.bench)
+    {
+        ++bench->done;
+        if (bench->done == bench->total)
+            FinishBench(*bench);
+        PumpBenches();
+    }
+}
+
+// Average equipped item level (shirt/tabard excluded).
+static uint32 AverageEquippedItemLevel(Player* bot)
+{
+    uint32 sum = 0, count = 0;
+    for (uint8 slot = EQUIPMENT_SLOT_START; slot < EQUIPMENT_SLOT_END; ++slot)
+    {
+        if (slot == EQUIPMENT_SLOT_BODY || slot == EQUIPMENT_SLOT_TABARD)
+            continue;
+        if (Item* item = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))
+        {
+            sum += item->GetTemplate()->ItemLevel;
+            ++count;
+        }
+    }
+    return count ? sum / count : 0;
+}
+
+void IntegrationTestMgr::HarvestBenchStats(TestRun& run, bool passed, uint32 fightMs)
+{
+    BenchState* bench = run.bench;
+    if (!bench)
+        return;
+
+    if (passed)
+        if (auto it = run.ctx.metrics.find("kill_time_ms"); it != run.ctx.metrics.end())
+            bench->killTimesSec.push_back(it->second / 1000.0);
+    if (passed)
+        ++bench->passCount;
+    bench->deaths.push_back(run.combat.deaths);
+
+    if (fightMs < 1000)
+        return;
+
+    for (size_t i = 0; i < run.ctx.botGuids.size() && i < run.ctx.botSpecs.size(); ++i)
+    {
+        auto dmgIt = run.combat.damageDealt.find(run.ctx.botGuids[i]);
+        if (dmgIt == run.combat.damageDealt.end())
+            continue;
+
+        std::string const& spec = run.ctx.botSpecs[i];
+        bench->specDps[spec].push_back(double(dmgIt->second) / (fightMs / 1000.0));
+        if (Player* bot = run.ctx.GetBot(i))
+            bench->specIlvl[spec].push_back(AverageEquippedItemLevel(bot));
+    }
+}
+
+void IntegrationTestMgr::FinishBench(BenchState& bench)
+{
+    auto stats = [](std::vector<double> const& v) -> std::array<double, 3>
+    {
+        if (v.empty())
+            return { 0, 0, 0 };
+        double sum = 0, mn = v[0], mx = v[0];
+        for (double x : v) { sum += x; mn = std::min(mn, x); mx = std::max(mx, x); }
+        return { sum / v.size(), mn, mx };
+    };
+
+    ScenarioResult result;
+    result.name = Acore::StringFormat("bench {}", bench.scenarioName);
+    result.passed = bench.passCount == bench.total;
+
+    auto kt = stats(bench.killTimesSec);
+    double deathSum = 0;
+    for (uint32 d : bench.deaths)
+        deathSum += d;
+    result.notes.push_back(Acore::StringFormat(
+        "runs {}: {} passed | kill avg {:.0f}s min {:.0f}s max {:.0f}s | deaths avg {:.1f}",
+        bench.total, bench.passCount, kt[0], kt[1], kt[2],
+        bench.deaths.empty() ? 0.0 : deathSum / bench.deaths.size()));
+
+    // Per spec, strongest first.
+    std::vector<std::pair<double, std::string>> order;
+    for (auto const& [spec, samples] : bench.specDps)
+        order.push_back({ stats(samples)[0], spec });
+    std::sort(order.rbegin(), order.rend());
+
+    for (auto const& [avg, spec] : order)
+    {
+        auto d = stats(bench.specDps[spec]);
+        auto const& ilvls = bench.specIlvl[spec];
+        uint64 ilvlSum = 0;
+        for (uint32 v : ilvls)
+            ilvlSum += v;
+        result.notes.push_back(Acore::StringFormat(
+            "spec {:<22} x{}: dps avg {:.0f} min {:.0f} max {:.0f} | ilvl {}",
+            spec, bench.specDps[spec].size(), d[0], d[1], d[2],
+            ilvls.empty() ? 0 : uint32(ilvlSum / ilvls.size())));
+    }
+
+    LOG_INFO("playerbots", "IntegrationTest: === bench {} finished ===", bench.scenarioName);
+    for (std::string const& line : result.notes)
+        LOG_INFO("playerbots", "IntegrationTest:   {}", line);
+
+    if (!result.passed)
+        _anyFailed = true;
+
+    _results.push_back(std::move(result));
+    WriteResults();
+}
+
+namespace
+{
+    std::string JsonEscape(std::string const& in)
+    {
+        std::string out;
+        for (char c : in)
+        {
+            switch (c)
+            {
+                case '"':  out += "\\\""; break;
+                case '\\': out += "\\\\"; break;
+                case '\n': out += "\\n"; break;
+                case '\r': out += "\\r"; break;
+                case '\t': out += "\\t"; break;
+                default:
+                    // Remaining control characters are invalid raw JSON.
+                    if (uint8(c) < 0x20)
+                        out += Acore::StringFormat("\\u{:04x}", uint32(uint8(c)));
+                    else
+                        out += c;
+            }
+        }
+        return out;
+    }
+}
+
+void IntegrationTestMgr::WriteResults() const
+{
+    std::ofstream file("test_results.json", std::ios::trunc);
+    if (!file)
+    {
+        LOG_ERROR("playerbots", "IntegrationTest: cannot open test_results.json for writing");
+        return;
+    }
+
+    file << "{\n  \"results\": [\n";
+    for (size_t i = 0; i < _results.size(); ++i)
+    {
+        ScenarioResult const& r = _results[i];
+        file << "    {\n";
+        file << "      \"name\": \"" << JsonEscape(r.name) << "\",\n";
+        file << "      \"passed\": " << (r.passed ? "true" : "false") << ",\n";
+        file << "      \"failedStep\": \"" << JsonEscape(r.failedStep) << "\",\n";
+        file << "      \"elapsedMs\": " << r.elapsedMs << ",\n";
+        file << "      \"metrics\": {";
+        size_t m = 0;
+        for (auto const& [key, value] : r.metrics)
+            file << (m++ ? ", " : "") << "\"" << JsonEscape(key) << "\": " << value;
+        file << "},\n";
+        file << "      \"notes\": [";
+        for (size_t n = 0; n < r.notes.size(); ++n)
+            file << (n ? ", " : "") << "\"" << JsonEscape(r.notes[n]) << "\"";
+        file << "],\n";
+        file << "      \"timeline\": [";
+        for (size_t t = 0; t < r.timeline.size(); ++t)
+            file << (t ? ", " : "") << "[" << r.timeline[t][0] << ", " << r.timeline[t][1] << ", " << r.timeline[t][2] << "]";
+        file << "]\n    }" << (i + 1 < _results.size() ? "," : "") << "\n";
+    }
+    file << "  ]\n}\n";
+}
+
+#endif  // PLAYERBOTS_INTEGRATION_TESTS

--- a/src/Test/TestRunner.cpp
+++ b/src/Test/TestRunner.cpp
@@ -1,0 +1,459 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifdef PLAYERBOTS_INTEGRATION_TESTS
+
+// Run lifecycle of the test runner: scenario registry, run queueing (including
+// "name*N" benches), per-tick stepping and teardown. Damage recording, bench
+// statistics and the results file live in TestReporting.cpp.
+
+#include "TestRunner.h"
+
+#include "Chat.h"
+#include "Config.h"
+#include "Log.h"
+#include "ScriptMgr.h"
+#include "World.h"
+
+#include "Creature.h"
+#include "Group.h"
+#include "ObjectAccessor.h"
+#include "Player.h"
+#include "PlayerbotAIConfig.h"
+#include "RandomPlayerbotMgr.h"
+#include "StringFormat.h"
+
+#include <set>
+#include <sstream>
+
+namespace
+{
+    // Global cap of concurrently running bench runs across ALL "name*N" series —
+    // benches drain in order, each finished run frees a slot for the next.
+    constexpr uint32 BENCH_CONCURRENCY = 10;
+    constexpr uint32 TIMELINE_SAMPLE_MS = 5000;
+}
+
+void IntegrationTestMgr::RegisterScenario(std::unique_ptr<TestScenario> scenario)
+{
+    _scenarios.push_back(std::move(scenario));
+}
+
+std::vector<std::string> IntegrationTestMgr::ScenarioNames() const
+{
+    std::vector<std::string> names;
+    for (auto const& scenario : _scenarios)
+        names.push_back(scenario->GetName());
+
+    return names;
+}
+
+bool IntegrationTestMgr::QueueRun(std::string const& csv, bool shutdownWhenDone)
+{
+    std::vector<std::string> requested;
+    std::vector<std::pair<std::string, uint32>> benches;   // "name*N" tokens
+    std::stringstream ss(csv);
+    std::string token;
+    while (std::getline(ss, token, ','))
+    {
+        token.erase(0, token.find_first_not_of(" \t"));
+        token.erase(token.find_last_not_of(" \t") + 1);
+        if (token.empty())
+            continue;
+
+        if (token == "all")
+        {
+            requested = ScenarioNames();
+            break;
+        }
+
+        // "name*N": a bench — N runs of the scenario with aggregated dps stats.
+        uint32 benchCount = 0;
+        if (size_t star = token.find('*'); star != std::string::npos)
+        {
+            benchCount = uint32(atoi(token.substr(star + 1).c_str()));
+            token = token.substr(0, star);
+        }
+
+        // Exact scenario name, or a prefix expanding to every scenario that
+        // starts with it ("mc" = all MC bosses, "quest" = the quest ladder,
+        // "mc*10" = every MC boss benched 10x).
+        std::vector<std::string> expanded;
+        for (auto const& scenario : _scenarios)
+        {
+            if (scenario->GetName() == token)
+            {
+                expanded = { token };
+                break;
+            }
+            if (scenario->GetName().compare(0, token.size(), token) == 0)
+                expanded.push_back(scenario->GetName());
+        }
+
+        if (expanded.empty())
+        {
+            LOG_ERROR("playerbots", "IntegrationTest: unknown scenario '{}'", token);
+            return false;
+        }
+        if (expanded.size() > 1)
+            LOG_INFO("playerbots", "IntegrationTest: '{}' expands to {} scenarios", token, expanded.size());
+
+        for (std::string& name : expanded)
+            if (benchCount)
+                benches.push_back({ std::move(name), benchCount });
+            else
+                requested.push_back(std::move(name));
+    }
+
+    if (requested.empty() && benches.empty())
+        return false;
+
+    if (_runs.empty())
+        _anyFailed = false;
+    if (shutdownWhenDone)
+        _shutdownWhenDone = true;
+
+    // Requested runs start concurrently. A continent scenario can't repeat concurrently
+    // (copies share the world and fight over spawns); instanced ones each get an instance.
+    std::map<std::string, uint32> nameCounts;
+    for (std::string const& name : requested)
+        ++nameCounts[name];
+
+    for (auto const& [name, count] : nameCounts)
+    {
+        TestScenario const* scenario = FindScenario(name);
+        if (count > 1 && scenario && scenario->SharesWorldWithCopies())
+        {
+            LOG_ERROR("playerbots",
+                      "IntegrationTest: '{}' requested {}x, but it shares its world with its own "
+                      "copies - they would contend for the same spawns. Boot once per repetition.",
+                      name, count);
+            return false;
+        }
+    }
+
+    std::map<std::string, uint32> nameSeen;
+    for (std::string const& name : requested)
+        _pending.push_back({ FindScenario(name),
+            nameCounts[name] > 1 ? Acore::StringFormat("{}#{}", name, ++nameSeen[name]) : name });
+    PumpPending();
+
+    for (auto const& [name, count] : benches)
+    {
+        auto bench = std::make_unique<BenchState>();
+        bench->scenarioName = name;
+        bench->scenario = FindScenario(name);
+        bench->total = count;
+        _benches.push_back(std::move(bench));
+
+        LOG_INFO("playerbots", "IntegrationTest: bench {}*{} queued ({} slots)", name, count, BENCH_CONCURRENCY);
+    }
+    PumpBenches();
+
+    LOG_INFO("playerbots", "IntegrationTest: {} run(s) in flight", _runs.size());
+    return true;
+}
+
+void IntegrationTestMgr::PumpPending()
+{
+    // Zone keys currently occupied by a run in flight. A finished run (scenario
+    // cleared, not yet erased from _runs) no longer holds its zone.
+    std::set<std::string> busyZones;
+    for (auto const& run : _runs)
+        if (run->scenario)
+            if (std::string zone = run->scenario->ZoneKey(); !zone.empty())
+                busyZones.insert(std::move(zone));
+
+    for (size_t i = 0; i < _pending.size();)
+    {
+        std::string const zone = _pending[i].scenario ? _pending[i].scenario->ZoneKey() : "";
+        if (!zone.empty() && busyZones.count(zone))
+        {
+            ++i;  // zone busy — hold this run
+            continue;
+        }
+
+        if (!zone.empty())
+            busyZones.insert(zone);  // claim it so the next same-zone pending waits
+        StartRun(_pending[i].scenario, std::move(_pending[i].label), nullptr);
+        _pending.erase(_pending.begin() + i);
+        // no ++i: erase shifted the next pending into slot i
+    }
+}
+
+void IntegrationTestMgr::PumpBenches()
+{
+    uint32 active = 0;
+    std::set<BenchState const*> busy;
+    for (auto const& run : _runs)
+        if (run->bench)
+        {
+            ++active;
+            busy.insert(run->bench);
+        }
+
+    for (auto& bench : _benches)
+    {
+        // Continent benches run serially (shared world); instanced ones fill the wave.
+        bool const serial = bench->scenario && bench->scenario->SharesWorldWithCopies();
+        if (serial && busy.count(bench.get()))
+            continue;
+
+        while (active < BENCH_CONCURRENCY && bench->started < bench->total)
+        {
+            ++bench->started;
+            ++active;
+            StartRun(bench->scenario, Acore::StringFormat("{}#{}", bench->scenarioName, bench->started),
+                     bench.get());
+            if (serial)
+                break;
+        }
+    }
+}
+
+TestScenario* IntegrationTestMgr::FindScenario(std::string const& name) const
+{
+    for (auto const& scenario : _scenarios)
+        if (scenario->GetName() == name)
+            return scenario.get();
+
+    return nullptr;
+}
+
+void IntegrationTestMgr::StartRun(TestScenario* scenario, std::string label, BenchState* bench)
+{
+    auto run = std::make_unique<TestRun>();
+    run->scenario = scenario;
+    run->label = std::move(label);
+    run->bench = bench;
+
+    scenario->Setup(run->ctx);
+    LOG_INFO("playerbots", "IntegrationTest: === {} started ({} steps) ===", run->label, run->ctx.steps.size());
+    _runs.push_back(std::move(run));
+}
+
+bool IntegrationTestMgr::IsParticipant(ObjectGuid guid)
+{
+    std::lock_guard<std::mutex> guard(_participantLock);
+    return _participants.count(guid) != 0;
+}
+
+void IntegrationTestMgr::SyncParticipants(TestRun& run)
+{
+    // Bot lists only grow and the boss guid is set once per fight; sync the flat
+    // index (read by map threads in RecordDamage) when either changes.
+    if (run.ctx.botGuids.size() == run.syncedBots && run.ctx.bossGuid == run.syncedBoss)
+        return;
+
+    std::lock_guard<std::mutex> guard(_participantLock);
+    for (size_t i = run.syncedBots; i < run.ctx.botGuids.size(); ++i)
+        _participants[run.ctx.botGuids[i]] = &run;
+    run.syncedBots = run.ctx.botGuids.size();
+
+    if (run.ctx.bossGuid != run.syncedBoss)
+    {
+        if (!run.syncedBoss.IsEmpty())
+            _participants.erase(run.syncedBoss);
+        if (!run.ctx.bossGuid.IsEmpty())
+            _participants[run.ctx.bossGuid] = &run;
+        run.syncedBoss = run.ctx.bossGuid;
+    }
+}
+
+void IntegrationTestMgr::Update(uint32 diff)
+{
+    bool removed = false;
+    for (size_t i = 0; i < _runs.size();)
+    {
+        TestRun& run = *_runs[i];
+        TickRun(run, diff);
+
+        // TickRun may have finished the run (it removes itself from _participants
+        // and pushes its result); drop it here.
+        if (run.scenario == nullptr)
+        {
+            _runs.erase(_runs.begin() + i);
+            removed = true;
+        }
+        else
+            ++i;
+    }
+
+    // A finished run frees its zone — start any pending run that was held on it.
+    if (removed && !_pending.empty())
+        PumpPending();
+
+    if (_runs.empty() && _pending.empty() && _shutdownWhenDone && !_results.empty())
+    {
+        LOG_INFO("playerbots", "IntegrationTest: all scenarios finished, {}",
+            _anyFailed ? "FAILURES present" : "all passed");
+        World::StopNow(_anyFailed ? ERROR_EXIT_CODE : SHUTDOWN_EXIT_CODE);
+    }
+}
+
+void IntegrationTestMgr::TickRun(TestRun& run, uint32 diff)
+{
+    run.ctx.elapsedMs += diff;
+    SyncParticipants(run);
+
+    run.timelineAccumMs += diff;
+    if (!run.ctx.bossGuid.IsEmpty() && run.timelineAccumMs >= TIMELINE_SAMPLE_MS)
+    {
+        run.timelineAccumMs = 0;
+        if (Player* ref = run.ctx.FirstAliveBot())
+            if (Creature* boss = ObjectAccessor::GetCreature(*ref, run.ctx.bossGuid))
+                run.timeline.push_back({ double(run.ctx.elapsedMs) / 1000.0, double(boss->GetHealthPct()), double(run.ctx.AliveBotCount()) });
+    }
+
+    if (run.ctx.steps.empty())
+    {
+        FinishRun(run, true, "");
+        return;
+    }
+
+    TestStep& step = run.ctx.steps.front();
+    step.elapsedMs += diff;
+
+    StepStatus status = step.tick(run.ctx);
+
+    // Publish picks before the next run ticks, so concurrent SpawnBots don't reuse them.
+    SyncParticipants(run);
+
+    if (status == StepStatus::InProgress && step.timeoutMs && step.elapsedMs > step.timeoutMs)
+    {
+        run.ctx.AddNote(Acore::StringFormat("step '{}' timed out after {} ms", step.name, step.elapsedMs));
+        status = StepStatus::Failed;
+    }
+
+    if (status == StepStatus::Done)
+    {
+        LOG_INFO("playerbots", "IntegrationTest: [{}] step '{}' done ({} ms)", run.label, step.name, step.elapsedMs);
+        run.ctx.steps.pop_front();
+    }
+    else if (status == StepStatus::Failed)
+    {
+        LOG_ERROR("playerbots", "IntegrationTest: [{}] step '{}' FAILED", run.label, step.name);
+        FinishRun(run, false, step.name);
+    }
+}
+
+void IntegrationTestMgr::Teardown(TestRun& run)
+{
+    // Log out spawned bots and disband the group; scenario-spawned creatures
+    // despawn naturally via LogoutPlayerBot / world cleanup.
+    Player* groupMember = run.ctx.groupLeader ? ObjectAccessor::FindConnectedPlayer(run.ctx.groupLeader) : nullptr;
+    if (!groupMember)
+        for (ObjectGuid const& guid : run.ctx.botGuids)
+            if ((groupMember = ObjectAccessor::FindConnectedPlayer(guid)) != nullptr)
+                break;
+
+    if (groupMember)
+        if (Group* group = groupMember->GetGroup())
+            group->Disband();
+
+    for (ObjectGuid const& guid : run.ctx.botGuids)
+        sRandomPlayerbotMgr.LogoutPlayerBot(guid);
+}
+
+void IntegrationTestMgr::OnWorldStartup()
+{
+    std::string run = sConfigMgr->GetOption<std::string>("AiPlayerbot.IntegrationTest.Run", "");
+    if (run.empty())
+        return;
+
+    // Results must not depend on local config: enforce every setting here.
+    sPlayerbotAIConfig.minRandomBots = 0;             // no random-bot horde around the runs
+    sPlayerbotAIConfig.maxRandomBots = 0;
+    sPlayerbotAIConfig.botActiveAlone = 100;          // no activity throttling without real players
+    sPlayerbotAIConfig.botActiveAloneSmartScale = false;
+    sPlayerbotAIConfig.dynamicReactDelay = false;     // master-equivalent combat cadence
+    sPlayerbotAIConfig.reactDelay = 40;
+    sPlayerbotAIConfig.autoGearBisCommand = 1;        // GearDef bis gearing
+    sPlayerbotAIConfig.autoGearQualityLimit = 4;
+    sPlayerbotAIConfig.autoGearScoreLimit = 999;
+    sPlayerbotAIConfig.logInGroupOnly = false;        // test bots are masterless; log them anyway
+
+    // Quest scenarios pin RPG_DO_QUEST; every status re-roll must land back on
+    // it instead of wandering off to grind/camp/rest.
+    for (auto& [status, weight] : sPlayerbotAIConfig.RpgStatusProbWeight)
+        weight = 0;
+    sPlayerbotAIConfig.RpgStatusProbWeight[RPG_DO_QUEST] = 100;
+
+    LOG_INFO("playerbots", "IntegrationTest: test config enforced (random bots off, full activity, "
+        "react delay 40, autogear bis, rpg status pinned to DO_QUEST)");
+
+    if (!QueueRun(run, true))
+    {
+        LOG_ERROR("playerbots", "IntegrationTest: could not queue configured run '{}'", run);
+        World::StopNow(ERROR_EXIT_CODE);
+    }
+}
+
+class IntegrationTestWorldScript : public WorldScript
+{
+public:
+    IntegrationTestWorldScript()
+        : WorldScript("IntegrationTestWorldScript", { WORLDHOOK_ON_STARTUP, WORLDHOOK_ON_UPDATE }) { }
+
+    void OnStartup() override { IntegrationTestMgr::instance().OnWorldStartup(); }
+    void OnUpdate(uint32 diff) override { IntegrationTestMgr::instance().Update(diff); }
+};
+
+using namespace Acore::ChatCommands;
+
+class IntegrationTestCommandScript : public CommandScript
+{
+public:
+    IntegrationTestCommandScript() : CommandScript("IntegrationTestCommandScript") { }
+
+    ChatCommandTable GetCommands() const override
+    {
+        static ChatCommandTable pbtestTable =
+        {
+            { "run",  HandleRunCommand,  SEC_GAMEMASTER, Console::Yes },
+            { "list", HandleListCommand, SEC_GAMEMASTER, Console::Yes },
+        };
+        static ChatCommandTable commandTable =
+        {
+            { "pbtest", pbtestTable },
+        };
+        return commandTable;
+    }
+
+    static bool HandleRunCommand(ChatHandler* handler, char const* args)
+    {
+        if (!args || !*args)
+        {
+            handler->SendSysMessage("Usage: .pbtest run <scenario[,scenario...]>");
+            return true;
+        }
+        if (!IntegrationTestMgr::instance().QueueRun(args, false))
+            handler->SendSysMessage("pbtest: unknown scenario.");
+        return true;
+    }
+
+    static bool HandleListCommand(ChatHandler* handler, char const* /*args*/)
+    {
+        for (std::string const& name : IntegrationTestMgr::instance().ScenarioNames())
+            handler->SendSysMessage(name.c_str());
+        handler->SendSysMessage("pbtest: end of scenario list.");
+        return true;
+    }
+};
+
+// One registration function per Scenarios/*Registrations.cpp file.
+void RegisterGenericScenarios(IntegrationTestMgr& mgr);
+void AddPlayerbotsTestCombatRecorder();
+
+void AddPlayerbotsIntegrationTestScripts()
+{
+    new IntegrationTestWorldScript();
+    new IntegrationTestCommandScript();
+    AddPlayerbotsTestCombatRecorder();
+    RegisterGenericScenarios(IntegrationTestMgr::instance());
+}
+
+#endif  // PLAYERBOTS_INTEGRATION_TESTS

--- a/src/Test/TestRunner.h
+++ b/src/Test/TestRunner.h
@@ -1,0 +1,143 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifdef PLAYERBOTS_INTEGRATION_TESTS
+#ifndef _PLAYERBOT_TESTRUNNER_H
+#define _PLAYERBOT_TESTRUNNER_H
+
+#include "TestScenario.h"
+
+#include <array>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <set>
+
+class Unit;
+
+struct ScenarioResult
+{
+    std::string name;
+    bool passed = false;
+    std::string failedStep;
+    uint32 elapsedMs = 0;
+    std::map<std::string, double> metrics;
+    std::vector<std::string> notes;
+    std::vector<std::array<double, 3>> timeline;  // [tSec, bossHpPct, aliveBots]
+};
+
+struct RecordedHit
+{
+    uint32 atMs;
+    std::string attacker;
+    uint32 amount;
+    uint32 healthAfter;
+};
+
+// Per-run combat telemetry, mutated from map-update threads under
+// IntegrationTestMgr's participant lock.
+struct RunCombatData
+{
+    uint32 deaths = 0;
+    std::map<ObjectGuid, std::deque<RecordedHit>> lastHits;  // per victim, capped at 10
+    std::set<ObjectGuid> reportedDeaths;                     // OnDamage is a pre-hook; hits on an already-dead bot re-satisfy the death check
+    std::vector<std::string> recapLines;
+    std::map<ObjectGuid, uint64> damageDealt;                // per bot (pets attributed to owner), vs hostile creatures
+    std::map<ObjectGuid, std::string> attackerNames;
+};
+
+// Repeated runs of one scenario ("name*N" in the run list) with aggregated
+// per-spec dps/ilvl statistics; runs execute in waves of BENCH_CONCURRENCY.
+struct BenchState
+{
+    std::string scenarioName;
+    TestScenario* scenario = nullptr;
+    uint32 total = 0;
+    uint32 started = 0;
+    uint32 done = 0;
+    uint32 passCount = 0;
+    std::vector<double> killTimesSec;                    // passed runs only
+    std::vector<uint32> deaths;
+    std::map<std::string, std::vector<double>> specDps;  // per-spec dps samples across runs
+    std::map<std::string, std::vector<uint32>> specIlvl;
+};
+
+// One concurrently-executing scenario run. Runs tick serially on the world
+// thread; combat telemetry arrives from map threads via the participant index.
+struct TestRun
+{
+    std::string label;            // scenario name, "#n"-suffixed when run in parallel with itself
+    TestScenario* scenario = nullptr;
+    TestContext ctx;
+    RunCombatData combat;
+    uint32 timelineAccumMs = 0;
+    std::vector<std::array<double, 3>> timeline;
+    size_t syncedBots = 0;        // participant-index sync watermark
+    ObjectGuid syncedBoss;
+    BenchState* bench = nullptr;  // owning bench when part of a "name*N" series
+};
+
+class IntegrationTestMgr
+{
+public:
+    static IntegrationTestMgr& instance()
+    {
+        static IntegrationTestMgr mgr;
+        return mgr;
+    }
+
+    void RegisterScenario(std::unique_ptr<TestScenario> scenario);
+    void OnWorldStartup();
+    void Update(uint32 diff);
+
+    bool QueueRun(std::string const& csv, bool shutdownWhenDone);
+    std::vector<std::string> ScenarioNames() const;
+    bool IsRunning() const { return !_runs.empty(); }
+
+    // Bot-picking guard: true while the guid belongs to any active run.
+    bool IsParticipant(ObjectGuid guid);
+
+    // Combat telemetry entry point (called from map-update threads).
+    void RecordDamage(Unit* attacker, Unit* victim, std::string attackerName, uint32 damage);
+
+private:
+    TestScenario* FindScenario(std::string const& name) const;
+    void TickRun(TestRun& run, uint32 diff);
+    void FinishRun(TestRun& run, bool passed, std::string const& failedStep);
+    void SyncParticipants(TestRun& run);
+    void Teardown(TestRun& run);
+    void WriteResults() const;
+    void StartRun(TestScenario* scenario, std::string label, BenchState* bench);
+    void HarvestBenchStats(TestRun& run, bool passed, uint32 fightMs);
+    void FinishBench(BenchState& bench);
+    void PumpBenches();
+    // Starts pending runs whose ZoneKey is free; holds those whose zone has a
+    // run in flight. Re-called whenever a run finishes.
+    void PumpPending();
+
+    // A requested (non-bench) run waiting for its zone to clear.
+    struct PendingRun
+    {
+        TestScenario* scenario = nullptr;
+        std::string label;
+    };
+
+    std::vector<std::unique_ptr<TestScenario>> _scenarios;
+    std::vector<std::unique_ptr<TestRun>> _runs;
+    std::vector<PendingRun> _pending;
+    std::vector<std::unique_ptr<BenchState>> _benches;
+    bool _shutdownWhenDone = false;
+    bool _anyFailed = false;
+    std::vector<ScenarioResult> _results;
+
+    std::mutex _participantLock;
+    std::map<ObjectGuid, TestRun*> _participants;  // bot/boss guid -> owning run
+};
+
+void AddPlayerbotsIntegrationTestScripts();
+
+#endif
+#endif  // PLAYERBOTS_INTEGRATION_TESTS

--- a/src/Test/TestScenario.cpp
+++ b/src/Test/TestScenario.cpp
@@ -1,0 +1,669 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifdef PLAYERBOTS_INTEGRATION_TESTS
+
+#include "TestRunner.h"
+#include "TestScenario.h"
+
+#include "Bag.h"
+#include "CharacterCache.h"
+#include "Creature.h"
+#include "GroupMgr.h"
+#include "Map.h"
+#include "MotionMaster.h"
+#include "ObjectAccessor.h"
+#include "ObjectMgr.h"
+#include "Player.h"
+#include "PlayerbotAIConfig.h"
+#include "PlayerbotFactory.h"
+#include "Playerbots.h"
+#include "SpellDefines.h"
+#include "SpellInfo.h"
+#include "SpellMgr.h"
+#include "StringFormat.h"
+
+#include <memory>
+#include <set>
+
+void TestContext::Step(std::string name, uint32 timeoutMs, std::function<StepStatus(TestContext&)> tick)
+{
+    steps.push_back(TestStep{ std::move(name), timeoutMs, std::move(tick) });
+}
+
+void TestContext::Do(std::string name, std::function<bool(TestContext&)> action)
+{
+    Step(std::move(name), 0, [action = std::move(action)](TestContext& ctx)
+    {
+        return action(ctx) ? StepStatus::Done : StepStatus::Failed;
+    });
+}
+
+void TestContext::WaitUntil(std::string name, uint32 timeoutMs, std::function<bool(TestContext&)> pred)
+{
+    Step(std::move(name), timeoutMs, [pred = std::move(pred)](TestContext& ctx)
+    {
+        return pred(ctx) ? StepStatus::Done : StepStatus::InProgress;
+    });
+}
+
+void TestContext::Assert(std::string name, std::function<bool(TestContext&)> pred)
+{
+    Do(std::move(name), std::move(pred));
+}
+
+Player* TestContext::GetBot(size_t index) const
+{
+    if (index >= botGuids.size())
+        return nullptr;
+
+    Player* bot = ObjectAccessor::FindConnectedPlayer(botGuids[index]);
+    return bot && bot->IsInWorld() ? bot : nullptr;
+}
+
+Player* TestContext::FirstAliveBot() const
+{
+    for (size_t i = 0; i < botGuids.size(); ++i)
+        if (Player* bot = GetBot(i))
+            if (bot->IsAlive())
+                return bot;
+
+    return nullptr;
+}
+
+uint32 TestContext::AliveBotCount() const
+{
+    uint32 count = 0;
+    for (size_t i = 0; i < botGuids.size(); ++i)
+        if (Player* bot = GetBot(i))
+            if (bot->IsAlive())
+                ++count;
+
+    return count;
+}
+
+void TestContext::ForEachBotAI(std::function<void(Player*, PlayerbotAI*)> const& fn) const
+{
+    for (size_t i = 0; i < botGuids.size(); ++i)
+        if (Player* bot = GetBot(i))
+            if (PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot))
+                fn(bot, botAI);
+}
+
+void TestContext::MarkSkull(ObjectGuid target) const
+{
+    Player* leader = GetBot(0);
+    if (!leader)
+        return;
+
+    if (Group* group = leader->GetGroup())
+        group->SetTargetIcon(7, leader->GetGUID(), target);
+}
+
+void TestContext::OrderAttack(size_t index) const
+{
+    if (Player* bot = GetBot(index))
+        if (bot->IsAlive())
+            if (PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot))
+                botAI->DoSpecificAction("attack rti target");
+}
+
+void TestContext::OrderAttackAll(size_t skipOffTanksBelow) const
+{
+    for (size_t i = 0; i < botGuids.size(); ++i)
+    {
+        if (i > 0 && i < skipOffTanksBelow)
+            continue;
+
+        OrderAttack(i);
+    }
+}
+
+void TestContext::PrepareRaid(uint32 level, std::vector<BotDef> const& comp, GearDef gear, uint8 progression,
+                              uint32 mapId, Position const& pos, std::vector<uint32> const& spare)
+{
+    SpawnBots(level, comp, gear);
+    SetProgression(progression);
+    FormGroup(true);
+    TeleportTo(mapId, pos);
+    ClearMap(spare);
+    ReadyCheck();
+}
+
+void TestContext::SpawnBots(uint32 level, std::vector<BotDef> const& bots, GearDef gear, bool alliance)
+{
+    struct SpawnState
+    {
+        bool requested = false;
+        uint32 lastPrepareMs = 0;
+        std::set<ObjectGuid> factoryDone;
+    };
+    auto state = std::make_shared<SpawnState>();
+
+    // Generous: a fresh test DB creates the whole account pool on first boot.
+    Step("spawn bots", 15 * MINUTE * IN_MILLISECONDS, [state, level, bots, gear, alliance](TestContext& ctx) -> StepStatus
+    {
+        if (!state->requested)
+        {
+            // Try to pick one offline character per requested class (alliance pool).
+            std::set<ObjectGuid> used;
+            std::vector<ObjectGuid> picked;
+            for (BotDef const& def : bots)
+            {
+                auto const& cache = sRandomPlayerbotMgr.addclassCache[RandomPlayerbotMgr::GetTeamClassIdx(alliance, def.cls)];
+                ObjectGuid chosen;
+                for (ObjectGuid const& guid : cache)
+                {
+                    // Skip bots connected, already picked, or owned by another run.
+                    if (used.count(guid) || ObjectAccessor::FindConnectedPlayer(guid) ||
+                        IntegrationTestMgr::instance().IsParticipant(guid))
+                        continue;
+
+                    // Race-locked pick for race-gated quests (SatisfyQuestRace).
+                    if (def.race != 0)
+                    {
+                        CharacterCacheEntry const* entry = sCharacterCache->GetCharacterCacheByGuid(guid);
+                        if (!entry || entry->Race != def.race)
+                            continue;
+                    }
+
+                    chosen = guid;
+                    break;
+                }
+
+                if (chosen.IsEmpty())
+                    break;
+
+                used.insert(chosen);
+                picked.push_back(chosen);
+            }
+
+            if (picked.size() < bots.size())
+            {
+                // Pool not ready (first boot) — refresh it periodically and retry.
+                uint32 nowMs = ctx.StepElapsedMs();
+                if (nowMs - state->lastPrepareMs >= 30000)
+                {
+                    state->lastPrepareMs = nowMs;
+                    sRandomPlayerbotMgr.PrepareAddclassCache();
+                }
+                return StepStatus::InProgress;
+            }
+
+            for (ObjectGuid const& guid : picked)
+                sRandomPlayerbotMgr.AddPlayerBot(guid, 0);  // masterless
+
+            // Class-qualified spec labels: premade names collide across classes.
+            static char const* CLASS_NAMES[MAX_CLASSES] = { "", "warrior", "paladin", "hunter", "rogue", "priest",
+                                                            "dk", "shaman", "mage", "warlock", "", "druid" };
+            ctx.botGuids = picked;
+            ctx.botSpecs.clear();
+            for (size_t i = 0; i < picked.size(); ++i)
+                ctx.botSpecs.push_back(Acore::StringFormat("{} {}",
+                    bots[i].cls < MAX_CLASSES ? CLASS_NAMES[bots[i].cls] : "?",
+                    bots[i].spec.empty() ? "random" : bots[i].spec));
+            state->requested = true;
+            return StepStatus::InProgress;
+        }
+
+        // Wait until every bot is fully logged in with AI attached.
+        for (size_t i = 0; i < ctx.botGuids.size(); ++i)
+        {
+            Player* bot = ctx.GetBot(i);
+            if (!bot || !GET_PLAYERBOT_AI(bot))
+                return StepStatus::InProgress;
+        }
+
+        // Level + gear each bot once; apply the requested spec after Randomize.
+        for (size_t i = 0; i < ctx.botGuids.size(); ++i)
+        {
+            if (state->factoryDone.count(ctx.botGuids[i]))
+                continue;
+
+            Player* bot = ctx.GetBot(i);
+
+            // Pooled chars saved with PLAYER_EXTRA_GM_ON load as GM, which creatures
+            // can't attack (they evade) — clear it so combat objectives work.
+            bot->SetGameMaster(false);
+
+            uint32 const gearScore = gear.ilvl ? PlayerbotFactory::CalcMixedGearScore(gear.ilvl, gear.quality) : 0;
+            PlayerbotFactory factory(bot, level, gear.quality, gearScore);
+            factory.Randomize(false);
+
+            std::string const& spec = bots[i].spec;
+            if (!spec.empty())
+            {
+                int specNo = -1;
+                for (int no = 0; no < MAX_SPECNO; ++no)
+                {
+                    if (sPlayerbotAIConfig.premadeSpecName[bots[i].cls][no] == spec)
+                    {
+                        specNo = no;
+                        break;
+                    }
+                }
+
+                if (specNo < 0)
+                {
+                    ctx.AddNote(Acore::StringFormat("SpawnBots: unknown premade spec '{}' for class {}", spec, bots[i].cls));
+                    return StepStatus::Failed;
+                }
+
+                PlayerbotFactory::InitTalentsBySpecNo(bot, specNo, true);
+                PlayerbotFactory regear(bot, level, gear.quality, gearScore);
+                regear.InitEquipment(false, sPlayerbotAIConfig.twoRoundsGearInit);
+                regear.InitGlyphs(false);
+                // Randomize enchanted the random-spec gear this regear just replaced.
+                if (level >= uint32(sPlayerbotAIConfig.minEnchantingBotLevel))
+                    regear.ApplyEnchantAndGemsNew();
+                if (PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot))
+                    botAI->ResetStrategies(false);
+            }
+
+            // BiS gearing runs after talents (BiS list resolves by active spec tab).
+            if (gear.bis)
+                if (PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot))
+                    if (!botAI->DoSpecificAction("autogear bis",
+                            gear.ilvl ? Event("autogear bis", std::to_string(gear.ilvl)) : Event("autogear bis")))
+                        ctx.AddNote(Acore::StringFormat("SpawnBots: bis gearing refused for {} (check AutoGearBis* config)",
+                            bot->GetName()));
+
+            // Restock consumables: reused pool bots deplete potions/reagents.
+            if (PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot))
+                botAI->DoSpecificAction("maintenance");
+
+            // Masterless bots skip the factory's avoid-aoe strategy; add it back.
+            if (PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot))
+                botAI->ChangeStrategy("+avoid aoe", BOT_STATE_COMBAT);
+
+            // Scenarios start topped off.
+            bot->SetFullHealth();
+            bot->SetPower(bot->getPowerType(), bot->GetMaxPower(bot->getPowerType()));
+
+            state->factoryDone.insert(ctx.botGuids[i]);
+        }
+
+        return StepStatus::Done;
+    });
+}
+
+void TestContext::FormGroup(bool raid)
+{
+    Do(raid ? "form raid" : "form group", [raid](TestContext& ctx)
+    {
+        Player* leader = ctx.GetBot(0);
+        if (!leader)
+            return false;
+
+        if (leader->GetGroup())
+        {
+            ctx.AddNote(Acore::StringFormat("FormGroup: bot '{}' is already in a group", leader->GetName()));
+            return false;
+        }
+
+        Group* group = new Group();
+        if (!group->Create(leader))
+        {
+            delete group;
+            return false;
+        }
+        sGroupMgr->AddGroup(group);
+
+        for (size_t i = 1; i < ctx.botGuids.size(); ++i)
+        {
+            Player* bot = ctx.GetBot(i);
+            if (!bot)
+            {
+                group->Disband();
+                return false;
+            }
+
+            if (bot->GetGroup())
+            {
+                ctx.AddNote(Acore::StringFormat("FormGroup: bot '{}' is already in a group", bot->GetName()));
+                group->Disband();
+                return false;
+            }
+
+            if (raid && !group->isRaidGroup() && group->GetMembersCount() >= 5)
+                group->ConvertToRaid();
+
+            if (!group->AddMember(bot))
+            {
+                group->Disband();
+                return false;
+            }
+        }
+
+        // Set difficulty by raid size unconditionally: a reused leader can carry a
+        // stale 25-man difficulty, so a 10-man comp would otherwise fight the 25-man
+        // boss (single-mode maps downscale anyway).
+        if (raid)
+            group->SetRaidDifficulty(ctx.botGuids.size() > 10 ? RAID_DIFFICULTY_25MAN_NORMAL
+                                                              : RAID_DIFFICULTY_10MAN_NORMAL);
+
+        ctx.groupLeader = leader->GetGUID();
+        return true;
+    });
+}
+
+void TestContext::ReadyCheck(uint32 minMs, uint32 softCapMs)
+{
+    // Mirrors the client ready check: 35s rounds, re-issued while anyone is pending,
+    // bounded by the soft cap.
+    constexpr uint32 ROUND_MS = 35 * IN_MILLISECONDS;
+    struct CheckState
+    {
+        bool started = false;
+        uint32 round = 1;
+        uint32 roundStartMs = 0;
+    };
+    auto state = std::make_shared<CheckState>();
+    Step("ready check", (softCapMs + 30000), [state, minMs, softCapMs](TestContext& ctx) -> StepStatus
+    {
+        bool anyInCombat = false;
+        uint32 pending = 0;
+        ctx.ForEachBotAI([&](Player* bot, PlayerbotAI* botAI)
+        {
+            if (!bot->IsAlive())
+                return;
+
+            if (!state->started)
+                botAI->forceRebuff.Begin(false);
+            else if (botAI->forceRebuff.IsPending())
+                ++pending;
+
+            if (bot->IsInCombat())
+                anyInCombat = true;
+        });
+
+        if (!state->started)
+        {
+            state->started = true;
+            return StepStatus::InProgress;
+        }
+
+        uint32 const elapsed = ctx.StepElapsedMs();
+
+        // Pending flags are only meaningful after a few buff cycles.
+        if (!anyInCombat && elapsed < minMs)
+            return StepStatus::InProgress;
+
+        if (!anyInCombat && pending && elapsed < softCapMs)
+        {
+            // Round expired with stragglers: check again, carrying rebuff state over.
+            if (elapsed - state->roundStartMs >= ROUND_MS)
+            {
+                ctx.AddNote(Acore::StringFormat("ready check round {} ended: {} still pending", state->round, pending));
+                ++state->round;
+                state->roundStartMs = elapsed;
+            }
+
+            return StepStatus::InProgress;
+        }
+
+        if (pending)
+        {
+            ctx.AddNote(anyInCombat ? "ready check cut short: combat started"
+                                    : "ready check timeout: proceeding with unready bots");
+            ctx.ForEachBotAI([](Player*, PlayerbotAI* botAI) { botAI->forceRebuff.End(); });
+        }
+
+        return StepStatus::Done;
+    });
+}
+
+TestContext::ReadinessSummary TestContext::NoteReadiness(std::string const& tag)
+{
+    ReadinessSummary summary;
+    for (size_t i = 0; i < botGuids.size(); ++i)
+    {
+        Player* bot = GetBot(i);
+        if (!bot)
+            continue;
+
+        PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+
+        uint32 manaPotions = 0;
+        uint32 freeBagSlots = 0;
+        auto scanItem = [&manaPotions](Item* item)
+        {
+            if (!item)
+                return;
+            ItemTemplate const* proto = item->GetTemplate();
+            if (proto->Class != ITEM_CLASS_CONSUMABLE ||
+                (proto->SubClass != ITEM_SUBCLASS_POTION && proto->SubClass != ITEM_SUBCLASS_FLASK))
+                return;
+            SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(proto->Spells[0].SpellId);
+            if (spellInfo && spellInfo->Effects[EFFECT_0].Effect == SPELL_EFFECT_ENERGIZE)
+                manaPotions += item->GetCount();
+        };
+        for (uint8 slot = INVENTORY_SLOT_ITEM_START; slot < INVENTORY_SLOT_ITEM_END; ++slot)
+        {
+            Item* item = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
+            if (!item)
+                ++freeBagSlots;
+            scanItem(item);
+        }
+        for (uint8 bagSlot = INVENTORY_SLOT_BAG_START; bagSlot < INVENTORY_SLOT_BAG_END; ++bagSlot)
+            if (Bag* bag = bot->GetBagByPos(bagSlot))
+                for (uint32 slot = 0; slot < bag->GetBagSize(); ++slot)
+                {
+                    Item* item = bag->GetItemByPos(slot);
+                    if (!item)
+                        ++freeBagSlots;
+                    scanItem(item);
+                }
+
+        // Capital = greater (class-wide) variant, lower = single-target.
+        std::string blessings;
+        if (botAI)
+        {
+            if (botAI->HasAura("greater blessing of might", bot)) blessings += 'M';
+            else if (botAI->HasAura("blessing of might", bot)) blessings += 'm';
+            if (botAI->HasAura("greater blessing of wisdom", bot)) blessings += 'W';
+            else if (botAI->HasAura("blessing of wisdom", bot)) blessings += 'w';
+            if (botAI->HasAura("greater blessing of kings", bot)) blessings += 'K';
+            else if (botAI->HasAura("blessing of kings", bot)) blessings += 'k';
+            if (botAI->HasAura("greater blessing of sanctuary", bot)) blessings += 'S';
+            else if (botAI->HasAura("blessing of sanctuary", bot)) blessings += 's';
+        }
+        if (blessings.empty())
+            blessings = "-";
+
+        uint32 manaPct = bot->GetMaxPower(POWER_MANA)
+            ? bot->GetPower(POWER_MANA) * 100 / bot->GetMaxPower(POWER_MANA) : 0;
+
+        if (blessings == "-")
+            ++summary.unblessed;
+        if (bot->GetMaxPower(POWER_MANA) && !manaPotions)
+            ++summary.unstockedManaUsers;
+
+        // Rogues/shamans imbue weapons (temp enchant slot); "-" = missing.
+        std::string imbues = "n/a";
+        if (bot->getClass() == CLASS_ROGUE || bot->getClass() == CLASS_SHAMAN)
+        {
+            imbues.clear();
+            for (uint8 slot : { uint8(EQUIPMENT_SLOT_MAINHAND), uint8(EQUIPMENT_SLOT_OFFHAND) })
+            {
+                Item* weapon = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
+                if (!weapon || weapon->GetTemplate()->Class != ITEM_CLASS_WEAPON)
+                    continue;
+                bool const imbued = weapon->GetEnchantmentId(TEMP_ENCHANTMENT_SLOT) != 0;
+                imbues += imbued ? (slot == EQUIPMENT_SLOT_MAINHAND ? "MH" : "OH") : "-";
+                if (!imbued)
+                    ++summary.unimbuedWeapons;
+            }
+            if (imbues.empty())
+                imbues = "none";
+        }
+
+        // A warlock's soulstone ends up as an aura on some raid member.
+        if (bot->getClass() == CLASS_WARLOCK && botAI)
+        {
+            bool stoned = false;
+            for (size_t j = 0; j < botGuids.size() && !stoned; ++j)
+                if (Player* member = GetBot(j))
+                    stoned = botAI->HasAura("soulstone resurrection", member);
+            if (!stoned)
+                ++summary.missingSoulstones;
+        }
+
+        Player* leader = GetBot(0);
+        float distToLeader = leader && leader != bot && leader->GetMapId() == bot->GetMapId()
+            ? bot->GetDistance(leader) : 0.0f;
+
+        AddNote(Acore::StringFormat("readiness@{}: {} class {} spec '{}' lvl {} hp {} mana {}% fr {} grp {} manapots {} bless {} imbue {} freebag {} pvp {} ffa {} map {} dist {:.0f}",
+            tag, bot->GetName(), bot->getClass(),
+            i < botSpecs.size() ? botSpecs[i] : "?",
+            bot->GetLevel(), bot->GetMaxHealth(), manaPct,
+            bot->GetResistance(SPELL_SCHOOL_FIRE),
+            bot->GetGroup() ? bot->GetGroup()->GetMemberGroup(bot->GetGUID()) : 99,
+            manaPotions, blessings, imbues, freeBagSlots,
+            bot->IsPvP(), bot->IsFFAPvP(), bot->GetMapId(), distToLeader));
+    }
+
+    return summary;
+}
+
+void TestContext::ClearMap(std::vector<uint32> const& spareEntries)
+{
+    Do("clear map", [spareEntries](TestContext& ctx)
+    {
+        Player* ref = ctx.GetBot(0);
+        if (!ref)
+            return false;
+
+        Map* map = ref->GetMap();
+        map->LoadAllGrids();
+
+        std::vector<Creature*> doomed;
+        for (auto const& [spawnId, creature] : map->GetCreatureBySpawnIdStore())
+        {
+            if (!creature->IsAlive() || creature->IsPet() || creature->IsSummon() || creature->IsInCombat())
+                continue;
+
+            if (!creature->IsHostileTo(ref))
+                continue;
+
+            if (std::find(spareEntries.begin(), spareEntries.end(), creature->GetEntry()) != spareEntries.end())
+                continue;
+
+            doomed.push_back(creature);
+        }
+
+        for (Creature* creature : doomed)
+            creature->DespawnOrUnsummon();
+
+        ctx.AddNote(Acore::StringFormat("cleared {} hostiles map-wide", doomed.size()));
+        return true;
+    });
+}
+
+void TestContext::SetProgression(uint8 state)
+{
+    Do("set progression", [state](TestContext& ctx)
+    {
+        for (size_t i = 0; i < ctx.botGuids.size(); ++i)
+        {
+            Player* bot = ctx.GetBot(i);
+            if (!bot)
+                return false;
+
+            for (uint8 tier = 1; tier <= 18; ++tier)
+            {
+                uint32 questId = 66000 + tier;
+                Quest const* quest = sObjectMgr->GetQuestTemplate(questId);
+                if (!quest)
+                    continue;
+
+                if (tier <= state)
+                {
+                    if (bot->GetQuestStatus(questId) != QUEST_STATUS_REWARDED)
+                    {
+                        bot->AddQuest(quest, nullptr);
+                        bot->CompleteQuest(questId);
+                        bot->RewardQuest(quest, 0, bot, false, false);
+                    }
+                }
+                else if (bot->GetQuestStatus(questId) == QUEST_STATUS_REWARDED)
+                    bot->RemoveRewardedQuest(questId);
+            }
+        }
+        return true;
+    });
+}
+
+namespace
+{
+    bool TeleportOneBot(Player* bot, uint32 mapId, float x, float y, float z, float o)
+    {
+        bot->GetMotionMaster()->Clear();
+        if (PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot))
+            botAI->Reset(true);
+        bot->RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_TELEPORTED | AURA_INTERRUPT_FLAG_CHANGE_MAP);
+        bool result = bot->TeleportTo(mapId, x, y, z, o);
+        bot->SendMovementFlagUpdate();
+        return result;
+    }
+
+    bool BotArrived(ObjectGuid guid, uint32 mapId)
+    {
+        Player* bot = ObjectAccessor::FindConnectedPlayer(guid);
+        return bot && !bot->IsBeingTeleported() && bot->IsInWorld() && bot->GetMapId() == mapId;
+    }
+}
+
+void TestContext::TeleportTo(uint32 mapId, float x, float y, float z, float o)
+{
+    // Leader zones in first to create/bind the instance; the rest follow next tick.
+    enum class Phase { Leader, Members, Wait };
+    auto phase = std::make_shared<Phase>(Phase::Leader);
+    Step("teleport", 120 * IN_MILLISECONDS, [phase, mapId, x, y, z, o](TestContext& ctx) -> StepStatus
+    {
+        switch (*phase)
+        {
+            case Phase::Leader:
+            {
+                Player* leader = ctx.GetBot(0);
+                if (!leader || !TeleportOneBot(leader, mapId, x, y, z, o))
+                    return StepStatus::Failed;
+
+                *phase = Phase::Members;
+                return StepStatus::InProgress;
+            }
+            case Phase::Members:
+            {
+                if (!BotArrived(ctx.botGuids[0], mapId))
+                    return StepStatus::InProgress;
+
+                for (size_t i = 1; i < ctx.botGuids.size(); ++i)
+                {
+                    Player* bot = ctx.GetBot(i);
+                    if (!bot)
+                        return StepStatus::Failed;
+
+                    // Stack everyone on one spot: spread bots fall out of buff LOS.
+                    if (!TeleportOneBot(bot, mapId, x, y, z, o))
+                        return StepStatus::Failed;
+                }
+                *phase = Phase::Wait;
+                return StepStatus::InProgress;
+            }
+            case Phase::Wait:
+            {
+                for (ObjectGuid const& guid : ctx.botGuids)
+                    if (!BotArrived(guid, mapId))
+                        return StepStatus::InProgress;
+
+                return StepStatus::Done;
+            }
+        }
+        return StepStatus::InProgress;
+    });
+}
+
+#endif  // PLAYERBOTS_INTEGRATION_TESTS

--- a/src/Test/TestScenario.h
+++ b/src/Test/TestScenario.h
@@ -1,0 +1,144 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifdef PLAYERBOTS_INTEGRATION_TESTS
+#ifndef _PLAYERBOT_TESTSCENARIO_H
+#define _PLAYERBOT_TESTSCENARIO_H
+
+#include "ObjectGuid.h"
+#include "Position.h"
+
+#include <deque>
+#include <functional>
+#include <map>
+#include <string>
+#include <vector>
+
+class Player;
+class PlayerbotAI;
+
+enum class StepStatus
+{
+    InProgress,
+    Done,
+    Failed
+};
+
+class TestContext;
+
+struct TestStep
+{
+    std::string name;
+    uint32 timeoutMs;
+    std::function<StepStatus(TestContext&)> tick;
+    uint32 elapsedMs = 0;
+};
+
+struct BotDef
+{
+    uint8 cls;
+    std::string spec;   // premade spec name from AiPlayerbot.PremadeSpecName.* ("prot pve"); empty = random
+    uint8 race = 0;     // RACE_* to force a specific race from the pool; 0 = any race of the faction
+};
+
+struct GearDef
+{
+    uint32 quality;     // ITEM_QUALITY_* cap for the factory
+    uint16 ilvl;        // 0 = level-appropriate; else gearscore-capped at this ilvl
+    bool bis;           // gear from the module's BiS list at ilvl ("autogear bis")
+    GearDef(uint32 quality, uint16 ilvl = 0, bool bis = false) : quality(quality), ilvl(ilvl), bis(bis) { }
+};
+
+// mod-individual-progression tiers (hidden quests 66000+tier), applied via
+// TestContext::SetProgression.
+constexpr uint8 PROGRESSION_VANILLA_START = 0;
+constexpr uint8 PROGRESSION_WOTLK_RAIDS = 13;
+
+class TestContext
+{
+public:
+    // Generic queued step; everything else is sugar over this.
+    void Step(std::string name, uint32 timeoutMs, std::function<StepStatus(TestContext&)> tick);
+    // One-shot action; returning false fails the scenario.
+    void Do(std::string name, std::function<bool(TestContext&)> action);
+    // Polled every world tick until true; timeout fails the scenario.
+    void WaitUntil(std::string name, uint32 timeoutMs, std::function<bool(TestContext&)> pred);
+    // One-shot check; false fails the scenario.
+    void Assert(std::string name, std::function<bool(TestContext&)> pred);
+
+    // Bot lifecycle primitives.
+    void SpawnBots(uint32 level, std::vector<BotDef> const& bots, GearDef gear, bool alliance = true);
+    void FormGroup(bool raid);
+    void TeleportTo(uint32 mapId, float x, float y, float z, float o);
+    void TeleportTo(uint32 mapId, Position const& pos)
+    {
+        TeleportTo(mapId, pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ(), pos.GetOrientation());
+    }
+    // Standard raid preamble: spawn, progression, group, teleport, clear, ready check.
+    void PrepareRaid(uint32 level, std::vector<BotDef> const& comp, GearDef gear, uint8 progression,
+                     uint32 mapId, Position const& pos, std::vector<uint32> const& spare = {});
+    // Despawns all hostiles except spareEntries, map-wide (a radius sweep misses patrols).
+    void ClearMap(std::vector<uint32> const& spareEntries);
+    // mod-individual-progression tier via hidden quests 66000+tier; no-op if absent.
+    void SetProgression(uint8 state);
+    struct ReadinessSummary
+    {
+        uint32 unblessed = 0;          // raid members without any paladin blessing
+        uint32 unstockedManaUsers = 0; // mana users without an energize potion
+        uint32 unimbuedWeapons = 0;    // rogues/shamans missing a weapon imbue (poison/enchant)
+        uint32 missingSoulstones = 0;  // warlocks with no soulstone aura anywhere in the raid
+    };
+    // Logs a per-bot readiness table (buffs, consumables, imbues) tagged @tag.
+    ReadinessSummary NoteReadiness(std::string const& tag);
+    // Rebuffs the raid via the ready-check machinery until nothing is pending.
+    // Proceeds early on combat; releases stuck bots at the soft cap.
+    void ReadyCheck(uint32 minMs = 15000, uint32 softCapMs = 140000);
+
+    Player* GetBot(size_t index) const;   // nullptr if not connected/in world
+    Player* FirstAliveBot() const;
+    uint32 AliveBotCount() const;
+
+    // Immediate helpers for use inside step ticks (not queued).
+    // Every connected bot with AI attached; liveness checks are the caller's.
+    void ForEachBotAI(std::function<void(Player*, PlayerbotAI*)> const& fn) const;
+    // Leader's group puts the skull on the kill target.
+    void MarkSkull(ObjectGuid target) const;
+    void OrderAttack(size_t index) const;
+    // Everyone attacks except off-tank indices 1..skipOffTanksBelow-1.
+    void OrderAttackAll(size_t skipOffTanksBelow = 0) const;
+    // Elapsed time of the currently executing step.
+    uint32 StepElapsedMs() const { return steps.empty() ? 0 : steps.front().elapsedMs; }
+
+    void SetMetric(std::string const& name, double value) { metrics[name] = value; }
+    void AddNote(std::string note) { notes.push_back(std::move(note)); }
+
+    std::vector<ObjectGuid> botGuids;
+    std::vector<std::string> botSpecs;    // parallel to botGuids; the BotDef spec each bot was given
+    ObjectGuid groupLeader;
+    ObjectGuid bossGuid;                  // set by scenarios; watched by recorder/timeline
+    uint32 elapsedMs = 0;                 // total scenario runtime so far
+    std::map<std::string, double> metrics;
+    std::vector<std::string> notes;
+    std::deque<TestStep> steps;
+};
+
+class TestScenario
+{
+public:
+    virtual ~TestScenario() = default;
+    virtual std::string GetName() const = 0;
+    virtual void Setup(TestContext& ctx) = 0;
+
+    // True on a non-instanceable map: two copies would share the world and contend
+    // for spawns, so the runner never runs such a scenario concurrently with itself.
+    virtual bool SharesWorldWithCopies() const { return false; }
+
+    // Runs sharing a non-empty key never run concurrently. Empty = ungrouped.
+    virtual std::string ZoneKey() const { return ""; }
+};
+
+#endif
+#endif  // PLAYERBOTS_INTEGRATION_TESTS


### PR DESCRIPTION
## Pull Request Description
<!-- Describe what this change does and why it is needed -->

Adds an in-process **integration-test harness** for mod-playerbots, compiled only under
`-DPLAYERBOTS_INTEGRATION_TESTS=ON` (**OFF by default**, so nothing compiles into a normal build).

The harness lets a stock worldserver boot headless, spawn/gear/group bots, drive them through a
scripted scenario (spawn → set progression → form raid → teleport → ready check → combat), assert
outcomes, and emit `test_results.json` plus a console summary. It is the foundation the raid/dps
and quest scenario PRs build on.

This PR contains only the framework core and the generic smoke scenarios; the raid/dps and quest scenarios are separate PRs.

> **Draft**: hard-depends on #2571 (ready-check / `forceRebuff`) and #2530 (paladin blessing rework);
> soft-depends on #2589 (keeps the global `PlayerbotAI` alive for cached values, may error without it).
> Stays draft until those merge into `test-staging`.

## Feature Evaluation

- **Minimum logic**: the entire subsystem is wrapped in `#ifdef PLAYERBOTS_INTEGRATION_TESTS`. In a
  default build none of it exists: no hooks registered, no per-tick work. In a test build it adds
  one `WorldScript::OnUpdate` that steps only *active* test runs, and one `UnitScript` (`OnDamage` /
  periodic-tick) that records only while participants are registered.
- **Processing cost**: **zero in production builds.** In a test build with no run queued,
  `Update()` early-returns on an empty run list and `RecordDamage()` early-returns on an empty
  participant map. Cost scales with the number of *active test runs*, not with the bot population.
  Test runs only exist on a machine explicitly built and launched for testing.

## How to Test the Changes

1. Build with `-DPLAYERBOTS_INTEGRATION_TESTS=ON`. CMake copies `run_test.py` + `test_env.example`
   into `bin/<config>/integration-tests/` beside the worldserver binary.
2. Create isolated test DBs (`acore_test_auth/characters/playerbots`; the world DB stays shared and
   is never written; see the README).
3. In that folder, copy `test_env.example` → `test_env` and fill in the test DB credentials.
4. Run: `python run_test.py "self_test bot_smoke ready_check"`
5. **Expected**: `self_test` and `bot_smoke` PASS; `ready_check` runs the full raid preamble and
   asserts buff/consumable coverage. Results land in `test_results.json`; `WORLDSERVER_EXIT_CODE=0`
   means all passed.

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)


## AI Assistance

Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)

Used for code generation and debugging. All code was read (multiple times) and is owned by me.

## Code Provenance / Attribution

Was any code in this PR copied or adapted from a sister / upstream project?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated. <!-- N/A: no bot dialogue added. -->
- - [x] Any code ported/adapted from another project is attributed. <!-- N/A: all original. -->
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers

- **Draft until deps merge**: needs #2571 (`forceRebuff` in `ready_check` / `TestScenario`) and #2530
  (blessing rework) to compile and pass; soft-depends on #2589. Based on `test-staging`, same base as
  those PRs.
- Everything is behind `-DPLAYERBOTS_INTEGRATION_TESTS=ON`; a normal build is unchanged.
- The run wrapper is cross-platform Python and is copied next to the binary at configure time; the
  real `test_env` lives only in the build output (never in the repo).
