### PR TITLE
feat(ub): add Underbog (tbc-ub) dungeon strategy for Hungarfen

### DIFF
--- a/src/Ai/Dungeon/DungeonStrategyContext.h
+++ b/src/Ai/Dungeon/DungeonStrategyContext.h
@@ -23,6 +23,7 @@
 #include "SethStrategy.h"
 #include "Strategy.h"
 #include "TOCStrategy.h"
+#include "UBStrategy.h"
 #include "UKStrategy.h"
 #include "UPStrategy.h"
 #include "VHStrategy.h"
@@ -39,6 +40,7 @@ class DungeonStrategyContext : public NamedObjectContext<Strategy>
             creators["tbc-ac"] = &DungeonStrategyContext::tbc_ac;           // Auchindoun: Auchenai Crypts
             creators["tbc-seth"] = &DungeonStrategyContext::tbc_seth;       // Auchindoun: Sethekk Halls
             creators["tbc-mech"] = &DungeonStrategyContext::tbc_mech;       // Tempest Keep: The Mechanar
+            creators["tbc-ub"] = &DungeonStrategyContext::tbc_ub;           // Coilfang Reservoir: The Underbog
 
             // Wrath of the Lich King
             creators["wotlk-uk"] = &DungeonStrategyContext::wotlk_uk;       // Utgarde Keep
@@ -61,6 +63,7 @@ class DungeonStrategyContext : public NamedObjectContext<Strategy>
         static Strategy* tbc_ac(PlayerbotAI* botAI) { return new TbcDungeonAuchenaiCryptsStrategy(botAI); }
         static Strategy* tbc_seth(PlayerbotAI* botAI) { return new TbcDungeonSethekkHallsStrategy(botAI); }
         static Strategy* tbc_mech(PlayerbotAI* botAI) { return new TbcDungeonMechanarStrategy(botAI); }
+        static Strategy* tbc_ub(PlayerbotAI* botAI) { return new TbcDungeonUnderbogStrategy(botAI); }
         static Strategy* wotlk_uk(PlayerbotAI* botAI) { return new WotlkDungeonUKStrategy(botAI); }
         static Strategy* wotlk_nex(PlayerbotAI* botAI) { return new WotlkDungeonNexStrategy(botAI); }
         static Strategy* wotlk_an(PlayerbotAI* botAI) { return new WotlkDungeonANStrategy(botAI); }

--- a/src/Ai/Dungeon/TbcDungeonActionContext.h
+++ b/src/Ai/Dungeon/TbcDungeonActionContext.h
@@ -10,5 +10,6 @@
 #include "ACActionContext.h"
 #include "MechActionContext.h"
 #include "SethActionContext.h"
+#include "UBActionContext.h"
 
 #endif

--- a/src/Ai/Dungeon/TbcDungeonTriggerContext.h
+++ b/src/Ai/Dungeon/TbcDungeonTriggerContext.h
@@ -10,5 +10,6 @@
 #include "ACTriggerContext.h"
 #include "MechTriggerContext.h"
 #include "SethTriggerContext.h"
+#include "UBTriggerContext.h"
 
 #endif

--- a/src/Ai/Dungeon/UB/UBActionContext.h
+++ b/src/Ai/Dungeon/UB/UBActionContext.h
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_UBACTIONCONTEXT_H
+#define PLAYERBOTS_UBACTIONCONTEXT_H
+
+#include "Action.h"
+#include "AiObjectContext.h"
+#include "UBActions.h"
+
+class TbcDungeonUnderbogActionContext : public NamedObjectContext<Action>
+{
+public:
+    TbcDungeonUnderbogActionContext()
+    {
+        creators["ub retreat from foul spores"] = &TbcDungeonUnderbogActionContext::ub_retreat_from_foul_spores;
+        creators["ub vacate spore cloud"] = &TbcDungeonUnderbogActionContext::ub_vacate_spore_cloud;
+    }
+
+private:
+    static Action* ub_retreat_from_foul_spores(PlayerbotAI* botAI) { return new UBRetreatFromFoulSporesAction(botAI); }
+
+    static Action* ub_vacate_spore_cloud(PlayerbotAI* botAI) { return new UBVacateSporeCloudAction(botAI); }
+};
+
+#endif

--- a/src/Ai/Dungeon/UB/UBActionContext.h
+++ b/src/Ai/Dungeon/UB/UBActionContext.h
@@ -8,7 +8,7 @@
 #define PLAYERBOTS_UBACTIONCONTEXT_H
 
 #include "Action.h"
-#include "AiObjectContext.h"
+#include "NamedObjectContext.h"
 #include "UBActions.h"
 
 class TbcDungeonUnderbogActionContext : public NamedObjectContext<Action>
@@ -18,12 +18,15 @@ public:
     {
         creators["ub retreat from foul spores"] = &TbcDungeonUnderbogActionContext::ub_retreat_from_foul_spores;
         creators["ub vacate spore cloud"] = &TbcDungeonUnderbogActionContext::ub_vacate_spore_cloud;
+        creators["ub clear underbat back"] = &TbcDungeonUnderbogActionContext::ub_clear_underbat_back;
     }
 
 private:
     static Action* ub_retreat_from_foul_spores(PlayerbotAI* botAI) { return new UBRetreatFromFoulSporesAction(botAI); }
 
     static Action* ub_vacate_spore_cloud(PlayerbotAI* botAI) { return new UBVacateSporeCloudAction(botAI); }
+
+    static Action* ub_clear_underbat_back(PlayerbotAI* botAI) { return new UBClearUnderbatBackAction(botAI); }
 };
 
 #endif

--- a/src/Ai/Dungeon/UB/UBActions.cpp
+++ b/src/Ai/Dungeon/UB/UBActions.cpp
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "UBActions.h"
+#include "Playerbots.h"
+#include "UBShared.h"
+
+#include <cmath>
+
+using namespace UnderbogHungarfen;
+
+bool UBRetreatFromFoulSporesAction::Execute(Event /*event*/)
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", "hungarfen");
+    if (!boss)
+        return false;
+
+    float const safeDistance = MaxEffectRadius(SPELL_FOUL_SPORES, FOUL_SPORES_RADIUS_FALLBACK) + FOUL_SPORES_MARGIN;
+    float const currentDistance = bot->GetDistance2d(boss);
+    if (currentDistance >= safeDistance)
+        return false;
+
+    float const moveDist = safeDistance - currentDistance + 1.0f;
+    float const awayAngle = boss->GetAngle(bot);
+
+    GuidVector const& mushrooms = AI_VALUE_REF(GuidVector, "ub mushrooms");
+
+    for (float delta : { 0.0f, float(M_PI / 8), float(-M_PI / 8), float(M_PI / 4), float(-M_PI / 4),
+                         float(3 * M_PI / 8), float(-3 * M_PI / 8), float(M_PI / 2), float(-M_PI / 2) })
+    {
+        float const angle = awayAngle + delta;
+        float dx = bot->GetPositionX() + cos(angle) * moveDist;
+        float dy = bot->GetPositionY() + sin(angle) * moveDist;
+        float dz = bot->GetPositionZ();
+        if (!bot->GetMap()->CheckCollisionAndGetValidCoords(bot, bot->GetPositionX(), bot->GetPositionY(),
+                                                            bot->GetPositionZ(), dx, dy, dz))
+            continue;
+
+        if (RetreatPathUnsafe(bot, mushrooms, dx, dy))
+            continue;
+
+        if (MoveTo(bot->GetMapId(), dx, dy, dz, false, false, true, true,
+                   MovementPriority::MOVEMENT_COMBAT))
+            return true;
+    }
+
+    return MoveAway(boss, moveDist);
+}
+
+bool UBVacateSporeCloudAction::Execute(Event /*event*/)
+{
+    float const dangerRange = MushroomDangerRange(bot);
+    GuidVector const& mushrooms = AI_VALUE_REF(GuidVector, "ub mushrooms");
+    Creature* mushroom = GetNearestDangerousMushroom(bot, mushrooms, dangerRange);
+    if (!mushroom)
+        return false;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "hungarfen");
+    if (botAI->IsTank(bot) && boss && boss->GetVictim() == bot)
+    {
+        float const currentDistance = bot->GetDistance2d(mushroom);
+        return MoveAway(mushroom, dangerRange - currentDistance + 2.0f);
+    }
+
+    return FleePosition(mushroom->GetPosition(), dangerRange);
+}

--- a/src/Ai/Dungeon/UB/UBActions.cpp
+++ b/src/Ai/Dungeon/UB/UBActions.cpp
@@ -6,8 +6,8 @@
 
 #include "UBActions.h"
 #include "Playerbots.h"
+#include "Timer.h"
 #include "UBShared.h"
-
 #include <cmath>
 
 using namespace UnderbogHungarfen;
@@ -66,4 +66,60 @@ bool UBVacateSporeCloudAction::Execute(Event /*event*/)
     }
 
     return FleePosition(mushroom->GetPosition(), dangerRange);
+}
+
+bool UBClearUnderbatBackAction::Execute(Event /*event*/)
+{
+    if (!bot->IsAlive() || botAI->IsTank(bot))
+        return false;
+
+    GuidVector const& attackers = AI_VALUE_REF(GuidVector, "attackers");
+    Creature* bat = GetNearestUnderbatInLashRange(bot, attackers);
+    if (!bat)
+        return false;
+
+    bool const throttled = _lastReposition && GetMSTimeDiffToNow(_lastReposition) < UNDERBAT_REPOSITION_COOLDOWN;
+
+    bool const melee = botAI->IsMelee(bot);
+    if (melee)
+    {
+        Unit* rally = UnderbatRallyUnit(bot, attackers);
+        bool const parked = rally && bot->GetExactDist(rally) <= UNDERBAT_RALLY_TOLERANCE;
+
+        if (rally && !parked)
+        {
+            if (throttled)
+                return false;
+
+            float const rx = rally->GetPositionX();
+            float const ry = rally->GetPositionY();
+            float const rz = rally->GetPositionZ();
+            if (SpotClearOfUnderbats(bot, attackers, rx, ry, rz) &&
+                MoveTo(bot->GetMapId(), rx, ry, rz, false, false, true, true,
+                       MovementPriority::MOVEMENT_COMBAT))
+            {
+                _lastReposition = getMSTime();
+                return true;
+            }
+        }
+
+        if (!GetLashingUnderbat(bot, attackers))
+            return false;
+    }
+    else if (bot->IsNonMeleeSpellCast(true) && !GetLashingUnderbat(bot, attackers))
+        return false;
+
+    if (throttled)
+        return false;
+
+    float const clearDistance = UNDERBAT_LASH_RANGE + UNDERBAT_LASH_MARGIN;
+    float const gap = bot->GetDistance2d(bat);
+    if (gap >= clearDistance)
+        return false;
+
+    if (!MoveAway(bat, clearDistance - gap + 1.0f))
+        return false;
+
+    _lastReposition = getMSTime();
+    return true;
 }

