### PR TITLE
fix food/drink delay

### DIFF
--- a/src/Ai/Base/Actions/NonCombatActions.cpp
+++ b/src/Ai/Base/Actions/NonCombatActions.cpp
@@ -7,6 +7,8 @@
 #include "NonCombatActions.h"
 #include "Event.h"
 #include "Playerbots.h"
+#include <algorithm>
+#include <cmath>
 
 namespace
 {
@@ -45,22 +47,16 @@ bool DrinkAction::Execute(Event event)
 
         if (bot->isMoving())
         {
+            bot->GetMotionMaster()->Clear(false);
             bot->StopMoving();
-            // botAI->SetNextCheckDelay(sPlayerbotAIConfig->globalCoolDown);
-            // return false;
         }
         bot->SetStandState(UNIT_STAND_STATE_SIT);
         botAI->InterruptSpell();
 
-        // float hp = bot->GetHealthPercent();
-        float mp = bot->GetPowerPct(POWER_MANA);
-        float p = mp;
         float delay;
 
-        if (!bot->InBattleground())
-            delay = 18000.0f * (100 - p) / 100.0f;
-        else
-            delay = 12000.0f * (100 - p) / 100.0f;
+        // 25990 restores 5% per 2s tick; wait whole ticks so the drink finishes.
+        delay = std::max(1.0f, std::ceil((100.0f - bot->GetPowerPct(POWER_MANA)) / 5.0f)) * 2 * IN_MILLISECONDS;
 
         botAI->SetNextCheckDelay(delay);
 
@@ -104,23 +100,17 @@ bool EatAction::Execute(Event event)
 
         if (bot->isMoving())
         {
+            bot->GetMotionMaster()->Clear(false);
             bot->StopMoving();
-            // botAI->SetNextCheckDelay(sPlayerbotAIConfig.globalCoolDown);
-            // return false;
         }
 
         bot->SetStandState(UNIT_STAND_STATE_SIT);
         botAI->InterruptSpell();
 
-        float hp = bot->GetHealthPct();
-        // float mp = bot->HasMana() ? bot->GetPowerPercent() : 0.f;
-        float p = hp;
         float delay;
 
-        if (!bot->InBattleground())
-            delay = 18000.0f * (100 - p) / 100.0f;
-        else
-            delay = 12000.0f * (100 - p) / 100.0f;
+        // 25990 restores 5% per 2s tick; wait whole ticks so the meal finishes.
+        delay = std::max(1.0f, std::ceil((100.0f - bot->GetHealthPct()) / 5.0f)) * 2 * IN_MILLISECONDS;
 
         botAI->SetNextCheckDelay(delay);
 

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -264,6 +264,10 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
 
     AllowActivity();
 
+    // If we get attacked, drop the pending delay so the engine can switch to combat.
+    if (nextAICheckDelay && bot->IsInCombat() && currentEngine != engines[BOT_STATE_COMBAT])
+        nextAICheckDelay = 0;
+
     if (!CanUpdateAI())
         return;
 


### PR DESCRIPTION
## Pull Request Description

Three fixes on the cheat-food rest path (`EatAction` / `DrinkAction`, on by default via `AiPlayerbot.BotCheats`).

1. The action applies aura `25990`, which restores 5% per 2s tick, and then slept for `18000ms * missing% / 100` (`12000ms` in a battleground). At 0% mana that is 18s of sleep against 40s of regen, so the bot stood up half full, re-triggered, and sat back down. The wait is now `ceil(missing% / 5) * 2s`, floored at one tick. The battleground constant goes with it, since the aura ticks at the same rate there.
2. Only time clears `nextAICheckDelay`, and the switch to the combat engine happens inside `AttackAction`, which the engine cannot reach while it is asleep. A bot that sat down to drink slept through the start of the fight. `UpdateAI` now zeroes a pending delay when the bot is in combat off the combat engine.
3. `StopMoving()` stops the spline but leaves the movement generator, which re-issues movement and breaks the seated aura. `GetMotionMaster()->Clear(false)` runs first, on the existing `isMoving()` branch.

## Feature Evaluation

- **Minimum logic**: the same arithmetic as before with different constants, one extra call on a branch that already existed, one `if` in `UpdateAI`.
- **Processing cost**: per bot per tick, a test of a `uint32` member that is 0 for any bot not sleeping. Sleeping bots also cost a unit-flag read and a pointer compare. No allocations, no lookups. Resting wakes up less often than it used to: one sit per meal instead of one per 18s.

## How to Test the Changes

Default config, one bot.

1. Drop a mana user to ~10% mana out of combat and let it drink. **Before**: stands up half full and re-sits, several cycles. **After**: one sit, stands at full.
2. Let a bot sit to eat, then pull a mob onto it. **Before**: stays seated until the delay expires. **After**: engages on the next tick.
3. Trigger the meal while the bot is moving (follow, or reach melee). **Before**: it drifts and the aura falls off. **After**: it stops and stays seated.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)

    One `uint32` test per bot per `UpdateAI`, short-circuiting for every bot that is not sleeping. Offset by far fewer rest wake-ups.

- Does this change modify default bot behavior?
    - - [x] Yes (**explain why**)

    The cheat-food path is default. Bots now stay seated for the whole meal, drop the rest of the wait when combat starts, and stop properly when they sit. Same regen, delivered in one cycle instead of several.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] Yes (**explain below**)

    One branch in `UpdateAI`, one call inside an existing `if`. `NonCombatActions.cpp` loses more lines than it gains.

## AI Assistance

Was AI assistance used while working on this change?
- - [x] Yes (**explain below**)

Used for tracing the delay/aura mismatch and drafting this description. Every line reviewed and understood.

## Code Provenance / Attribution

- - [x] No, all code in this PR is original

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated. (n/a, no dialogue)
- - [x] Any code ported/adapted from another project is attributed. (n/a, original)
- - [x] New source files use the GPLv2 header. (n/a, no new files)
- - [x] Documentation updated if needed (Conf comments, WiKi commands). (n/a, no config or command surface changed)
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers

- The wake-up guard clears *any* pending delay while the bot is in combat off the combat engine, not just a resting one. The delay is what blocks `AttackAction` in every case.
