### PR TITLE
Imprevement Sapphiron strategy

### DIFF
--- a/src/Ai/Raid/Naxx/Action/NaxxActions_Sapphiron.cpp
+++ b/src/Ai/Raid/Naxx/Action/NaxxActions_Sapphiron.cpp
@@ -75,7 +75,7 @@ bool SapphironFlightPositionAction::MoveToNearestIcebolt()
     Group* group = bot->GetGroup();
     if (!group)
         return false;
-    
+
     Player* playerWithIcebolt = nullptr;
     float minDistance;
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
@@ -91,7 +91,6 @@ bool SapphironFlightPositionAction::MoveToNearestIcebolt()
             }
         }
     }
-
     if (playerWithIcebolt)
     {
         Unit* boss = AI_VALUE2(Unit*, "find target", "sapphiron");

--- a/src/Ai/Raid/Naxx/Action/NaxxActions_Sapphiron.cpp
+++ b/src/Ai/Raid/Naxx/Action/NaxxActions_Sapphiron.cpp
@@ -105,8 +105,8 @@ bool SapphironFlightPositionAction::MoveToNearestIcebolt()
             float angle = boss->GetAngle(playerWithIcebolt);
             float posX = playerWithIcebolt->GetPositionX() + cos(angle) * 3.0f;
             float posY = playerWithIcebolt->GetPositionY() + sin(angle) * 3.0f;
-            float distToIcebolt = bot->GetDistance2d(posX, posY);
-            if (distToIcebolt < 0.9f)
+            float distToSafePoint = bot->GetExactDist2d(posX, posY);
+            if (distToSafePoint < 1.0f)
             {
                 if (botAI->IsRanged(bot))
                 {

--- a/src/Ai/Raid/Naxx/Action/NaxxActions_Sapphiron.cpp
+++ b/src/Ai/Raid/Naxx/Action/NaxxActions_Sapphiron.cpp
@@ -75,6 +75,9 @@ bool SapphironFlightPositionAction::MoveToNearestIcebolt()
     Group* group = bot->GetGroup();
     if (!group)
         return false;
+    //raid25: 3 icebolts, raid10: 2 icebolts
+    uint8 requiredIceboltCount = (bot->GetRaidDifficulty() == RAID_DIFFICULTY_25MAN_NORMAL) ? 3 : 2;
+    uint8 iceboltCount = 0; //calculate 
 
     Player* playerWithIcebolt = nullptr;
     float minDistance;
@@ -84,6 +87,7 @@ bool SapphironFlightPositionAction::MoveToNearestIcebolt()
         if (NaxxSpellIds::HasAnyAura(member, {NaxxSpellIds::Icebolt10, NaxxSpellIds::Icebolt25}) ||
             botAI->HasAura("icebolt", member, false, false, -1, true))
         {
+            ++iceboltCount;
             if (!playerWithIcebolt || minDistance > bot->GetDistance(member))
             {
                 playerWithIcebolt = member;
@@ -91,6 +95,10 @@ bool SapphironFlightPositionAction::MoveToNearestIcebolt()
             }
         }
     }
+
+    if (iceboltCount < requiredIceboltCount)
+        return false;
+
     if (playerWithIcebolt)
     {
         Unit* boss = AI_VALUE2(Unit*, "find target", "sapphiron");
@@ -99,6 +107,16 @@ bool SapphironFlightPositionAction::MoveToNearestIcebolt()
             float angle = boss->GetAngle(playerWithIcebolt);
             float posX = playerWithIcebolt->GetPositionX() + cos(angle) * 3.0f;
             float posY = playerWithIcebolt->GetPositionY() + sin(angle) * 3.0f;
+            //distance check
+            float distToIcebolt = bot->GetDistance2d(posX, posY);
+            if (distToIcebolt < 0.9f) //i think it will be a safe distance, less than half length of safe area which cause by icebolt.
+            {
+                if (botAI->IsRanged(bot))
+                {
+                    return false;//rangebot can still cast spells behind icebolt
+                }
+                return true; //prevent melee to move
+            }
             if (MoveTo(NAXX_MAP_ID, posX, posY, helper.GENERIC_HEIGHT, false, false, false, false, MovementPriority::MOVEMENT_COMBAT))
                 return true;
 

--- a/src/Ai/Raid/Naxx/Action/NaxxActions_Sapphiron.cpp
+++ b/src/Ai/Raid/Naxx/Action/NaxxActions_Sapphiron.cpp
@@ -75,9 +75,8 @@ bool SapphironFlightPositionAction::MoveToNearestIcebolt()
     Group* group = bot->GetGroup();
     if (!group)
         return false;
-    //raid25: 3 icebolts, raid10: 2 icebolts
     uint8 requiredIceboltCount = (bot->GetRaidDifficulty() == RAID_DIFFICULTY_25MAN_NORMAL) ? 3 : 2;
-    uint8 iceboltCount = 0; //calculate 
+    uint8 iceboltCount = 0;
     Player* playerWithIcebolt = nullptr;
     float minDistance;
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
@@ -106,15 +105,14 @@ bool SapphironFlightPositionAction::MoveToNearestIcebolt()
             float angle = boss->GetAngle(playerWithIcebolt);
             float posX = playerWithIcebolt->GetPositionX() + cos(angle) * 3.0f;
             float posY = playerWithIcebolt->GetPositionY() + sin(angle) * 3.0f;
-            //distance check
             float distToIcebolt = bot->GetDistance2d(posX, posY);
-            if (distToIcebolt < 0.9f) //i think it will be a safe distance, less than half length of safe area which cause by icebolt.
+            if (distToIcebolt < 0.9f)
             {
                 if (botAI->IsRanged(bot))
                 {
-                    return false;//rangebot can still cast spells behind icebolt
+                    return false;
                 }
-                return true; //prevent melee to move
+                return true;
             }
             if (MoveTo(NAXX_MAP_ID, posX, posY, helper.GENERIC_HEIGHT, false, false, false, false, MovementPriority::MOVEMENT_COMBAT))
                 return true;

--- a/src/Ai/Raid/Naxx/Action/NaxxActions_Sapphiron.cpp
+++ b/src/Ai/Raid/Naxx/Action/NaxxActions_Sapphiron.cpp
@@ -75,8 +75,7 @@ bool SapphironFlightPositionAction::MoveToNearestIcebolt()
     Group* group = bot->GetGroup();
     if (!group)
         return false;
-    uint8 requiredIceboltCount = (bot->GetRaidDifficulty() == RAID_DIFFICULTY_25MAN_NORMAL) ? 3 : 2;
-    uint8 iceboltCount = 0;
+    
     Player* playerWithIcebolt = nullptr;
     float minDistance;
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
@@ -85,7 +84,6 @@ bool SapphironFlightPositionAction::MoveToNearestIcebolt()
         if (NaxxSpellIds::HasAnyAura(member, {NaxxSpellIds::Icebolt10, NaxxSpellIds::Icebolt25}) ||
             botAI->HasAura("icebolt", member, false, false, -1, true))
         {
-            ++iceboltCount;
             if (!playerWithIcebolt || minDistance > bot->GetDistance(member))
             {
                 playerWithIcebolt = member;
@@ -93,9 +91,6 @@ bool SapphironFlightPositionAction::MoveToNearestIcebolt()
             }
         }
     }
-
-    if (iceboltCount < requiredIceboltCount)
-        return false;
 
     if (playerWithIcebolt)
     {
@@ -108,11 +103,8 @@ bool SapphironFlightPositionAction::MoveToNearestIcebolt()
             float distToSafePoint = bot->GetExactDist2d(posX, posY);
             if (distToSafePoint < 1.0f)
             {
-                if (botAI->IsRanged(bot))
-                {
-                    return false;
-                }
-                return true;
+                if (botAI->IsMelee(bot))
+                    return true;
             }
             if (MoveTo(NAXX_MAP_ID, posX, posY, helper.GENERIC_HEIGHT, false, false, false, false, MovementPriority::MOVEMENT_COMBAT))
                 return true;

--- a/src/Ai/Raid/Naxx/Action/NaxxActions_Sapphiron.cpp
+++ b/src/Ai/Raid/Naxx/Action/NaxxActions_Sapphiron.cpp
@@ -78,7 +78,6 @@ bool SapphironFlightPositionAction::MoveToNearestIcebolt()
     //raid25: 3 icebolts, raid10: 2 icebolts
     uint8 requiredIceboltCount = (bot->GetRaidDifficulty() == RAID_DIFFICULTY_25MAN_NORMAL) ? 3 : 2;
     uint8 iceboltCount = 0; //calculate 
-
     Player* playerWithIcebolt = nullptr;
     float minDistance;
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
This change improves the bot positioning logic for Sapphiron  in Naxx. 
1. Dynamic Icebolt count requirement based on raid size
` if (iceboltCount < requiredIceboltCount)
        return false;`
Added an iceboltCount calculation that iterates through raid members and counts how many currently have the Icebolt effect . If the current Icebolt count is lower than the required count for the raid difficulty, the function returns false immediately, since the bot should not proceed with positioning logic until enough Icebolts have been applied.
2. `float distToSafePoint = bot->GetEaxctDist2d(posX, posY);`
Added a safe-distance check 
3. `botAI->IsRanged(bot)` 
For range bots, if arrive safe pos, they will continue cast spells.
For melee bots, once they are already within the safe distance, returning true prevents the melee bot from continuing to move toward the boss to attack it.
## TEST VIDEO
[Youtube](https://www.youtube.com/watch?v=QGgDzcJiuQk)

The original strategy was unable to successfully clear the Sapphiron  when the raid's gear level was in the 200–205 range. The main issue occurred during the flight phase: bots would repeatedly move back and forth while trying to dodge the boss's breath .



## Feature Evaluation
This change does not increase complexity,only little calculation. The added early-return checks (Icebolt count validation, safe-distance validation) actually reduce the frequency of unnecessary pathfinding.


## How to Test the Changes
Enter Naxx with 10raid or 25raid with 1player + other bots and progress to the Sapphiron encounter
## Expected behavior
1.Bots take no positioning/movement action when the Icebolt count is insufficient
2.Ranged/healer bots continue casting in place when already within the safe distance
3.Melee bots stop moving and do nothing  when already within the safe distance


## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
-
Purpose of usage: As a non-native English speaker, I used an AI tool to help translate my PR description from Chinese into English for clearer documentation.

Which parts were influenced by AI, and review status: Only the language translation of the PR description was assisted by AI. The code logic and implementation were written and tested independently by me, and were fully reviewed by myself before submission.
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->



## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note).
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