--- a/src/Ai/Dungeon/UB/UBActions.cpp
+++ b/src/Ai/Dungeon/UB/UBActions.cpp
@@ -26,7 +26,7 @@ bool UBRetreatFromFoulSporesAction::Execute(Event /*event*/)
     float const moveDist = safeDistance - currentDistance + 1.0f;
     float const awayAngle = boss->GetAngle(bot);
 
-    GuidVector const& mushrooms = AI_VALUE_REF(GuidVector, "ub mushrooms");
+    auto const& mushrooms = AI_VALUE_REF(GuidVector, "ub mushrooms");
 
     for (float delta : { 0.0f, float(M_PI / 8), float(-M_PI / 8), float(M_PI / 4), float(-M_PI / 4),
                          float(3 * M_PI / 8), float(-3 * M_PI / 8), float(M_PI / 2), float(-M_PI / 2) })
@@ -53,16 +53,19 @@ bool UBRetreatFromFoulSporesAction::Execute(Event /*event*/)
 bool UBVacateSporeCloudAction::Execute(Event /*event*/)
 {
     float const dangerRange = MushroomDangerRange(bot);
-    GuidVector const& mushrooms = AI_VALUE_REF(GuidVector, "ub mushrooms");
+    auto const& mushrooms = AI_VALUE_REF(GuidVector, "ub mushrooms");
     Creature* mushroom = GetNearestDangerousMushroom(bot, mushrooms, dangerRange);
     if (!mushroom)
         return false;
 
-    Unit* boss = AI_VALUE2(Unit*, "find target", "hungarfen");
-    if (botAI->IsTank(bot) && boss && boss->GetVictim() == bot)
+    if (PlayerbotAI::IsTank(bot))
     {
-        float const currentDistance = bot->GetDistance2d(mushroom);
-        return MoveAway(mushroom, dangerRange - currentDistance + 2.0f);
+        Unit* boss = AI_VALUE2(Unit*, "find target", "hungarfen");
+        if (boss && boss->GetVictim() == bot)
+        {
+            float const currentDistance = bot->GetDistance2d(mushroom);
+            return MoveAway(mushroom, dangerRange - currentDistance + 2.0f);
+        }
     }
 
     return FleePosition(mushroom->GetPosition(), dangerRange);
@@ -70,17 +73,17 @@ bool UBVacateSporeCloudAction::Execute(Event /*event*/)
 
 bool UBClearUnderbatBackAction::Execute(Event /*event*/)
 {
-    if (!bot->IsAlive() || botAI->IsTank(bot))
+    if (PlayerbotAI::IsTank(bot))
         return false;
 
-    GuidVector const& attackers = AI_VALUE_REF(GuidVector, "attackers");
+    auto const& attackers = AI_VALUE_REF(GuidVector, "attackers");
     Creature* bat = GetNearestUnderbatInLashRange(bot, attackers);
     if (!bat)
         return false;
 
     bool const throttled = _lastReposition && GetMSTimeDiffToNow(_lastReposition) < UNDERBAT_REPOSITION_COOLDOWN;
 
-    bool const melee = botAI->IsMelee(bot);
+    bool const melee = PlayerbotAI::IsMelee(bot);
     if (melee)
     {
         Unit* rally = UnderbatRallyUnit(bot, attackers);

--- a/src/Ai/Dungeon/UB/UBActions.h
+++ b/src/Ai/Dungeon/UB/UBActions.h
@@ -23,4 +23,14 @@ public:
     bool Execute(Event event) override;
 };
 
+class UBClearUnderbatBackAction : public MovementAction
+{
+public:
+    UBClearUnderbatBackAction(PlayerbotAI* botAI) : MovementAction(botAI, "ub clear underbat back") {}
+    bool Execute(Event event) override;
+
+private:
+    uint32 _lastReposition = 0;
+};
+
 #endif

--- a/src/Ai/Dungeon/UB/UBActions.h
+++ b/src/Ai/Dungeon/UB/UBActions.h
@@ -1,0 +1,26 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_UBACTIONS_H
+#define PLAYERBOTS_UBACTIONS_H
+
+#include "MovementActions.h"
+
+class UBRetreatFromFoulSporesAction : public MovementAction
+{
+public:
+    UBRetreatFromFoulSporesAction(PlayerbotAI* botAI) : MovementAction(botAI, "ub retreat from foul spores") {}
+    bool Execute(Event event) override;
+};
+
+class UBVacateSporeCloudAction : public MovementAction
+{
+public:
+    UBVacateSporeCloudAction(PlayerbotAI* botAI) : MovementAction(botAI, "ub vacate spore cloud") {}
+    bool Execute(Event event) override;
+};
+
+#endif

--- a/src/Ai/Dungeon/UB/UBMultipliers.cpp
+++ b/src/Ai/Dungeon/UB/UBMultipliers.cpp
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "UBMultipliers.h"
+#include "AttackAction.h"
+#include "GenericSpellActions.h"
+#include "MovementActions.h"
+#include "Playerbots.h"
+#include "ReachTargetActions.h"
+#include "UBActions.h"
+#include "UBShared.h"
+
+using namespace UnderbogHungarfen;
+
+float HungarfenFoulSporesMultiplier::GetValue(Action* action)
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", "hungarfen");
+    if (!boss || !boss->HasAura(SPELL_FOUL_SPORES))
+        return 1.0f;
+
+    if (dynamic_cast<UBRetreatFromFoulSporesAction*>(action) || dynamic_cast<UBVacateSporeCloudAction*>(action) ||
+        dynamic_cast<AttackAction*>(action))
+        return 1.0f;
+
+    if (dynamic_cast<MovementAction*>(action) || dynamic_cast<CastReachTargetSpellAction*>(action))
+        return 0.0f;
+
+    return 1.0f;
+}
+
+float HungarfenMushroomIgnoreMultiplier::GetValue(Action* action)
+{
+    if (action->getThreatType() != Action::ActionThreatType::Aoe)
+        return 1.0f;
+
+    if (!botAI->IsDps(bot))
+        return 1.0f;
+
+    if (dynamic_cast<CastHealingSpellAction*>(action))
+        return 1.0f;
+
+    if (!AI_VALUE2(Unit*, "find target", "hungarfen"))
+        return 1.0f;
+
+    return 0.0f;
+}

--- a/src/Ai/Dungeon/UB/UBMultipliers.cpp
+++ b/src/Ai/Dungeon/UB/UBMultipliers.cpp
@@ -6,6 +6,7 @@
 
 #include "UBMultipliers.h"
 #include "AttackAction.h"
+#include "ChooseTargetActions.h"
 #include "GenericSpellActions.h"
 #include "MovementActions.h"
 #include "Playerbots.h"
@@ -33,8 +34,16 @@ float HungarfenFoulSporesMultiplier::GetValue(Action* action)
 
 float HungarfenMushroomIgnoreMultiplier::GetValue(Action* action)
 {
-    if (action->getThreatType() != Action::ActionThreatType::Aoe)
+    bool const aoe = action->getThreatType() == Action::ActionThreatType::Aoe;
+    if (!aoe && !dynamic_cast<AttackAnythingAction*>(action))
         return 1.0f;
+
+    GuidVector const& mushrooms = AI_VALUE_REF(GuidVector, "ub mushrooms");
+    if (!AnyMushroomAlive(bot, mushrooms))
+        return 1.0f;
+
+    if (!aoe)
+        return IsMushroom(AI_VALUE(Unit*, "grind target")) ? 0.0f : 1.0f;
 
     if (!botAI->IsDps(bot))
         return 1.0f;
@@ -42,8 +51,14 @@ float HungarfenMushroomIgnoreMultiplier::GetValue(Action* action)
     if (dynamic_cast<CastHealingSpellAction*>(action))
         return 1.0f;
 
-    if (!AI_VALUE2(Unit*, "find target", "hungarfen"))
+    return 0.0f;
+}
+
+float UnderbatFacingMultiplier::GetValue(Action* action)
+{
+    if (!dynamic_cast<SetBehindTargetAction*>(action))
         return 1.0f;
 
-    return 0.0f;
+    GuidVector const& attackers = AI_VALUE_REF(GuidVector, "attackers");
+    return AnyUnderbatInLashRange(bot, attackers) ? 0.0f : 1.0f;
 }

--- a/src/Ai/Dungeon/UB/UBMultipliers.cpp
+++ b/src/Ai/Dungeon/UB/UBMultipliers.cpp
@@ -18,18 +18,18 @@ using namespace UnderbogHungarfen;
 
 float HungarfenFoulSporesMultiplier::GetValue(Action* action)
 {
-    Unit* boss = AI_VALUE2(Unit*, "find target", "hungarfen");
-    if (!boss || !boss->HasAura(SPELL_FOUL_SPORES))
+    if (!dynamic_cast<MovementAction*>(action) && !dynamic_cast<CastReachTargetSpellAction*>(action))
         return 1.0f;
 
     if (dynamic_cast<UBRetreatFromFoulSporesAction*>(action) || dynamic_cast<UBVacateSporeCloudAction*>(action) ||
         dynamic_cast<AttackAction*>(action))
         return 1.0f;
 
-    if (dynamic_cast<MovementAction*>(action) || dynamic_cast<CastReachTargetSpellAction*>(action))
-        return 0.0f;
+    Unit* boss = AI_VALUE2(Unit*, "find target", "hungarfen");
+    if (!boss || !boss->HasAura(SPELL_FOUL_SPORES))
+        return 1.0f;
 
-    return 1.0f;
+    return 0.0f;
 }
 
 float HungarfenMushroomIgnoreMultiplier::GetValue(Action* action)
@@ -38,18 +38,15 @@ float HungarfenMushroomIgnoreMultiplier::GetValue(Action* action)
     if (!aoe && !dynamic_cast<AttackAnythingAction*>(action))
         return 1.0f;
 
-    GuidVector const& mushrooms = AI_VALUE_REF(GuidVector, "ub mushrooms");
+    if (aoe && (dynamic_cast<CastHealingSpellAction*>(action) || !PlayerbotAI::IsDps(bot)))
+        return 1.0f;
+
+    auto const& mushrooms = AI_VALUE_REF(GuidVector, "ub mushrooms");
     if (!AnyMushroomAlive(bot, mushrooms))
         return 1.0f;
 
     if (!aoe)
         return IsMushroom(AI_VALUE(Unit*, "grind target")) ? 0.0f : 1.0f;
-
-    if (!botAI->IsDps(bot))
-        return 1.0f;
-
-    if (dynamic_cast<CastHealingSpellAction*>(action))
-        return 1.0f;
 
     return 0.0f;
 }
