### PR TITLE
Prevent silent random bot account creation failures

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -103,6 +103,9 @@ AiPlayerbot.AddClassAccountPoolSize = 50
 
 # Prefix for created bot accounts (of any type).
 # Do not change this prefix while there are existing bot accounts.
+# The decimal account number is appended to this prefix. The longest generated account name must be at most
+# 16 characters when AiPlayerbot.RandomBotRandomPassword is 0 because the account name is also used as the password,
+# or 17 characters when AiPlayerbot.RandomBotRandomPassword is 1.
 AiPlayerbot.RandomBotAccountPrefix = "rndbot"
 
 # Delete all randombot accounts

--- a/src/Bot/Factory/RandomPlayerbotFactory.cpp
+++ b/src/Bot/Factory/RandomPlayerbotFactory.cpp
@@ -21,6 +21,33 @@
 #include "SharedDefines.h"
 #include "SocialMgr.h"
 #include "Timer.h"
+#include "Util.h"
+
+namespace
+{
+char const* GetAccountCreationError(AccountOpResult result)
+{
+    switch (result)
+    {
+        case AOR_OK:
+            return "no error";
+        case AOR_NAME_TOO_LONG:
+            return "account name is too long";
+        case AOR_PASS_TOO_LONG:
+            return "password is too long";
+        case AOR_EMAIL_TOO_LONG:
+            return "email is too long";
+        case AOR_NAME_ALREADY_EXIST:
+            return "account name already exists";
+        case AOR_NAME_NOT_EXIST:
+            return "account name does not exist";
+        case AOR_DB_INTERNAL_ERROR:
+            return "database error";
+    }
+
+    return "unknown error";
+}
+}
 
 constexpr RandomPlayerbotFactory::NameRaceAndGender RandomPlayerbotFactory::CombineRaceAndGender(uint8 race,
                                                                                                 uint8 gender)
@@ -595,8 +622,9 @@ void RandomPlayerbotFactory::CreateRandomBots()
 
     LOG_INFO("playerbots", "Creating random bot accounts...");
     std::unordered_map<NameRaceAndGender, std::vector<std::string>> nameCache;
-    std::vector<std::future<void>> account_creations;
+    std::vector<std::string> accountNamesToCreate;
     int account_creation = 0;
+    bool accountCreationFailed = false;
 
     // Calculates the total number of required accounts.
     uint32 totalAccountCount = CalculateTotalAccountCount();
@@ -611,11 +639,38 @@ void RandomPlayerbotFactory::CreateRandomBots()
         LoginDatabasePreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_GET_ACCOUNT_ID_BY_USERNAME);
         stmt->SetData(0, accountName);
         PreparedQueryResult result = LoginDatabase.Query(stmt);
-        if (result)
+        if (!result)
+            accountNamesToCreate.push_back(accountName);
+    }
+
+    if (!accountNamesToCreate.empty())
+    {
+        std::string const& longestAccountName = accountNamesToCreate.back();
+        std::string accountNameForLength = longestAccountName;
+        std::size_t const longestAccountNameLength = utf8length(accountNameForLength);
+
+        if (longestAccountNameLength > MAX_ACCOUNT_STR)
         {
-            continue;
+            LOG_ERROR("playerbots",
+                "Cannot create random bot accounts: generated account name '{}' is {} characters, exceeding the "
+                "{}-character account name limit. Shorten AiPlayerbot.RandomBotAccountPrefix.",
+                longestAccountName, longestAccountNameLength, MAX_ACCOUNT_STR);
+            return;
         }
-        account_creation++;
+
+        if (!sPlayerbotAIConfig.randomBotRandomPassword && longestAccountNameLength > MAX_PASS_STR)
+        {
+            LOG_ERROR("playerbots",
+                "Cannot create random bot accounts: generated account name '{}' is {} characters and will also be "
+                "used as its password, exceeding the {}-character password limit. Shorten "
+                "AiPlayerbot.RandomBotAccountPrefix or enable AiPlayerbot.RandomBotRandomPassword.",
+                longestAccountName, longestAccountNameLength, MAX_PASS_STR);
+            return;
+        }
+    }
+
+    for (std::string const& accountName : accountNamesToCreate)
+    {
         std::string password = "";
         if (sPlayerbotAIConfig.randomBotRandomPassword)
         {
@@ -627,9 +682,17 @@ void RandomPlayerbotFactory::CreateRandomBots()
         else
             password = accountName;
 
-        sAccountMgr->CreateAccount(accountName, password);
+        AccountOpResult const result = sAccountMgr->CreateAccount(accountName, password);
+        if (result != AOR_OK)
+        {
+            LOG_ERROR("playerbots", "Failed to create random bot account '{}': {} (error code {})", accountName,
+                GetAccountCreationError(result), static_cast<uint32>(result));
+            accountCreationFailed = true;
+            break;
+        }
 
-        LOG_DEBUG("playerbots", "Account {} created for random bots", accountName.c_str());
+        account_creation++;
+        LOG_DEBUG("playerbots", "Account {} created for random bots", accountName);
     }
     if (account_creation)
     {
@@ -641,6 +704,12 @@ void RandomPlayerbotFactory::CreateRandomBots()
             std::this_thread::sleep_for(1s);
         }
         LOG_INFO("playerbots", ">> {} Accounts loaded into database in {} ms", account_creation, GetMSTimeDiffToNow(timer));
+    }
+
+    if (accountCreationFailed)
+    {
+        LOG_ERROR("playerbots", "Aborting random bot character creation because an account could not be created.");
+        return;
     }
 
     LOG_INFO("playerbots", "Creating random bot characters...");


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

