### PR TITLE
Test staging

### DIFF
--- a/src/Ai/Base/Actions/LootAction.cpp
+++ b/src/Ai/Base/Actions/LootAction.cpp
@@ -140,8 +140,9 @@ bool OpenLootAction::DoLoot(LootObject& lootObject)
     if (go && (go->GetGoState() != GO_STATE_READY))
         return false;
 
-    // This prevents dungeon chests like Tribunal Chest (Halls of Stone) from being ninja'd by the bots
-    if (go && go->HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_INTERACT_COND))
+    // This prevents dungeon chests like Tribunal Chest (Halls of Stone) from being ninja'd by the bots.
+    // Quest objects carry the same flag but are gated on quest state, which ActivateToQuest answers.
+    if (go && go->HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_INTERACT_COND) && !go->ActivateToQuest(bot))
         return false;
 
     // This prevents raid chests like Gunship Armory (ICC) from being ninja'd by the bots

--- a/src/Ai/Base/Trigger/WithinAreaTrigger.cpp
+++ b/src/Ai/Base/Trigger/WithinAreaTrigger.cpp
@@ -62,8 +62,8 @@ bool WithinAreaTrigger::IsPointInAreaTriggerZone(AreaTrigger const* atEntry, uin
         float dz = z - atEntry->z;
         float dx = rotPlayerX - atEntry->x;
         float dy = rotPlayerY - atEntry->y;
-        if ((fabs(dx) > atEntry->x / 2 + delta) || (fabs(dy) > atEntry->y / 2 + delta) ||
-            (fabs(dz) > atEntry->z / 2 + delta))
+        if ((fabs(dx) > atEntry->length / 2 + delta) || (fabs(dy) > atEntry->width / 2 + delta) ||
+            (fabs(dz) > atEntry->height / 2 + delta))
         {
             return false;
         }

--- a/src/Ai/Base/Value/QuestValues.cpp
+++ b/src/Ai/Base/Value/QuestValues.cpp
@@ -278,7 +278,7 @@ std::vector<GuidPosition> ActiveQuestObjectivesValue::Calculate()
 
             if (quest->RequiredNpcOrGoCount[objective])
             {
-                uint32 reqCount = quest->RequiredItemCount[objective];
+                uint32 reqCount = quest->RequiredNpcOrGoCount[objective];
                 uint32 hasCount = statusData.CreatureOrGOCount[objective];
 
                 if (!reqCount || hasCount >= reqCount)

--- a/src/Ai/Class/Druid/Strategy/BearDruidStrategy.cpp
+++ b/src/Ai/Class/Druid/Strategy/BearDruidStrategy.cpp
@@ -19,6 +19,7 @@ public:
         creators["bash"] = &bash;
         creators["swipe (bear)"] = &swipe_bear;
         creators["lacerate"] = &lacerate;
+        creators["taunt spell"] = &growl; // Empty ActionNode needed to register as taunt spell
     }
 
 private:
@@ -78,6 +79,16 @@ private:
             "lacerate",
             /*P*/ {},
             /*A*/ { NextAction("maul") },
+            /*C*/ {}
+        );
+    }
+
+    static ActionNode* growl([[maybe_unused]] PlayerbotAI* botAI)
+    {
+        return new ActionNode(
+            "growl",
+            /*P*/ {},
+            /*A*/ {},
             /*C*/ {}
         );
     }

--- a/src/Ai/Dungeon/DungeonStrategyContext.h
+++ b/src/Ai/Dungeon/DungeonStrategyContext.h
@@ -25,23 +25,6 @@
 #include "PoSStrategy.h"
 #include "TOCStrategy.h"
 
