### PR TITLE
feat(rogue): use riposte in the combat dps rotation

### DIFF
--- a/src/Ai/Class/Rogue/RogueAiObjectContext.cpp
+++ b/src/Ai/Class/Rogue/RogueAiObjectContext.cpp
@@ -63,6 +63,7 @@ public:
     RogueTriggerFactoryInternal()
     {
         creators["kick"] = &RogueTriggerFactoryInternal::kick;
+        creators["riposte"] = &RogueTriggerFactoryInternal::riposte;
         creators["rupture"] = &RogueTriggerFactoryInternal::rupture;
         creators["slice and dice"] = &RogueTriggerFactoryInternal::slice_and_dice;
         creators["hunger for blood"] = &RogueTriggerFactoryInternal::hunger_for_blood;
@@ -85,6 +86,7 @@ private:
     static Trigger* adrenaline_rush(PlayerbotAI* botAI) { return new AdrenalineRushTrigger(botAI); }
     static Trigger* blade_fury(PlayerbotAI* botAI) { return new BladeFuryTrigger(botAI); }
     static Trigger* kick(PlayerbotAI* botAI) { return new KickInterruptSpellTrigger(botAI); }
+    static Trigger* riposte(PlayerbotAI* botAI) { return new RiposteAvailableTrigger(botAI); }
     static Trigger* rupture(PlayerbotAI* botAI) { return new RuptureTrigger(botAI); }
     static Trigger* slice_and_dice(PlayerbotAI* botAI) { return new SliceAndDiceTrigger(botAI); }
     static Trigger* hunger_for_blood(PlayerbotAI* botAI) { return new HungerForBloodTrigger(botAI); }

--- a/src/Ai/Class/Rogue/RogueTriggers.h
+++ b/src/Ai/Class/Rogue/RogueTriggers.h
@@ -43,6 +43,12 @@ public:
     BladeFuryTrigger(PlayerbotAI* botAI) : BoostTrigger(botAI, "blade fury") {}
 };
 
+class RiposteAvailableTrigger : public SpellCanBeCastTrigger
+{
+public:
+    RiposteAvailableTrigger(PlayerbotAI* botAI) : SpellCanBeCastTrigger(botAI, "riposte") {}
+};
+
 class RuptureTrigger : public DebuffTrigger
 {
 public:

--- a/src/Ai/Class/Rogue/Strategy/DpsRogueStrategy.cpp
+++ b/src/Ai/Class/Rogue/Strategy/DpsRogueStrategy.cpp
@@ -109,6 +109,15 @@ void DpsRogueStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 
     triggers.push_back(
         new TriggerNode(
+            "riposte",
+            {
+                NextAction("riposte", ACTION_HIGH + 4)
+            }
+        )
+    );
+
+    triggers.push_back(
+        new TriggerNode(
             "combo points 5 available",
             {
                 NextAction("rupture", ACTION_HIGH + 1),


### PR DESCRIPTION
## Pull Request Description

`CastRiposteAction` was registered as the action `"riposte"`, but nothing could reach it: no trigger of that name existed and no strategy referenced it. Combat rogues never used Riposte.

This copies the warrior proc-window pattern. `RiposteAvailableTrigger` is a `CAN_CAST_TRIGGER`, same as `revenge` and `overpower`, and it goes into `DpsRogueStrategy` at `ACTION_HIGH + 4`, the priority `overpower` already uses in `ArmsWarriorStrategy`. The parry window and every other cast condition stay with `Spell::CheckCast`, which `CanCastSpell` runs anyway. `AiFactory` maps only `ROGUE_TAB_COMBAT` to the `dps` strategy, which is the tree Riposte is talented in.

None of the premade combat builds use Riposte, so random bots on a stock config never reach the trigger. This is for bots that got their talents from a player: alts and selfbots.

## Feature Evaluation

- **Minimum logic**: one factory entry and one trigger node, plus a trigger class that is a bare macro expansion. No new condition is written.
- **Processing cost**: one `CanCastSpell` per tick, and only for combat-spec rogues in combat. A rogue without the talent returns on the cached spell-id lookup. Same cost as the warrior triggers.

## How to Test the Changes

Take a combat-spec rogue bot talented into Riposte and give it a mob that attacks it, so it can parry. Riposte shows up in the combat log after a parry. Before this change it never did. Assassination and subtlety run `melee`, not `dps`, so they still never cast it.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] Minimal impact (**explain below**)

    One more trigger per tick for combat rogues in combat, the same as the warrior equivalents.

- Does this change modify default bot behavior?
    - - [x] Yes (**explain why**)

    Combat rogues now use Riposte when they parry. It was dead code before.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] Yes (**explain below**)

    One trigger node. The trigger class has no body.

## AI Assistance

Was AI assistance used while working on this change?
- - [x] Yes (**explain below**)

Used for tracing the unreachable action and drafting this description. Every line reviewed and understood.

## Code Provenance / Attribution

- - [x] No, all code in this PR is original

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated. (n/a, no dialogue)
- - [x] Any code ported/adapted from another project is attributed. (n/a, original)
- - [x] New source files use the GPLv2 header. (n/a, no new files)
- - [x] Documentation updated if needed (Conf comments, WiKi commands). (n/a, no config or command surface changed)
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