@@ -59,6 +56,6 @@ float UnderbatFacingMultiplier::GetValue(Action* action)
     if (!dynamic_cast<SetBehindTargetAction*>(action))
         return 1.0f;
 
-    GuidVector const& attackers = AI_VALUE_REF(GuidVector, "attackers");
+    auto const& attackers = AI_VALUE_REF(GuidVector, "attackers");
     return AnyUnderbatInLashRange(bot, attackers) ? 0.0f : 1.0f;
 }

--- a/src/Ai/Dungeon/UB/UBMultipliers.h
+++ b/src/Ai/Dungeon/UB/UBMultipliers.h
@@ -23,4 +23,11 @@ public:
     float GetValue(Action* action) override;
 };
 
+class UnderbatFacingMultiplier : public Multiplier
+{
+public:
+    UnderbatFacingMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "underbat facing") {}
+    float GetValue(Action* action) override;
+};
+
 #endif

--- a/src/Ai/Dungeon/UB/UBMultipliers.h
+++ b/src/Ai/Dungeon/UB/UBMultipliers.h
@@ -1,0 +1,26 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_UBMULTIPLIERS_H
+#define PLAYERBOTS_UBMULTIPLIERS_H
+
+#include "Multiplier.h"
+
+class HungarfenFoulSporesMultiplier : public Multiplier
+{
+public:
+    HungarfenFoulSporesMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "hungarfen foul spores") {}
+    float GetValue(Action* action) override;
+};
+
+class HungarfenMushroomIgnoreMultiplier : public Multiplier
+{
+public:
+    HungarfenMushroomIgnoreMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "hungarfen mushroom ignore") {}
+    float GetValue(Action* action) override;
+};
+
+#endif

--- a/src/Ai/Dungeon/UB/UBShared.cpp
+++ b/src/Ai/Dungeon/UB/UBShared.cpp
@@ -1,0 +1,124 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "UBShared.h"
+#include "Creature.h"
+#include "ObjectAccessor.h"
+#include "Playerbots.h"
+#include "SpellAuras.h"
+#include "SpellInfo.h"
+#include "SpellMgr.h"
+
+#include <algorithm>
+#include <cmath>
+#include <list>
+
+namespace UnderbogHungarfen
+{
+    float MaxEffectRadius(uint32 spellId, float fallback)
+    {
+        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+        if (!spellInfo)
+            return fallback;
+
+        float radius = 0.0f;
+        for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
+            radius = std::max(radius, spellInfo->Effects[i].CalcRadius());
+
+        return radius > 0.0f ? radius : fallback;
+    }
+
+    float MushroomDangerRange(Player* bot)
+    {
+        return MaxEffectRadius(SPELL_SPORE_CLOUD, SPORE_CLOUD_RADIUS_FALLBACK) + bot->GetCombatReach() +
+               SPORE_CLOUD_MARGIN;
+    }
+
+    bool IsMushroomDangerous(Creature* mushroom)
+    {
+        if (!mushroom || !mushroom->IsAlive())
+            return false;
+
+        if (mushroom->HasAura(SPELL_SPORE_CLOUD))
+            return true;
+
+        Aura* grow = mushroom->GetAura(SPELL_GROW);
+        return grow && grow->GetStackAmount() >= GROW_STACKS_DANGER;
+    }
+
+    GuidVector FindMushroomGuids(Player* bot)
+    {
+        std::list<Creature*> mushrooms;
+        bot->GetCreatureListWithEntryInGrid(mushrooms, NPC_UNDERBOG_MUSHROOM, MUSHROOM_SCAN_RANGE);
+
+        GuidVector guids;
+        for (Creature* mushroom : mushrooms)
+        {
+            if (mushroom->IsAlive())
+                guids.push_back(mushroom->GetGUID());
+        }
+
+        return guids;
+    }
+
+    Creature* GetNearestDangerousMushroom(Player* bot, GuidVector const& mushrooms, float range)
+    {
+        Creature* best = nullptr;
+        float bestDist = range;
+        for (ObjectGuid guid : mushrooms)
+        {
+            Creature* mushroom = ObjectAccessor::GetCreature(*bot, guid);
+            if (!IsMushroomDangerous(mushroom))
+                continue;
+
+            float const dist = bot->GetDistance2d(mushroom);
+            if (dist <= bestDist)
+            {
+                bestDist = dist;
+                best = mushroom;
+            }
+        }
+
+        return best;
+    }
+
+    namespace
+    {
+        float PointSegmentDist2d(float px, float py, float ax, float ay, float bx, float by)
+        {
+            float const dx = bx - ax;
+            float const dy = by - ay;
+            float const len2 = dx * dx + dy * dy;
+            float t = (len2 < 1e-6f) ? 0.0f : ((px - ax) * dx + (py - ay) * dy) / len2;
+            t = std::max(0.0f, std::min(1.0f, t));
+            return std::hypot(px - (ax + t * dx), py - (ay + t * dy));
+        }
+    }
+
+    bool RetreatPathUnsafe(Player* bot, GuidVector const& mushrooms, float destX, float destY)
+    {
+        float const dangerRange = MushroomDangerRange(bot);
+        float const startX = bot->GetPositionX();
+        float const startY = bot->GetPositionY();
+
+        for (ObjectGuid guid : mushrooms)
+        {
+            Creature* mushroom = ObjectAccessor::GetCreature(*bot, guid);
+            if (!mushroom || !mushroom->IsAlive())
+                continue;
+
+            if (mushroom->GetExactDist2d(destX, destY) < dangerRange)
+                return true;
+
+            if (IsMushroomDangerous(mushroom) &&
+                PointSegmentDist2d(mushroom->GetPositionX(), mushroom->GetPositionY(), startX, startY, destX, destY) <
+                    dangerRange)
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Ai/Dungeon/UB/UBShared.cpp
+++ b/src/Ai/Dungeon/UB/UBShared.cpp
@@ -6,12 +6,12 @@
 
 #include "UBShared.h"
 #include "Creature.h"
+#include "Group.h"
 #include "ObjectAccessor.h"
 #include "Playerbots.h"
 #include "SpellAuras.h"
 #include "SpellInfo.h"
 #include "SpellMgr.h"
-
 #include <algorithm>
 #include <cmath>
 #include <list>
@@ -29,6 +29,23 @@ namespace UnderbogHungarfen
             radius = std::max(radius, spellInfo->Effects[i].CalcRadius());
 
         return radius > 0.0f ? radius : fallback;
+    }
+
+    Unit* HungarfenTarget(AiObjectContext* context)
+    {
+        return AI_VALUE2(Unit*, "find target", "hungarfen");
+    }
+
+    ObjectGuid FindHungarfenGuid(Player* bot)
+    {
+        Creature* hungarfen = bot->FindNearestCreature(NPC_HUNGARFEN, MUSHROOM_SCAN_RANGE, false);
+        return hungarfen ? hungarfen->GetGUID() : ObjectGuid::Empty;
+    }
+
+    bool HungarfenGone(Player* bot, ObjectGuid guid)
+    {
+        Creature* hungarfen = ObjectAccessor::GetCreature(*bot, guid);
+        return !hungarfen || !hungarfen->IsAlive();
     }
 
     float MushroomDangerRange(Player* bot)
@@ -64,6 +81,23 @@ namespace UnderbogHungarfen
         return guids;
     }
 
+    bool IsMushroom(Unit* unit)
+    {
+        return unit && unit->GetEntry() == NPC_UNDERBOG_MUSHROOM;
+    }
+
+    bool AnyMushroomAlive(Player* bot, GuidVector const& mushrooms)
+    {
+        for (ObjectGuid guid : mushrooms)
+        {
+            Creature* mushroom = ObjectAccessor::GetCreature(*bot, guid);
+            if (mushroom && mushroom->IsAlive())
+                return true;
+        }
+
+        return false;
+    }
+
     Creature* GetNearestDangerousMushroom(Player* bot, GuidVector const& mushrooms, float range)
     {
         Creature* best = nullptr;
@@ -83,6 +117,119 @@ namespace UnderbogHungarfen
         }
 
         return best;
+    }
+
+    Creature* GetNearestUnderbatInLashRange(Player* bot, GuidVector const& attackers)
+    {
+        Creature* best = nullptr;
+        float bestDist = 0.0f;
+        for (ObjectGuid guid : attackers)
+        {
+            Unit* unit = ObjectAccessor::GetUnit(*bot, guid);
+            Creature* bat = unit ? unit->ToCreature() : nullptr;
+            if (!bat || !bat->IsAlive() || bat->GetEntry() != NPC_UNDERBAT)
+                continue;
+
+            if (!bat->IsWithinCombatRange(bot, UNDERBAT_LASH_RANGE + UNDERBAT_LASH_MARGIN))
+                continue;
+
+            float const dist = bot->GetDistance2d(bat);
+            if (!best || dist < bestDist)
+            {
+                bestDist = dist;
+                best = bat;
+            }
+        }
+
+        return best;
+    }
+
+    bool AnyUnderbatInLashRange(Player* bot, GuidVector const& attackers)
+    {
+        return GetNearestUnderbatInLashRange(bot, attackers) != nullptr;
+    }
+
+    Creature* GetLashingUnderbat(Player* bot, GuidVector const& attackers)
+    {
+        Creature* best = nullptr;
+        float bestDist = 0.0f;
+        for (ObjectGuid guid : attackers)
+        {
+            Unit* unit = ObjectAccessor::GetUnit(*bot, guid);
+            Creature* bat = unit ? unit->ToCreature() : nullptr;
+            if (!bat || !bat->IsAlive() || bat->GetEntry() != NPC_UNDERBAT)
+                continue;
+
+            if (!bat->IsWithinCombatRange(bot, UNDERBAT_LASH_RANGE + UNDERBAT_LASH_MARGIN))
+                continue;
+
+            if (bat->HasInArc(UNDERBAT_SAFE_ARC, bot))
+                continue;
+
+            float const dist = bot->GetDistance2d(bat);
+            if (!best || dist < bestDist)
+            {
+                bestDist = dist;
+                best = bat;
+            }
+        }
+
+        return best;
+    }
+
+    Unit* UnderbatRallyUnit(Player* bot, GuidVector const& attackers)
+    {
+        Creature* bat = GetNearestUnderbatInLashRange(bot, attackers);
+        if (!bat)
+            return nullptr;
+
+        if (Group* group = bot->GetGroup())
+        {
+            for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+            {
+                Player* member = ref->GetSource();
+                if (!member || member == bot || !member->IsAlive() ||
+                    member->GetMapId() != bot->GetMapId())
+                    continue;
+
+                if (!PlayerbotAI::IsTank(member))
+                    continue;
+
+                if (bot->GetExactDist(member) > UNDERBAT_RALLY_MAX_RANGE)
+                    continue;
+
+                return member;
+            }
+        }
+
+        Unit* victim = bat->GetVictim();
+        if (victim && victim != bot && victim->IsAlive() &&
+            bot->GetExactDist(victim) <= UNDERBAT_RALLY_MAX_RANGE)
+            return victim;
+
+        return nullptr;
+    }
+
+    bool SpotClearOfUnderbats(Player* bot, GuidVector const& attackers, float x, float y, float z)
+    {
+        Position const spot(x, y, z);
+        for (ObjectGuid guid : attackers)
+        {
+            Unit* unit = ObjectAccessor::GetUnit(*bot, guid);
+            Creature* bat = unit ? unit->ToCreature() : nullptr;
+            if (!bat || !bat->IsAlive() || bat->GetEntry() != NPC_UNDERBAT)
+                continue;
+
+            float const window =
+                UNDERBAT_LASH_RANGE + UNDERBAT_LASH_MARGIN + bat->GetCombatReach() + bot->GetCombatReach();
+            if (bat->GetExactDist(x, y, z) > window)
+                continue;
+
+            if (!bat->HasInArc(UNDERBAT_SAFE_ARC, &spot))
+                return false;
+        }
+
+        return true;
     }
 
     namespace

