### PR TITLE
fix(rpg): fill shared npc-flag lists at static init

### DIFF
--- a/src/Ai/Base/Value/PossibleRpgTargetsValue.cpp
+++ b/src/Ai/Base/Value/PossibleRpgTargetsValue.cpp
@@ -16,35 +16,33 @@
 #include "NearestGameObjects.h"
 #include <unordered_set>
 
-std::vector<uint32> PossibleRpgTargetsValue::allowedNpcFlags;
+const std::vector<uint32> PossibleRpgTargetsValue::allowedNpcFlags = {
+    UNIT_NPC_FLAG_INNKEEPER,
+    UNIT_NPC_FLAG_GOSSIP,
+    UNIT_NPC_FLAG_QUESTGIVER,
+    UNIT_NPC_FLAG_FLIGHTMASTER,
+    UNIT_NPC_FLAG_BANKER,
+    UNIT_NPC_FLAG_GUILD_BANKER,
+    UNIT_NPC_FLAG_TRAINER_CLASS,
+    UNIT_NPC_FLAG_TRAINER_PROFESSION,
+    UNIT_NPC_FLAG_VENDOR_AMMO,
+    UNIT_NPC_FLAG_VENDOR_FOOD,
+    UNIT_NPC_FLAG_VENDOR_POISON,
+    UNIT_NPC_FLAG_VENDOR_REAGENT,
+    UNIT_NPC_FLAG_AUCTIONEER,
+    UNIT_NPC_FLAG_STABLEMASTER,
+    UNIT_NPC_FLAG_PETITIONER,
+    UNIT_NPC_FLAG_TABARDDESIGNER,
+    UNIT_NPC_FLAG_BATTLEMASTER,
+
+    UNIT_NPC_FLAG_TRAINER,
+    UNIT_NPC_FLAG_VENDOR,
+    UNIT_NPC_FLAG_REPAIR,
+};
 
 PossibleRpgTargetsValue::PossibleRpgTargetsValue(PlayerbotAI* botAI, float range)
     : NearestUnitsValue(botAI, "possible rpg targets", range, true)
 {
-    if (allowedNpcFlags.empty())
-    {
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_INNKEEPER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_GOSSIP);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_QUESTGIVER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_FLIGHTMASTER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_BANKER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_GUILD_BANKER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_TRAINER_CLASS);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_TRAINER_PROFESSION);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR_AMMO);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR_FOOD);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR_POISON);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR_REAGENT);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_AUCTIONEER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_STABLEMASTER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_PETITIONER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_TABARDDESIGNER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_BATTLEMASTER);
-
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_TRAINER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_REPAIR);
-    }
 }
 
 void PossibleRpgTargetsValue::FindUnits(std::list<Unit*>& targets)
@@ -88,7 +86,29 @@ bool PossibleRpgTargetsValue::AcceptUnit(Unit* unit)
     return false;
 }
 
-std::vector<uint32> PossibleNewRpgTargetsValue::allowedNpcFlags;
+const std::vector<uint32> PossibleNewRpgTargetsValue::allowedNpcFlags = {
+    UNIT_NPC_FLAG_INNKEEPER,
+    UNIT_NPC_FLAG_GOSSIP,
+    UNIT_NPC_FLAG_QUESTGIVER,
+    UNIT_NPC_FLAG_FLIGHTMASTER,
+    UNIT_NPC_FLAG_BANKER,
+    UNIT_NPC_FLAG_GUILD_BANKER,
+    UNIT_NPC_FLAG_TRAINER_CLASS,
+    UNIT_NPC_FLAG_TRAINER_PROFESSION,
+    UNIT_NPC_FLAG_VENDOR_AMMO,
+    UNIT_NPC_FLAG_VENDOR_FOOD,
+    UNIT_NPC_FLAG_VENDOR_POISON,
+    UNIT_NPC_FLAG_VENDOR_REAGENT,
+    UNIT_NPC_FLAG_AUCTIONEER,
+    UNIT_NPC_FLAG_STABLEMASTER,
+    UNIT_NPC_FLAG_PETITIONER,
+    UNIT_NPC_FLAG_TABARDDESIGNER,
+    UNIT_NPC_FLAG_BATTLEMASTER,
+
+    UNIT_NPC_FLAG_TRAINER,
+    UNIT_NPC_FLAG_VENDOR,
+    UNIT_NPC_FLAG_REPAIR,
+};
 
 // Sparse starting zones where the default scan range is insufficient for WANDER_NPC (requires >= 3 NPCs)
 static const std::unordered_set<uint32> rpgRangeOverrideAreaIds = { 3526 /* Ammen Vale */, 2117 /* Deathknell */ };
