### PR TITLE
BWL Bot Strategies: fire resistance for the remaining bosses

### DIFF
--- a/src/Ai/Base/Trigger/BossAuraTriggers.cpp
+++ b/src/Ai/Base/Trigger/BossAuraTriggers.cpp
@@ -12,13 +12,13 @@
 
 bool BossFireResistanceTrigger::IsActive()
 {
+    // Check if bot is paladin first: cheap check that filters out most of the raid
+    if (bot->getClass() != CLASS_PALADIN)
+        return false;
+
     // Check boss and it is alive
     Unit* boss = AI_VALUE2(Unit*, "find target", bossName);
     if (!boss || !boss->IsAlive() || boss->IsFriendlyTo(bot))
-        return false;
-
-    // Check if bot is paladin
-    if (bot->getClass() != CLASS_PALADIN)
         return false;
 
     // Check if bot have fire resistance aura
@@ -63,13 +63,13 @@ bool BossFireResistanceTrigger::IsActive()
 
 bool BossFrostResistanceTrigger::IsActive()
 {
+    // Check if bot is paladin first: cheap check that filters out most of the raid
+    if (bot->getClass() != CLASS_PALADIN)
+        return false;
+
     // Check boss and it is alive
     Unit* boss = AI_VALUE2(Unit*, "find target", bossName);
     if (!boss || !boss->IsAlive() || boss->IsFriendlyTo(bot))
-        return false;
-
-    // Check if bot is paladin
-    if (bot->getClass() != CLASS_PALADIN)
         return false;
 
     // Check if bot have frost resistance aura
@@ -114,17 +114,17 @@ bool BossFrostResistanceTrigger::IsActive()
 
 bool BossNatureResistanceTrigger::IsActive()
 {
-    // Check boss and it is alive
-    Unit* boss = AI_VALUE2(Unit*, "find target", bossName);
-    if (!boss || !boss->IsAlive() || boss->IsFriendlyTo(bot))
+    // Check if bot is hunter first: cheap check that filters out most of the raid
+    if (bot->getClass() != CLASS_HUNTER)
         return false;
 
     // Check if bot is alive
     if (!bot->IsAlive())
         return false;
 
-    // Check if bot is hunter
-    if (bot->getClass() != CLASS_HUNTER)
+    // Check boss and it is alive
+    Unit* boss = AI_VALUE2(Unit*, "find target", bossName);
+    if (!boss || !boss->IsAlive() || boss->IsFriendlyTo(bot))
         return false;
 
     // Check if bot have nature resistance aura
@@ -168,13 +168,13 @@ bool BossNatureResistanceTrigger::IsActive()
 
 bool BossShadowResistanceTrigger::IsActive()
 {
+    // Check if bot is paladin first: cheap check that filters out most of the raid
+    if (bot->getClass() != CLASS_PALADIN)
+        return false;
+
     // Check boss and it is alive
     Unit* boss = AI_VALUE2(Unit*, "find target", bossName);
     if (!boss || !boss->IsAlive() || boss->IsFriendlyTo(bot))
-        return false;
-
-    // Check if bot is paladin
-    if (bot->getClass() != CLASS_PALADIN)
         return false;
 
     // Check if bot have shadow resistance aura

--- a/src/Ai/Raid/BWL/BWLActionContext.h
+++ b/src/Ai/Raid/BWL/BWLActionContext.h
@@ -27,6 +27,11 @@ public:
         creators["bwl vaelastrasz fire resistance"] = &RaidBwlActionContext::bwl_vaelastrasz_fire_resistance_action;
         creators["bwl vaelastrasz move away"] = &RaidBwlActionContext::bwl_vaelastrasz_move_away;
 
+        creators["bwl broodlord fire resistance"] = &RaidBwlActionContext::bwl_broodlord_fire_resistance_action;
+
+        creators["bwl firemaw fire resistance"] = &RaidBwlActionContext::bwl_firemaw_fire_resistance_action;
+        creators["bwl flamegor fire resistance"] = &RaidBwlActionContext::bwl_flamegor_fire_resistance_action;
+
         creators["bwl use hourglass sand"] = &RaidBwlActionContext::bwl_use_hourglass_sand;
         creators["bwl nefarian fear ward"] = &RaidBwlActionContext::bwl_nefarian_fear_ward;
         creators["bwl death talon wyrmguard tank move away"] = &RaidBwlActionContext::bwl_death_talon_wyrmguard_tank_move_away;
@@ -41,6 +46,9 @@ private:
     static Action* bwl_razorgore_mark_boss(PlayerbotAI* ai) { return new BwlRazorgoreMarkBossAction(ai); }
     static Action* bwl_vaelastrasz_fire_resistance_action(PlayerbotAI* ai) { return new BossFireResistanceAction(ai, "vaelastrasz the corrupt"); }
     static Action* bwl_vaelastrasz_move_away(PlayerbotAI* ai) { return new BwlVaelastraszMoveAwayAction(ai); }
+    static Action* bwl_broodlord_fire_resistance_action(PlayerbotAI* ai) { return new BossFireResistanceAction(ai, "broodlord lashlayer"); }
+    static Action* bwl_firemaw_fire_resistance_action(PlayerbotAI* ai) { return new BossFireResistanceAction(ai, "firemaw"); }
+    static Action* bwl_flamegor_fire_resistance_action(PlayerbotAI* ai) { return new BossFireResistanceAction(ai, "flamegor"); }
     static Action* bwl_use_hourglass_sand(PlayerbotAI* ai) { return new BwlUseHourglassSandAction(ai); }
     static Action* bwl_nefarian_fear_ward(PlayerbotAI* ai) { return new BwlNefarianFearWardAction(ai); }
     static Action* bwl_death_talon_wyrmguard_tank_move_away(PlayerbotAI* ai) { return new BwlDeathTalonWyrmguardTankMoveAwayAction(ai); }

--- a/src/Ai/Raid/BWL/BWLStrategy.cpp
+++ b/src/Ai/Raid/BWL/BWLStrategy.cpp
@@ -28,6 +28,14 @@ void RaidBwlStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(new TriggerNode("bwl vaelastrasz burning adrenaline", {
         NextAction("bwl vaelastrasz move away", ACTION_RAID + 5) }));
 
+    triggers.push_back(new TriggerNode("bwl broodlord fire resistance", {
+        NextAction("bwl broodlord fire resistance", ACTION_RAID) }));
+
+    triggers.push_back(new TriggerNode("bwl firemaw fire resistance", {
+        NextAction("bwl firemaw fire resistance", ACTION_RAID) }));
+    triggers.push_back(new TriggerNode("bwl flamegor fire resistance", {
+        NextAction("bwl flamegor fire resistance", ACTION_RAID) }));
+
     triggers.push_back(new TriggerNode("bwl affliction bronze", {
         NextAction("bwl use hourglass sand", ACTION_RAID) }));
 

--- a/src/Ai/Raid/BWL/BWLTriggerContext.h
+++ b/src/Ai/Raid/BWL/BWLTriggerContext.h
@@ -25,6 +25,11 @@ public:
         creators["bwl vaelastrasz positioning"] = &RaidBwlTriggerContext::bwl_vaelastrasz_positioning;
         creators["bwl vaelastrasz burning adrenaline"] = &RaidBwlTriggerContext::bwl_vaelastrasz_burning_adrenaline;
 
+        creators["bwl broodlord fire resistance"] = &RaidBwlTriggerContext::bwl_broodlord_fire_resistance_trigger;
+
+        creators["bwl firemaw fire resistance"] = &RaidBwlTriggerContext::bwl_firemaw_fire_resistance_trigger;
+        creators["bwl flamegor fire resistance"] = &RaidBwlTriggerContext::bwl_flamegor_fire_resistance_trigger;
+
         creators["bwl affliction bronze"] = &RaidBwlTriggerContext::bwl_affliction_bronze;
         creators["bwl wild magic"] = &RaidBwlTriggerContext::bwl_wild_magic;
         creators["bwl nefarian fear ward"] = &RaidBwlTriggerContext::bwl_nefarian_fear_ward;
@@ -39,6 +44,9 @@ private:
     static Trigger* bwl_vaelastrasz_fire_resistance_trigger(PlayerbotAI* ai) { return new BossFireResistanceTrigger(ai, "vaelastrasz the corrupt"); }
     static Trigger* bwl_vaelastrasz_positioning(PlayerbotAI* ai) { return new BwlVaelastraszPositioningTrigger(ai); }
     static Trigger* bwl_vaelastrasz_burning_adrenaline(PlayerbotAI* ai) { return new BwlVaelastraszBurningAdrenalineTrigger(ai); }
+    static Trigger* bwl_broodlord_fire_resistance_trigger(PlayerbotAI* ai) { return new BossFireResistanceTrigger(ai, "broodlord lashlayer"); }
+    static Trigger* bwl_firemaw_fire_resistance_trigger(PlayerbotAI* ai) { return new BossFireResistanceTrigger(ai, "firemaw"); }
+    static Trigger* bwl_flamegor_fire_resistance_trigger(PlayerbotAI* ai) { return new BossFireResistanceTrigger(ai, "flamegor"); }
     static Trigger* bwl_affliction_bronze(PlayerbotAI* ai) { return new BwlAfflictionBronzeTrigger(ai); }
     static Trigger* bwl_wild_magic(PlayerbotAI* ai) { return new BwlWildMagicTrigger(ai); }
     static Trigger* bwl_nefarian_fear_ward(PlayerbotAI* ai) { return new BwlNefarianFearWardTrigger(ai); }


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

Razorgore and Vaelastrasz already register the shared fire resistance trigger/action pair, but the bosses after them do not, so bots stop buffing for fire partway through the raid. Broodlord's Blast Wave (23331), Firemaw's Flame Buffet (23341) and the Fire Nova (23462) that Flamegor's Frenzy triggers are all fire damage.

Registers the existing BossFireResistanceTrigger / BossFireResistanceAction for Broodlord Lashlayer, Firemaw and Flamegor. No new logic, no new classes - the same wiring the two earlier bosses already use.

Ebonroc is deliberately left out: his kit is Shadow Flame, Shadow of Ebonroc and Wing Buffet, which is shadow and physical only.


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

Minimum logic: three registrations of an existing trigger/action pair, plus three trigger nodes. No new code paths.

Processing cost: three additional trigger evaluations per tick for bots on map 469, identical in cost to the two already present for Razorgore and Vaelastrasz.


## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

Take a bot raid into BWL and engage Broodlord, Firemaw or Flamegor. Bots should apply fire resistance the same way they already do for Razorgore and Vaelastrasz. Ebonroc is unchanged.


## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

Three extra trigger evaluations per tick for bots on map 469, same cost as the two already there.


- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

Bots in BWL now buff fire resistance for three more bosses; nothing outside map 469.


- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)


## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

Yes; mechanical wiring of an existing trigger/action pair to three more bosses. Damage schools were verified against Spell.dbc before deciding which bosses belong in the list.


## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->


<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note).
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->

Second of the BWL series. Ebonroc was dropped from the original draft of this as his Shadow Flame entirely shadow, not fire, so fire resistance would not help against him!