--- a/src/Ai/Dungeon/UB/UBShared.cpp
+++ b/src/Ai/Dungeon/UB/UBShared.cpp
@@ -16,256 +16,255 @@
 #include <cmath>
 #include <list>
 
+namespace
+{
+float PointSegmentDist2d(float px, float py, float ax, float ay, float bx, float by)
+{
+    float const dx = bx - ax;
+    float const dy = by - ay;
+    float const len2 = dx * dx + dy * dy;
+    float t = (len2 < 1e-6f) ? 0.0f : ((px - ax) * dx + (py - ay) * dy) / len2;
+    t = std::max(0.0f, std::min(1.0f, t));
+    return std::hypot(px - (ax + t * dx), py - (ay + t * dy));
+}
+
+bool IsMushroomDangerous(Creature* mushroom)
+{
+    if (!mushroom || !mushroom->IsAlive())
+        return false;
+
+    if (mushroom->HasAura(UnderbogHungarfen::SPELL_SPORE_CLOUD))
+        return true;
+
+    Aura* grow = mushroom->GetAura(UnderbogHungarfen::SPELL_GROW);
+    return grow && grow->GetStackAmount() >= UnderbogHungarfen::GROW_STACKS_DANGER;
+}
+}
+
 namespace UnderbogHungarfen
 {
-    float MaxEffectRadius(uint32 spellId, float fallback)
+float MaxEffectRadius(uint32 spellId, float fallback)
+{
+    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+    if (!spellInfo)
+        return fallback;
+
+    float radius = 0.0f;
+    for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
+        radius = std::max(radius, spellInfo->Effects[i].CalcRadius());
+
+    return radius > 0.0f ? radius : fallback;
+}
+
+Unit* HungarfenTarget(AiObjectContext* context)
+{
+    return AI_VALUE2(Unit*, "find target", "hungarfen");
+}
+
+ObjectGuid FindHungarfenGuid(Player* bot)
+{
+    Creature* hungarfen = bot->FindNearestCreature(NPC_HUNGARFEN, MUSHROOM_SCAN_RANGE, false);
+    return hungarfen ? hungarfen->GetGUID() : ObjectGuid::Empty;
+}
+
+bool HungarfenGone(Player* bot, ObjectGuid guid)
+{
+    Creature* hungarfen = ObjectAccessor::GetCreature(*bot, guid);
+    return !hungarfen || !hungarfen->IsAlive();
+}
+
+float MushroomDangerRange(Player* bot)
+{
+    return MaxEffectRadius(SPELL_SPORE_CLOUD, SPORE_CLOUD_RADIUS_FALLBACK) + bot->GetCombatReach() +
+           SPORE_CLOUD_MARGIN;
+}
+
+GuidVector FindMushroomGuids(Player* bot)
+{
+    std::list<Creature*> mushrooms;
+    bot->GetCreatureListWithEntryInGrid(mushrooms, NPC_UNDERBOG_MUSHROOM, MUSHROOM_SCAN_RANGE);
+
+    GuidVector guids;
+    for (Creature* mushroom : mushrooms)
     {
-        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
-        if (!spellInfo)
-            return fallback;
-
-        float radius = 0.0f;
-        for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
-            radius = std::max(radius, spellInfo->Effects[i].CalcRadius());
-
-        return radius > 0.0f ? radius : fallback;
+        if (mushroom->IsAlive())
+            guids.push_back(mushroom->GetGUID());
     }
 
-    Unit* HungarfenTarget(AiObjectContext* context)
+    return guids;
+}
+
+bool IsMushroom(Unit* unit)
+{
+    return unit && unit->GetEntry() == NPC_UNDERBOG_MUSHROOM;
+}
+
+bool AnyMushroomAlive(Player* bot, GuidVector const& mushrooms)
+{
+    for (ObjectGuid guid : mushrooms)
     {
-        return AI_VALUE2(Unit*, "find target", "hungarfen");
+        Creature* mushroom = ObjectAccessor::GetCreature(*bot, guid);
+        if (mushroom && mushroom->IsAlive())
+            return true;
     }
 
-    ObjectGuid FindHungarfenGuid(Player* bot)
+    return false;
+}
+
+Creature* GetNearestDangerousMushroom(Player* bot, GuidVector const& mushrooms, float range)
+{
+    Creature* best = nullptr;
+    float bestDist = range;
+    for (ObjectGuid guid : mushrooms)
     {
-        Creature* hungarfen = bot->FindNearestCreature(NPC_HUNGARFEN, MUSHROOM_SCAN_RANGE, false);
-        return hungarfen ? hungarfen->GetGUID() : ObjectGuid::Empty;
+        Creature* mushroom = ObjectAccessor::GetCreature(*bot, guid);
+        if (!IsMushroomDangerous(mushroom))
+            continue;
+
+        float const dist = bot->GetDistance2d(mushroom);
+        if (dist <= bestDist)
+        {
+            bestDist = dist;
+            best = mushroom;
+        }
     }
 
-    bool HungarfenGone(Player* bot, ObjectGuid guid)
+    return best;
+}
+
+Creature* GetNearestUnderbatInLashRange(Player* bot, GuidVector const& attackers)
+{
+    Creature* best = nullptr;
+    float bestDist = 0.0f;
+    for (ObjectGuid guid : attackers)
     {
-        Creature* hungarfen = ObjectAccessor::GetCreature(*bot, guid);
-        return !hungarfen || !hungarfen->IsAlive();
+        Unit* unit = ObjectAccessor::GetUnit(*bot, guid);
+        Creature* bat = unit ? unit->ToCreature() : nullptr;
+        if (!bat || !bat->IsAlive() || bat->GetEntry() != NPC_UNDERBAT)
+            continue;
+
+        if (!bat->IsWithinCombatRange(bot, UNDERBAT_LASH_RANGE + UNDERBAT_LASH_MARGIN))
+            continue;
+
+        float const dist = bot->GetDistance2d(bat);
+        if (!best || dist < bestDist)
+        {
+            bestDist = dist;
+            best = bat;
+        }
     }
 
-    float MushroomDangerRange(Player* bot)
+    return best;
+}
+
+bool AnyUnderbatInLashRange(Player* bot, GuidVector const& attackers)
+{
+    return GetNearestUnderbatInLashRange(bot, attackers) != nullptr;
+}
+
+Creature* GetLashingUnderbat(Player* bot, GuidVector const& attackers)
+{
+    Creature* best = nullptr;
+    float bestDist = 0.0f;
+    for (ObjectGuid guid : attackers)
     {
-        return MaxEffectRadius(SPELL_SPORE_CLOUD, SPORE_CLOUD_RADIUS_FALLBACK) + bot->GetCombatReach() +
-               SPORE_CLOUD_MARGIN;
+        Unit* unit = ObjectAccessor::GetUnit(*bot, guid);
+        Creature* bat = unit ? unit->ToCreature() : nullptr;
+        if (!bat || !bat->IsAlive() || bat->GetEntry() != NPC_UNDERBAT)
+            continue;
+
+        if (!bat->IsWithinCombatRange(bot, UNDERBAT_LASH_RANGE + UNDERBAT_LASH_MARGIN))
+            continue;
+
+        if (bat->HasInArc(UNDERBAT_SAFE_ARC, bot))
+            continue;
+
+        float const dist = bot->GetDistance2d(bat);
+        if (!best || dist < bestDist)
+        {
+            bestDist = dist;
+            best = bat;
+        }
     }
 
-    bool IsMushroomDangerous(Creature* mushroom)
+    return best;
+}
+
+Unit* UnderbatRallyUnit(Player* bot, GuidVector const& attackers)
+{
+    Creature* bat = GetNearestUnderbatInLashRange(bot, attackers);
+    if (!bat)
+        return nullptr;
+
+    if (Group* group = bot->GetGroup())
     {
-        if (!mushroom || !mushroom->IsAlive())
+        for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+        {
+            Player* member = ref->GetSource();
+            if (!member || member == bot || !member->IsAlive() ||
+                member->GetMapId() != bot->GetMapId())
+                continue;
+
+            if (!PlayerbotAI::IsTank(member))
+                continue;
+
+            if (bot->GetExactDist(member) > UNDERBAT_RALLY_MAX_RANGE)
+                continue;
+
+            return member;
+        }
+    }
+
+    Unit* victim = bat->GetVictim();
+    if (victim && victim != bot && bot->GetExactDist(victim) <= UNDERBAT_RALLY_MAX_RANGE)
+        return victim;
+
+    return nullptr;
+}
+
+bool SpotClearOfUnderbats(Player* bot, GuidVector const& attackers, float x, float y, float z)
+{
+    Position const spot(x, y, z);
+    for (ObjectGuid guid : attackers)
+    {
+        Unit* unit = ObjectAccessor::GetUnit(*bot, guid);
+        Creature* bat = unit ? unit->ToCreature() : nullptr;
+        if (!bat || !bat->IsAlive() || bat->GetEntry() != NPC_UNDERBAT)
+            continue;
+
+        float const window =
+            UNDERBAT_LASH_RANGE + UNDERBAT_LASH_MARGIN + bat->GetCombatReach() + bot->GetCombatReach();
+        if (bat->GetExactDist(x, y, z) > window)
+            continue;
+
+        if (!bat->HasInArc(UNDERBAT_SAFE_ARC, &spot))
             return false;
+    }
 
-        if (mushroom->HasAura(SPELL_SPORE_CLOUD))
+    return true;
+}
+
+bool RetreatPathUnsafe(Player* bot, GuidVector const& mushrooms, float destX, float destY)
+{
+    float const dangerRange = MushroomDangerRange(bot);
+    float const startX = bot->GetPositionX();
+    float const startY = bot->GetPositionY();
+
+    for (ObjectGuid guid : mushrooms)
+    {
+        Creature* mushroom = ObjectAccessor::GetCreature(*bot, guid);
+        if (!mushroom || !mushroom->IsAlive())
+            continue;
+
+        if (mushroom->GetExactDist2d(destX, destY) < dangerRange)
             return true;
 
-        Aura* grow = mushroom->GetAura(SPELL_GROW);
-        return grow && grow->GetStackAmount() >= GROW_STACKS_DANGER;
+        if (IsMushroomDangerous(mushroom) &&
+            PointSegmentDist2d(mushroom->GetPositionX(), mushroom->GetPositionY(), startX, startY, destX, destY) <
+                dangerRange)
+            return true;
     }
 
-    GuidVector FindMushroomGuids(Player* bot)
-    {
-        std::list<Creature*> mushrooms;
-        bot->GetCreatureListWithEntryInGrid(mushrooms, NPC_UNDERBOG_MUSHROOM, MUSHROOM_SCAN_RANGE);
-
-        GuidVector guids;
-        for (Creature* mushroom : mushrooms)
-        {
-            if (mushroom->IsAlive())
-                guids.push_back(mushroom->GetGUID());
-        }
-
-        return guids;
-    }
-
-    bool IsMushroom(Unit* unit)
-    {
-        return unit && unit->GetEntry() == NPC_UNDERBOG_MUSHROOM;
-    }
-
-    bool AnyMushroomAlive(Player* bot, GuidVector const& mushrooms)
-    {
-        for (ObjectGuid guid : mushrooms)
-        {
-            Creature* mushroom = ObjectAccessor::GetCreature(*bot, guid);
-            if (mushroom && mushroom->IsAlive())
-                return true;
-        }
-
-        return false;
-    }
-
-    Creature* GetNearestDangerousMushroom(Player* bot, GuidVector const& mushrooms, float range)
-    {
-        Creature* best = nullptr;
-        float bestDist = range;
-        for (ObjectGuid guid : mushrooms)
-        {
-            Creature* mushroom = ObjectAccessor::GetCreature(*bot, guid);
-            if (!IsMushroomDangerous(mushroom))
-                continue;
-
-            float const dist = bot->GetDistance2d(mushroom);
-            if (dist <= bestDist)
-            {
-                bestDist = dist;
-                best = mushroom;
-            }
-        }
-
-        return best;
-    }
-
-    Creature* GetNearestUnderbatInLashRange(Player* bot, GuidVector const& attackers)
-    {
-        Creature* best = nullptr;
-        float bestDist = 0.0f;
-        for (ObjectGuid guid : attackers)
-        {
-            Unit* unit = ObjectAccessor::GetUnit(*bot, guid);
-            Creature* bat = unit ? unit->ToCreature() : nullptr;
-            if (!bat || !bat->IsAlive() || bat->GetEntry() != NPC_UNDERBAT)
-                continue;
-
-            if (!bat->IsWithinCombatRange(bot, UNDERBAT_LASH_RANGE + UNDERBAT_LASH_MARGIN))
-                continue;
-
-            float const dist = bot->GetDistance2d(bat);
-            if (!best || dist < bestDist)
-            {
-                bestDist = dist;
-                best = bat;
-            }
-        }
-
-        return best;
-    }
-
-    bool AnyUnderbatInLashRange(Player* bot, GuidVector const& attackers)
-    {
-        return GetNearestUnderbatInLashRange(bot, attackers) != nullptr;
-    }
-
-    Creature* GetLashingUnderbat(Player* bot, GuidVector const& attackers)
-    {
-        Creature* best = nullptr;
-        float bestDist = 0.0f;
-        for (ObjectGuid guid : attackers)
-        {
-            Unit* unit = ObjectAccessor::GetUnit(*bot, guid);
-            Creature* bat = unit ? unit->ToCreature() : nullptr;
-            if (!bat || !bat->IsAlive() || bat->GetEntry() != NPC_UNDERBAT)
-                continue;
-
-            if (!bat->IsWithinCombatRange(bot, UNDERBAT_LASH_RANGE + UNDERBAT_LASH_MARGIN))
-                continue;
-
-            if (bat->HasInArc(UNDERBAT_SAFE_ARC, bot))
-                continue;
-
-            float const dist = bot->GetDistance2d(bat);
-            if (!best || dist < bestDist)
-            {
-                bestDist = dist;
-                best = bat;
-            }
-        }
-
-        return best;
-    }
-
-    Unit* UnderbatRallyUnit(Player* bot, GuidVector const& attackers)
-    {
-        Creature* bat = GetNearestUnderbatInLashRange(bot, attackers);
-        if (!bat)
-            return nullptr;
-
-        if (Group* group = bot->GetGroup())
-        {
-            for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
-            {
-                Player* member = ref->GetSource();
-                if (!member || member == bot || !member->IsAlive() ||
-                    member->GetMapId() != bot->GetMapId())
-                    continue;
-
-                if (!PlayerbotAI::IsTank(member))
-                    continue;
-
-                if (bot->GetExactDist(member) > UNDERBAT_RALLY_MAX_RANGE)
-                    continue;
-
-                return member;
-            }
-        }
-
-        Unit* victim = bat->GetVictim();
-        if (victim && victim != bot && victim->IsAlive() &&
-            bot->GetExactDist(victim) <= UNDERBAT_RALLY_MAX_RANGE)
-            return victim;
-
-        return nullptr;
-    }
-
-    bool SpotClearOfUnderbats(Player* bot, GuidVector const& attackers, float x, float y, float z)
-    {
-        Position const spot(x, y, z);
-        for (ObjectGuid guid : attackers)
-        {
-            Unit* unit = ObjectAccessor::GetUnit(*bot, guid);
-            Creature* bat = unit ? unit->ToCreature() : nullptr;
-            if (!bat || !bat->IsAlive() || bat->GetEntry() != NPC_UNDERBAT)
-                continue;
-
-            float const window =
-                UNDERBAT_LASH_RANGE + UNDERBAT_LASH_MARGIN + bat->GetCombatReach() + bot->GetCombatReach();
-            if (bat->GetExactDist(x, y, z) > window)
-                continue;
-
-            if (!bat->HasInArc(UNDERBAT_SAFE_ARC, &spot))
-                return false;
-        }
-
-        return true;
-    }
-
-    namespace
-    {
-        float PointSegmentDist2d(float px, float py, float ax, float ay, float bx, float by)
-        {
-            float const dx = bx - ax;
-            float const dy = by - ay;
-            float const len2 = dx * dx + dy * dy;
-            float t = (len2 < 1e-6f) ? 0.0f : ((px - ax) * dx + (py - ay) * dy) / len2;
-            t = std::max(0.0f, std::min(1.0f, t));
-            return std::hypot(px - (ax + t * dx), py - (ay + t * dy));
-        }
-    }
-
-    bool RetreatPathUnsafe(Player* bot, GuidVector const& mushrooms, float destX, float destY)
-    {
-        float const dangerRange = MushroomDangerRange(bot);
-        float const startX = bot->GetPositionX();
-        float const startY = bot->GetPositionY();
-
-        for (ObjectGuid guid : mushrooms)
-        {
-            Creature* mushroom = ObjectAccessor::GetCreature(*bot, guid);
-            if (!mushroom || !mushroom->IsAlive())
-                continue;
-
-            if (mushroom->GetExactDist2d(destX, destY) < dangerRange)
-                return true;
-
-            if (IsMushroomDangerous(mushroom) &&
-                PointSegmentDist2d(mushroom->GetPositionX(), mushroom->GetPositionY(), startX, startY, destX, destY) <
-                    dangerRange)
-                return true;
-        }
-
-        return false;
-    }
+    return false;
+}
 }

