### PR TITLE
Implement Sethekk Halls Strategies

### DIFF
--- a/src/Ai/Base/Actions/InviteToGroupAction.cpp
+++ b/src/Ai/Base/Actions/InviteToGroupAction.cpp
@@ -4,6 +4,15 @@
  * or (at your option) any later version.
  */
 
+/*
+ * Ported from the CMaNGOS playerbots project (https://github.com/cmangos/playerbots), GPL v2,
+ * with modifications for AzerothCore.
+ * Original authors:
+ *   Sebastiaan Keek (mostlikely4r) <sebastiaan.keek@gmail.com> - original author
+ *   David Parra Ausina (Flekz) <davidparraausina@gmail.com>
+ *   celguar <celguar@gmail.com>
+ */
+
 #include "InviteToGroupAction.h"
 
 #include "BroadcastHelper.h"

--- a/src/Ai/Base/Actions/InviteToGroupAction.h
+++ b/src/Ai/Base/Actions/InviteToGroupAction.h
@@ -4,6 +4,15 @@
  * or (at your option) any later version.
  */
 
+/*
+ * Ported from the CMaNGOS playerbots project (https://github.com/cmangos/playerbots), GPL v2,
+ * with modifications for AzerothCore.
+ * Original authors:
+ *   Sebastiaan Keek (mostlikely4r) <sebastiaan.keek@gmail.com> - original author
+ *   David Parra Ausina (Flekz) <davidparraausina@gmail.com>
+ *   celguar <celguar@gmail.com>
+ */
+
 #ifndef PLAYERBOTS_INVITETOGROUPACTION_H
 #define PLAYERBOTS_INVITETOGROUPACTION_H
 

--- a/src/Ai/Base/Actions/LootAction.cpp
+++ b/src/Ai/Base/Actions/LootAction.cpp
@@ -140,8 +140,9 @@ bool OpenLootAction::DoLoot(LootObject& lootObject)
     if (go && (go->GetGoState() != GO_STATE_READY))
         return false;
 
-    // This prevents dungeon chests like Tribunal Chest (Halls of Stone) from being ninja'd by the bots
-    if (go && go->HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_INTERACT_COND))
+    // This prevents dungeon chests like Tribunal Chest (Halls of Stone) from being ninja'd by the bots.
+    // Quest objects carry the same flag but are gated on quest state, which ActivateToQuest answers.
+    if (go && go->HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_INTERACT_COND) && !go->ActivateToQuest(bot))
         return false;
 
     // This prevents raid chests like Gunship Armory (ICC) from being ninja'd by the bots

--- a/src/Ai/Base/Actions/PullActions.cpp
+++ b/src/Ai/Base/Actions/PullActions.cpp
@@ -4,6 +4,15 @@
  * or (at your option) any later version.
  */
 
+/*
+ * Ported from the CMaNGOS playerbots project (https://github.com/cmangos/playerbots), GPL v2,
+ * with modifications for AzerothCore.
+ * Original authors:
+ *   David Parra Ausina (davidonete/Flekz) <davidparraausina@gmail.com> - original author
+ *   Sebastiaan Keek (mostlikely4r) <sebastiaan.keek@gmail.com>
+ *   Cyberium <cyberium@users.noreply.github.com>
+ */
+
 #include "AttackersValue.h"
 #include "CreatureAI.h"
 #include "Playerbots.h"

--- a/src/Ai/Base/Actions/PullActions.h
+++ b/src/Ai/Base/Actions/PullActions.h
@@ -4,6 +4,15 @@
  * or (at your option) any later version.
  */
 
+/*
+ * Ported from the CMaNGOS playerbots project (https://github.com/cmangos/playerbots), GPL v2,
+ * with modifications for AzerothCore.
+ * Original authors:
+ *   David Parra Ausina (davidonete/Flekz) <davidparraausina@gmail.com> - original author
+ *   Sebastiaan Keek (mostlikely4r) <sebastiaan.keek@gmail.com>
+ *   Cyberium <cyberium@users.noreply.github.com>
+ */
+
 #ifndef PLAYERBOTS_PULLACTIONS_H
 #define PLAYERBOTS_PULLACTIONS_H
 

--- a/src/Ai/Base/Actions/WaitForAttackAction.cpp
+++ b/src/Ai/Base/Actions/WaitForAttackAction.cpp
@@ -4,6 +4,15 @@
  * or (at your option) any later version.
  */
 
+/*
+ * Ported from the CMaNGOS playerbots project (https://github.com/cmangos/playerbots), GPL v2,
+ * with modifications for AzerothCore.
+ * Original authors:
+ *   David Parra Ausina (davidonete/Flekz) <davidparraausina@gmail.com> - original author
+ *   Sebastiaan Keek (mostlikely4r) <sebastiaan.keek@gmail.com>
+ *   Cyberium <cyberium@users.noreply.github.com>
+ */
+
 #include "WaitForAttackAction.h"
 
 #include <algorithm>

--- a/src/Ai/Base/Actions/WaitForAttackAction.h
+++ b/src/Ai/Base/Actions/WaitForAttackAction.h
@@ -4,6 +4,15 @@
  * or (at your option) any later version.
  */
 
+/*
+ * Ported from the CMaNGOS playerbots project (https://github.com/cmangos/playerbots), GPL v2,
+ * with modifications for AzerothCore.
+ * Original authors:
+ *   David Parra Ausina (davidonete/Flekz) <davidparraausina@gmail.com> - original author
+ *   Sebastiaan Keek (mostlikely4r) <sebastiaan.keek@gmail.com>
+ *   Cyberium <cyberium@users.noreply.github.com>
+ */
+
 #ifndef PLAYERBOTS_WAITFORATTACKACTION_H
 #define PLAYERBOTS_WAITFORATTACKACTION_H
 

--- a/src/Ai/Base/Strategy/PullStrategy.cpp
+++ b/src/Ai/Base/Strategy/PullStrategy.cpp
@@ -4,6 +4,15 @@
  * or (at your option) any later version.
  */
 
+/*
+ * Ported from the CMaNGOS playerbots project (https://github.com/cmangos/playerbots), GPL v2,
+ * with modifications for AzerothCore.
+ * Original authors:
+ *   ike3 <ike@email.org> - original author
+ *   Sebastiaan Keek (mostlikely4r) <sebastiaan.keek@gmail.com>
+ *   David Parra Ausina (Flekz) <davidparraausina@gmail.com>
+ */
+
 #include "PullStrategy.h"
 
 #include "AiObjectContext.h"

--- a/src/Ai/Base/Strategy/PullStrategy.h
+++ b/src/Ai/Base/Strategy/PullStrategy.h
@@ -4,6 +4,15 @@
  * or (at your option) any later version.
  */
 
+/*
+ * Ported from the CMaNGOS playerbots project (https://github.com/cmangos/playerbots), GPL v2,
+ * with modifications for AzerothCore.
+ * Original authors:
+ *   ike3 <ike@email.org> - original author
+ *   Sebastiaan Keek (mostlikely4r) <sebastiaan.keek@gmail.com>
+ *   David Parra Ausina (Flekz) <davidparraausina@gmail.com>
+ */
+
 #ifndef PLAYERBOTS_PULLSTRATEGY_H
 #define PLAYERBOTS_PULLSTRATEGY_H
 

--- a/src/Ai/Base/Trigger/PullTriggers.cpp
+++ b/src/Ai/Base/Trigger/PullTriggers.cpp
@@ -4,6 +4,15 @@
  * or (at your option) any later version.
  */
 
+/*
+ * Ported from the CMaNGOS playerbots project (https://github.com/cmangos/playerbots), GPL v2,
+ * with modifications for AzerothCore.
+ * Original authors:
+ *   David Parra Ausina (davidonete/Flekz) <davidparraausina@gmail.com> - original author
+ *   Sebastiaan Keek (mostlikely4r) <sebastiaan.keek@gmail.com>
+ *   Cyberium <cyberium@users.noreply.github.com>
+ */
+
 #include "PullTriggers.h"
 
 #include "PositionValue.h"

--- a/src/Ai/Base/Trigger/PullTriggers.h
+++ b/src/Ai/Base/Trigger/PullTriggers.h
@@ -4,6 +4,15 @@
  * or (at your option) any later version.
  */
 
+/*
+ * Ported from the CMaNGOS playerbots project (https://github.com/cmangos/playerbots), GPL v2,
+ * with modifications for AzerothCore.
+ * Original authors:
+ *   David Parra Ausina (davidonete/Flekz) <davidparraausina@gmail.com> - original author
+ *   Sebastiaan Keek (mostlikely4r) <sebastiaan.keek@gmail.com>
+ *   Cyberium <cyberium@users.noreply.github.com>
+ */
+
 #ifndef PLAYERBOTS_PULLTRIGGERS_H
 #define PLAYERBOTS_PULLTRIGGERS_H
 

--- a/src/Ai/Base/Trigger/WithinAreaTrigger.cpp
+++ b/src/Ai/Base/Trigger/WithinAreaTrigger.cpp
@@ -62,8 +62,8 @@ bool WithinAreaTrigger::IsPointInAreaTriggerZone(AreaTrigger const* atEntry, uin
         float dz = z - atEntry->z;
         float dx = rotPlayerX - atEntry->x;
         float dy = rotPlayerY - atEntry->y;
-        if ((fabs(dx) > atEntry->x / 2 + delta) || (fabs(dy) > atEntry->y / 2 + delta) ||
-            (fabs(dz) > atEntry->z / 2 + delta))
+        if ((fabs(dx) > atEntry->length / 2 + delta) || (fabs(dy) > atEntry->width / 2 + delta) ||
+            (fabs(dz) > atEntry->height / 2 + delta))
         {
             return false;
         }

--- a/src/Ai/Base/Value/QuestValues.cpp
+++ b/src/Ai/Base/Value/QuestValues.cpp
@@ -278,7 +278,7 @@ std::vector<GuidPosition> ActiveQuestObjectivesValue::Calculate()
 
             if (quest->RequiredNpcOrGoCount[objective])
             {
-                uint32 reqCount = quest->RequiredItemCount[objective];
+                uint32 reqCount = quest->RequiredNpcOrGoCount[objective];
                 uint32 hasCount = statusData.CreatureOrGOCount[objective];
 
                 if (!reqCount || hasCount >= reqCount)

--- a/src/Ai/Base/Value/WaitForAttackTimeValue.h
+++ b/src/Ai/Base/Value/WaitForAttackTimeValue.h
@@ -4,6 +4,13 @@
  * or (at your option) any later version.
  */
 
+/*
+ * Ported from the CMaNGOS playerbots project (https://github.com/cmangos/playerbots), GPL v2,
+ * with modifications for AzerothCore.
+ * Original authors:
+ *   David Parra Ausina (davidonete/Flekz) <davidparraausina@gmail.com> - original author
+ */
+
 #ifndef PLAYERBOTS_WAITFORATTACKTIMEVALUE_H
 #define PLAYERBOTS_WAITFORATTACKTIMEVALUE_H
 

--- a/src/Ai/Class/Druid/Strategy/BearDruidStrategy.cpp
+++ b/src/Ai/Class/Druid/Strategy/BearDruidStrategy.cpp
@@ -19,6 +19,7 @@ public:
         creators["bash"] = &bash;
         creators["swipe (bear)"] = &swipe_bear;
         creators["lacerate"] = &lacerate;
+        creators["taunt spell"] = &growl; // Empty ActionNode needed to register as taunt spell
     }
 
 private:
@@ -78,6 +79,16 @@ private:
             "lacerate",
             /*P*/ {},
             /*A*/ { NextAction("maul") },
+            /*C*/ {}
+        );
+    }
+
+    static ActionNode* growl([[maybe_unused]] PlayerbotAI* botAI)
+    {
+        return new ActionNode(
+            "growl",
+            /*P*/ {},
+            /*A*/ {},
             /*C*/ {}
         );
     }

--- a/src/Ai/Dungeon/DungeonStrategyContext.h
+++ b/src/Ai/Dungeon/DungeonStrategyContext.h
@@ -9,6 +9,7 @@
 
 #include "Strategy.h"
 #include "ACStrategy.h"
