### PR TITLE
fix(value): index creature_multispawn alternates and every dropper

### DIFF
--- a/src/Ai/Base/Value/LootValues.h
+++ b/src/Ai/Base/Value/LootValues.h
@@ -25,7 +25,8 @@ public:
 };
 
 //                   itemId, entry
-typedef std::unordered_map<uint32, int32> DropMap;
+// Multi: one item has many droppers.
+typedef std::unordered_multimap<uint32, int32> DropMap;
 
 // Returns the loot map of all entries
 class DropMapValue : public SingleCalculatedValue<DropMap*>

--- a/src/Ai/Base/Value/QuestValues.cpp
+++ b/src/Ai/Base/Value/QuestValues.cpp
@@ -6,11 +6,10 @@
 
 #include "QuestValues.h"
 
-#include <array>
-
 #include "MapMgr.h"
 #include "Playerbots.h"
 #include "SharedValueContext.h"
+#include <array>
 
 // What kind of a relation does this entry have with this quest.
 entryQuestRelationMap EntryQuestRelationMapValue::Calculate()

--- a/src/Ai/Base/Value/QuestValues.cpp
+++ b/src/Ai/Base/Value/QuestValues.cpp
@@ -5,6 +5,9 @@
  */
 
 #include "QuestValues.h"
+
+#include <array>
+
 #include "MapMgr.h"
 #include "Playerbots.h"
 #include "SharedValueContext.h"
@@ -60,17 +63,34 @@ void FindQuestObjectData::GetObjectiveEntries()
     relationMap = GAI_VALUE(entryQuestRelationMap, "entry quest relation");
 }
 
+// Every entry a spawn point can hold: the base from `creature`, plus up to two
+// `creature_multispawn` alternates rolled between on respawn. 0 = no alternate.
+static std::array<uint32, 3> SpawnEntries(CreatureData const& creData)
+{
+    return { creData.id, creData.id2, creData.id3 };
+}
+
 // Data worker. Checks for a specific creature what quest they are needed for and puts them in the proper place in the
 // quest map.
 void FindQuestObjectData::operator()(CreatureData const& creData)
 {
-    uint32 entry = creData.id;
-
-    for (auto& relation : relationMap[entry])
+    // The GuidPosition keeps the spawn's base entry, which can disagree with the alternate it
+    // is filed under. It resolves by spawnId, and consumers read the map key.
+    for (uint32 entry : SpawnEntries(creData))
     {
-        uint32 questId = relation.first;
-        uint32 flag = relation.second;
-        data[questId][flag][entry].push_back(GuidPosition(creData));
+        if (!entry)
+            continue;
+
+        auto relations = relationMap.find(int32(entry));
+        if (relations == relationMap.end())
+            continue;
+
+        for (auto& relation : relations->second)
+        {
+            uint32 questId = relation.first;
+            uint32 flag = relation.second;
+            data[questId][flag][entry].push_back(GuidPosition(creData));
+        }
     }
 }
 


### PR DESCRIPTION
## Pull Request Description

Two independent indexing bugs in the shared quest/loot value layer.

**1. `creature_multispawn` alternates are never indexed.** A spawn point carries a base entry in `creature` plus up to two alternates in `creature_multispawn` (`CreatureData::id2`/`id3`), rolled between on respawn. `FindQuestObjectData::operator()(CreatureData const&)` read only `creData.id`, so a creature that exists *solely* as an alternate has no spawn position anywhere in the index. It is not a rare shape: quest 5082's Winterfall Totemic shares all of its spawn points with the Den Watcher as the base entry, so the objective resolves to nothing at all.

**2. `DropMap` drops all but the first dropper of each item.** `DropMapValue::Calculate` builds the map with `insert()`, and `ItemDropListValue::Calculate` reads it with `equal_range()` — both multimap idioms. The typedef was `std::unordered_map`, so `insert()` on a key that already exists is a no-op and `equal_range()` can only ever return one element. Every consumer has been seeing a single source per quest item.

Both are one-line-shaped fixes to code that already intended the corrected behaviour.

## Feature Evaluation

- Describe the **minimum logic** required to achieve the intended behavior.

For (1), iterate the three entries a `CreatureData` can hold instead of one, skipping zeroes, and file the spawn under each entry that some quest wants. The `GuidPosition` keeps the spawn's base entry, which can disagree with the alternate it is filed under; that is harmless because it resolves by `spawnId` and every consumer reads the map's entry key rather than the guid's.

For (2), change the typedef to `std::unordered_multimap`. No call site changes: the build side already used `insert()` and the read side already used `equal_range()`.

- Describe the **processing cost** when this logic executes across many bots.

None per bot or per tick. Both structures are built once, inside `SingleCalculatedValue`s in the process-wide `SharedValueContext`, and read back afterwards. The multispawn change adds two integer checks per creature spawn row during that one-time build. The multimap change increases the shared drop map from roughly one node per distinct item to one node per loot row — measured against the base world DB, 7,645 items becoming 101,017 pairs, about 0.37 MB to 4.85 MB, once for the whole process.

## How to Test the Changes

The multispawn half is directly observable:

Pick a quest whose objective creature only ever appears as a `creature_multispawn` alternate — quest 5082 (Winterfall Totemic) is the reference case.
Before: the objective has no indexed spawn positions. After: it resolves to the 19 shared spawn points.


## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

Neither structure is touched per tick. Both are built once and read from afterwards. The only recurring cost is memory: about 4.5 MB more for the shared drop map, once per process, not per bot.

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

Quest objectives that resolve only through a `creature_multispawn` alternate now have spawn positions where previously they had none. Any consumer that walks bots to quest objectives will therefore find destinations it previously could not.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)

## AI Assistance

Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)

Used for review and verification rather than authorship. The multimap/`equal_range` mismatch was found by an AI-assisted audit of the value layer.

## Code Provenance / Attribution

Was any code in this PR copied or adapted from a sister / upstream project?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note).
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

No new source files and no new bot dialogue in this PR. Built clean from a fresh CMake configure: zero errors, zero warnings, and `apps/codestyle/codestyle-cpp.py` passes on both touched files.

## Notes for Reviewers

The drop-map half currently has no live reader but I have a followup PR with a new quest system coming and this is an easy bugfix for splitting off.