--- a/src/Ai/Dungeon/UB/UBShared.h
+++ b/src/Ai/Dungeon/UB/UBShared.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_UBSHARED_H
+#define PLAYERBOTS_UBSHARED_H
+
+#include "ObjectGuid.h"
+
+class Creature;
+class Player;
+
+namespace UnderbogHungarfen
+{
+    constexpr uint32 NPC_UNDERBOG_MUSHROOM = 17990;
+
+    constexpr uint32 SPELL_FOUL_SPORES = 31673;
+    constexpr uint32 SPELL_GROW        = 31698;
+    constexpr uint32 SPELL_SPORE_CLOUD = 34168;
+
+    constexpr float SPORE_CLOUD_RADIUS_FALLBACK = 8.0f;
+    constexpr float FOUL_SPORES_RADIUS_FALLBACK = 20.0f;
+
+    constexpr float SPORE_CLOUD_MARGIN = 1.5f;
+    constexpr float FOUL_SPORES_MARGIN = 2.0f;
+
+    constexpr uint32 GROW_STACKS_DANGER = 8;
+
+    constexpr float MUSHROOM_SCAN_RANGE = 40.0f;
+
+    float MaxEffectRadius(uint32 spellId, float fallback);
+
+    float MushroomDangerRange(Player* bot);
+
+    bool IsMushroomDangerous(Creature* mushroom);
+
+    GuidVector FindMushroomGuids(Player* bot);
+
+    Creature* GetNearestDangerousMushroom(Player* bot, GuidVector const& mushrooms, float range);
+
+    bool RetreatPathUnsafe(Player* bot, GuidVector const& mushrooms, float destX, float destY);
+}
+
+#endif

--- a/src/Ai/Dungeon/UB/UBShared.h
+++ b/src/Ai/Dungeon/UB/UBShared.h
@@ -7,14 +7,19 @@
 #ifndef PLAYERBOTS_UBSHARED_H
 #define PLAYERBOTS_UBSHARED_H
 
+#include "Define.h"
 #include "ObjectGuid.h"
 
+class AiObjectContext;
 class Creature;
 class Player;