+#include "SethStrategy.h"
 #include "UKStrategy.h"
 #include "NexStrategy.h"
 #include "ANStrategy.h"
@@ -52,6 +53,7 @@ class DungeonStrategyContext : public NamedObjectContext<Strategy>
 
             // Burning Crusade
             creators["tbc-ac"] = &DungeonStrategyContext::tbc_ac;           // Auchindoun: Auchenai Crypts
+            creators["tbc-seth"] = &DungeonStrategyContext::tbc_seth;       // Auchindoun: Sethekk Halls
 
             // Wrath of the Lich King
             creators["wotlk-uk"] = &DungeonStrategyContext::wotlk_uk;       // Utgarde Keep
@@ -73,6 +75,7 @@ class DungeonStrategyContext : public NamedObjectContext<Strategy>
         }
     private:
         static Strategy* tbc_ac(PlayerbotAI* botAI) { return new TbcDungeonAuchenaiCryptsStrategy(botAI); }
+        static Strategy* tbc_seth(PlayerbotAI* botAI) { return new TbcDungeonSethekkHallsStrategy(botAI); }
         static Strategy* wotlk_uk(PlayerbotAI* botAI) { return new WotlkDungeonUKStrategy(botAI); }
         static Strategy* wotlk_nex(PlayerbotAI* botAI) { return new WotlkDungeonNexStrategy(botAI); }
         static Strategy* wotlk_an(PlayerbotAI* botAI) { return new WotlkDungeonANStrategy(botAI); }

--- a/src/Ai/Dungeon/DungeonStrategyContext.h
+++ b/src/Ai/Dungeon/DungeonStrategyContext.h
@@ -26,23 +26,6 @@
 #include "PoSStrategy.h"
 #include "TOCStrategy.h"
 
-/*
-Full list/TODO:
-
-Trial of the Champion - ToC
-Alliance Champions: Deathstalker Visceri, Eressea Dawnsinger, Mokra the Skullcrusher, Runok Wildmane, Zul'tore
-Horde Champions: Ambrose Boltspark, Colosos, Jacob Alerius, Jaelyne Evensong, Lana Stouthammer
-Argent Champion: Argent Confessor Paletress/Eadric the Pure
-The Black Knight
-Halls of Reflection - HoR
-Falric, Marwyn, The Lich King
-Pit of Saron - PoS
-Forgemaster Garfrost, Krick & Ick, Scourgelord Tyrannus
-The Forge of Souls - FoS
-Bronjahm, Devourer of Souls
-
-*/
-
 class DungeonStrategyContext : public NamedObjectContext<Strategy>
 {
     public:
@@ -69,7 +52,6 @@ class DungeonStrategyContext : public NamedObjectContext<Strategy>
             creators["wotlk-up"] = &DungeonStrategyContext::wotlk_up;       // Utgarde Pinnacle
             creators["wotlk-cos"] = &DungeonStrategyContext::wotlk_cos;     // The Culling of Stratholme
             creators["wotlk-toc"] = &DungeonStrategyContext::wotlk_toc;     // Trial of the Champion
-            creators["wotlk-hor"] = &DungeonStrategyContext::wotlk_hor;     // Halls of Reflection
             creators["wotlk-pos"] = &DungeonStrategyContext::wotlk_pos;     // Pit of Saron
             creators["wotlk-fos"] = &DungeonStrategyContext::wotlk_fos;     // The Forge of Souls
         }
@@ -91,8 +73,6 @@ class DungeonStrategyContext : public NamedObjectContext<Strategy>
         static Strategy* wotlk_fos(PlayerbotAI* botAI) { return new WotlkDungeonFoSStrategy(botAI); }
         static Strategy* wotlk_pos(PlayerbotAI* botAI) { return new WotlkDungeonPoSStrategy(botAI); }
         static Strategy* wotlk_toc(PlayerbotAI* botAI) { return new WotlkDungeonToCStrategy(botAI); }
-        // NYI from here down
-        static Strategy* wotlk_hor(PlayerbotAI* botAI) { return new WotlkDungeonUKStrategy(botAI); }
 };
 
 #endif

--- a/src/Ai/Dungeon/Seth/SethActionContext.h
+++ b/src/Ai/Dungeon/Seth/SethActionContext.h
@@ -1,0 +1,75 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_SETHACTIONCONTEXT_H
+#define PLAYERBOTS_SETHACTIONCONTEXT_H
+
+#include "NamedObjectContext.h"
+#include "SethActions.h"
+
+class TbcDungeonSethekkHallsActionContext : public NamedObjectContext<Action>
+{
+public:
+    TbcDungeonSethekkHallsActionContext()
+    {
+        creators["time-lost controller mark charming totem with skull"] =
+            &TbcDungeonSethekkHallsActionContext::time_lost_controller_mark_charming_totem_with_skull;
+
+        creators["sethekk prophet set tremor totem"] =
+            &TbcDungeonSethekkHallsActionContext::sethekk_prophet_set_tremor_totem;
+
+        creators["darkweaver syth mark elementals with skull"] =
+            &TbcDungeonSethekkHallsActionContext::darkweaver_syth_mark_elementals_with_skull;
+
+        creators["anzu alternate marks on boss"] =
+            &TbcDungeonSethekkHallsActionContext::anzu_alternate_marks_on_boss;
+
+        creators["anzu cast heal over time spell on bird spirit"] =
+            &TbcDungeonSethekkHallsActionContext::anzu_cast_heal_over_time_spell_on_bird_spirit;
+
+        creators["talon king ikiss tank move boss to pillar position"] =
+            &TbcDungeonSethekkHallsActionContext::talon_king_ikiss_tank_move_boss_to_pillar_position;
+
+        creators["talon king ikiss ranged stay near victim of boss"] =
+            &TbcDungeonSethekkHallsActionContext::talon_king_ikiss_ranged_stay_near_victim_of_boss;
+
+        creators["talon king ikiss los arcane explosion"] =
+            &TbcDungeonSethekkHallsActionContext::talon_king_ikiss_los_arcane_explosion;
+
+        creators["talon king ikiss move to within los"] =
+            &TbcDungeonSethekkHallsActionContext::talon_king_ikiss_move_to_within_los;
+    }
+private:
+    static Action* time_lost_controller_mark_charming_totem_with_skull(PlayerbotAI* botAI) {
+        return new TimeLostControllerMarkCharmingTotemWithSkullAction(botAI);
+    }
+    static Action* sethekk_prophet_set_tremor_totem(PlayerbotAI* botAI) {
+        return new SethekkProphetSetTremorTotemAction(botAI);
+    }
+    static Action* darkweaver_syth_mark_elementals_with_skull(PlayerbotAI* botAI) {
+        return new DarkweaverSythMarkElementalsWithSkullAction(botAI);
+    }
+    static Action* anzu_alternate_marks_on_boss(PlayerbotAI* botAI) {
+        return new AnzuAlternateMarksOnBossAction(botAI);
+    }
+    static Action* anzu_cast_heal_over_time_spell_on_bird_spirit(PlayerbotAI* botAI) {
+        return new AnzuCastHealOverTimeSpellOnBirdSpiritAction(botAI);
+    }
+    static Action* talon_king_ikiss_tank_move_boss_to_pillar_position(PlayerbotAI* botAI) {
+        return new TalonKingIkissTankMoveBossToPillarPositionAction(botAI);
+    }
+    static Action* talon_king_ikiss_ranged_stay_near_victim_of_boss(PlayerbotAI* botAI) {
+        return new TalonKingIkissRangedStayNearVictimOfBossAction(botAI);
+    }
+    static Action* talon_king_ikiss_los_arcane_explosion(PlayerbotAI* botAI) {
+        return new TalonKingIkissLosArcaneExplosionAction(botAI);
+    }
+    static Action* talon_king_ikiss_move_to_within_los(PlayerbotAI* botAI) {
+        return new TalonKingIkissMoveToWithinLosAction(botAI);
+    }
+};
+
+#endif

