### PR TITLE
fix(loot): scope the disallowed-gameobject list to gameobjects

### DIFF
--- a/src/Ai/Base/Actions/LootAction.cpp
+++ b/src/Ai/Base/Actions/LootAction.cpp
@@ -35,9 +35,8 @@ bool LootAction::Execute(Event /*event*/)
         // bot->GetSession()->HandleLootReleaseOpcode(packet);
     }
 
-    // Provide a system to check if the game object id is disallowed in the user configurable list or not.
-    // Check if the game object id is disallowed in the user configurable list or not.
-    if (sPlayerbotAIConfig.disallowedGameObjects.find(lootObject.guid.GetEntry()) != sPlayerbotAIConfig.disallowedGameObjects.end())
+    if (lootObject.guid.IsGameObject() &&
+        sPlayerbotAIConfig.disallowedGameObjects.contains(lootObject.guid.GetEntry()))
     {
         return false;  // Game object ID is disallowed, so do not proceed
     }


### PR DESCRIPTION
## Pull Request Description

`AiPlayerbot.DisallowedGameObjects` lists **gameobject** entries, but `LootAction::Execute` matched it against `lootObject.guid.GetEntry()` without checking what kind of object the guid points at.

A loot target can just as well be a creature, and the two entry spaces overlap, so an id in the list also blocks the creature that happens to share it. Those corpses never get looted.

## Feature Evaluation

- **Minimum logic**: one `ObjectGuid::IsGameObject()` call in front of the existing set lookup.
- **Processing cost**: cheaper than before, since creature loot now short-circuits before the lookup.

## How to Test the Changes

1. Pick a creature you can kill and note its entry id (`.npcinfo` on a targeted creature).
2. Put that id in `AiPlayerbot.DisallowedGameObjects` in `playerbots.conf`, restart worldserver.
3. Have a bot kill that creature with loot enabled.
   - **Before this PR**: the bot moves to the corpse and never loots it.
   - **After this PR**: the bot loots the corpse normally.
4. Regression check for gameobjects: put a gameobject id from the default list (e.g. `176213`) back in the config and confirm the bot still refuses to loot that gameobject.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all

- Does this change modify default bot behavior?
    - - [x] Yes (**explain why**)

    Bots now loot creatures whose entry id collides with an id in the default `AiPlayerbot.DisallowedGameObjects` list. That was the intent all along, since the list is documented as a gameobject list.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No

## AI Assistance

Was AI assistance used while working on this change?
- - [x] Yes (**explain below**)


## Code Provenance / Attribution

- - [x] No, all code in this PR is original

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated. (n/a, no dialogue)
- - [x] Any code ported/adapted from another project is attributed. (n/a, original)
- - [x] New source files use the GPLv2 header. (n/a, no new files)
- - [x] Documentation updated if needed (Conf comments, WiKi commands). (n/a: config semantics are unchanged, the code now matches what the conf comment already says)
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