+class Unit;
 
 namespace UnderbogHungarfen
 {
+    constexpr uint32 NPC_HUNGARFEN = 17770;
     constexpr uint32 NPC_UNDERBOG_MUSHROOM = 17990;
+    constexpr uint32 NPC_UNDERBAT = 17724;
 
     constexpr uint32 SPELL_FOUL_SPORES = 31673;
     constexpr uint32 SPELL_GROW        = 31698;
@@ -30,7 +35,25 @@ namespace UnderbogHungarfen
 
     constexpr float MUSHROOM_SCAN_RANGE = 40.0f;
 
+    constexpr float UNDERBAT_LASH_RANGE = 5.0f;
+    constexpr float UNDERBAT_LASH_MARGIN = 1.5f;
+    constexpr float UNDERBAT_SAFE_ARC = 2.6f;
+    constexpr uint32 UNDERBAT_REPOSITION_COOLDOWN = 750;
+
+    constexpr float UNDERBAT_RALLY_TOLERANCE = 3.0f;
+    constexpr float UNDERBAT_RALLY_MAX_RANGE = 20.0f;
+
+    constexpr uint32 MUSHROOM_SCAN_INTERVAL = 1000;
+    constexpr uint32 MUSHROOM_IDLE_SCAN_SKIPS = 9;
+    constexpr uint32 MUSHROOM_LINGER_TIME = 30000;
+
     float MaxEffectRadius(uint32 spellId, float fallback);
+
+    Unit* HungarfenTarget(AiObjectContext* context);
+
+    ObjectGuid FindHungarfenGuid(Player* bot);
+
+    bool HungarfenGone(Player* bot, ObjectGuid guid);
 
     float MushroomDangerRange(Player* bot);
 
@@ -38,9 +61,23 @@ namespace UnderbogHungarfen
 
     GuidVector FindMushroomGuids(Player* bot);
 
+    bool IsMushroom(Unit* unit);
+
+    bool AnyMushroomAlive(Player* bot, GuidVector const& mushrooms);
+
     Creature* GetNearestDangerousMushroom(Player* bot, GuidVector const& mushrooms, float range);
 
     bool RetreatPathUnsafe(Player* bot, GuidVector const& mushrooms, float destX, float destY);
+
+    bool AnyUnderbatInLashRange(Player* bot, GuidVector const& attackers);
+
+    Creature* GetNearestUnderbatInLashRange(Player* bot, GuidVector const& attackers);
+
+    Creature* GetLashingUnderbat(Player* bot, GuidVector const& attackers);
+
+    Unit* UnderbatRallyUnit(Player* bot, GuidVector const& attackers);
+
+    bool SpotClearOfUnderbats(Player* bot, GuidVector const& attackers, float x, float y, float z);
 }
 
 #endif

--- a/src/Ai/Dungeon/UB/UBShared.h
+++ b/src/Ai/Dungeon/UB/UBShared.h
@@ -17,67 +17,65 @@ class Unit;
 
 namespace UnderbogHungarfen
 {
-    constexpr uint32 NPC_HUNGARFEN = 17770;
-    constexpr uint32 NPC_UNDERBOG_MUSHROOM = 17990;
-    constexpr uint32 NPC_UNDERBAT = 17724;
+constexpr uint32 NPC_HUNGARFEN = 17770;
+constexpr uint32 NPC_UNDERBOG_MUSHROOM = 17990;
+constexpr uint32 NPC_UNDERBAT = 17724;
 
-    constexpr uint32 SPELL_FOUL_SPORES = 31673;
-    constexpr uint32 SPELL_GROW        = 31698;
-    constexpr uint32 SPELL_SPORE_CLOUD = 34168;
+constexpr uint32 SPELL_FOUL_SPORES = 31673;
+constexpr uint32 SPELL_GROW        = 31698;
+constexpr uint32 SPELL_SPORE_CLOUD = 34168;
 
-    constexpr float SPORE_CLOUD_RADIUS_FALLBACK = 8.0f;
-    constexpr float FOUL_SPORES_RADIUS_FALLBACK = 20.0f;
+constexpr float SPORE_CLOUD_RADIUS_FALLBACK = 8.0f;
+constexpr float FOUL_SPORES_RADIUS_FALLBACK = 20.0f;
 
-    constexpr float SPORE_CLOUD_MARGIN = 1.5f;
-    constexpr float FOUL_SPORES_MARGIN = 2.0f;
+constexpr float SPORE_CLOUD_MARGIN = 1.5f;
+constexpr float FOUL_SPORES_MARGIN = 2.0f;
 
-    constexpr uint32 GROW_STACKS_DANGER = 8;
+constexpr uint8 GROW_STACKS_DANGER = 8;
 
-    constexpr float MUSHROOM_SCAN_RANGE = 40.0f;
+constexpr float MUSHROOM_SCAN_RANGE = 40.0f;
 
-    constexpr float UNDERBAT_LASH_RANGE = 5.0f;
-    constexpr float UNDERBAT_LASH_MARGIN = 1.5f;
-    constexpr float UNDERBAT_SAFE_ARC = 2.6f;
-    constexpr uint32 UNDERBAT_REPOSITION_COOLDOWN = 750;
+constexpr float UNDERBAT_LASH_RANGE = 5.0f;
+constexpr float UNDERBAT_LASH_MARGIN = 1.5f;
+constexpr float UNDERBAT_SAFE_ARC = 2.6f;
+constexpr uint32 UNDERBAT_REPOSITION_COOLDOWN = 750;
 
-    constexpr float UNDERBAT_RALLY_TOLERANCE = 3.0f;
-    constexpr float UNDERBAT_RALLY_MAX_RANGE = 20.0f;
+constexpr float UNDERBAT_RALLY_TOLERANCE = 3.0f;
+constexpr float UNDERBAT_RALLY_MAX_RANGE = 20.0f;
 
-    constexpr uint32 MUSHROOM_SCAN_INTERVAL = 1000;
-    constexpr uint32 MUSHROOM_IDLE_SCAN_SKIPS = 9;
-    constexpr uint32 MUSHROOM_LINGER_TIME = 30000;
+constexpr uint32 MUSHROOM_SCAN_INTERVAL = 1000;
+constexpr uint8 MUSHROOM_IDLE_SCAN_SKIPS = 9;
+constexpr uint32 MUSHROOM_LINGER_TIME = 30000;
 
-    float MaxEffectRadius(uint32 spellId, float fallback);
+float MaxEffectRadius(uint32 spellId, float fallback);
 
-    Unit* HungarfenTarget(AiObjectContext* context);
+Unit* HungarfenTarget(AiObjectContext* context);
 
-    ObjectGuid FindHungarfenGuid(Player* bot);
+ObjectGuid FindHungarfenGuid(Player* bot);
 
-    bool HungarfenGone(Player* bot, ObjectGuid guid);
+bool HungarfenGone(Player* bot, ObjectGuid guid);
 
-    float MushroomDangerRange(Player* bot);
+float MushroomDangerRange(Player* bot);
 
-    bool IsMushroomDangerous(Creature* mushroom);
+GuidVector FindMushroomGuids(Player* bot);
 
-    GuidVector FindMushroomGuids(Player* bot);
+bool IsMushroom(Unit* unit);
 
-    bool IsMushroom(Unit* unit);
+bool AnyMushroomAlive(Player* bot, GuidVector const& mushrooms);
 
-    bool AnyMushroomAlive(Player* bot, GuidVector const& mushrooms);
+Creature* GetNearestDangerousMushroom(Player* bot, GuidVector const& mushrooms, float range);
 
-    Creature* GetNearestDangerousMushroom(Player* bot, GuidVector const& mushrooms, float range);
+bool RetreatPathUnsafe(Player* bot, GuidVector const& mushrooms, float destX, float destY);
 
-    bool RetreatPathUnsafe(Player* bot, GuidVector const& mushrooms, float destX, float destY);
+bool AnyUnderbatInLashRange(Player* bot, GuidVector const& attackers);
 
-    bool AnyUnderbatInLashRange(Player* bot, GuidVector const& attackers);
+Creature* GetNearestUnderbatInLashRange(Player* bot, GuidVector const& attackers);
 
-    Creature* GetNearestUnderbatInLashRange(Player* bot, GuidVector const& attackers);
+Creature* GetLashingUnderbat(Player* bot, GuidVector const& attackers);
 
-    Creature* GetLashingUnderbat(Player* bot, GuidVector const& attackers);
+Unit* UnderbatRallyUnit(Player* bot, GuidVector const& attackers);
 
-    Unit* UnderbatRallyUnit(Player* bot, GuidVector const& attackers);
-
-    bool SpotClearOfUnderbats(Player* bot, GuidVector const& attackers, float x, float y, float z);
+bool SpotClearOfUnderbats(Player* bot, GuidVector const& attackers, float x, float y, float z);
 }
 
 #endif

--- a/src/Ai/Dungeon/UB/UBStrategy.cpp
+++ b/src/Ai/Dungeon/UB/UBStrategy.cpp
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "UBStrategy.h"
+#include "Playerbots.h"
+#include "UBMultipliers.h"
+
+void TbcDungeonUnderbogStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+{
+    triggers.push_back(new TriggerNode("ub foul spores", {
+        NextAction("ub retreat from foul spores", ACTION_EMERGENCY + 10) }));
+
+    triggers.push_back(new TriggerNode("ub spore cloud danger", {
+        NextAction("ub vacate spore cloud", ACTION_EMERGENCY + 2) }));
+}
+
+void TbcDungeonUnderbogStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
+{
+    multipliers.push_back(new HungarfenFoulSporesMultiplier(botAI));
+    multipliers.push_back(new HungarfenMushroomIgnoreMultiplier(botAI));
+}
+
+void TbcDungeonUnderbogStrategy::AppendTargetExclusions(GuidSet& exclusions, TargetValueExclusionType /*type*/)
+{
+    AiObjectContext* context = botAI->GetAiObjectContext();
+    if (!AI_VALUE2(Unit*, "find target", "hungarfen"))
+        return;
+
+    GuidVector const& mushrooms = AI_VALUE_REF(GuidVector, "ub mushrooms");
+    exclusions.insert(mushrooms.begin(), mushrooms.end());
+}

--- a/src/Ai/Dungeon/UB/UBStrategy.cpp
+++ b/src/Ai/Dungeon/UB/UBStrategy.cpp
@@ -30,6 +30,6 @@ void TbcDungeonUnderbogStrategy::InitMultipliers(std::vector<Multiplier*>& multi
 void TbcDungeonUnderbogStrategy::AppendTargetExclusions(GuidSet& exclusions, TargetValueExclusionType /*type*/)
 {
     AiObjectContext* context = botAI->GetAiObjectContext();
-    GuidVector const& mushrooms = AI_VALUE_REF(GuidVector, "ub mushrooms");
+    auto const& mushrooms = AI_VALUE_REF(GuidVector, "ub mushrooms");
     exclusions.insert(mushrooms.begin(), mushrooms.end());
 }

--- a/src/Ai/Dungeon/UB/UBStrategy.cpp
+++ b/src/Ai/Dungeon/UB/UBStrategy.cpp
@@ -15,20 +15,21 @@ void TbcDungeonUnderbogStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
 
     triggers.push_back(new TriggerNode("ub spore cloud danger", {
         NextAction("ub vacate spore cloud", ACTION_EMERGENCY + 2) }));
+
+    triggers.push_back(new TriggerNode("ub underbat lash", {
+        NextAction("ub clear underbat back", ACTION_EMERGENCY + 1) }));
 }
 
 void TbcDungeonUnderbogStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
 {
     multipliers.push_back(new HungarfenFoulSporesMultiplier(botAI));
     multipliers.push_back(new HungarfenMushroomIgnoreMultiplier(botAI));
+    multipliers.push_back(new UnderbatFacingMultiplier(botAI));
 }
 
 void TbcDungeonUnderbogStrategy::AppendTargetExclusions(GuidSet& exclusions, TargetValueExclusionType /*type*/)
 {
     AiObjectContext* context = botAI->GetAiObjectContext();
-    if (!AI_VALUE2(Unit*, "find target", "hungarfen"))
-        return;
-
     GuidVector const& mushrooms = AI_VALUE_REF(GuidVector, "ub mushrooms");
     exclusions.insert(mushrooms.begin(), mushrooms.end());
 }