--- a/src/Ai/Dungeon/Seth/SethActions.cpp
+++ b/src/Ai/Dungeon/Seth/SethActions.cpp
@@ -116,18 +116,18 @@ bool TalonKingIkissTankMoveBossToPillarPositionAction::Execute(Event /*event*/)
 
     if (distToPosition > 2.0f)
     {
-        if (bot->IsWithinMeleeRange(ikiss))
-        {
-            float const dX = position.GetPositionX() - bot->GetPositionX();
-            float const dY = position.GetPositionY() - bot->GetPositionY();
-            float const moveDist = std::min(2.0f, distToPosition);
-            float const moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
-            float const moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
+        if (!bot->IsWithinMeleeRange(ikiss))
+            return false;
 
-            return MoveTo(
-                SETHEKK_HALLS_MAP_ID, moveX, moveY, position.GetPositionZ(), false, false,
-                false, false, MovementPriority::MOVEMENT_COMBAT, true, false);
-        }
+        float const dX = position.GetPositionX() - bot->GetPositionX();
+        float const dY = position.GetPositionY() - bot->GetPositionY();
+        float const moveDist = std::min(2.0f, distToPosition);
+        float const moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
+        float const moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
+
+        return MoveTo(
+            SETHEKK_HALLS_MAP_ID, moveX, moveY, position.GetPositionZ(), false, false,
+            false, false, MovementPriority::MOVEMENT_COMBAT, true, false);
     }
     else
     {

--- a/src/Ai/Dungeon/Seth/SethActions.cpp
+++ b/src/Ai/Dungeon/Seth/SethActions.cpp
@@ -15,13 +15,9 @@ using namespace SethData;
 bool TimeLostControllerMarkCharmingTotemWithSkullAction::Execute(Event /*event*/)
 {
     constexpr uint32 searchRadius = 40.0f;
-    if (Unit* totem = bot->FindNearestCreature(
-            static_cast<uint32>(SethNpcs::NPC_CHARMING_TOTEM), searchRadius, true))
-    {
-        return MarkTargetWithSkull(bot, totem);
-    }
-
-    return false;
+    Unit* totem = bot->FindNearestCreature(
+        static_cast<uint32>(SethNpcs::NPC_CHARMING_TOTEM), searchRadius, true);
+    return totem && MarkTargetWithSkull(bot, totem);
 }
 
 bool SethekkProphetSetTremorTotemAction::Execute(Event /*event*/)
@@ -111,23 +107,29 @@ bool TalonKingIkissTankMoveBossToPillarPositionAction::Execute(Event /*event*/)
         return false;
 
     Position const& position = PILLAR_POSITION;
-    float const distToPosition =
-        bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY());
+    float const distToPosition = bot->GetExactDist2d(position);
 
     if (distToPosition > 2.0f)
     {
-        if (!bot->IsWithinMeleeRange(ikiss))
-            return false;
+        float const posX = position.GetPositionX();
+        float const posY = position.GetPositionY();
+        float const botX = bot->GetPositionX();
+        float const botY = bot->GetPositionY();
+        float const toPosX = posX - botX;
+        float const toPosY = posY - botY;
 
-        float const dX = position.GetPositionX() - bot->GetPositionX();
-        float const dY = position.GetPositionY() - bot->GetPositionY();
-        float const moveDist = std::min(2.0f, distToPosition);
-        float const moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
-        float const moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
+        float const toBossX = ikiss->GetPositionX() - botX;
+        float const toBossY = ikiss->GetPositionY() - botY;
+        bool const backwards = (toPosX * toBossX + toPosY * toBossY) < 0.0f;
+
+        float const maxMoveDist = backwards ? 2.25f : 3.5f;
+        float const moveDist = std::min(maxMoveDist, distToPosition);
+        float const moveX = botX + (toPosX / distToPosition) * moveDist;
+        float const moveY = botY + (toPosY / distToPosition) * moveDist;
 
         return MoveTo(
             SETHEKK_HALLS_MAP_ID, moveX, moveY, position.GetPositionZ(), false, false,
-            false, false, MovementPriority::MOVEMENT_COMBAT, true, false);
+            false, false, MovementPriority::MOVEMENT_COMBAT, true, backwards);
     }
     else
     {
@@ -147,15 +149,15 @@ bool TalonKingIkissRangedStayNearVictimOfBossAction::Execute(Event /*event*/)
     if (!victim)
         return false;
 
-    constexpr float targetDistance = 10.0f;
+    constexpr float targetDist = 10.0f;
     constexpr float tolerance = 5.0f;
-    float const distanceToVictim = bot->GetExactDist2d(victim);
-    if (distanceToVictim <= targetDistance + tolerance)
+    float const distToVictim = bot->GetExactDist2d(victim);
+    if (distToVictim <= targetDist + tolerance)
         return false;
 
     float const angle = victim->GetAngle(bot);
-    float const destX = victim->GetPositionX() + std::cos(angle) * targetDistance;
-    float const destY = victim->GetPositionY() + std::sin(angle) * targetDistance;
+    float const destX = victim->GetPositionX() + std::cos(angle) * targetDist;
+    float const destY = victim->GetPositionY() + std::sin(angle) * targetDist;
 
     return MoveTo(
         SETHEKK_HALLS_MAP_ID, destX, destY, victim->GetPositionZ(), false, false,
@@ -175,13 +177,13 @@ bool TalonKingIkissLosArcaneExplosionAction::Execute(Event event)
 bool TalonKingIkissLosArcaneExplosionAction::MoveToPillar(
     Position const& pillarCenter, float botAngle, float distToPillar)
 {
-    constexpr float circleRadiusAcceptMin = 10.0f;
-    constexpr float circleRadiusAcceptMax = 13.0f;
+    constexpr float minRadius = 10.0f;
+    constexpr float maxRadius = 13.0f;
 
-    if (distToPillar >= circleRadiusAcceptMin && distToPillar <= circleRadiusAcceptMax)
+    if (distToPillar >= minRadius && distToPillar <= maxRadius)
         return false;
 
-    float const targetRadius = distToPillar < circleRadiusAcceptMin ? 11.0f : 12.0f;
+    float const targetRadius = distToPillar < minRadius ? 11.0f : 12.0f;
     float const moveX = pillarCenter.GetPositionX() + targetRadius * cos(botAngle);
     float const moveY = pillarCenter.GetPositionY() + targetRadius * sin(botAngle);
 
@@ -198,16 +200,27 @@ bool TalonKingIkissLosArcaneExplosionAction::MoveAroundPillar(
     if (!ikiss)
         return false;
 
-    float const destAngle = pillarCenter.GetAngle(ikiss) + M_PI;
-    float const destX = pillarCenter.GetPositionX() + distToPillar * cos(destAngle);
-    float const destY = pillarCenter.GetPositionY() + distToPillar * sin(destAngle);
+    constexpr float angularStep = M_PI / 8.0f;
+    constexpr float angularDeadzone = 0.105f;  // ~6°
 
-    if (bot->GetExactDist2d(destX, destY) < 1.0f)
+    float const botAngle = pillarCenter.GetAngle(bot);
+    float const targetAngle = pillarCenter.GetAngle(ikiss) + M_PI;
+    float delta = Position::NormalizeOrientation(targetAngle - botAngle);
+    if (delta > M_PI)
+        delta -= 2.0f * M_PI;
+
+    if (fabs(delta) < angularDeadzone)
         return false;
+
+    float const angularDirection = (delta > 0.0f) ? 1.0f : -1.0f;
+    float const stepAngle = botAngle + angularDirection * std::min(angularStep, fabs(delta));
+
+    float const moveX = pillarCenter.GetPositionX() + distToPillar * cos(stepAngle);
+    float const moveY = pillarCenter.GetPositionY() + distToPillar * sin(stepAngle);
 
     botAI->InterruptSpell();
     return MoveTo(
-        SETHEKK_HALLS_MAP_ID, destX, destY, bot->GetPositionZ(), false, false,
+        SETHEKK_HALLS_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false,
         false, false, MovementPriority::MOVEMENT_FORCED, true, false);
 }
 
@@ -219,17 +232,20 @@ bool TalonKingIkissMoveToWithinLosAction::Execute(Event /*event*/)
 
     Position const& pillarCenter = PILLAR_CENTER;
     constexpr float angularStep = M_PI / 8.0f;
+    constexpr float angularDeadzone = 0.105f;  // ~6°
 
     float const botAngle = pillarCenter.GetAngle(bot);
     float const targetAngle = pillarCenter.GetAngle(ikiss);
     float const radius = bot->GetExactDist2d(pillarCenter);
-    float const delta = Position::NormalizeOrientation(targetAngle - botAngle);
+    float delta = Position::NormalizeOrientation(targetAngle - botAngle);
+    if (delta > M_PI)
+        delta -= 2.0f * M_PI;
 
-    if (fabs(delta) < angularStep)
+    if (fabs(delta) < angularDeadzone)
         return false;
 
-    float const direction = (delta > 0.0f && delta < M_PI) ? 1.0f : -1.0f;
-    float const stepAngle = botAngle + direction * angularStep;
+    float const angularDirection = (delta > 0.0f) ? 1.0f : -1.0f;
+    float const stepAngle = botAngle + angularDirection * std::min(angularStep, fabs(delta));
 
     float const moveX = pillarCenter.GetPositionX() + radius * cos(stepAngle);
     float const moveY = pillarCenter.GetPositionY() + radius * sin(stepAngle);

--- a/src/Ai/Dungeon/Seth/SethActions.cpp
+++ b/src/Ai/Dungeon/Seth/SethActions.cpp
@@ -27,8 +27,7 @@ bool SethekkProphetSetTremorTotemAction::Execute(Event /*event*/)
 
 bool DarkweaverSythMarkElementalsWithSkullAction::Execute(Event /*event*/)
 {
-    static constexpr std::array elementals =
-    {
+    static constexpr std::array elementals = {
         "syth frost elemental",
         "syth shadow elemental",
         "syth arcane elemental",
@@ -62,8 +61,7 @@ bool AnzuCastHealOverTimeSpellOnBirdSpiritAction::Execute(Event /*event*/)
     constexpr float searchRadius = 60.0f;
     Creature* targetSpirit = nullptr;
 
-    static constexpr std::array spiritEntries =
-    {
+    static constexpr std::array spiritEntries = {
         Id(SethNpcs::NPC_FALCON_SPIRIT),
         Id(SethNpcs::NPC_HAWK_SPIRIT),
         Id(SethNpcs::NPC_EAGLE_SPIRIT),

--- a/src/Ai/Dungeon/Seth/SethActions.cpp
+++ b/src/Ai/Dungeon/Seth/SethActions.cpp
@@ -1,0 +1,240 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "SethActions.h"
+#include "Playerbots.h"
+#include "RaidBossHelpers.h"
+#include "SethData.h"
+#include <array>
+
+using namespace SethData;
+
+bool TimeLostControllerMarkCharmingTotemWithSkullAction::Execute(Event /*event*/)
+{
+    constexpr uint32 searchRadius = 40.0f;
+    if (Unit* totem = bot->FindNearestCreature(
+            static_cast<uint32>(SethNpcs::NPC_CHARMING_TOTEM), searchRadius, true))
+    {
+        return MarkTargetWithSkull(bot, totem);
+    }
+
+    return false;
+}
+
+bool SethekkProphetSetTremorTotemAction::Execute(Event /*event*/)
+{
+    return botAI->CanCastSpell(static_cast<uint32>(SethSpells::SPELL_TREMOR_TOTEM), bot) &&
+        botAI->CastSpell(static_cast<uint32>(SethSpells::SPELL_TREMOR_TOTEM), bot);
+}
+
+bool DarkweaverSythMarkElementalsWithSkullAction::Execute(Event /*event*/)
+{
+    std::array<const char*, 4> const elementals =
+    {
+        "syth frost elemental",
+        "syth shadow elemental",
+        "syth arcane elemental",
+        "syth fire elemental",
+    };
+
+    for (auto const& name : elementals)
+    {
+        if (Unit* elemental = AI_VALUE2(Unit*, "find target", name))
+            return MarkTargetWithSkull(bot, elemental);
+    }
+
+    return false;
+}
+
+bool AnzuAlternateMarksOnBossAction::Execute(Event /*event*/)
+{
+    Unit* anzu = AI_VALUE2(Unit*, "find target", "anzu");
+    if (!anzu)
+        return false;
+
+    if (anzu->HasAura(static_cast<uint32>(SethSpells::SPELL_BANISH_ANZU)))
+        return MarkTargetWithMoon(bot, anzu);
+
+    return MarkTargetWithSkull(bot, anzu);
+}
+
+// Priority: Falcon (haste) > Eagle during Banish (damage all enemies) > Hawk (damage reduction)
+bool AnzuCastHealOverTimeSpellOnBirdSpiritAction::Execute(Event /*event*/)
+{
+    constexpr float searchRadius = 60.0f;
+    Creature* targetSpirit = nullptr;
+
+    std::array<uint32, 3> const spiritEntries =
+    {
+        static_cast<uint32>(SethNpcs::NPC_FALCON_SPIRIT),
+        static_cast<uint32>(SethNpcs::NPC_HAWK_SPIRIT),
+        static_cast<uint32>(SethNpcs::NPC_EAGLE_SPIRIT),
+    };
+
+    for (uint32 entry : spiritEntries)
+    {
+        Creature* spirit = bot->FindNearestCreature(entry, searchRadius, true);
+        if (spirit && !spirit->GetAuraEffect(
+                SPELL_AURA_PERIODIC_HEAL, SPELLFAMILY_DRUID, REJUVENATION_SPELL_ICON_ID, 0))
+        {
+            targetSpirit = spirit;
+            break;
+        }
+    }
+
+    if (!targetSpirit)
+        return false;
+
+    if (!botAI->CanCastSpell(
+            static_cast<uint32>(SethSpells::SPELL_REJUVENATION_RANK_1), targetSpirit))
+    {
+        return false;
+    }
+
+    return botAI->CastSpell(
+        static_cast<uint32>(SethSpells::SPELL_REJUVENATION_RANK_1), targetSpirit);
+}
+
+bool TalonKingIkissTankMoveBossToPillarPositionAction::Execute(Event /*event*/)
+{
+    Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");
+    if (!ikiss)
+        return false;
+
+    if (ikiss->GetHealthPct() > 95.0f)
+        _hasReachedPillarPosition = false;
+
+    if (_hasReachedPillarPosition == true)
+        return false;
+
+    Position const& position = PILLAR_POSITION;
+    float const distToPosition =
+        bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY());
+
+    if (distToPosition > 2.0f)
+    {
+        if (bot->IsWithinMeleeRange(ikiss))
+        {
+            float const dX = position.GetPositionX() - bot->GetPositionX();
+            float const dY = position.GetPositionY() - bot->GetPositionY();
+            float const moveDist = std::min(2.0f, distToPosition);
+            float const moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
+            float const moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
+
+            return MoveTo(
+                SETHEKK_HALLS_MAP_ID, moveX, moveY, position.GetPositionZ(), false, false,
+                false, false, MovementPriority::MOVEMENT_COMBAT, true, false);
+        }
+    }
+    else
+    {
+        _hasReachedPillarPosition = true;
+    }
+
+    return false;
+}
+
+bool TalonKingIkissRangedStayNearVictimOfBossAction::Execute(Event /*event*/)
+{
+    Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");
+    if (!ikiss || !ikiss->GetVictim())
+        return false;
+
+    Player* victim = ikiss->GetVictim()->ToPlayer();
+    if (!victim)
+        return false;
+
+    constexpr float targetDistance = 10.0f;
+    constexpr float tolerance = 5.0f;
+    float const distanceToVictim = bot->GetExactDist2d(victim);
+    if (distanceToVictim <= targetDistance + tolerance)
+        return false;
+
+    float const angle = victim->GetAngle(bot);
+    float const destX = victim->GetPositionX() + std::cos(angle) * targetDistance;
+    float const destY = victim->GetPositionY() + std::sin(angle) * targetDistance;
+
+    return MoveTo(
+        SETHEKK_HALLS_MAP_ID, destX, destY, victim->GetPositionZ(), false, false,
+        false, false, MovementPriority::MOVEMENT_COMBAT, true, false);
+}
+
+bool TalonKingIkissLosArcaneExplosionAction::Execute(Event event)
+{
+    Position const& pillarCenter = PILLAR_CENTER;
+    float const botAngle = pillarCenter.GetAngle(bot);
+    float const distToPillar = bot->GetExactDist2d(pillarCenter);
+
+    return MoveToPillar(pillarCenter, botAngle, distToPillar) ||
+        MoveAroundPillar(pillarCenter, distToPillar);
+}
+
+bool TalonKingIkissLosArcaneExplosionAction::MoveToPillar(
+    Position const& pillarCenter, float botAngle, float distToPillar)
+{
+    constexpr float circleRadiusAcceptMin = 10.0f;
+    constexpr float circleRadiusAcceptMax = 13.0f;
+
+    if (distToPillar >= circleRadiusAcceptMin && distToPillar <= circleRadiusAcceptMax)
+        return false;
+
+    float const targetRadius = distToPillar < circleRadiusAcceptMin ? 11.0f : 12.0f;
+    float const moveX = pillarCenter.GetPositionX() + targetRadius * cos(botAngle);
+    float const moveY = pillarCenter.GetPositionY() + targetRadius * sin(botAngle);
+
+    botAI->InterruptSpell();
+    return MoveTo(
+        SETHEKK_HALLS_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false,
+        false, false, MovementPriority::MOVEMENT_FORCED, true, false);
+}
+
+bool TalonKingIkissLosArcaneExplosionAction::MoveAroundPillar(
+    Position const& pillarCenter, float distToPillar)
+{
+    Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");
+    if (!ikiss)
+        return false;
+
+    float const destAngle = pillarCenter.GetAngle(ikiss) + M_PI;
+    float const destX = pillarCenter.GetPositionX() + distToPillar * cos(destAngle);
+    float const destY = pillarCenter.GetPositionY() + distToPillar * sin(destAngle);
+
+    if (bot->GetExactDist2d(destX, destY) < 1.0f)
+        return false;
+
+    botAI->InterruptSpell();
+    return MoveTo(
+        SETHEKK_HALLS_MAP_ID, destX, destY, bot->GetPositionZ(), false, false,
+        false, false, MovementPriority::MOVEMENT_FORCED, true, false);
+}
+
+bool TalonKingIkissMoveToWithinLosAction::Execute(Event /*event*/)
+{
+    Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");
+    if (!ikiss)
+        return false;
+
+    Position const& pillarCenter = PILLAR_CENTER;
+    constexpr float angularStep = M_PI / 8.0f;
+
+    float const botAngle = pillarCenter.GetAngle(bot);
+    float const targetAngle = pillarCenter.GetAngle(ikiss);
+    float const radius = bot->GetExactDist2d(pillarCenter);
+    float const delta = Position::NormalizeOrientation(targetAngle - botAngle);
+
+    if (fabs(delta) < angularStep)
+        return false;
+
+    float const direction = (delta > 0.0f && delta < M_PI) ? 1.0f : -1.0f;
+    float const stepAngle = botAngle + direction * angularStep;
+
+    float const moveX = pillarCenter.GetPositionX() + radius * cos(stepAngle);
+    float const moveY = pillarCenter.GetPositionY() + radius * sin(stepAngle);
+
+    return MoveTo(
+        SETHEKK_HALLS_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false,
+        false, false, MovementPriority::MOVEMENT_COMBAT, true, false);
+}

--- a/src/Ai/Dungeon/Seth/SethActions.cpp
+++ b/src/Ai/Dungeon/Seth/SethActions.cpp
@@ -15,20 +15,19 @@ using namespace SethData;
 bool TimeLostControllerMarkCharmingTotemWithSkullAction::Execute(Event /*event*/)
 {
     constexpr uint32 searchRadius = 40.0f;
-    Unit* totem = bot->FindNearestCreature(
-        static_cast<uint32>(SethNpcs::NPC_CHARMING_TOTEM), searchRadius, true);
+    Unit* totem = bot->FindNearestCreature(Id(SethNpcs::NPC_CHARMING_TOTEM), searchRadius, true);
     return totem && MarkTargetWithSkull(bot, totem);
 }
 
 bool SethekkProphetSetTremorTotemAction::Execute(Event /*event*/)
 {
-    return botAI->CanCastSpell(static_cast<uint32>(SethSpells::SPELL_TREMOR_TOTEM), bot) &&
-        botAI->CastSpell(static_cast<uint32>(SethSpells::SPELL_TREMOR_TOTEM), bot);
+    return botAI->CanCastSpell(Id(SethSpells::SPELL_TREMOR_TOTEM), bot) &&
+        botAI->CastSpell(Id(SethSpells::SPELL_TREMOR_TOTEM), bot);
 }
 
 bool DarkweaverSythMarkElementalsWithSkullAction::Execute(Event /*event*/)
 {
-    std::array<const char*, 4> const elementals =
+    static constexpr std::array elementals =
     {
         "syth frost elemental",
         "syth shadow elemental",
@@ -51,7 +50,7 @@ bool AnzuAlternateMarksOnBossAction::Execute(Event /*event*/)
     if (!anzu)
         return false;
 
-    if (anzu->HasAura(static_cast<uint32>(SethSpells::SPELL_BANISH_ANZU)))
+    if (anzu->HasAura(Id(SethSpells::SPELL_BANISH_ANZU)))
         return MarkTargetWithMoon(bot, anzu);
 
     return MarkTargetWithSkull(bot, anzu);
@@ -63,11 +62,11 @@ bool AnzuCastHealOverTimeSpellOnBirdSpiritAction::Execute(Event /*event*/)
     constexpr float searchRadius = 60.0f;
     Creature* targetSpirit = nullptr;
 
-    std::array<uint32, 3> const spiritEntries =
+    static constexpr std::array spiritEntries =
     {
-        static_cast<uint32>(SethNpcs::NPC_FALCON_SPIRIT),
-        static_cast<uint32>(SethNpcs::NPC_HAWK_SPIRIT),
-        static_cast<uint32>(SethNpcs::NPC_EAGLE_SPIRIT),
+        Id(SethNpcs::NPC_FALCON_SPIRIT),
+        Id(SethNpcs::NPC_HAWK_SPIRIT),
+        Id(SethNpcs::NPC_EAGLE_SPIRIT),
     };
 
     for (uint32 entry : spiritEntries)
@@ -84,14 +83,10 @@ bool AnzuCastHealOverTimeSpellOnBirdSpiritAction::Execute(Event /*event*/)
     if (!targetSpirit)
         return false;
 
-    if (!botAI->CanCastSpell(
-            static_cast<uint32>(SethSpells::SPELL_REJUVENATION_RANK_1), targetSpirit))
-    {
+    if (!botAI->CanCastSpell(Id(SethSpells::SPELL_REJUVENATION_RANK_1), targetSpirit))
         return false;
-    }
 
-    return botAI->CastSpell(
-        static_cast<uint32>(SethSpells::SPELL_REJUVENATION_RANK_1), targetSpirit);
+    return botAI->CastSpell(Id(SethSpells::SPELL_REJUVENATION_RANK_1), targetSpirit);
 }
 
 bool TalonKingIkissTankMoveBossToPillarPositionAction::Execute(Event /*event*/)
@@ -109,34 +104,31 @@ bool TalonKingIkissTankMoveBossToPillarPositionAction::Execute(Event /*event*/)
     Position const& position = PILLAR_POSITION;
     float const distToPosition = bot->GetExactDist2d(position);
 
-    if (distToPosition > 2.0f)
-    {
-        float const posX = position.GetPositionX();
-        float const posY = position.GetPositionY();
-        float const botX = bot->GetPositionX();
-        float const botY = bot->GetPositionY();
-        float const toPosX = posX - botX;
-        float const toPosY = posY - botY;
-
-        float const toBossX = ikiss->GetPositionX() - botX;
-        float const toBossY = ikiss->GetPositionY() - botY;
-        bool const backwards = (toPosX * toBossX + toPosY * toBossY) < 0.0f;
-
-        float const maxMoveDist = backwards ? 2.25f : 3.5f;
-        float const moveDist = std::min(maxMoveDist, distToPosition);
-        float const moveX = botX + (toPosX / distToPosition) * moveDist;
-        float const moveY = botY + (toPosY / distToPosition) * moveDist;
-
-        return MoveTo(
-            SETHEKK_HALLS_MAP_ID, moveX, moveY, position.GetPositionZ(), false, false,
-            false, false, MovementPriority::MOVEMENT_COMBAT, true, backwards);
-    }
-    else
+    if (distToPosition <= 2.0f)
     {
         _hasReachedPillarPosition = true;
+        return false;
     }
 
-    return false;
+    float const posX = position.GetPositionX();
+    float const posY = position.GetPositionY();
+    float const botX = bot->GetPositionX();
+    float const botY = bot->GetPositionY();
+    float const toPosX = posX - botX;
+    float const toPosY = posY - botY;
+
+    float const toBossX = ikiss->GetPositionX() - botX;
+    float const toBossY = ikiss->GetPositionY() - botY;
+    bool const backwards = (toPosX * toBossX + toPosY * toBossY) < 0.0f;
+
+    float const maxMoveDist = backwards ? 2.25f : 3.5f;
+    float const moveDist = std::min(maxMoveDist, distToPosition);
+    float const moveX = botX + (toPosX / distToPosition) * moveDist;
+    float const moveY = botY + (toPosY / distToPosition) * moveDist;
+
+    return MoveTo(
+        SETH_MAP_ID, moveX, moveY, position.GetPositionZ(), false, false,
+        false, false, MovementPriority::MOVEMENT_COMBAT, true, backwards);
 }
 
 bool TalonKingIkissRangedStayNearVictimOfBossAction::Execute(Event /*event*/)
@@ -160,7 +152,7 @@ bool TalonKingIkissRangedStayNearVictimOfBossAction::Execute(Event /*event*/)
     float const destY = victim->GetPositionY() + std::sin(angle) * targetDist;
 
     return MoveTo(
-        SETHEKK_HALLS_MAP_ID, destX, destY, victim->GetPositionZ(), false, false,
+        SETH_MAP_ID, destX, destY, victim->GetPositionZ(), false, false,
         false, false, MovementPriority::MOVEMENT_COMBAT, true, false);
 }
 
@@ -189,7 +181,7 @@ bool TalonKingIkissLosArcaneExplosionAction::MoveToPillar(
 
     botAI->InterruptSpell();
     return MoveTo(
-        SETHEKK_HALLS_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false,
+        SETH_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false,
         false, false, MovementPriority::MOVEMENT_FORCED, true, false);
 }
 
@@ -220,7 +212,7 @@ bool TalonKingIkissLosArcaneExplosionAction::MoveAroundPillar(
 
     botAI->InterruptSpell();
     return MoveTo(
-        SETHEKK_HALLS_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false,
+        SETH_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false,
         false, false, MovementPriority::MOVEMENT_FORCED, true, false);
 }
 
@@ -251,6 +243,6 @@ bool TalonKingIkissMoveToWithinLosAction::Execute(Event /*event*/)
     float const moveY = pillarCenter.GetPositionY() + radius * sin(stepAngle);
 
     return MoveTo(
-        SETHEKK_HALLS_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false,
+        SETH_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false,
         false, false, MovementPriority::MOVEMENT_COMBAT, true, false);
 }

--- a/src/Ai/Dungeon/Seth/SethActions.h
+++ b/src/Ai/Dungeon/Seth/SethActions.h
@@ -1,0 +1,92 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_SETHACTIONS_H
+#define PLAYERBOTS_SETHACTIONS_H
+
+#include "Action.h"
+#include "MovementActions.h"
+
+class TimeLostControllerMarkCharmingTotemWithSkullAction : public Action
+{
+public:
+    TimeLostControllerMarkCharmingTotemWithSkullAction(
+        PlayerbotAI* botAI) : Action(botAI, "time-lost controller mark charming totem with skull") {}
+    bool Execute(Event event) override;
+};
+
+class SethekkProphetSetTremorTotemAction : public Action
+{
+public:
+    SethekkProphetSetTremorTotemAction(
+        PlayerbotAI* botAI) : Action(botAI, "sethekk prophet set tremor totem") {}
+    bool Execute(Event event) override;
+};
+
+class DarkweaverSythMarkElementalsWithSkullAction : public Action
+{
+public:
+    DarkweaverSythMarkElementalsWithSkullAction(
+        PlayerbotAI* botAI) : Action(botAI, "darkweaver syth mark elementals with skull") {}
+    bool Execute(Event event) override;
+};
+
+class AnzuAlternateMarksOnBossAction : public Action
+{
+public:
+    AnzuAlternateMarksOnBossAction(
+        PlayerbotAI* botAI) : Action(botAI, "anzu alternate marks on boss") {}
+    bool Execute(Event event) override;
+};
+
+class AnzuCastHealOverTimeSpellOnBirdSpiritAction : public Action
+{
+public:
+    AnzuCastHealOverTimeSpellOnBirdSpiritAction(
+        PlayerbotAI* botAI) : Action(botAI, "anzu cast heal over time spell on bird spirit") {}
+    bool Execute(Event event) override;
+};
+
+class TalonKingIkissTankMoveBossToPillarPositionAction : public MovementAction
+{
+public:
+    TalonKingIkissTankMoveBossToPillarPositionAction(
+        PlayerbotAI* botAI) : MovementAction(botAI, "talon king ikiss tank move boss to pillar position") {}
+    bool Execute(Event event) override;
+
+private:
+    bool _hasReachedPillarPosition = false;
+};
+
+class TalonKingIkissRangedStayNearVictimOfBossAction : public MovementAction
+{
+public:
+    TalonKingIkissRangedStayNearVictimOfBossAction(
+        PlayerbotAI* botAI) : MovementAction(botAI, "talon king ikiss ranged stay near victim of boss") {}
+    bool Execute(Event event) override;
+};
+
+class TalonKingIkissLosArcaneExplosionAction : public MovementAction
+{
+public:
+    TalonKingIkissLosArcaneExplosionAction(
+        PlayerbotAI* botAI) : MovementAction(botAI, "talon king ikiss los arcane explosion") {}
+    bool Execute(Event event) override;
+
+private:
+    bool MoveToPillar(Position const& pillarCenter, float botAngle, float distToPillar);
+    bool MoveAroundPillar(Position const& pillarCenter, float distToPillar);
+};
+
+class TalonKingIkissMoveToWithinLosAction : public MovementAction
+{
+public:
+    TalonKingIkissMoveToWithinLosAction(
+        PlayerbotAI* botAI) : MovementAction(botAI, "talon king ikiss move to within los") {}
+    bool Execute(Event event) override;
+};
+
+#endif

--- a/src/Ai/Dungeon/Seth/SethData.h
+++ b/src/Ai/Dungeon/Seth/SethData.h
@@ -29,11 +29,11 @@ enum class SethNpcs : uint32
     NPC_EAGLE_SPIRIT          = 23136,
 };
 
-constexpr uint32 SETHEKK_HALLS_MAP_ID       = 556;
-constexpr uint32 REJUVENATION_SPELL_ICON_ID = 64;
+inline constexpr uint32 SETH_MAP_ID = 556;
+inline constexpr uint32 REJUVENATION_SPELL_ICON_ID = 64;
 
-Position const PILLAR_CENTER   = { 23.730f, 309.230f };
-Position const PILLAR_POSITION = { 35.538f, 309.573f, 25.086f };
+inline Position const PILLAR_CENTER   = { 23.730f, 309.230f };
+inline Position const PILLAR_POSITION = { 35.538f, 309.573f, 25.086f };
 
 }
 

--- a/src/Ai/Dungeon/Seth/SethData.h
+++ b/src/Ai/Dungeon/Seth/SethData.h
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_SETHDATA_H
+#define PLAYERBOTS_SETHDATA_H
+
+#include "Common.h"
+
+namespace SethData
+{
+
+enum class SethSpells : uint32
+{
+    SPELL_REJUVENATION_RANK_1 = 774,
+    SPELL_TREMOR_TOTEM        = 8143,
+    SPELL_ARCANE_BUBBLE       = 9438,
+    SPELL_SPELL_BOMB          = 40303,
+    SPELL_BANISH_ANZU         = 42354,
+};
+
+enum class SethNpcs : uint32
+{
+    NPC_CHARMING_TOTEM        = 20343,
+    NPC_HAWK_SPIRIT           = 23134,
+    NPC_FALCON_SPIRIT         = 23135,
+    NPC_EAGLE_SPIRIT          = 23136,
+};
+
+constexpr uint32 SETHEKK_HALLS_MAP_ID       = 556;
+constexpr uint32 REJUVENATION_SPELL_ICON_ID = 64;
+
+Position const PILLAR_CENTER   = { 23.730f, 309.230f };
+Position const PILLAR_POSITION = { 35.538f, 309.573f, 25.086f };
+
+}
+
+#endif

--- a/src/Ai/Dungeon/Seth/SethMultipliers.cpp
+++ b/src/Ai/Dungeon/Seth/SethMultipliers.cpp
@@ -45,7 +45,7 @@ float AnzuControlSpellCastingWithSpellBombMultiplier::GetValue(Action* action)
     if (bot->getPowerType() != POWER_MANA || PlayerbotAI::IsTank(bot))
         return 1.0f;
 
-    if (!bot->HasAura(static_cast<uint32>(SethSpells::SPELL_SPELL_BOMB)))
+    if (!bot->HasAura(Id(SethSpells::SPELL_SPELL_BOMB)))
         return 1.0f;
 
     if (PlayerbotAI::IsDps(bot))
@@ -106,7 +106,7 @@ float TalonKingIkissControlMovementMultiplier::GetValue(Action* action)
     if (isAlwaysDisabled)
         return 0.0f;
 
-    if (!ikiss->HasAura(static_cast<uint32>(SethSpells::SPELL_ARCANE_BUBBLE)))
+    if (!ikiss->HasAura(Id(SethSpells::SPELL_ARCANE_BUBBLE)))
         return 1.0f;
 
     if (isDisabledDuringArcaneExplosion)

--- a/src/Ai/Dungeon/Seth/SethMultipliers.cpp
+++ b/src/Ai/Dungeon/Seth/SethMultipliers.cpp
@@ -23,37 +23,38 @@ float SethekkProphetSetTremorTotemMultiplier::GetValue(Action* action)
     if (bot->getClass() != CLASS_SHAMAN)
         return 1.0f;
 
-    if (!AI_VALUE2(Unit*, "find target", "sethekk prophet"))
-        return 1.0f;
-
-    if (dynamic_cast<CastStrengthOfEarthTotemAction*>(action) ||
-        dynamic_cast<CastStoneskinTotemAction*>(action) ||
-        dynamic_cast<CastStoneclawTotemAction*>(action) ||
-        dynamic_cast<CastEarthbindTotemAction*>(action))
+    if (!dynamic_cast<CastStrengthOfEarthTotemAction*>(action) &&
+        !dynamic_cast<CastStoneskinTotemAction*>(action) &&
+        !dynamic_cast<CastStoneclawTotemAction*>(action) &&
+        !dynamic_cast<CastEarthbindTotemAction*>(action))
     {
-        return 0.0f;
+        return 1.0f;
     }
+
+    if (AI_VALUE2(Unit*, "find target", "sethekk prophet"))
+        return 0.0f;
 
     return 1.0f;
 }
 
 float AnzuControlSpellCastingWithSpellBombMultiplier::GetValue(Action* action)
 {
+    if (!dynamic_cast<CastSpellAction*>(action))
+        return 1.0f;
+
     if (bot->getPowerType() != POWER_MANA || botAI->IsTank(bot))
         return 1.0f;
 
     if (!bot->HasAura(static_cast<uint32>(SethSpells::SPELL_SPELL_BOMB)))
         return 1.0f;
 
-    if (botAI->IsDps(bot) && dynamic_cast<CastSpellAction*>(action))
+    if (botAI->IsDps(bot))
         return 0.0f;
 
+    // For healer
     Player* mainTank = GetGroupMainTank(botAI, bot);
-    if (mainTank && mainTank->GetHealthPct() > 50.0f &&
-        dynamic_cast<CastSpellAction*>(action))
-    {
+    if (mainTank && mainTank->GetHealthPct() > 50.0f)
         return 0.0f;
-    }
 
     return 1.0f;
 }
@@ -63,52 +64,53 @@ float TalonKingIkissDelayBloodlustAndHeroismMultiplier::GetValue(Action* action)
     if (bot->getClass() != CLASS_SHAMAN)
         return 1.0f;
 
-    if (Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");
-        ikiss && ikiss->GetHealthPct() > 95.0f)
-    {
-        return 0.0f;
-    }
-
     if (!dynamic_cast<CastHeroismAction*>(action) &&
         !dynamic_cast<CastBloodlustAction*>(action))
     {
         return 1.0f;
     }
 
+    Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");
+    if (ikiss && ikiss->GetHealthPct() > 95.0f)
+        return 0.0f;
+
     return 1.0f;
 }
 
 float TalonKingIkissControlMovementMultiplier::GetValue(Action* action)
 {
+    if (dynamic_cast<TalonKingIkissLosArcaneExplosionAction*>(action) ||
+        dynamic_cast<TankFaceAction*>(action) ||
+        dynamic_cast<SetBehindTargetAction*>(action))
+    {
+        return 1.0f;
+    }
+
+    bool const isAlwaysDisabled =
+        dynamic_cast<CombatFormationMoveAction*>(action) ||
+        dynamic_cast<FleeAction*>(action) ||
+        dynamic_cast<CastBlinkBackAction*>(action) ||
+        dynamic_cast<CastDisengageAction*>(action);
+
+    bool const isDisabledDuringArcaneExplosion =
+        dynamic_cast<CastReachTargetSpellAction*>(action) ||
+        dynamic_cast<MovementAction*>(action);
+
+    if (!isAlwaysDisabled && !isDisabledDuringArcaneExplosion)
+        return 1.0f;
+
     Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");
     if (!ikiss)
         return 1.0f;
 
-    if (/*dynamic_cast<FleeAction*>(action) ||*/
-        dynamic_cast<CastBlinkBackAction*>(action) ||
-        dynamic_cast<CastDisengageAction*>(action))
-    {
+    if (isAlwaysDisabled)
         return 0.0f;
-    }
 
-    if (dynamic_cast<CombatFormationMoveAction*>(action) &&
-        !dynamic_cast<SetBehindTargetAction*>(action) &&
-        !dynamic_cast<TankFaceAction*>(action))
-    {
+    if (!ikiss->HasAura(static_cast<uint32>(SethSpells::SPELL_ARCANE_BUBBLE)))
+        return 1.0f;
+
+    if (isDisabledDuringArcaneExplosion)
         return 0.0f;
-    }
-
-    if (ikiss->HasAura(static_cast<uint32>(SethSpells::SPELL_ARCANE_BUBBLE)))
-    {
-        if (dynamic_cast<CastReachTargetSpellAction*>(action))
-            return 0.0f;
-
-        if (dynamic_cast<MovementAction*>(action) &&
-            !dynamic_cast<TalonKingIkissLosArcaneExplosionAction*>(action))
-        {
-            return 0.0f;
-        }
-    }
 
     return 1.0f;
 }

--- a/src/Ai/Dungeon/Seth/SethMultipliers.cpp
+++ b/src/Ai/Dungeon/Seth/SethMultipliers.cpp
@@ -42,13 +42,13 @@ float AnzuControlSpellCastingWithSpellBombMultiplier::GetValue(Action* action)
     if (!dynamic_cast<CastSpellAction*>(action))
         return 1.0f;
 
-    if (bot->getPowerType() != POWER_MANA || botAI->IsTank(bot))
+    if (bot->getPowerType() != POWER_MANA || PlayerbotAI::IsTank(bot))
         return 1.0f;
 
     if (!bot->HasAura(static_cast<uint32>(SethSpells::SPELL_SPELL_BOMB)))
         return 1.0f;
 
-    if (botAI->IsDps(bot))
+    if (PlayerbotAI::IsDps(bot))
         return 0.0f;
 
     // For healer

--- a/src/Ai/Dungeon/Seth/SethMultipliers.cpp
+++ b/src/Ai/Dungeon/Seth/SethMultipliers.cpp
@@ -1,0 +1,114 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "SethMultipliers.h"
+#include "FollowActions.h"
+#include "GenericSpellActions.h"
+#include "HunterActions.h"
+#include "MageActions.h"
+#include "Playerbots.h"
+#include "RaidBossHelpers.h"
+#include "ReachTargetActions.h"
+#include "SethActions.h"
+#include "SethData.h"
+#include "ShamanActions.h"
+
+using namespace SethData;
+
+float SethekkProphetSetTremorTotemMultiplier::GetValue(Action* action)
+{
+    if (bot->getClass() != CLASS_SHAMAN)
+        return 1.0f;
+
+    if (!AI_VALUE2(Unit*, "find target", "sethekk prophet"))
+        return 1.0f;
+
+    if (dynamic_cast<CastStrengthOfEarthTotemAction*>(action) ||
+        dynamic_cast<CastStoneskinTotemAction*>(action) ||
+        dynamic_cast<CastStoneclawTotemAction*>(action) ||
+        dynamic_cast<CastEarthbindTotemAction*>(action))
+    {
+        return 0.0f;
+    }
+
+    return 1.0f;
+}
+
+float AnzuControlSpellCastingWithSpellBombMultiplier::GetValue(Action* action)
+{
+    if (bot->getPowerType() != POWER_MANA || botAI->IsTank(bot))
+        return 1.0f;
+
+    if (!bot->HasAura(static_cast<uint32>(SethSpells::SPELL_SPELL_BOMB)))
+        return 1.0f;
+
+    if (botAI->IsDps(bot) && dynamic_cast<CastSpellAction*>(action))
+        return 0.0f;
+
+    Player* mainTank = GetGroupMainTank(botAI, bot);
+    if (mainTank && mainTank->GetHealthPct() > 50.0f &&
+        dynamic_cast<CastSpellAction*>(action))
+    {
+        return 0.0f;
+    }
+
+    return 1.0f;
+}
+
+float TalonKingIkissDelayBloodlustAndHeroismMultiplier::GetValue(Action* action)
+{
+    if (bot->getClass() != CLASS_SHAMAN)
+        return 1.0f;
+
+    if (Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");
+        ikiss && ikiss->GetHealthPct() > 95.0f)
+    {
+        return 0.0f;
+    }
+
+    if (!dynamic_cast<CastHeroismAction*>(action) &&
+        !dynamic_cast<CastBloodlustAction*>(action))
+    {
+        return 1.0f;
+    }
+
+    return 1.0f;
+}
+
+float TalonKingIkissControlMovementMultiplier::GetValue(Action* action)
+{
+    Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");
+    if (!ikiss)
+        return 1.0f;
+
+    if (/*dynamic_cast<FleeAction*>(action) ||*/
+        dynamic_cast<CastBlinkBackAction*>(action) ||
+        dynamic_cast<CastDisengageAction*>(action))
+    {
+        return 0.0f;
+    }
+
+    if (dynamic_cast<CombatFormationMoveAction*>(action) &&
+        !dynamic_cast<SetBehindTargetAction*>(action) &&
+        !dynamic_cast<TankFaceAction*>(action))
+    {
+        return 0.0f;
+    }
+
+    if (ikiss->HasAura(static_cast<uint32>(SethSpells::SPELL_ARCANE_BUBBLE)))
+    {
+        if (dynamic_cast<CastReachTargetSpellAction*>(action))
+            return 0.0f;
+
+        if (dynamic_cast<MovementAction*>(action) &&
+            !dynamic_cast<TalonKingIkissLosArcaneExplosionAction*>(action))
+        {
+            return 0.0f;
+        }
+    }
+
+    return 1.0f;
+}

--- a/src/Ai/Dungeon/Seth/SethMultipliers.h
+++ b/src/Ai/Dungeon/Seth/SethMultipliers.h
@@ -14,7 +14,7 @@ class SethekkProphetSetTremorTotemMultiplier : public Multiplier
 public:
     SethekkProphetSetTremorTotemMultiplier(
         PlayerbotAI* botAI) : Multiplier(botAI, "sethekk prophet set tremor totem") {}
-    virtual float GetValue(Action* action);
+    float GetValue(Action* action) override;
 };
 
 class AnzuControlSpellCastingWithSpellBombMultiplier : public Multiplier