Random bot account creation could silently fail when the configured prefix plus its decimal suffix exceeded
[AzerothCore's account limits](https://github.com/mod-playerbots/azerothcore-wotlk/blob/test-staging/src/server/game/Accounts/AccountMgr.h#L23-L35).
Account names are limited to 17 characters, and passwords to 16. When
`AiPlayerbot.RandomBotRandomPassword = 0`, the generated account name is also used as the password, so the effective
generated-name limit is 16 characters.

The current loop ignores the result of `AccountMgr::CreateAccount`, increments the creation count before the call,
and logs success unconditionally. During local load-test setup, `codexloadbot20260723` produced no bot accounts
because even `codexloadbot202607230` is 21 characters. The shorter `codexlt23` prefix worked, but startup did not
identify the invalid generated name.

This change:

- collects the account names that are actually missing;
- validates the longest missing generated name before creating any accounts, including suffix digit boundaries;
- reports the applicable account-name or password limit with an actionable configuration error;
- checks every `CreateAccount` result and counts only successful calls;
- drains prior asynchronous inserts before aborting character creation after an unexpected failure; and
- documents the generated-name limits next to `AiPlayerbot.RandomBotAccountPrefix`.

Existing accounts are not rejected merely because the password mode changed; validation applies only to names that
would actually be created. Generated names are rejected rather than truncated to avoid collisions and unsafe prefix
ownership ambiguity.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.

  Reuse the existing startup account-existence scan to collect missing names, check the longest missing name against
  AzerothCore's account/password limits, and handle the existing `CreateAccount` return value.

- Describe the **processing cost** when this logic executes across many bots.

  No per-bot or per-tick logic is added. This runs only during random-bot account initialization. It performs the same
  account-existence queries as before and temporarily stores one short string per missing account.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

Use disposable databases or take a snapshot first because these tests create accounts. Start with no matching
random-bot accounts. Set `AiPlayerbot.MaxRandomBots = 0` and `AiPlayerbot.AddClassAccountPoolSize = 0` so the explicit
`AiPlayerbot.RandomBotAccountCount` drives these focused cases.

| Random password | Account count | Prefix | Longest generated name | Expected result |
|---|---:|---|---|---|
| `0` | `1` | `rndprefix123456` | `rndprefix1234560` (16) | Account creation succeeds |
| `0` | `1` | `rndprefix1234567` | `rndprefix12345670` (17) | Reports the 16-character password limit; creates no pending accounts |
| `1` | `1` | `rndprefix1234567` | `rndprefix12345670` (17) | Account creation succeeds |
| `1` | `1` | `rndprefix12345678` | `rndprefix123456780` (18) | Reports the 17-character account-name limit; creates no pending accounts |
| `0` | `10` | `rndprefix123456` | `rndprefix1234569` (16) | Account creation succeeds |
| `0` | `11` | `rndprefix123456` | `rndprefix12345610` (17) | Rejects before creation, covering the `9` → `10` suffix boundary |

For each case, start `worldserver` and verify valid cases create the expected accounts. For invalid cases, verify the
log includes the generated name, actual length, applicable limit, and corrective configuration guidance, and that
random-bot character creation does not begin.

Finally, create a valid 17-character account with random passwords enabled, then disable random passwords and restart
with no accounts missing. Existing account initialization should not be rejected.

Checks run locally:

- `python3 apps/codestyle/codestyle-cpp.py`
- AzerothCore parent-tree C++ codestyle check
- `git diff --check`

The module has no registered unit-test target, and its CI does not enable `BUILD_TESTING`. Adding useful automated
coverage would require new module CMake/CI plumbing and a new public test seam, so no unit test is included in this
startup-only fix. Cross-platform compilation is left to this draft PR's existing CI.

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)

  Valid default configurations behave as before. Invalid configurations now stop with an actionable error.



- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [x] Yes (**explain below**)

  It adds startup-only validation and error-result branches. They do not execute in bot AI or update loops.

## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

Codex was used to trace the silent failure through the module and AzerothCore account manager, inspect the relevant
Git history and open PRs, draft the implementation and documentation, and perform a second-pass review. The submitted
diff was reviewed against the current source, core limits, asynchronous database behavior, project style rules, and
the boundary cases listed above.

## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note).
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

No new source files, bot dialogue, translations, or ported code are included. The macOS, Windows, and Ubuntu
cross-platform CI builds passed.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->

This is a latent error path rather than a regression from the recent account-count work:

- The unchecked account-creation loop dates to #971 (`624e4806`, February 2025).
- #2354 (`ccce1423`) only migrated the call to the `AccountMgr` singleton and preserved the ignored result.
- #2438 (`58b67038`) added user-error handling for insufficient `RandomBotAccountCount`, but does not handle account creation
  failures.

Open PR #2284 also changes this account-selection/creation area for realm-scoped ownership and currently retains the
unchecked `CreateAccount` call. This focused fix may need a straightforward rebase or equivalent handling folded into
that PR if #2284 lands first.

Malformed UTF-8 and empty/SQL-wildcard prefixes are intentionally outside this PR. Prefixes also participate in
`LIKE`-based ownership/deletion logic, so those cases need a broader safety design rather than being mixed into the
length/error-handling fix.