-/*
-Full list/TODO:
-
-Trial of the Champion - ToC
-Alliance Champions: Deathstalker Visceri, Eressea Dawnsinger, Mokra the Skullcrusher, Runok Wildmane, Zul'tore
-Horde Champions: Ambrose Boltspark, Colosos, Jacob Alerius, Jaelyne Evensong, Lana Stouthammer
-Argent Champion: Argent Confessor Paletress/Eadric the Pure
-The Black Knight
-Halls of Reflection - HoR
-Falric, Marwyn, The Lich King
-Pit of Saron - PoS
-Forgemaster Garfrost, Krick & Ick, Scourgelord Tyrannus
-The Forge of Souls - FoS
-Bronjahm, Devourer of Souls
-
-*/
-
 class DungeonStrategyContext : public NamedObjectContext<Strategy>
 {
     public:
@@ -67,7 +50,6 @@ class DungeonStrategyContext : public NamedObjectContext<Strategy>
             creators["wotlk-up"] = &DungeonStrategyContext::wotlk_up;       // Utgarde Pinnacle
             creators["wotlk-cos"] = &DungeonStrategyContext::wotlk_cos;     // The Culling of Stratholme
             creators["wotlk-toc"] = &DungeonStrategyContext::wotlk_toc;     // Trial of the Champion
-            creators["wotlk-hor"] = &DungeonStrategyContext::wotlk_hor;     // Halls of Reflection
             creators["wotlk-pos"] = &DungeonStrategyContext::wotlk_pos;     // Pit of Saron
             creators["wotlk-fos"] = &DungeonStrategyContext::wotlk_fos;     // The Forge of Souls
         }
@@ -88,8 +70,6 @@ class DungeonStrategyContext : public NamedObjectContext<Strategy>
         static Strategy* wotlk_fos(PlayerbotAI* botAI) { return new WotlkDungeonFoSStrategy(botAI); }
         static Strategy* wotlk_pos(PlayerbotAI* botAI) { return new WotlkDungeonPoSStrategy(botAI); }
         static Strategy* wotlk_toc(PlayerbotAI* botAI) { return new WotlkDungeonToCStrategy(botAI); }
-        // NYI from here down
-        static Strategy* wotlk_hor(PlayerbotAI* botAI) { return new WotlkDungeonUKStrategy(botAI); }
 };
 
 #endif

--- a/src/Ai/Dungeon/WotlkDungeonActionContext.h
+++ b/src/Ai/Dungeon/WotlkDungeonActionContext.h
@@ -22,6 +22,5 @@
 #include "FoSActionContext.h"
 #include "PoSActionContext.h"
 #include "TOCActionContext.h"
-// #include "HallsOfReflection/HallsOfReflectionActionContext.h"
 
 #endif

--- a/src/Ai/Dungeon/WotlkDungeonTriggerContext.h
+++ b/src/Ai/Dungeon/WotlkDungeonTriggerContext.h
@@ -22,6 +22,5 @@
 #include "FoSTriggerContext.h"
 #include "PoSTriggerContext.h"
 #include "TOCTriggerContext.h"
-// #include "HallsOfReflection/HallsOfReflectionTriggerContext.h"
 
 #endif

--- a/src/Ai/Raid/OS/OSActions.cpp
+++ b/src/Ai/Raid/OS/OSActions.cpp
@@ -124,7 +124,7 @@ bool AvoidFlameTsunamiAction::Execute(Event /*event*/)
             // I always saw these accurate to around 6 decimal places, but if there are issues,
             // can switch this to abs comparison of floats which would technically be more robust.
             int posY = (int) unit->GetPositionY();
-            if (posY == 505 || posY == 555)     // RIGHT WAVE
+            if (posY == 500 || posY == 564)     // RIGHT WAVE
             {
                 bool wavePassed = currentPos.GetPositionX() > unit->GetPositionX();
                 if (wavePassed)

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -1625,7 +1625,7 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
         "aq20", "blacktemple", "bwl", "gruulslair", "hyjal", "icc", "karazhan",
         "magtheridon", "moltencore", "naxx", "onyxia", "rs", "ssc", "tbc-ac", "tempestkeep",
         "ulduar", "voa", "wotlk-an", "wotlk-cos", "wotlk-dtk", "wotlk-eoe", "wotlk-fos",
-        "wotlk-gd", "wotlk-hol", "wotlk-hor", "wotlk-hos", "wotlk-nex", "wotlk-occ",
+        "wotlk-gd", "wotlk-hol", "wotlk-hos", "wotlk-nex", "wotlk-occ",
         "wotlk-ok", "wotlk-os", "wotlk-pos", "wotlk-toc", "wotlk-uk", "wotlk-up",
         "wotlk-vh", "zulaman"
     };
@@ -1740,9 +1740,6 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
             break;
         case 658:
             strategyName = "wotlk-pos";  // Pit of Saron
-            break;
-        case 668:
-            strategyName = "wotlk-hor";  // Halls of Reflection
             break;
         case 724:
             strategyName = "rs";  // Ruby Sanctum