@@ -22,7 +22,7 @@ class AnzuControlSpellCastingWithSpellBombMultiplier : public Multiplier
 public:
     AnzuControlSpellCastingWithSpellBombMultiplier(
         PlayerbotAI* botAI) : Multiplier(botAI, "anzu control spell casting with spell bomb") {}
-    virtual float GetValue(Action* action);
+    float GetValue(Action* action) override;
 };
 
 class TalonKingIkissDelayBloodlustAndHeroismMultiplier : public Multiplier
@@ -30,7 +30,7 @@ class TalonKingIkissDelayBloodlustAndHeroismMultiplier : public Multiplier
 public:
     TalonKingIkissDelayBloodlustAndHeroismMultiplier(
         PlayerbotAI* botAI) : Multiplier(botAI, "talon king ikiss delay bloodlust and heroism") {}
-    virtual float GetValue(Action* action);
+    float GetValue(Action* action) override;
 };
 
 class TalonKingIkissControlMovementMultiplier : public Multiplier
@@ -38,7 +38,7 @@ class TalonKingIkissControlMovementMultiplier : public Multiplier
 public:
     TalonKingIkissControlMovementMultiplier(
         PlayerbotAI* botAI) : Multiplier(botAI, "talon king ikiss control movement") {}
-    virtual float GetValue(Action* action);
+    float GetValue(Action* action) override;
 };
 
 #endif

