### PR TITLE
Fix double free when disabling playerbots

### DIFF
--- a/src/Bot/PlayerbotMgr.cpp
+++ b/src/Bot/PlayerbotMgr.cpp
@@ -434,13 +434,6 @@ void PlayerbotHolder::DisablePlayerBot(ObjectGuid guid)
 
         bot->SaveToDB(false, false);
 
-        if (botAI->GetAiObjectContext())  // Maybe some day re-write to delate all pointer values.
-        {
-            TravelTarget* target = botAI->GetAiObjectContext()->GetValue<TravelTarget*>("travel target")->Get();
-            if (target)
-                delete target;
-        }
-
         RemoveFromPlayerbotsMap(guid);  // deletes bot player ptr inside this WorldSession PlayerBotMap
 
         delete botAI;


### PR DESCRIPTION
## Pull Request Description

Remove the manual deletion of the AI context's `TravelTarget` from `PlayerbotHolder::DisablePlayerBot`.

`TravelTargetValue` owns that allocation and deletes it when `PlayerbotAI` destroys its `AiObjectContext`. The old code
deleted the target directly and then deleted `botAI`, causing the same allocation to be freed a second time.

This is reachable when an account is deleted while one of its playerbots is online:

```text
TravelTargetValue::~TravelTargetValue
AiObjectContext::~AiObjectContext
PlayerbotAI::~PlayerbotAI
PlayerbotHolder::DisablePlayerBot
RandomPlayerbotMgr::OnPlayerLogout
WorldSession::LogoutPlayer
AccountMgr::DeleteAccount
```

The ownership correction matches the one made for the neighboring logout path in
https://github.com/mod-playerbots/mod-playerbots/pull/2131, which did not remove the duplicate pattern from
`DisablePlayerBot`.

### Historical Context

- In January 2021, `TravelTargetValue` changed from storing a GUID to owning a heap-allocated `TravelTarget`; its
  destructor was added to delete that pointer:
  [celguar/mangosbot-bots commit `5bc7dd8`](https://github.com/celguar/mangosbot-bots/commit/5bc7dd810e9811931f3fb7ff92fced9a5799536b).
- Six days later, a manual `delete target` was added to `LogoutPlayerBot` during a broad travel-system change that
  included a `.bot reload` crash fix. Its comment—"Maybe some day re-write to delate all pointer values"—shows that
  it was ad-hoc teardown rather than gameplay behavior:
  [commit `ba4b5d2`](https://github.com/celguar/mangosbot-bots/commit/ba4b5d285f58079be4697091b16a0129182c9ee2).
- In March 2021, `DisablePlayerBot` was introduced so self-bot AI could be disabled without disconnecting the real
  player. It copied the manual travel-target cleanup and then deleted `PlayerbotAI`:
  [commit `de16948`](https://github.com/celguar/mangosbot-bots/commit/de169488f0a491edc41c9abf59bdff8d4e3a70f8).
- The AzerothCore module imported that older lineage wholesale in its 2022
  ["Big update"](https://github.com/mod-playerbots/mod-playerbots/commit/b952636f0d9c5982c1b829fb6c26c5596d97ee57),
  retaining both destructor ownership and the copied manual delete.
- The sister CMaNGOS lineage later fixed this exact ownership conflict by restoring destructor ownership and removing
  the manual deletes from both logout and disable paths:
  [commit `c4a7b2b`](https://github.com/celguar/mangosbot-bots/commit/c4a7b2b1c2f7b5c216da9c79995a103829eb74cd).
- Finally, mod-playerbots PR #2131 confirmed the same double-free in the normal logout path and removed that copy,
  but left the duplicate block in `DisablePlayerBot`.

This history shows that the original goal was legitimate travel-state cleanup, including releasing destination and
position visitor bookkeeping. That cleanup still occurs when `delete botAI` destroys the AI context and its owning
`TravelTargetValue`; this PR removes only the second destruction of the same object.

## Feature Evaluation

- The minimum logic is to remove the non-owning manual delete and let `TravelTargetValue` perform its existing cleanup.
- This removes work from a bot-disable path. It adds no per-bot or per-tick processing.

## How to Test the Changes

1. Start `worldserver` with at least one random bot online.
2. At the server console, run `account delete <bot-account-name>` for that bot's account.
3. Verify that account deletion completes and that `server info` still responds.
4. Repeat with a bot that has an active travel destination.

Before this change, step 2 aborts in the allocator while `TravelTargetValue` is being destroyed. After this change, the
target remains owned by the AI context and is destroyed exactly once.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)

## AI Assistance

Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)

OpenAI Codex was used to trace a symbolicated allocator crash through the ownership chain, compare the duplicate pattern
with PR #2131, review the minimal patch, audit available test infrastructure, and prepare this draft. The resulting
change was reviewed against the current destructors and local diff. Runtime verification of the patched binary remains
pending and is called out below.

## Code Provenance / Attribution

Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)

No code was copied for this change: the seven-line deletion was derived independently from the captured allocator
crash and the current ownership chain. The history audit subsequently found the equivalent sister-project ownership
correction cited above, which is included as supporting evidence.

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note).
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers

Local checks:

- `git diff --check`
- `python3 apps/codestyle/codestyle-cpp.py`

Both pass. No local build was run; the draft CI builds are expected to provide platform compilation coverage.

`mod-playerbots` does not currently have an established automated test suite. AzerothCore exposes module test hooks, but
this lifecycle requires a real player session, motion state, AI registry, and database persistence that the current
mocks do not provide. A context-only destructor test would pass even with the original bug and would not protect this
path, so the integration regression procedure above is used instead.