--- a/src/Ai/Dungeon/UB/UBStrategy.h
+++ b/src/Ai/Dungeon/UB/UBStrategy.h
@@ -7,7 +7,6 @@
 #ifndef PLAYERBOTS_UBSTRATEGY_H
 #define PLAYERBOTS_UBSTRATEGY_H
 
-#include "AiObjectContext.h"
 #include "Multiplier.h"
 #include "Strategy.h"
 

--- a/src/Ai/Dungeon/UB/UBStrategy.h
+++ b/src/Ai/Dungeon/UB/UBStrategy.h
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_UBSTRATEGY_H
+#define PLAYERBOTS_UBSTRATEGY_H
+
+#include "AiObjectContext.h"
+#include "Multiplier.h"
+#include "Strategy.h"
+
+class TbcDungeonUnderbogStrategy : public Strategy
+{
+public:
+    TbcDungeonUnderbogStrategy(PlayerbotAI* botAI) : Strategy(botAI) {}
+
+    std::string const getName() override { return "tbc-ub"; }
+
+    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
+    void InitMultipliers(std::vector<Multiplier*>& multipliers) override;
+
+    bool HasTargetExclusions() const override { return true; }
+    void AppendTargetExclusions(GuidSet& exclusions, TargetValueExclusionType type) override;
+};
+
+#endif

--- a/src/Ai/Dungeon/UB/UBTriggerContext.h
+++ b/src/Ai/Dungeon/UB/UBTriggerContext.h
@@ -7,7 +7,7 @@
 #ifndef PLAYERBOTS_UBTRIGGERCONTEXT_H
 #define PLAYERBOTS_UBTRIGGERCONTEXT_H
 
-#include "AiObjectContext.h"
+#include "NamedObjectContext.h"
 #include "TriggerContext.h"
 #include "UBTriggers.h"
 
@@ -18,12 +18,15 @@ public:
     {
         creators["ub foul spores"] = &TbcDungeonUnderbogTriggerContext::ub_foul_spores;
         creators["ub spore cloud danger"] = &TbcDungeonUnderbogTriggerContext::ub_spore_cloud_danger;
+        creators["ub underbat lash"] = &TbcDungeonUnderbogTriggerContext::ub_underbat_lash;
     }
 
 private:
     static Trigger* ub_foul_spores(PlayerbotAI* botAI) { return new UBFoulSporesTrigger(botAI); }
 
     static Trigger* ub_spore_cloud_danger(PlayerbotAI* botAI) { return new UBSporeCloudDangerTrigger(botAI); }
+
+    static Trigger* ub_underbat_lash(PlayerbotAI* botAI) { return new UBUnderbatLashTrigger(botAI); }
 };
 
 #endif

--- a/src/Ai/Dungeon/UB/UBTriggerContext.h
+++ b/src/Ai/Dungeon/UB/UBTriggerContext.h
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_UBTRIGGERCONTEXT_H
+#define PLAYERBOTS_UBTRIGGERCONTEXT_H
+
+#include "AiObjectContext.h"
+#include "TriggerContext.h"
+#include "UBTriggers.h"
+
+class TbcDungeonUnderbogTriggerContext : public NamedObjectContext<Trigger>
+{
+public:
+    TbcDungeonUnderbogTriggerContext()
+    {
+        creators["ub foul spores"] = &TbcDungeonUnderbogTriggerContext::ub_foul_spores;
+        creators["ub spore cloud danger"] = &TbcDungeonUnderbogTriggerContext::ub_spore_cloud_danger;
+    }
+
+private:
+    static Trigger* ub_foul_spores(PlayerbotAI* botAI) { return new UBFoulSporesTrigger(botAI); }
+
+    static Trigger* ub_spore_cloud_danger(PlayerbotAI* botAI) { return new UBSporeCloudDangerTrigger(botAI); }
+};
+
+#endif

--- a/src/Ai/Dungeon/UB/UBTriggers.cpp
+++ b/src/Ai/Dungeon/UB/UBTriggers.cpp
@@ -1,0 +1,26 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "UBTriggers.h"
+#include "Playerbots.h"
+#include "UBShared.h"
+
+using namespace UnderbogHungarfen;
+
+bool UBFoulSporesTrigger::IsActive()
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", "hungarfen");
+    return boss && boss->HasAura(SPELL_FOUL_SPORES);
+}
+
+bool UBSporeCloudDangerTrigger::IsActive()
+{
+    if (!AI_VALUE2(Unit*, "find target", "hungarfen"))
+        return false;
+
+    GuidVector const& mushrooms = AI_VALUE_REF(GuidVector, "ub mushrooms");
+    return GetNearestDangerousMushroom(bot, mushrooms, MushroomDangerRange(bot)) != nullptr;
+}

--- a/src/Ai/Dungeon/UB/UBTriggers.cpp
+++ b/src/Ai/Dungeon/UB/UBTriggers.cpp
@@ -18,18 +18,15 @@ bool UBFoulSporesTrigger::IsActive()
 
 bool UBSporeCloudDangerTrigger::IsActive()
 {
-    if (!bot->IsAlive())
-        return false;
-
-    GuidVector const& mushrooms = AI_VALUE_REF(GuidVector, "ub mushrooms");
+    auto const& mushrooms = AI_VALUE_REF(GuidVector, "ub mushrooms");
     return GetNearestDangerousMushroom(bot, mushrooms, MushroomDangerRange(bot)) != nullptr;
 }
 
 bool UBUnderbatLashTrigger::IsActive()
 {
-    if (!bot->IsAlive() || botAI->IsTank(bot))
+    if (PlayerbotAI::IsTank(bot))
         return false;
 
-    GuidVector const& attackers = AI_VALUE_REF(GuidVector, "attackers");
+    auto const& attackers = AI_VALUE_REF(GuidVector, "attackers");
     return GetNearestUnderbatInLashRange(bot, attackers) != nullptr;
 }

--- a/src/Ai/Dungeon/UB/UBTriggers.cpp
+++ b/src/Ai/Dungeon/UB/UBTriggers.cpp
@@ -18,9 +18,18 @@ bool UBFoulSporesTrigger::IsActive()
 
 bool UBSporeCloudDangerTrigger::IsActive()
 {
-    if (!AI_VALUE2(Unit*, "find target", "hungarfen"))
+    if (!bot->IsAlive())
         return false;
 
     GuidVector const& mushrooms = AI_VALUE_REF(GuidVector, "ub mushrooms");
     return GetNearestDangerousMushroom(bot, mushrooms, MushroomDangerRange(bot)) != nullptr;
+}
+
+bool UBUnderbatLashTrigger::IsActive()
+{
+    if (!bot->IsAlive() || botAI->IsTank(bot))
+        return false;
+
+    GuidVector const& attackers = AI_VALUE_REF(GuidVector, "attackers");
+    return GetNearestUnderbatInLashRange(bot, attackers) != nullptr;
 }

--- a/src/Ai/Dungeon/UB/UBTriggers.h
+++ b/src/Ai/Dungeon/UB/UBTriggers.h
@@ -23,4 +23,11 @@ public:
     bool IsActive() override;
 };
 
+class UBUnderbatLashTrigger : public Trigger
+{
+public:
+    UBUnderbatLashTrigger(PlayerbotAI* botAI) : Trigger(botAI, "ub underbat lash") {}
+    bool IsActive() override;
+};
+
 #endif

--- a/src/Ai/Dungeon/UB/UBTriggers.h
+++ b/src/Ai/Dungeon/UB/UBTriggers.h
@@ -1,0 +1,26 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_UBTRIGGERS_H
+#define PLAYERBOTS_UBTRIGGERS_H
+
+#include "Trigger.h"
+
+class UBFoulSporesTrigger : public Trigger
+{
+public:
+    UBFoulSporesTrigger(PlayerbotAI* botAI) : Trigger(botAI, "ub foul spores") {}
+    bool IsActive() override;
+};
+
+class UBSporeCloudDangerTrigger : public Trigger
+{
+public:
+    UBSporeCloudDangerTrigger(PlayerbotAI* botAI) : Trigger(botAI, "ub spore cloud danger") {}
+    bool IsActive() override;
+};
+
+#endif

--- a/src/Ai/Dungeon/UB/UBValueContext.h
+++ b/src/Ai/Dungeon/UB/UBValueContext.h
@@ -1,0 +1,32 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_UBVALUECONTEXT_H
+#define PLAYERBOTS_UBVALUECONTEXT_H
+
+#include "NamedObjectContext.h"
+#include "UBShared.h"
+#include "Value.h"
+
+class UnderbogMushroomsValue : public CalculatedValue<GuidVector>
+{
+public:
+    UnderbogMushroomsValue(PlayerbotAI* botAI) : CalculatedValue<GuidVector>(botAI, "ub mushrooms", 200) {}
+
+protected:
+    GuidVector Calculate() override { return UnderbogHungarfen::FindMushroomGuids(bot); }
+};
+
+class TbcDungeonUnderbogValueContext : public NamedObjectContext<UntypedValue>
+{
+public:
+    TbcDungeonUnderbogValueContext() { creators["ub mushrooms"] = &TbcDungeonUnderbogValueContext::ub_mushrooms; }
+
+private:
+    static UntypedValue* ub_mushrooms(PlayerbotAI* botAI) { return new UnderbogMushroomsValue(botAI); }
+};
+
+#endif