--- a/src/Ai/Dungeon/Seth/SethMultipliers.h
+++ b/src/Ai/Dungeon/Seth/SethMultipliers.h
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_SETHMULTIPLIERS_H
+#define PLAYERBOTS_SETHMULTIPLIERS_H
+
+#include "Multiplier.h"
+
+class SethekkProphetSetTremorTotemMultiplier : public Multiplier
+{
+public:
+    SethekkProphetSetTremorTotemMultiplier(
+        PlayerbotAI* botAI) : Multiplier(botAI, "sethekk prophet set tremor totem") {}
+    virtual float GetValue(Action* action);
+};
+
+class AnzuControlSpellCastingWithSpellBombMultiplier : public Multiplier
+{
+public:
+    AnzuControlSpellCastingWithSpellBombMultiplier(
+        PlayerbotAI* botAI) : Multiplier(botAI, "anzu control spell casting with spell bomb") {}
+    virtual float GetValue(Action* action);
+};
+
+class TalonKingIkissDelayBloodlustAndHeroismMultiplier : public Multiplier
+{
+public:
+    TalonKingIkissDelayBloodlustAndHeroismMultiplier(
+        PlayerbotAI* botAI) : Multiplier(botAI, "talon king ikiss delay bloodlust and heroism") {}
+    virtual float GetValue(Action* action);
+};
+
+class TalonKingIkissControlMovementMultiplier : public Multiplier
+{
+public:
+    TalonKingIkissControlMovementMultiplier(
+        PlayerbotAI* botAI) : Multiplier(botAI, "talon king ikiss control movement") {}
+    virtual float GetValue(Action* action);
+};
+
+#endif