--- a/src/Mgr/Item/LootObjectStack.cpp
+++ b/src/Mgr/Item/LootObjectStack.cpp
@@ -308,7 +308,12 @@ bool LootObject::IsLootPossible(Player* bot)
     // Prevent bot from running to chests that are unlootable (e.g. Gunship Armory before completing the event) or on
     // respawn time
     GameObject* go = botAI->GetGameObject(guid);
-    if (go && (go->HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_INTERACT_COND | GO_FLAG_NOT_SELECTABLE) || !go->isSpawned()))
+    if (go && (go->HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_NOT_SELECTABLE) || !go->isSpawned()))
+        return false;
+
+    // Conditional objects (quest chests, goobers, ...) are gated client-side on quest state.
+    // A bot has no client, so make the same call the server makes for one.
+    if (go && go->HasFlag(GAMEOBJECT_FLAGS, GO_FLAG_INTERACT_COND) && !go->ActivateToQuest(bot))
         return false;
 
     if (skillId == SKILL_NONE)

--- a/src/Mgr/Travel/TravelMgr.cpp
+++ b/src/Mgr/Travel/TravelMgr.cpp
@@ -1068,7 +1068,7 @@ GuidPosition::GuidPosition(CreatureData const& creData)
 }
 
 GuidPosition::GuidPosition(GameObjectData const& goData)
-    : ObjectGuid(HighGuid::GameObject, goData.id),
+    : ObjectGuid(HighGuid::GameObject, goData.id, goData.spawnId),
       WorldPosition(goData.mapid, goData.posX, goData.posY, goData.posZ, goData.orientation)
 {
     loadedFromDB = true;


### PR DESCRIPTION
83830c6e3 — fix(loot): let bots loot quest objects again (#2579)
LootAction.cpp/LootObjectStack.cpp: bots had stopped looting quest-flagged objects; restores that behavior. Author notes a related case (Tribunal Chest) looks like an AzerothCore data issue, not something fixable on the playerbots side, and left it alone.

2ad26fd7c — Fix WithinAreaTrigger box check using trigger coords as box extents (#2583)
Bug: bots following a master into a dungeon would stop at the entrance and never trigger the teleport. In WithinAreaTrigger::IsPointInAreaTriggerZone, the box-check branch (radius == 0) compared distance against the trigger's position instead of its box extents — for triggers with negative coordinates (e.g. Ragefire Chasm entrance) the check could never pass, so the trigger was effectively dead.

e83b5e479 — fix(value): use NPC/GO count for creature objective in ActiveQuestObjectives (#2587)
One-line fix: ActiveQuestObjectivesValue::Calculate() was reading RequiredItemCount instead of RequiredNpcOrGoCount for kill/interact objectives, so progress on those quest objectives was judged against the wrong counter.

132d3d6c2 — fix(travel): set spawnId on GameObject GuidPosition (#2588)
GuidPosition(GameObjectData const&) built its GUID from entry ID only, omitting spawnId — so multiple spawns of the same GO entry collapsed into one GUID, breaking anything keyed on it (travel write-off sets, map lookups). Now passes spawnId to the base ctor, matching the creature constructor's existing behavior.

713bd1116 — Remove non-existent HoR strategy references (#2591)
Cleanup: strips dead references to a Halls of Reflection ("HoR") strategy that no longer exists, across DungeonStrategyContext.h, WotlkDungeonActionContext.h, WotlkDungeonTriggerContext.h, and PlayerbotAI.cpp.

5c08a51ff — Fix regression - register Growl as "taunt spell" (#2603)
Regression fix in BearDruidStrategy.cpp: an earlier cleanup pass removed empty action nodes across class strategies, including the one that mapped Growl to the generic "taunt spell" action. Restores the empty growl ActionNode and its creators["taunt spell"] registration, matching the pattern used for Taunt/Dark Command/Hand of Reckoning — without it, single-call taunt actions silently skipped bear druids.

8f812e35e — Fix coords of Right Wave (#2609)
OSActions.cpp (Obsidian Sanctum, Flame Tsunami avoidance): updates the Y-coordinate thresholds for the "right wave" from 505/555 to 500/564 to match a recent AzerothCore core fix (upstream PR #24218, commit 4331cdf) that corrected the sniffed spawn coordinates for that encounter.