@@ -96,30 +116,6 @@ static const std::unordered_set<uint32> rpgRangeOverrideAreaIds = { 3526 /* Amme
 PossibleNewRpgTargetsValue::PossibleNewRpgTargetsValue(PlayerbotAI* botAI, float range)
     : NearestUnitsValue(botAI, "possible new rpg targets", range, true), defaultRange(range)
 {
-    if (allowedNpcFlags.empty())
-    {
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_INNKEEPER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_GOSSIP);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_QUESTGIVER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_FLIGHTMASTER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_BANKER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_GUILD_BANKER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_TRAINER_CLASS);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_TRAINER_PROFESSION);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR_AMMO);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR_FOOD);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR_POISON);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR_REAGENT);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_AUCTIONEER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_STABLEMASTER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_PETITIONER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_TABARDDESIGNER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_BATTLEMASTER);
-
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_TRAINER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_REPAIR);
-    }
 }
 
 GuidVector PossibleNewRpgTargetsValue::Calculate()
@@ -177,7 +173,9 @@ bool PossibleNewRpgTargetsValue::AcceptUnit(Unit* unit)
     return false;
 }
 
-std::vector<GameobjectTypes> PossibleNewRpgGameObjectsValue::allowedGOFlags;
+const std::vector<GameobjectTypes> PossibleNewRpgGameObjectsValue::allowedGOFlags = {
+    GAMEOBJECT_TYPE_QUESTGIVER,
+};
 
 GuidVector PossibleNewRpgGameObjectsValue::Calculate()
 {

--- a/src/Ai/Base/Value/PossibleRpgTargetsValue.h
+++ b/src/Ai/Base/Value/PossibleRpgTargetsValue.h
@@ -19,7 +19,7 @@ class PossibleRpgTargetsValue : public NearestUnitsValue
 public:
     PossibleRpgTargetsValue(PlayerbotAI* botAI, float range = 70.0f);
 
-    static std::vector<uint32> allowedNpcFlags;
+    static const std::vector<uint32> allowedNpcFlags;
 
 protected:
     void FindUnits(std::list<Unit*>& targets) override;
@@ -31,7 +31,7 @@ class PossibleNewRpgTargetsValue : public NearestUnitsValue
 public:
     PossibleNewRpgTargetsValue(PlayerbotAI* botAI, float range = 150.0f);
 
-    static std::vector<uint32> allowedNpcFlags;
+    static const std::vector<uint32> allowedNpcFlags;
     GuidVector Calculate() override;
 protected:
     void FindUnits(std::list<Unit*>& targets) override;
@@ -46,13 +46,9 @@ public:
     PossibleNewRpgGameObjectsValue(PlayerbotAI* botAI, float range = 150.0f, bool ignoreLos = true)
         : ObjectGuidListCalculatedValue(botAI, "possible new rpg game objects"), range(range), ignoreLos(ignoreLos)
     {
-        if (allowedGOFlags.empty())
-        {
-            allowedGOFlags.push_back(GAMEOBJECT_TYPE_QUESTGIVER);
-        }
     }
 
-    static std::vector<GameobjectTypes> allowedGOFlags;
+    static const std::vector<GameobjectTypes> allowedGOFlags;
     GuidVector Calculate() override;
 
 private:


### PR DESCRIPTION
## Pull Request Description

A multi-map run crashed in `memmove` while a bot was constructing `PossibleNewRpgTargetsValue`.

Three process-wide statics (`PossibleRpgTargetsValue::allowedNpcFlags`, `PossibleNewRpgTargetsValue::allowedNpcFlags`, `PossibleNewRpgGameObjectsValue::allowedGOFlags`) were filled lazily from the constructor, under an `if (list.empty())` guard.

The lists are constants, so they are now filled during static initialisation, before any map thread exists. Same entries, same order. The constructors lose their bodies.

## Feature Evaluation

- Describe the **minimum logic** required to achieve the intended behavior.

  None at runtime. The data is constant, so it is initialised at load time.

- Describe the **processing cost** when this logic executes across many bots.

  Lower than before.

## How to Test the Changes

Server with `MapUpdate.Threads` > 1 and bots reaching RPG behaviour on several maps at once.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

It drops a branch per value construction, and that branch was the contended one.

- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)

Three branches removed, none added.

## AI Assistance

Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)

Claude Code.

## Code Provenance / Attribution

Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots, MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated. (none added)
- - [x] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note). (nothing ported)
- - [x] New source files use the GPLv2 header. (no new files)
- - [x] Documentation updated if needed (Conf comments, WiKi commands). (nothing user-facing changed)
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