--- a/src/Ai/Dungeon/Seth/SethStrategy.cpp
+++ b/src/Ai/Dungeon/Seth/SethStrategy.cpp
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "SethStrategy.h"
+#include "SethMultipliers.h"
+#include "SethTriggers.h"
+
+void TbcDungeonSethekkHallsStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+{
+    triggers.push_back(new TriggerNode("time-lost controller drops charming totem", {
+        NextAction("time-lost controller mark charming totem with skull", ACTION_RAID) }));
+
+    triggers.push_back(new TriggerNode("sethekk prophet casts fear", {
+        NextAction("sethekk prophet set tremor totem", ACTION_RAID) }));
+
+    triggers.push_back(new TriggerNode("darkweaver syth boss summons elementals", {
+        NextAction("darkweaver syth mark elementals with skull", ACTION_RAID) }));
+
+    triggers.push_back(new TriggerNode("anzu encounter has two phases", {
+        NextAction("anzu alternate marks on boss", ACTION_RAID) }));
+
+    triggers.push_back(new TriggerNode("anzu bird spirits provide buffs", {
+        NextAction("anzu cast heal over time spell on bird spirit", ACTION_HIGH) }));
+
+    triggers.push_back(new TriggerNode("talon king ikiss boss engaged by tank", {
+        NextAction("talon king ikiss tank move boss to pillar position", ACTION_RAID) }));
+
+    triggers.push_back(new TriggerNode("talon king ikiss ranged prepare for arcane explosion", {
+        NextAction("talon king ikiss ranged stay near victim of boss", ACTION_RAID) }));
+
+    triggers.push_back(new TriggerNode("talon king ikiss boss casting arcane explosion", {
+        NextAction("talon king ikiss los arcane explosion", ACTION_EMERGENCY + 10) }));
+
+    triggers.push_back(new TriggerNode("talon king ikiss boss out of los", {
+        NextAction("talon king ikiss move to within los", ACTION_RAID + 1) }));
+}
+
+void TbcDungeonSethekkHallsStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
+{
+    multipliers.push_back(new SethekkProphetSetTremorTotemMultiplier(botAI));
+    multipliers.push_back(new AnzuControlSpellCastingWithSpellBombMultiplier(botAI));
+    multipliers.push_back(new TalonKingIkissDelayBloodlustAndHeroismMultiplier(botAI));
+    multipliers.push_back(new TalonKingIkissControlMovementMultiplier(botAI));
+}

--- a/src/Ai/Dungeon/Seth/SethStrategy.h
+++ b/src/Ai/Dungeon/Seth/SethStrategy.h
@@ -1,0 +1,23 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_SETHSTRATEGY_H
+#define PLAYERBOTS_SETHSTRATEGY_H
+
+#include "Strategy.h"
+
+class TbcDungeonSethekkHallsStrategy : public Strategy
+{
+public:
+    TbcDungeonSethekkHallsStrategy(PlayerbotAI* botAI) : Strategy(botAI) {}
+
+    virtual std::string const getName() override { return "tbc-seth"; }
+
+    virtual void InitTriggers(std::vector<TriggerNode*> &triggers) override;
+    virtual void InitMultipliers(std::vector<Multiplier*> &multipliers) override;
+};
+
+#endif

--- a/src/Ai/Dungeon/Seth/SethTriggerContext.h
+++ b/src/Ai/Dungeon/Seth/SethTriggerContext.h
@@ -1,0 +1,75 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_SETHTRIGGERCONTEXT_H
+#define PLAYERBOTS_SETHTRIGGERCONTEXT_H
+
+#include "NamedObjectContext.h"
+#include "SethTriggers.h"
+
+class TbcDungeonSethekkHallsTriggerContext : public NamedObjectContext<Trigger>
+{
+public:
+    TbcDungeonSethekkHallsTriggerContext()
+    {
+        creators["time-lost controller drops charming totem"] =
+            &TbcDungeonSethekkHallsTriggerContext::time_lost_controller_drops_charming_totem;
+
+        creators["sethekk prophet casts fear"] =
+            &TbcDungeonSethekkHallsTriggerContext::sethekk_prophet_casts_fear;
+
+        creators["darkweaver syth boss summons elementals"] =
+            &TbcDungeonSethekkHallsTriggerContext::darkweaver_syth_boss_summons_elementals;
+
+        creators["anzu encounter has two phases"] =
+            &TbcDungeonSethekkHallsTriggerContext::anzu_encounter_has_two_phases;
+
+        creators["anzu bird spirits provide buffs"] =
+            &TbcDungeonSethekkHallsTriggerContext::anzu_bird_spirits_provide_buffs;
+
+        creators["talon king ikiss ranged prepare for arcane explosion"] =
+            &TbcDungeonSethekkHallsTriggerContext::talon_king_ikiss_ranged_prepare_for_arcane_explosion;
+
+        creators["talon king ikiss boss engaged by tank"] =
+            &TbcDungeonSethekkHallsTriggerContext::talon_king_ikiss_boss_engaged_by_tank;
+
+        creators["talon king ikiss boss casting arcane explosion"] =
+            &TbcDungeonSethekkHallsTriggerContext::talon_king_ikiss_boss_casting_arcane_explosion;
+
+        creators["talon king ikiss boss out of los"] =
+            &TbcDungeonSethekkHallsTriggerContext::talon_king_ikiss_boss_out_of_los;
+    }
+private:
+    static Trigger* time_lost_controller_drops_charming_totem(PlayerbotAI* botAI) {
+        return new TimeLostControllerDropsCharmingTotemTrigger(botAI);
+    }
+    static Trigger* sethekk_prophet_casts_fear(PlayerbotAI* botAI) {
+        return new SethekkProphetCastsFearTrigger(botAI);
+    }
+    static Trigger* darkweaver_syth_boss_summons_elementals(PlayerbotAI* botAI) {
+        return new DarkweaverSythBossSummonsElementalsTrigger(botAI);
+    }
+    static Trigger* anzu_encounter_has_two_phases(PlayerbotAI* botAI) {
+        return new AnzuEncounterHasTwoPhasesTrigger(botAI);
+    }
+    static Trigger* anzu_bird_spirits_provide_buffs(PlayerbotAI* botAI) {
+        return new AnzuBirdSpiritsProvideBuffsTrigger(botAI);
+    }
+    static Trigger* talon_king_ikiss_ranged_prepare_for_arcane_explosion(PlayerbotAI* botAI) {
+        return new TalonKingIkissRangedPrepareForArcaneExplosionTrigger(botAI);
+    }
+    static Trigger* talon_king_ikiss_boss_engaged_by_tank(PlayerbotAI* botAI) {
+        return new TalonKingIkissBossEngagedByTankTrigger(botAI);
+    }
+    static Trigger* talon_king_ikiss_boss_casting_arcane_explosion(PlayerbotAI* botAI) {
+        return new TalonKingIkissBossCastingArcaneExplosionTrigger(botAI);
+    }
+    static Trigger* talon_king_ikiss_boss_out_of_los(PlayerbotAI* botAI) {
+        return new TalonKingIkissBossOutOfLosTrigger(botAI);
+    }
+};
+
+#endif