--- a/src/Ai/Dungeon/UB/UBValueContext.h
+++ b/src/Ai/Dungeon/UB/UBValueContext.h
@@ -26,16 +26,21 @@ public:
 protected:
     GuidVector Calculate() override
     {
+        if (!_scanning && !bot->IsInCombat())
+            return {};
+
+        Unit* boss = UnderbogHungarfen::HungarfenTarget(context);
+
         if (!_scanning)
         {
-            if (!bot->IsInCombat() || UnderbogHungarfen::HungarfenGone(bot, _hungarfen))
+            if (!boss)
                 return {};
 
             _scanning = true;
-            _deadSince = 0;
+            _skipped = 0;
+            _sawMushrooms = false;
         }
 
-        Unit* boss = UnderbogHungarfen::HungarfenTarget(context);
         if (boss)
         {
             _hungarfen = boss->GetGUID();

--- a/src/Ai/Dungeon/UB/UBValueContext.h
+++ b/src/Ai/Dungeon/UB/UBValueContext.h
@@ -8,16 +8,76 @@
 #define PLAYERBOTS_UBVALUECONTEXT_H
 
 #include "NamedObjectContext.h"
+#include "ObjectGuid.h"
+#include "Player.h"
+#include "Timer.h"
 #include "UBShared.h"
+#include "Unit.h"
 #include "Value.h"
 
 class UnderbogMushroomsValue : public CalculatedValue<GuidVector>
 {
 public:
-    UnderbogMushroomsValue(PlayerbotAI* botAI) : CalculatedValue<GuidVector>(botAI, "ub mushrooms", 200) {}
+    UnderbogMushroomsValue(PlayerbotAI* botAI)
+        : CalculatedValue<GuidVector>(botAI, "ub mushrooms", UnderbogHungarfen::MUSHROOM_SCAN_INTERVAL)
+    {
+    }
 
 protected:
-    GuidVector Calculate() override { return UnderbogHungarfen::FindMushroomGuids(bot); }
+    GuidVector Calculate() override
+    {
+        if (!_scanning)
+        {
+            if (!bot->IsInCombat() || UnderbogHungarfen::HungarfenGone(bot, _hungarfen))
+                return {};
+
+            _scanning = true;
+            _deadSince = 0;
+        }
+
+        Unit* boss = UnderbogHungarfen::HungarfenTarget(context);
+        if (boss)
+        {
+            _hungarfen = boss->GetGUID();
+            _deadSince = 0;
+        }
+
+        if (!boss && !_sawMushrooms && _skipped++ < UnderbogHungarfen::MUSHROOM_IDLE_SCAN_SKIPS)
+            return {};
+
+        _skipped = 0;
+        GuidVector mushrooms = UnderbogHungarfen::FindMushroomGuids(bot);
+        _sawMushrooms = !mushrooms.empty();
+
+        if (!boss)
+            CheckHungarfenGone();
+
+        return mushrooms;
+    }
+
+private:
+    void CheckHungarfenGone()
+    {
+        if (_hungarfen.IsEmpty())
+            _hungarfen = UnderbogHungarfen::FindHungarfenGuid(bot);
+
+        if (_hungarfen.IsEmpty() || !UnderbogHungarfen::HungarfenGone(bot, _hungarfen))
+        {
+            _deadSince = 0;
+            return;
+        }
+
+        if (!_deadSince)
+            _deadSince = getMSTime();
+        else if (GetMSTimeDiffToNow(_deadSince) >= UnderbogHungarfen::MUSHROOM_LINGER_TIME)
+            _scanning = false;
+    }
+
+    ObjectGuid _hungarfen;
+    uint32 _deadSince = 0;
+    uint32 _skipped = 0;
+    bool _sawMushrooms = false;
+    bool _scanning = true;
 };
 
 class TbcDungeonUnderbogValueContext : public NamedObjectContext<UntypedValue>

--- a/src/Bot/Engine/BuildSharedActionContexts.cpp
+++ b/src/Bot/Engine/BuildSharedActionContexts.cpp
@@ -57,6 +57,7 @@ void AiObjectContext::BuildSharedActionContexts(SharedNamedObjectContextList<Act
     actionContexts.Add(new TbcDungeonAuchenaiCryptsActionContext());
     actionContexts.Add(new TbcDungeonSethekkHallsActionContext());
     actionContexts.Add(new TbcDungeonMechanarActionContext());
+    actionContexts.Add(new TbcDungeonUnderbogActionContext());
     actionContexts.Add(new WotlkDungeonUKActionContext());
     actionContexts.Add(new WotlkDungeonNexActionContext());
     actionContexts.Add(new WotlkDungeonANActionContext());

--- a/src/Bot/Engine/BuildSharedTriggerContexts.cpp
+++ b/src/Bot/Engine/BuildSharedTriggerContexts.cpp
@@ -57,6 +57,7 @@ void AiObjectContext::BuildSharedTriggerContexts(SharedNamedObjectContextList<Tr
     triggerContexts.Add(new TbcDungeonAuchenaiCryptsTriggerContext());
     triggerContexts.Add(new TbcDungeonSethekkHallsTriggerContext());
     triggerContexts.Add(new TbcDungeonMechanarTriggerContext());
+    triggerContexts.Add(new TbcDungeonUnderbogTriggerContext());
     triggerContexts.Add(new WotlkDungeonUKTriggerContext());
     triggerContexts.Add(new WotlkDungeonNexTriggerContext());
     triggerContexts.Add(new WotlkDungeonANTriggerContext());

--- a/src/Bot/Engine/BuildSharedValueContexts.cpp
+++ b/src/Bot/Engine/BuildSharedValueContexts.cpp
@@ -6,10 +6,12 @@
 
 #include "AiObjectContext.h"
 #include "MechValueContext.h"
+#include "UBValueContext.h"
 #include "ValueContext.h"
 
 void AiObjectContext::BuildSharedValueContexts(SharedNamedObjectContextList<UntypedValue>& valueContexts)
 {
     valueContexts.Add(new ValueContext());
     valueContexts.Add(new TbcDungeonMechValueContext());
+    valueContexts.Add(new TbcDungeonUnderbogValueContext());
 }

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -1634,7 +1634,7 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
     static const std::vector<std::string> allInstanceStrategies =
     {
         "aq20", "blacktemple", "bwl", "gruulslair", "hyjal", "icc", "karazhan", "magtheridon",
-        "moltencore", "naxx", "onyxia", "rs", "ssc", "tbc-ac", "tbc-mech", "tbc-seth",
+        "moltencore", "naxx", "onyxia", "rs", "ssc", "tbc-ac", "tbc-mech", "tbc-seth", "tbc-ub",
         "tempestkeep", "ulduar", "voa", "wotlk-an", "wotlk-cos", "wotlk-dtk", "wotlk-eoe",
         "wotlk-fos", "wotlk-gd", "wotlk-hol", "wotlk-hos", "wotlk-nex", "wotlk-occ", "wotlk-ok",
         "wotlk-os", "wotlk-pos", "wotlk-toc", "wotlk-uk", "wotlk-up", "wotlk-vh", "zulaman"
@@ -1672,6 +1672,9 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
             break;
         case 544:
             strategyName = "magtheridon";  // Magtheridon's Lair
+            break;
+        case 546:
+            strategyName = "tbc-ub";  // Coilfang Reservoir: The Underbog
             break;
         case 548:
             strategyName = "ssc";  // Serpentshrine Cavern


### PR DESCRIPTION
## Pull Request Description

Adds a combat strategy for the Hungarfen fight in The Underbog.

Hungarfen periodically spawns an Underbog Mushroom under a random party member.
The mushroom is harmless while it grows but aggroes whoever it spawned on, so
every stock target value treats it as a live add: bots peel onto it, the tank
taunts it, and dps flip into aoe rotations. Ten Grow stacks later it blooms into
a Spore Cloud and the group is standing in it. At 20% health the boss roots
itself and health-leeches everyone within 20yd for 11 seconds; by default the
whole group stands in that and dies.

The strategy:

- Ignores mushrooms entirely on both difficulties. Party dps is too low to make
  killing them worthwhile even on Normal, so the group burns the boss and steps
  out of blooms instead. This runs on two fronts: strategy target exclusions
  keep dps/tank/attacker selection off them, and a multiplier suppresses dps aoe
  rotations while the boss is up so the inflated attacker count cannot flip bots
  into splashing the adds.
- Vacates a Spore Cloud pre-emptively. Grow stacks are an exact countdown (one
  every 2s, bloom on the tenth), so at 8 stacks the bot already moves. A tank who
  is holding the boss walks him out of the cloud rather than fleeing, so the boss
  does not sit in it either.
- Retreats every bot, tank included, past the Foul Spores leech radius and holds
  there for the 11s. There is nothing to tank while he is rooted. The retreat
  fans across candidate lanes so the run out never crosses a spore cloud and
  never parks the bot next to a mushroom that is about to bloom.

It follows the existing per-dungeon pattern, so it is inert everywhere except
inside The Underbog.

## Feature Evaluation

- Describe the **minimum logic** required to achieve the intended behavior.

  Two triggers with their actions, two multipliers, and one target-exclusion
  hook, installed only inside The Underbog. Every one of them leads with the
  threat-list `find target` check for the boss, so outside the Hungarfen fight
  they cost one cached lookup and exit. The single grid search (nearby
  mushrooms) lives behind a short-interval per-bot value, so the trigger, the
  action and the exclusion hook share one search instead of repeating it.

- Describe the **processing cost** when this logic executes across many bots.

  Nothing runs outside The Underbog, so the open-world population is unaffected.
  Inside, everything before the boss is a cached `find target` miss. During the
  fight the per-bot cost is one 40yd creature search on a short interval plus
  short loops over that list; the Foul Spores retreat scoring runs only for the
  ~11s the aura is up.

## How to Test the Changes

With a group covering tank, healer and dps, clear to Hungarfen and pull.

Expected:

- No bot ever attacks or taunts an Underbog Mushroom, and dps do not fire aoe
  rotations at them.
- Bots step out of a mushroom before it blooms, not after it starts ticking.
- A tank holding the boss walks the boss out of a cloud instead of running away
  from him.
- At 20% the whole group, tank included, walks out past 20yd and holds until the
  aura drops, and the run out does not path through a spore cloud.
- Ranged keep casting on the boss from outside the leech radius during Foul
  Spores.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly
  with thousands of bots?
  - [x] Minimal impact

  The added work exists only for bots inside The Underbog, and inside that
  instance it is one cached boss lookup per trigger/multiplier until Hungarfen
  is engaged. It does not scale with global bot count.

- Does this change modify default bot behavior?
  - [x] Yes

  During the Hungarfen fight it overrides targeting (mushrooms are excluded and
  aoe is suppressed for dps) and movement (vacate the cloud, retreat from Foul
  Spores), because the default behavior wipes the group. The override is
  confined to that fight and mirrors the existing per-dungeon strategies.

- Does this change add new decision branches or increase maintenance complexity?
  - [x] Yes

  It adds a self-contained `Ai/Dungeon/UB/` unit plus one registration line each
  in the existing dungeon strategy/action/trigger/value context files. The
  complexity is isolated to the new directory.

## AI Assistance

- [x] Yes

  Used for code generation, iteration on the retreat/vacate geometry, and
  documentation. The behavior was refined against the live fight, and all logic
  has been reviewed and is owned by the contributor.

## Code Provenance / Attribution

- [x] No, all code in this PR is original

## Final Checklist

- [x] Stability is not compromised.
- [x] Performance impact is understood, tested, and acceptable.
- [x] Added logic complexity is justified and explained.
- [x] Any new bot dialogue lines are translated. (N/A: no dialogue added.)
- [x] Any code ported/adapted from another project is attributed. (N/A.)
- [x] New source files use the GPLv2 header.
- [x] New and modified files do not introduce new compiler warnings.
- [x] Documentation updated if needed. (N/A: no config or commands added.)