### PR TITLE
feat(RandomBot): make periodic stats log interval configurable

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1382,6 +1382,11 @@ AiPlayerbot.MaxRandomBotRandomizeTime = 1209600
 # Default: 60
 AiPlayerbot.RandomBotsPerInterval = 60
 
+# Interval (in seconds) between periodic random bot statistics dumps in the log
+# (online count, level/race/class distribution, roles, status). Set to 0 to disable.
+# Default: 300
+AiPlayerbot.RandomBotPrintStatsInterval = 300
+
 # Minimum and maximum seconds after death before a bot revives
 # Defaults: 60 (min), 300 (max)
 AiPlayerbot.MinRandomBotReviveTime = 60

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -390,7 +390,8 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 /*elapsed*/, bool /*minimal*/)
             sRandomPlayerbotMgr.CheckLfgQueue();
     }
 
-    if (sPlayerbotAIConfig.randomBotAutologin && time(nullptr) > (printStatsTimer + 300))
+    if (sPlayerbotAIConfig.randomBotAutologin && sPlayerbotAIConfig.randomBotPrintStatsInterval &&
+        time(nullptr) > (printStatsTimer + sPlayerbotAIConfig.randomBotPrintStatsInterval))
     {
         if (!printStatsTimer)
         {

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -246,6 +246,7 @@ bool PlayerbotAIConfig::Initialize()
         sConfigMgr->GetOption<int32>("AiPlayerbot.PermanentlyInWorldTime", 1 * YEAR);
     randomBotTeleportDistance = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotTeleportDistance", 100);
     randomBotsPerInterval = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotsPerInterval", 60);
+    randomBotPrintStatsInterval = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotPrintStatsInterval", 300);
     minRandomBotsPriceChangeInterval =
         sConfigMgr->GetOption<int32>("AiPlayerbot.MinRandomBotsPriceChangeInterval", 2 * HOUR);
     maxRandomBotsPriceChangeInterval =

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -160,6 +160,7 @@ public:
     uint32 permanentlyInWorldTime;
     uint32 minRandomBotPvpTime, maxRandomBotPvpTime;
     uint32 randomBotsPerInterval;
+    uint32 randomBotPrintStatsInterval;
     uint32 minRandomBotsPriceChangeInterval, maxRandomBotsPriceChangeInterval;
     uint32 disabledWithoutRealPlayerLoginDelay, disabledWithoutRealPlayerLogoutDelay;
     bool randomBotJoinLfg;


### PR DESCRIPTION
## Pull Request Description

The periodic random-bot stats dump in `RandomPlayerbotMgr::UpdateAIInternal` is hardcoded to 300s, with no way to change it or turn it off.
Adds `AiPlayerbot.RandomBotPrintStatsInterval`, in seconds, defaulting to the old hardcoded 300. `0` short-circuits the condition, so the dump and its per-bot pass never run.

## Feature Evaluation

- Describe the **minimum logic** required to achieve the intended behavior.

  One config read, one `uint32` member, `300` in the existing `if` replaced by it. The off switch is one more term on the same condition, not a new branch.

- Describe the **processing cost** when this logic executes across many bots.

  None per bot. `UpdateAIInternal` is the single manager update, not a per-bot or per-trigger path. One integer test added per manager tick. `0` removes the O(bots) `PrintStats()` pass.

## How to Test the Changes

1. Option absent: `Random Bots Stats: N online` still logs every ~300s, unchanged.
2. Set to `30`: logs every ~30s. First dump lands one interval late: existing arming behavior, `printStatsTimer` starts at 0.
3. Set to `0`: never logs.

Needs `AiPlayerbot.RandomBotAutologin = 1`, restart between changes.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all

    Manager-level, once per `RandomPlayerbotMgr` update. Nothing scales with bot count. No pmon before/after taken. The change sits outside the per-bot tick pmon measures.

- Does this change modify default bot behavior?
    - - [x] No

    Default 300 is the hardcoded value. Log output only.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No

    Same `if`, one more term. Option follows the interval options around it.

## AI Assistance

Was AI assistance used while working on this change?
- - [x] Yes (**explain below**)

Conf comment and this description. Change is four lines; all reviewed and understood.

## Code Provenance / Attribution

Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated. (n/a, no dialogue)
- - [x] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note). (n/a, original)
- - [x] New source files use the GPLv2 header. (n/a, no new files)
- - [x] Documentation updated if needed (Conf comments, WiKi commands). (conf comment added)
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