--- a/src/Ai/Dungeon/Seth/SethTriggers.cpp
+++ b/src/Ai/Dungeon/Seth/SethTriggers.cpp
@@ -42,13 +42,13 @@ bool AnzuEncounterHasTwoPhasesTrigger::IsActive()
 
 bool AnzuBirdSpiritsProvideBuffsTrigger::IsActive()
 {
-    return bot->getClass() == CLASS_DRUID && botAI->IsHeal(bot) &&
+    return bot->getClass() == CLASS_DRUID && PlayerbotAI::IsHeal(bot) &&
         AI_VALUE2(Unit*, "find target", "anzu");
 }
 
 bool TalonKingIkissBossEngagedByTankTrigger::IsActive()
 {
-    if (!botAI->IsTank(bot))
+    if (!PlayerbotAI::IsTank(bot))
         return false;
 
     Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");
@@ -57,7 +57,7 @@ bool TalonKingIkissBossEngagedByTankTrigger::IsActive()
 
 bool TalonKingIkissRangedPrepareForArcaneExplosionTrigger::IsActive()
 {
-    if (!botAI->IsRanged(bot))
+    if (!PlayerbotAI::IsRanged(bot))
         return false;
 
     Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");

--- a/src/Ai/Dungeon/Seth/SethTriggers.cpp
+++ b/src/Ai/Dungeon/Seth/SethTriggers.cpp
@@ -1,0 +1,80 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "SethTriggers.h"
+#include "Playerbots.h"
+#include "RaidBossHelpers.h"
+#include "SethData.h"
+
+using namespace SethData;
+
+bool TimeLostControllerDropsCharmingTotemTrigger::IsActive()
+{
+    return IsMechanicTrackerBot(bot, SETHEKK_HALLS_MAP_ID) &&
+        AI_VALUE2(Unit*, "find target", "time-lost controller");
+}
+
+bool SethekkProphetCastsFearTrigger::IsActive()
+{
+    if (bot->getClass() != CLASS_SHAMAN)
+        return false;
+
+    return AI_VALUE2(Unit*, "find target", "sethekk prophet") &&
+        !AI_VALUE2(bool, "has totem", "tremor totem");
+}
+
+bool DarkweaverSythBossSummonsElementalsTrigger::IsActive()
+{
+    if (!IsMechanicTrackerBot(bot, SETHEKK_HALLS_MAP_ID))
+        return false;
+
+    Unit* syth = AI_VALUE2(Unit*, "find target", "darkweaver syth");
+    return syth && syth->GetHealthPct() > 10.0f;
+}
+
+bool AnzuEncounterHasTwoPhasesTrigger::IsActive()
+{
+    return AI_VALUE2(Unit*, "find target", "anzu");
+}
+
+bool AnzuBirdSpiritsProvideBuffsTrigger::IsActive()
+{
+    return bot->getClass() == CLASS_DRUID && botAI->IsHeal(bot) &&
+        AI_VALUE2(Unit*, "find target", "anzu");
+}
+
+bool TalonKingIkissBossEngagedByTankTrigger::IsActive()
+{
+    if (!botAI->IsTank(bot))
+        return false;
+
+    Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");
+    return ikiss && ikiss->GetVictim() == bot;
+}
+
+bool TalonKingIkissRangedPrepareForArcaneExplosionTrigger::IsActive()
+{
+    if (!botAI->IsRanged(bot))
+        return false;
+
+    Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");
+    return ikiss && !ikiss->HasAura(static_cast<uint32>(SethSpells::SPELL_ARCANE_BUBBLE)) &&
+        bot->IsWithinLOSInMap(ikiss);
+}
+
+bool TalonKingIkissBossCastingArcaneExplosionTrigger::IsActive()
+{
+    // Arcane Bubble is put up 1s before casting Arcane Explosion
+    Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");
+    return ikiss && ikiss->HasAura(static_cast<uint32>(SethSpells::SPELL_ARCANE_BUBBLE));
+}
+
+bool TalonKingIkissBossOutOfLosTrigger::IsActive()
+{
+    Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");
+    return ikiss && !ikiss->HasAura(static_cast<uint32>(SethSpells::SPELL_ARCANE_BUBBLE)) &&
+        !bot->IsWithinLOSInMap(ikiss);
+}

--- a/src/Ai/Dungeon/Seth/SethTriggers.cpp
+++ b/src/Ai/Dungeon/Seth/SethTriggers.cpp
@@ -52,7 +52,7 @@ bool TalonKingIkissBossEngagedByTankTrigger::IsActive()
         return false;
 
     Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");
-    return ikiss && ikiss->GetVictim() == bot;
+    return ikiss && ikiss->GetVictim() == bot && bot->IsWithinMeleeRange(ikiss);
 }
 
 bool TalonKingIkissRangedPrepareForArcaneExplosionTrigger::IsActive()

--- a/src/Ai/Dungeon/Seth/SethTriggers.cpp
+++ b/src/Ai/Dungeon/Seth/SethTriggers.cpp
@@ -13,7 +13,7 @@ using namespace SethData;
 
 bool TimeLostControllerDropsCharmingTotemTrigger::IsActive()
 {
-    return IsMechanicTrackerBot(bot, SETHEKK_HALLS_MAP_ID) &&
+    return IsMechanicTrackerBot(bot, SETH_MAP_ID) &&
         AI_VALUE2(Unit*, "find target", "time-lost controller");
 }
 
@@ -22,13 +22,15 @@ bool SethekkProphetCastsFearTrigger::IsActive()
     if (bot->getClass() != CLASS_SHAMAN)
         return false;
 
-    return AI_VALUE2(Unit*, "find target", "sethekk prophet") &&
-        !AI_VALUE2(bool, "has totem", "tremor totem");
+    if (!AI_VALUE2(Unit*, "find target", "sethekk prophet"))
+        return false;
+
+    return !AI_VALUE2(bool, "has totem", "tremor totem");
 }
 
 bool DarkweaverSythBossSummonsElementalsTrigger::IsActive()
 {
-    if (!IsMechanicTrackerBot(bot, SETHEKK_HALLS_MAP_ID))
+    if (!IsMechanicTrackerBot(bot, SETH_MAP_ID))
         return false;
 
     Unit* syth = AI_VALUE2(Unit*, "find target", "darkweaver syth");
@@ -61,7 +63,7 @@ bool TalonKingIkissRangedPrepareForArcaneExplosionTrigger::IsActive()
         return false;
 
     Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");
-    return ikiss && !ikiss->HasAura(static_cast<uint32>(SethSpells::SPELL_ARCANE_BUBBLE)) &&
+    return ikiss && !ikiss->HasAura(Id(SethSpells::SPELL_ARCANE_BUBBLE)) &&
         bot->IsWithinLOSInMap(ikiss);
 }
 
@@ -69,12 +71,12 @@ bool TalonKingIkissBossCastingArcaneExplosionTrigger::IsActive()
 {
     // Arcane Bubble is put up 1s before casting Arcane Explosion
     Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");
-    return ikiss && ikiss->HasAura(static_cast<uint32>(SethSpells::SPELL_ARCANE_BUBBLE));
+    return ikiss && ikiss->HasAura(Id(SethSpells::SPELL_ARCANE_BUBBLE));
 }
 
 bool TalonKingIkissBossOutOfLosTrigger::IsActive()
 {
     Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");
-    return ikiss && !ikiss->HasAura(static_cast<uint32>(SethSpells::SPELL_ARCANE_BUBBLE)) &&
+    return ikiss && !ikiss->HasAura(Id(SethSpells::SPELL_ARCANE_BUBBLE)) &&
         !bot->IsWithinLOSInMap(ikiss);
 }

--- a/src/Ai/Dungeon/Seth/SethTriggers.h
+++ b/src/Ai/Dungeon/Seth/SethTriggers.h
@@ -1,0 +1,84 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_SETHTRIGGERS_H
+#define PLAYERBOTS_SETHTRIGGERS_H
+
+#include "Trigger.h"
+
+class TimeLostControllerDropsCharmingTotemTrigger : public Trigger
+{
+public:
+    TimeLostControllerDropsCharmingTotemTrigger(
+        PlayerbotAI* botAI) : Trigger(botAI, "time-lost controller drops charming totem") {}
+    bool IsActive() override;
+};
+
+class SethekkProphetCastsFearTrigger : public Trigger
+{
+public:
+    SethekkProphetCastsFearTrigger(
+        PlayerbotAI* botAI) : Trigger(botAI, "sethekk prophet casts fear") {}
+    bool IsActive() override;
+};
+
+class DarkweaverSythBossSummonsElementalsTrigger : public Trigger
+{
+public:
+    DarkweaverSythBossSummonsElementalsTrigger(
+        PlayerbotAI* botAI) : Trigger(botAI, "darkweaver syth boss summons elementals") {}
+    bool IsActive() override;
+};
+
+class AnzuEncounterHasTwoPhasesTrigger : public Trigger
+{
+public:
+    AnzuEncounterHasTwoPhasesTrigger(
+        PlayerbotAI* botAI) : Trigger(botAI, "anzu encounter has two phases") {}
+    bool IsActive() override;
+};
+
+class AnzuBirdSpiritsProvideBuffsTrigger : public Trigger
+{
+public:
+    AnzuBirdSpiritsProvideBuffsTrigger(
+        PlayerbotAI* botAI) : Trigger(botAI, "anzu bird spirits provide buffs") {}
+    bool IsActive() override;
+};
+
+class TalonKingIkissBossEngagedByTankTrigger : public Trigger
+{
+public:
+    TalonKingIkissBossEngagedByTankTrigger(
+        PlayerbotAI* botAI) : Trigger(botAI, "talon king ikiss boss engaged by tank") {}
+    bool IsActive() override;
+};
+
+class TalonKingIkissRangedPrepareForArcaneExplosionTrigger : public Trigger
+{
+public:
+    TalonKingIkissRangedPrepareForArcaneExplosionTrigger(
+        PlayerbotAI* botAI) : Trigger(botAI, "talon king ikiss ranged prepare for arcane explosion") {}
+    bool IsActive() override;
+};
+
+class TalonKingIkissBossCastingArcaneExplosionTrigger : public Trigger
+{
+public:
+    TalonKingIkissBossCastingArcaneExplosionTrigger(
+        PlayerbotAI* botAI) : Trigger(botAI, "talon king ikiss boss casting arcane explosion") {}
+    bool IsActive() override;
+};
+
+class TalonKingIkissBossOutOfLosTrigger : public Trigger
+{
+public:
+    TalonKingIkissBossOutOfLosTrigger(
+        PlayerbotAI* botAI) : Trigger(botAI, "talon king ikiss boss out of los") {}
+    bool IsActive() override;
+};
+
+#endif

--- a/src/Ai/Dungeon/TbcDungeonActionContext.h
+++ b/src/Ai/Dungeon/TbcDungeonActionContext.h
@@ -8,5 +8,6 @@
 #define PLAYERBOTS_TBCDUNGEONACTIONCONTEXT_H
 
 #include "ACActionContext.h"
+#include "SethActionContext.h"
 
 #endif

--- a/src/Ai/Dungeon/TbcDungeonTriggerContext.h
+++ b/src/Ai/Dungeon/TbcDungeonTriggerContext.h
@@ -8,5 +8,6 @@
 #define PLAYERBOTS_TBCDUNGEONTRIGGERCONTEXT_H
 
 #include "ACTriggerContext.h"
+#include "SethTriggerContext.h"
 
 #endif

--- a/src/Ai/Dungeon/WotlkDungeonActionContext.h
+++ b/src/Ai/Dungeon/WotlkDungeonActionContext.h
@@ -22,6 +22,5 @@
 #include "FoSActionContext.h"
 #include "PoSActionContext.h"
 #include "TOCActionContext.h"
-// #include "HallsOfReflection/HallsOfReflectionActionContext.h"
 
 #endif

--- a/src/Ai/Dungeon/WotlkDungeonTriggerContext.h
+++ b/src/Ai/Dungeon/WotlkDungeonTriggerContext.h
@@ -22,6 +22,5 @@
 #include "FoSTriggerContext.h"
 #include "PoSTriggerContext.h"
 #include "TOCTriggerContext.h"
-// #include "HallsOfReflection/HallsOfReflectionTriggerContext.h"
 
 #endif

--- a/src/Ai/Raid/OS/OSActions.cpp
+++ b/src/Ai/Raid/OS/OSActions.cpp
@@ -124,7 +124,7 @@ bool AvoidFlameTsunamiAction::Execute(Event /*event*/)
             // I always saw these accurate to around 6 decimal places, but if there are issues,
             // can switch this to abs comparison of floats which would technically be more robust.
             int posY = (int) unit->GetPositionY();
-            if (posY == 505 || posY == 555)     // RIGHT WAVE
+            if (posY == 500 || posY == 564)     // RIGHT WAVE
             {
                 bool wavePassed = currentPos.GetPositionX() > unit->GetPositionX();
                 if (wavePassed)

--- a/src/Ai/Raid/RaidBossHelpers.h
+++ b/src/Ai/Raid/RaidBossHelpers.h
@@ -9,6 +9,14 @@
 
 #include "AiObject.h"
 #include "Unit.h"
+#include <type_traits>
+
+// To avoid repeated casting of enum classes to uint32
+template <typename T, std::enable_if_t<std::is_enum_v<T>, int> = 0>
+constexpr uint32 Id(T value)
+{
+    return static_cast<uint32>(value);
+}
 
 bool MarkTargetWithIcon(Player* bot, Unit* target, uint8 iconId);
 bool MarkTargetWithSkull(Player* bot, Unit* target);

--- a/src/Bot/Debug/PerfMonitor.cpp
+++ b/src/Bot/Debug/PerfMonitor.cpp
@@ -4,6 +4,14 @@
  * or (at your option) any later version.
  */
 
+/*
+ * Ported from the CMaNGOS playerbots project (https://github.com/cmangos/playerbots), GPL v2,
+ * with modifications for AzerothCore.
+ * Original authors:
+ *   ike3 <ike@email.org> - original author
+ *   Sebastiaan Keek (mostlikely4r) <sebastiaan.keek@gmail.com>
+ */
+
 #include "PerfMonitor.h"
 
 #include "Playerbots.h"

--- a/src/Bot/Debug/PerfMonitor.h
+++ b/src/Bot/Debug/PerfMonitor.h
@@ -4,6 +4,14 @@
  * or (at your option) any later version.
  */
 
+/*
+ * Ported from the CMaNGOS playerbots project (https://github.com/cmangos/playerbots), GPL v2,
+ * with modifications for AzerothCore.
+ * Original authors:
+ *   ike3 <ike@email.org> - original author
+ *   Sebastiaan Keek (mostlikely4r) <sebastiaan.keek@gmail.com>
+ */
+
 #ifndef PLAYERBOTS_PERFMONITOR_H
 #define PLAYERBOTS_PERFMONITOR_H
 

--- a/src/Bot/Engine/BuildSharedActionContexts.cpp
+++ b/src/Bot/Engine/BuildSharedActionContexts.cpp
@@ -55,6 +55,7 @@ void AiObjectContext::BuildSharedActionContexts(SharedNamedObjectContextList<Act
     actionContexts.Add(new RaidIccActionContext());
     actionContexts.Add(new RaidRsActionContext());
     actionContexts.Add(new TbcDungeonAuchenaiCryptsActionContext());
+    actionContexts.Add(new TbcDungeonSethekkHallsActionContext());
     actionContexts.Add(new WotlkDungeonUKActionContext());
     actionContexts.Add(new WotlkDungeonNexActionContext());
     actionContexts.Add(new WotlkDungeonANActionContext());

--- a/src/Bot/Engine/BuildSharedTriggerContexts.cpp
+++ b/src/Bot/Engine/BuildSharedTriggerContexts.cpp
@@ -55,6 +55,7 @@ void AiObjectContext::BuildSharedTriggerContexts(SharedNamedObjectContextList<Tr
     triggerContexts.Add(new RaidIccTriggerContext());
     triggerContexts.Add(new RaidRsTriggerContext());
     triggerContexts.Add(new TbcDungeonAuchenaiCryptsTriggerContext());
+    triggerContexts.Add(new TbcDungeonSethekkHallsTriggerContext());
     triggerContexts.Add(new WotlkDungeonUKTriggerContext());
     triggerContexts.Add(new WotlkDungeonNexTriggerContext());
     triggerContexts.Add(new WotlkDungeonANTriggerContext());

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -1625,7 +1625,7 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
         "aq20", "blacktemple", "bwl", "gruulslair", "hyjal", "icc", "karazhan", "magtheridon",
         "moltencore", "naxx", "onyxia", "rs", "ssc", "tbc-ac", "tbc-seth", "tempestkeep",
         "ulduar", "voa", "wotlk-an", "wotlk-cos", "wotlk-dtk", "wotlk-eoe", "wotlk-fos",
-        "wotlk-gd", "wotlk-hol", "wotlk-hor", "wotlk-hos", "wotlk-nex", "wotlk-occ",
+        "wotlk-gd", "wotlk-hol", "wotlk-hos", "wotlk-nex", "wotlk-occ",
         "wotlk-ok", "wotlk-os", "wotlk-pos", "wotlk-toc", "wotlk-uk", "wotlk-up",
         "wotlk-vh", "zulaman"
     };
@@ -1743,9 +1743,6 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
             break;
         case 658:
             strategyName = "wotlk-pos";  // Pit of Saron
-            break;
-        case 668:
-            strategyName = "wotlk-hor";  // Halls of Reflection
             break;
         case 724:
             strategyName = "rs";  // Ruby Sanctum

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -1622,8 +1622,8 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
 {
     static const std::vector<std::string> allInstanceStrategies =
     {
-        "aq20", "blacktemple", "bwl", "gruulslair", "hyjal", "icc", "karazhan",
-        "magtheridon", "moltencore", "naxx", "onyxia", "rs", "ssc", "tbc-ac", "tempestkeep",
+        "aq20", "blacktemple", "bwl", "gruulslair", "hyjal", "icc", "karazhan", "magtheridon",
+        "moltencore", "naxx", "onyxia", "rs", "ssc", "tbc-ac", "tbc-seth", "tempestkeep",
         "ulduar", "voa", "wotlk-an", "wotlk-cos", "wotlk-dtk", "wotlk-eoe", "wotlk-fos",
         "wotlk-gd", "wotlk-hol", "wotlk-hor", "wotlk-hos", "wotlk-nex", "wotlk-occ",
         "wotlk-ok", "wotlk-os", "wotlk-pos", "wotlk-toc", "wotlk-uk", "wotlk-up",
@@ -1668,6 +1668,9 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
             break;
         case 550:
             strategyName = "tempestkeep";  // Tempest Keep: The Eye
+            break;
+        case 556:
+            strategyName = "tbc-seth";  // Auchindoun: Sethekk Halls
             break;
         case 558:
             strategyName = "tbc-ac";  // Auchindoun: Auchenai Crypts

--- a/src/Mgr/Item/LootObjectStack.cpp
+++ b/src/Mgr/Item/LootObjectStack.cpp
@@ -308,7 +308,12 @@ bool LootObject::IsLootPossible(Player* bot)
     // Prevent bot from running to chests that are unlootable (e.g. Gunship Armory before completing the event) or on
     // respawn time
     GameObject* go = botAI->GetGameObject(guid);
-    if (go && (go->HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_INTERACT_COND | GO_FLAG_NOT_SELECTABLE) || !go->isSpawned()))
+    if (go && (go->HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE) || !go->isSpawned()))
+        return false;
+
+    // Conditional objects (quest chests, goobers, ...) are gated client-side on quest state.
+    // A bot has no client, so make the same call the server makes for one.
+    if (go && go->HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_INTERACT_COND) && !go->ActivateToQuest(bot))
         return false;
 
     if (skillId == SKILL_NONE)

--- a/src/Mgr/Travel/TravelMgr.cpp
+++ b/src/Mgr/Travel/TravelMgr.cpp
@@ -1068,7 +1068,7 @@ GuidPosition::GuidPosition(CreatureData const& creData)
 }
 
 GuidPosition::GuidPosition(GameObjectData const& goData)
-    : ObjectGuid(HighGuid::GameObject, goData.id),
+    : ObjectGuid(HighGuid::GameObject, goData.id, goData.spawnId),
       WorldPosition(goData.mapid, goData.posX, goData.posY, goData.posZ, goData.orientation)
 {
     loadedFromDB = true;


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

This PR adds Sethekk Halls strategies for both Heroic and Non-Heroic. They are not required to complete the instance, but Talon King Ikiss does require manual movement of bots without this strategy.

Overview of strategies:

**Trash**
- Bots mark Charming Totems with skull when summoned by Time-Lost Controllers (the totems MC)
- Shaman use Tremor Totem when fighting Sethekk Prophets. This does not involve a strategy swap so you can keep whatever Earth Totem strategy active throughout the instance; it will be overriden only when engaging a Sethekk Prophet.

**Darkweaver Syth**
- Bots mark elemental adds with skull when they spawn in the following order: Frost, Shadow, Arcane, Fire.

**Anzu**
- Bots mark Anzu with Moon when he is banished and immune to damage. They mark him with Skull when he can be damaged.
- Resto Druids will cast ahnd maintain Rejuvenation Rank 1 on the Falcon, Hawk, and Eagle Spirits to activate their buffs (haste from Falcon, damage mitigation from Hawk, and AoE damage from Eagle).

**Talon King Ikiss**
- The tank will pull the boss to the SW pillar.
- Ranged bots will stay close-ish (5-15 yards) from the tank.
- When Ikiss teleports and puts up an immunity shield and casts Arcane Explosion, bots will run around the pillar to the opposite side to LoS the Arcane Explosion.
- When Ikiss is finished casting, bots will run back around the pillar to reengage.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

Standard approach to strategy registration and implementation.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

1. Go to Sethekk Halls
2. Set dungeon to Heroic
3. Run the dungeon and ensure all stated strategies work and do not have significant performance impact
4. Repeat with dungeon on Normal

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

New triggers, multipliers, and actions are evaluated only when the tbc-seth strategy is added. Performance impact of the strategies, even when active, should be minimal.

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

Bots follow strategies when tbc-seth is active in the Sethekk Halls instance.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

Just assistance with mathematical calculations for Ikiss pillar movement

## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note).
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


