### PR TITLE
feat(rpg): actively execute quest objectives in RPG_DO_QUEST

### DIFF
--- a/src/Ai/Base/ActionContext.h
+++ b/src/Ai/Base/ActionContext.h
@@ -44,6 +44,7 @@
 #include "MoveToTravelTargetAction.h"
 #include "MovementActions.h"
 #include "NewRpgAction.h"
+#include "NewRpgDoQuest.h"
 #include "NewRpgOutdoorPvP.h"
 #include "NonCombatActions.h"
 #include "OutfitAction.h"
@@ -278,6 +279,7 @@ public:
         creators["new rpg do quest"] = &ActionContext::new_rpg_do_quest;
         creators["new rpg travel flight"] = &ActionContext::new_rpg_travel_flight;
         creators["new rpg outdoor pvp"] = &ActionContext::new_rpg_outdoor_pvp;
+        creators["new rpg attack quest target"] = &ActionContext::new_rpg_attack_quest_target;
         creators["wait for attack keep safe distance"] = &ActionContext::wait_for_attack_keep_safe_distance;
     }
 
@@ -482,6 +484,7 @@ private:
     static Action* new_rpg_wander_random(PlayerbotAI* ai) { return new NewRpgWanderRandomAction(ai); }
     static Action* new_rpg_wander_npc(PlayerbotAI* ai) { return new NewRpgWanderNpcAction(ai); }
     static Action* new_rpg_do_quest(PlayerbotAI* ai) { return new NewRpgDoQuestAction(ai); }
+    static Action* new_rpg_attack_quest_target(PlayerbotAI* ai) { return new NewRpgAttackQuestTargetAction(ai); }
     static Action* new_rpg_travel_flight(PlayerbotAI* ai) { return new NewRpgTravelFlightAction(ai); }
     static Action* new_rpg_outdoor_pvp(PlayerbotAI* ai) { return new NewRpgOutdoorPvpAction(ai); }
     static Action* wait_for_attack_keep_safe_distance(PlayerbotAI* ai) { return new WaitForAttackKeepSafeDistanceAction(ai); }

--- a/src/Ai/Base/Actions/CheckMountStateAction.cpp
+++ b/src/Ai/Base/Actions/CheckMountStateAction.cpp
@@ -11,6 +11,9 @@
 #include "BattlegroundWS.h"
 #include "DBCStores.h"
 #include "Event.h"
+#include "LootObjectStack.h"
+#include "NewRpgDoQuest.h"
+#include "NewRpgInfo.h"
 #include "PlayerbotAI.h"
 #include "PlayerbotAIConfig.h"
 #include "Playerbots.h"
@@ -86,6 +89,7 @@ bool CheckMountStateAction::Execute(Event /*event*/)
     bool shouldMount = false;
 
     Unit* currentTarget = AI_VALUE(Unit*, "current target");
+    LootObject lootTarget = AI_VALUE(LootObject, "loot target");
     if (currentTarget)
     {
         float dismountDistance = CalculateDismountDistance();
@@ -95,6 +99,10 @@ bool CheckMountStateAction::Execute(Event /*event*/)
 
         shouldDismount = (distanceToTarget <= dismountDistance + combatReach);
         shouldMount = (distanceToTarget > mountDistance + combatReach);
+    }
+    else if (lootTarget.IsLootPossible(bot))
+    {
+        shouldMount = (AI_VALUE2(float, "distance", "loot target") >= CalculateMountDistance());
     }
     else
     {
@@ -135,7 +143,18 @@ bool CheckMountStateAction::Execute(Event /*event*/)
     // No real master (random bot or self-bot) OR bot in BG
     if ((noRealMaster || inBattleground) && !bot->IsMounted() &&
         noAttackers && shouldMount && !bot->IsInCombat())
+    {
+        // Do-quest travel dismounts at engage range from a target, or on arrival otherwise.
+        if (auto const* doQuest = std::get_if<NewRpgInfo::DoQuest>(&botAI->rpgInfo.data))
+        {
+            float const arrival = doQuest->targetGuid ? NEW_RPG_ENGAGE_RANGE : 10.0f;
+            WorldPosition dest = doQuest->targetGuid ? doQuest->targetPos : doQuest->pos;
+            if (dest != WorldPosition() && bot->GetMapId() == dest.GetMapId() &&
+                bot->GetExactDist(dest) <= arrival + CalculateMountDistance())
+                return false;
+        }
         return Mount();
+    }
 
     if (!bot->IsFlying() && shouldDismount && bot->IsMounted() &&
         (enemy || dps || (!noAttackers && bot->IsInCombat())))

--- a/src/Ai/Base/Actions/LootAction.cpp
+++ b/src/Ai/Base/Actions/LootAction.cpp
@@ -15,6 +15,7 @@
 #include "LootStrategyValue.h"
 #include "PlayerbotAIConfig.h"
 #include "Playerbots.h"
+#include "QuestValues.h"
 #include "ServerFacade.h"
 
 bool LootAction::Execute(Event /*event*/)
@@ -492,7 +493,11 @@ bool StoreLootAction::IsLootAllowed(uint32 itemid, PlayerbotAI* botAI)
         if (!quest)
             continue;
 
-        for (uint8 i = 0; i < 4; i++)
+        // ItemDrops and use-reagents: needed for the quest, but named by no RequiredItemId.
+        if (IsQuestExtraItemWanted(botAI->GetBot(), quest, itemid))
+            return true;
+
+        for (uint8 i = 0; i < QUEST_ITEM_OBJECTIVES_COUNT; i++)
         {
             if (quest->RequiredItemId[i] == itemid)
             {

--- a/src/Ai/Base/ChatActionContext.h
+++ b/src/Ai/Base/ChatActionContext.h
@@ -42,6 +42,7 @@
 #include "MailAction.h"
 #include "NamedObjectContext.h"
 #include "NewRpgAction.h"
+#include "NewRpgDoQuest.h"
 #include "OpenItemAction.h"
 #include "PassLeadershipToMasterAction.h"
 #include "PetsAction.h"

--- a/src/Ai/Base/Value/NearestGameObjects.h
+++ b/src/Ai/Base/Value/NearestGameObjects.h
@@ -16,11 +16,13 @@ class PlayerbotAI;
 class AnyGameObjectInObjectRangeCheck
 {
 public:
-    AnyGameObjectInObjectRangeCheck(WorldObject const* obj, float range) : i_obj(obj), i_range(range) {}
+    AnyGameObjectInObjectRangeCheck(WorldObject const* obj, float range, bool scriptActivated = false)
+        : i_obj(obj), i_range(range), i_scriptActivated(scriptActivated) {}
     WorldObject const& GetFocusObject() const { return *i_obj; }
     bool operator()(GameObject* u)
     {
-        if (u && i_obj->IsWithinDistInMap(u, i_range) && u->isSpawned() && u->GetGOInfo())
+        if (u && i_obj->IsWithinDistInMap(u, i_range) && u->GetGOInfo() &&
+            (u->isSpawned() || (i_scriptActivated && !u->isSpawnedByDefault() && !u->GetRespawnTime())))
             return true;
 
         return false;
@@ -29,6 +31,7 @@ public:
 private:
     WorldObject const* i_obj;
     float i_range;
+    bool i_scriptActivated;
 };
 
 class NearestGameObjects : public ObjectGuidListCalculatedValue

--- a/src/Ai/Base/Value/PossibleRpgTargetsValue.cpp
+++ b/src/Ai/Base/Value/PossibleRpgTargetsValue.cpp
@@ -181,7 +181,7 @@ std::vector<GameobjectTypes> PossibleNewRpgGameObjectsValue::allowedGOFlags;
 GuidVector PossibleNewRpgGameObjectsValue::Calculate()
 {
     std::list<GameObject*> targets;
-    AnyGameObjectInObjectRangeCheck u_check(bot, range);
+    AnyGameObjectInObjectRangeCheck u_check(bot, range, true);
     Acore::GameObjectListSearcher<AnyGameObjectInObjectRangeCheck> searcher(bot, targets, u_check);
     Cell::VisitObjects(bot, searcher, range);
 

--- a/src/Ai/Base/Value/QuestValues.cpp
+++ b/src/Ai/Base/Value/QuestValues.cpp
@@ -6,10 +6,21 @@
 
 #include "QuestValues.h"
 
+#include "DatabaseEnv.h"
+#include "GameObjectData.h"
+#include "LootValues.h"
 #include "MapMgr.h"
 #include "Playerbots.h"
 #include "SharedValueContext.h"
+#include "SmartScriptMgr.h"
+#include "SpellInfo.h"
+#include "SpellMgr.h"
+#include <algorithm>
 #include <array>
+#include <cstdlib>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 // What kind of a relation does this entry have with this quest.
 entryQuestRelationMap EntryQuestRelationMapValue::Calculate()
@@ -117,6 +128,709 @@ questGuidpMap QuestGuidpMapValue::Calculate()
         worker(itr.second);
 
     return worker.GetResult();
+}
+
+// entry -> mapId -> positions.
+static std::unordered_map<int32, std::unordered_map<uint32, std::vector<GuidPosition>>> g_entrySpawns;
+
+// questId -> objective flag -> the entries that satisfy it.
+static std::unordered_map<uint32, std::unordered_map<uint32, std::vector<int32>>> g_questObjectiveEntries;
+
+// questId -> the entries it turns in at.
+static std::unordered_map<uint32, std::vector<int32>> g_questEnderEntries;
+
+// Above this an item objective is a world drop: no useful nearest spawn to walk to.
+static constexpr size_t MAX_ITEM_OBJECTIVE_SPAWNS = 500;
+
+// questId -> pre-transform creature entries (see GetQuestTransformSources).
+static std::unordered_map<uint32, std::unordered_set<uint32>> g_questTransformSources;
+
+// questId -> per-objective summon anchor (see GetQuestSummonAnchor).
+static std::unordered_map<uint32, std::array<QuestSummonAnchor, QUEST_OBJECTIVES_COUNT>> g_questSummonAnchors;
+
+// questId -> per-objective creatures the bot must kill (see GetQuestKillSources).
+static std::unordered_map<uint32, std::array<std::vector<uint32>, QUEST_OBJECTIVES_COUNT>> g_questKillSources;
+
+// questId -> everything the provided item consumes per use (see GetQuestItemReagents).
+static std::unordered_map<uint32, std::vector<QuestCraftReagent>> g_questItemReagents;
+
+// How many casts' worth of reagent the bot keeps stocked.
+static constexpr uint32 REAGENT_STOCK_CASTS = 5;
+
+// questId -> per item-objective reagents its required item is crafted from (GetQuestCraftReagents).
+static std::unordered_map<uint32, std::array<std::vector<QuestCraftReagent>, QUEST_ITEM_OBJECTIVES_COUNT>>
+    g_questCraftReagents;
+
+// questId -> per item-objective, the item whose on-use spell does the crafting. Resolved at
+// index time: the reagents alone do not name it, and a quest with no StartItem keeps it on a
+// looted ItemDrop.
+static std::unordered_map<uint32, std::array<uint32, QUEST_ITEM_OBJECTIVES_COUNT>> g_questCraftItems;
+
+static uint32 GetItemSpell(uint32 itemId)
+{
+    ItemTemplate const* proto = itemId ? sObjectMgr->GetItemTemplate(itemId) : nullptr;
+    if (!proto)
+        return 0;
+
+    for (auto const& spell : proto->Spells)
+        if (spell.SpellId > 0)
+            return spell.SpellId;
+
+    return 0;
+}
+
+static uint32 GetSrcItemSpell(Quest const* quest) { return GetItemSpell(quest->GetSrcItemId()); }
+
+// spell -> [(pre-transform entry, post-transform entry)] from SmartAI
+// SMART_EVENT_SPELLHIT (8) -> SMART_ACTION_UPDATE_TEMPLATE (36).
+static std::unordered_map<uint32, std::vector<std::pair<uint32, uint32>>> LoadSpellTransforms()
+{
+    std::unordered_map<uint32, std::vector<std::pair<uint32, uint32>>> transforms;
+    QueryResult result = WorldDatabase.Query(
+        "SELECT entryorguid, event_param1, action_param1 FROM smart_scripts "
+        "WHERE source_type = 0 AND event_type = 8 AND action_type = 36 "
+        "AND entryorguid > 0 AND event_param1 > 0 AND action_param1 > 0");
+    if (!result)
+        return transforms;
+
+    do
+    {
+        Field* fields = result->Fetch();
+        transforms[fields[1].Get<uint32>()].emplace_back(fields[0].Get<uint32>(), fields[2].Get<uint32>());
+    } while (result->NextRow());
+
+    return transforms;
+}
+
+// Creature proximity hints from SmartAI, keyed by the summoned trigger. SMART_TARGET_CLOSEST_
+// CREATURE is how a trigger finds the NPC that reacts to it, and how an NPC finds the trigger,
+// so either direction names a creature the item has to be used next to.
+static std::unordered_map<uint32, std::vector<uint32>> LoadSmartAnchorHints(
+    std::unordered_map<uint32, std::vector<uint32>>& deathAnchors)
+{
+    std::unordered_map<uint32, std::vector<uint32>> hints;
+    QueryResult result = WorldDatabase.Query(
+        "SELECT entryorguid, target_param1, event_type FROM smart_scripts "
+        "WHERE source_type = 0 AND target_type = 19 AND entryorguid > 0 AND target_param1 > 0 "
+        "AND entryorguid <> target_param1");
+    if (!result)
+        return hints;
+
+    do
+    {
+        Field* fields = result->Fetch();
+        uint32 const owner = fields[0].Get<uint32>();
+        uint32 const target = fields[1].Get<uint32>();
+        hints[owner].push_back(target);  // the trigger looks for its reactor
+        hints[target].push_back(owner);  // the reactor looks for the trigger
+
+        // A reactor that reaches for the trigger from its own death event only credits once it
+        // dies, making it a kill target as much as an anchor.
+        if (fields[2].Get<uint32>() == SMART_EVENT_DEATH)
+            deathAnchors[target].push_back(owner);
+    } while (result->NextRow());
+
+    return hints;
+}
+
+static uint32 SpellKillCreditEntry(uint32 spellId)
+{
+    SpellInfo const* info = sSpellMgr->GetSpellInfo(spellId);
+    if (!info)
+        return 0;
+
+    for (uint8 e = 0; e < MAX_SPELL_EFFECTS; ++e)
+        if ((info->Effects[e].Effect == SPELL_EFFECT_KILL_CREDIT ||
+             info->Effects[e].Effect == SPELL_EFFECT_KILL_CREDIT2) &&
+            info->Effects[e].MiscValue > 0)
+            return uint32(info->Effects[e].MiscValue);
+
+    return 0;
+}
+
+static uint32 SpellSummonEntry(uint32 spellId)
+{
+    SpellInfo const* info = sSpellMgr->GetSpellInfo(spellId);
+    if (!info)
+        return 0;
+
+    for (uint8 e = 0; e < MAX_SPELL_EFFECTS; ++e)
+        if (info->Effects[e].Effect == SPELL_EFFECT_SUMMON && info->Effects[e].MiscValue > 0)
+            return uint32(info->Effects[e].MiscValue);
+
+    return 0;
+}
+
+// objective creature entry -> the creatures to kill for it to progress. A quest wires that up
+// three ways, all meaning "kill this one instead": the creature hands the credit over directly,
+// it casts a credit spell, or it casts a spell that summons the objective (which is only
+// creditable once it exists). Resolved through sSpellMgr, since many of those spells are
+// server-side and absent from Spell.dbc.
+static std::unordered_map<uint32, std::vector<uint32>> LoadObjectiveKillSources()
+{
+    std::unordered_map<uint32, std::vector<uint32>> sources;
+    QueryResult result = WorldDatabase.Query(
+        "SELECT entryorguid, action_type, action_param1 FROM smart_scripts "
+        "WHERE source_type = 0 AND action_type IN (11, 33) AND entryorguid > 0 "
+        "AND action_param1 > 0");
+    if (!result)
+        return sources;
+
+    do
+    {
+        Field* fields = result->Fetch();
+        uint32 const owner = fields[0].Get<uint32>();
+        uint32 const param = fields[2].Get<uint32>();
+
+        uint32 wanted = 0;
+        if (fields[1].Get<uint32>() == 33)
+            wanted = param;
+        else if (uint32 credited = SpellKillCreditEntry(param))
+            wanted = credited;
+        else
+            wanted = SpellSummonEntry(param);
+
+        if (wanted && wanted != owner)
+            sources[wanted].push_back(owner);
+    } while (result->NextRow());
+
+    return sources;
+}
+
+// The reagent a spell consumes to create `itemId`, if that is what it does. When a required
+// item drops nowhere, the reagent is what the bot actually has to farm.
+static bool SpellCraftsItem(uint32 spellId, uint32 itemId, std::vector<QuestCraftReagent>& reagents)
+{
+    SpellInfo const* info = sSpellMgr->GetSpellInfo(spellId);
+    if (!info)
+        return false;
+
+    bool creates = false;
+    for (uint8 e = 0; e < MAX_SPELL_EFFECTS; ++e)
+        if (info->Effects[e].Effect == SPELL_EFFECT_CREATE_ITEM && info->Effects[e].ItemType == itemId)
+            creates = true;
+
+    if (!creates)
+        return false;
+
+    for (uint8 r = 0; r < MAX_SPELL_REAGENTS; ++r)
+        if (info->Reagent[r] > 0 && info->ReagentCount[r] > 0)
+            reagents.push_back({ uint32(info->Reagent[r]), info->ReagentCount[r] });
+
+    return !reagents.empty();
+}
+
+// What has to be gathered to make `itemId`, when a quest hands out no such item directly.
+// Returns the item carrying the crafting spell - the provided item, or one of the quest's own
+// ItemDrops when there is no StartItem - and fills `reagents`. 0 if nothing crafts `itemId`.
+static uint32 FindCraftReagents(Quest const* quest, uint32 itemId, std::vector<QuestCraftReagent>& reagents)
+{
+    if (SpellCraftsItem(GetItemSpell(quest->GetSrcItemId()), itemId, reagents))
+        return quest->GetSrcItemId();
+
+    for (uint8 i = 0; i < QUEST_SOURCE_ITEM_IDS_COUNT; ++i)
+        if (SpellCraftsItem(GetItemSpell(quest->ItemDrop[i]), itemId, reagents))
+            return quest->ItemDrop[i];
+
+    return 0;
+}
+
+// The creature entry named by a CONDITION_NEAR_CREATURE on a spell, 0 if it has none. The
+// explicit form of the same "use it next to this" rule the SmartAI hints imply.
+static std::unordered_map<uint32, uint32> LoadSpellNearCreature()
+{
+    std::unordered_map<uint32, uint32> nearCreature;
+    QueryResult result = WorldDatabase.Query(
+        "SELECT SourceEntry, ConditionValue1 FROM conditions "
+        "WHERE SourceTypeOrReferenceId = 17 AND ConditionTypeOrReference = 29 "
+        "AND NegativeCondition = 0 AND ConditionValue1 > 0");
+    if (!result)
+        return nearCreature;
+
+    do
+    {
+        Field* fields = result->Fetch();
+        nearCreature[fields[0].Get<uint32>()] = fields[1].Get<uint32>();
+    } while (result->NextRow());
+
+    return nearCreature;
+}
+
+static void CollectWantedDrops(LootTemplateAccess const* loot, std::unordered_set<uint32> const& wanted, int32 entry,
+                               std::unordered_map<uint32, std::vector<int32>>& dropSources, uint32 depth = 0)
+{
+    // References nest a level or two in practice; the guard is only against a cyclic table.
+    if (!loot || depth > 3)
+        return;
+
+    for (auto const& item : loot->Entries)
+    {
+        // Signed, and negative rows are ordinary references in the shipped tables - the core
+        // itself only ever tests the field for zero and takes its absolute value.
+        if (item->reference)
+        {
+            CollectWantedDrops(reinterpret_cast<LootTemplateAccess const*>(
+                                   LootTemplates_Reference.GetLootFor(uint32(std::abs(item->reference)))),
+                               wanted, entry, dropSources, depth + 1);
+            continue;
+        }
+
+        if (wanted.count(item->itemid))
+            dropSources[item->itemid].push_back(entry);
+    }
+}
+
+// Collect the spawn positions of every wanted entry, once each. entry: negative = gameobject.
+static void FileSpawnPositions(std::unordered_map<int32, std::vector<std::pair<uint32, uint32>>> const& entryMap)
+{
+    for (auto const& [spawnId, creData] : sObjectMgr->GetAllCreatureData())
+    {
+        // A point whose base and alternate are both wanted is filed under each of them - it
+        // can serve either, depending on what the respawn rolled.
+        for (uint32 entry : SpawnEntries(creData))
+        {
+            if (entry && entryMap.count(int32(entry)))
+                g_entrySpawns[int32(entry)][creData.mapid].push_back(GuidPosition(creData));
+        }
+    }
+
+    for (auto const& [spawnId, goData] : sObjectMgr->GetAllGOData())
+    {
+        if (entryMap.count(-int32(goData.id)))
+            g_entrySpawns[-int32(goData.id)][goData.mapid].push_back(GuidPosition(goData));
+    }
+}
+
+// Total spawns of an entry across every map.
+static size_t GetEntrySpawnCount(int32 entry)
+{
+    auto it = g_entrySpawns.find(entry);
+    if (it == g_entrySpawns.end())
+        return 0;
+
+    size_t total = 0;
+    for (auto const& [mapId, positions] : it->second)
+        total += positions.size();
+
+    return total;
+}
+
+// Attach the wanted entries to their quest objectives, dropping world-drop item objectives.
+static void FileObjectiveEntries(std::unordered_map<int32, std::vector<std::pair<uint32, uint32>>> const& entryMap)
+{
+    uint32 constexpr firstItemFlag = 1u << QUEST_OBJECTIVES_COUNT;
+
+    // One entry can reach the same objective by more than one route - two reagents of the same
+    // craft, an anchor that also drops, several transform pairs.
+    std::unordered_map<int32, std::vector<std::pair<uint32, uint32>>> spawned;
+    for (auto const& [entry, wants] : entryMap)
+    {
+        if (!g_entrySpawns.count(entry))
+            continue;
+
+        std::vector<std::pair<uint32, uint32>> objectives = wants;
+        std::sort(objectives.begin(), objectives.end());
+        objectives.erase(std::unique(objectives.begin(), objectives.end()), objectives.end());
+        spawned.emplace(entry, std::move(objectives));
+    }
+
+    // Sum per (quest, flag) first: the cap is about how scattered the objective is overall,
+    // not about any single dropper.
+    std::unordered_map<uint32, std::unordered_map<uint32, size_t>> spawnTotals;
+    for (auto const& [entry, wants] : spawned)
+        for (auto const& [questId, flag] : wants)
+            spawnTotals[questId][flag] += GetEntrySpawnCount(entry);
+
+    for (auto const& [entry, wants] : spawned)
+    {
+        for (auto const& [questId, flag] : wants)
+        {
+            if (flag >= firstItemFlag && spawnTotals[questId][flag] > MAX_ITEM_OBJECTIVE_SPAWNS)
+                continue;
+
+            g_questObjectiveEntries[questId][flag].push_back(entry);
+        }
+    }
+}
+
+void BuildQuestObjectiveSpawns()
+{
+    // Appends to the globals below, so a second call would double every spawn vector.
+    if (!g_entrySpawns.empty())
+        return;
+
+    // entry (negative = gameobject) -> the quests/objectives wanting it
+    std::unordered_map<int32, std::vector<std::pair<uint32, uint32>>> entryMap;
+    std::unordered_set<uint32> questItems;
+
+    // Quest enders. Keyed with an empty want-list: FileSpawnPositions collects their spawn
+    // points, FileObjectiveEntries has nothing to file them under.
+    for (auto const& [entry, questId] : *sObjectMgr->GetCreatureQuestInvolvedRelationMap())
+    {
+        g_questEnderEntries[questId].push_back(int32(entry));
+        entryMap[int32(entry)];
+    }
+
+    for (auto const& [entry, questId] : *sObjectMgr->GetGOQuestInvolvedRelationMap())
+    {
+        g_questEnderEntries[questId].push_back(-int32(entry));
+        entryMap[-int32(entry)];
+    }
+    for (auto const& [questId, quest] : sObjectMgr->GetQuestTemplates())
+    {
+        for (uint32 idx = 0; idx < QUEST_OBJECTIVES_COUNT; ++idx)
+        {
+            int32 const entry = quest->RequiredNpcOrGo[idx];
+            if (entry && quest->RequiredNpcOrGoCount[idx])
+                entryMap[entry].emplace_back(questId, 1u << idx);
+        }
+
+        uint32 const srcSpellId = GetSrcItemSpell(quest);
+
+        // Whatever the provided item consumes per use.
+        if (SpellInfo const* srcSpell = sSpellMgr->GetSpellInfo(srcSpellId))
+            for (uint8 r = 0; r < MAX_SPELL_REAGENTS; ++r)
+                if (srcSpell->Reagent[r] > 0 && srcSpell->ReagentCount[r] > 0)
+                    g_questItemReagents[questId].push_back(
+                        { uint32(srcSpell->Reagent[r]), srcSpell->ReagentCount[r] });
+
+        for (uint32 i = 0; i < QUEST_ITEM_OBJECTIVES_COUNT; ++i)
+        {
+            if (!quest->RequiredItemId[i] || !quest->RequiredItemCount[i])
+                continue;
+
+            questItems.insert(quest->RequiredItemId[i]);
+
+            // Craft objectives: the required item is made, not looted, so the reagents are what
+            // the loot walk below has to resolve to droppers.
+            std::vector<QuestCraftReagent> reagents;
+            uint32 const crafter = FindCraftReagents(quest, quest->RequiredItemId[i], reagents);
+            if (reagents.empty())
+                continue;
+
+            for (QuestCraftReagent const& reagent : reagents)
+                questItems.insert(reagent.item);
+
+            // The carrier is looted like any reagent when the quest provides no StartItem.
+            questItems.insert(crafter);
+
+            g_questCraftReagents[questId][i] = std::move(reagents);
+            g_questCraftItems[questId][i] = crafter;
+        }
+    }
+
+    // Item objectives name no source entry, so walk the loot tables once to
+    // find who drops them.
+    std::unordered_map<uint32, std::vector<int32>> dropSources;
+    if (!questItems.empty())
+    {
+        if (CreatureTemplateContainer const* creatures = sObjectMgr->GetCreatureTemplates())
+        {
+            for (auto const& [entry, tmpl] : *creatures)
+                CollectWantedDrops(DropMapValue::GetLootTemplate(
+                                       ObjectGuid::Create<HighGuid::Unit>(entry, uint32(1)), LOOT_CORPSE),
+                                   questItems, int32(entry), dropSources);
+        }
+
+        if (GameObjectTemplateContainer const* gos = sObjectMgr->GetGameObjectTemplates())
+        {
+            for (auto const& [entry, tmpl] : *gos)
+                CollectWantedDrops(DropMapValue::GetLootTemplate(
+                                       ObjectGuid::Create<HighGuid::GameObject>(entry, uint32(1)), LOOT_CORPSE),
+                                   questItems, -int32(entry), dropSources);
+        }
+    }
+
+    // Creatures that actually have a spawn row - a drop source with none is unreachable
+    // unless something puts it into the world (see the transform substitution below).
+    std::unordered_set<uint32> spawnedEntries;
+    for (auto const& [spawnId, creData] : sObjectMgr->GetAllCreatureData())
+        for (uint32 entry : SpawnEntries(creData))
+            if (entry)
+                spawnedEntries.insert(entry);
+
+    auto const spellTransforms = LoadSpellTransforms();
+
+    // Anchors for objectives whose mob has no spawn row at all: the quest item conjures it
+    // beside a spell focus or a creature, or it is only a marker something else credits.
+    std::unordered_map<uint32, std::vector<uint32>> focusObjects;
+    if (GameObjectTemplateContainer const* gos = sObjectMgr->GetGameObjectTemplates())
+        for (auto const& [goEntry, goInfo] : *gos)
+            if (goInfo.type == GAMEOBJECT_TYPE_SPELL_FOCUS && goInfo.spellFocus.focusId)
+                focusObjects[goInfo.spellFocus.focusId].push_back(goEntry);
+
+    std::unordered_map<uint32, std::vector<uint32>> deathAnchors;
+    auto const smartAnchorHints = LoadSmartAnchorHints(deathAnchors);
+    auto const objectiveKillSources = LoadObjectiveKillSources();
+    auto const spellNearCreature = LoadSpellNearCreature();
+
+    // Item objectives live at index QUEST_OBJECTIVES_COUNT + i, matching objectiveIdx in
+    // NewRpgInfo::DoQuest; creature objectives keep their own index.
+    for (auto const& [questId, quest] : sObjectMgr->GetQuestTemplates())
+    {
+        uint32 const srcSpellId = GetSrcItemSpell(quest);
+        SpellInfo const* srcSpell = sSpellMgr->GetSpellInfo(srcSpellId);
+        auto const craftIt = g_questCraftReagents.find(questId);
+
+        for (uint32 i = 0; i < QUEST_ITEM_OBJECTIVES_COUNT; ++i)
+        {
+            if (!quest->RequiredItemId[i] || !quest->RequiredItemCount[i])
+                continue;
+
+            // A craft objective's required item is looted from nothing; walk the bot to the
+            // reagents' droppers instead.
+            std::vector<uint32> wanted{ quest->RequiredItemId[i] };
+            if (craftIt != g_questCraftReagents.end() && !craftIt->second[i].empty())
+            {
+                wanted.clear();
+                for (QuestCraftReagent const& reagent : craftIt->second[i])
+                    wanted.push_back(reagent.item);
+
+                // The item carrying the crafting spell is farmed like a reagent when the
+                // quest hands out no StartItem, so its droppers have to be walkable too.
+                if (uint32 const crafter = GetQuestCraftItem(questId, i);
+                    crafter && crafter != quest->GetSrcItemId())
+                    wanted.push_back(crafter);
+            }
+
+            uint32 const flag = 1u << (QUEST_OBJECTIVES_COUNT + i);
+            for (uint32 wantedItem : wanted)
+            {
+                auto src = dropSources.find(wantedItem);
+                if (src == dropSources.end())
+                    continue;
+
+                for (int32 entry : src->second)
+                {
+                    // A drop source with no spawn row exists only as the result of a SmartAI
+                    // transform: the quest's own provided item is used on a creature that does
+                    // spawn and turns it into this one. Index the pre-transform creature so the
+                    // bot has somewhere to walk to.
+                    if (entry > 0 && !spawnedEntries.count(uint32(entry)))
+                    {
+                        auto tf = spellTransforms.find(srcSpellId);
+                        if (tf == spellTransforms.end())
+                            continue;
+
+                        for (auto const& [pre, post] : tf->second)
+                        {
+                            if (post != uint32(entry) || !spawnedEntries.count(pre))
+                                continue;
+
+                            entryMap[int32(pre)].emplace_back(questId, flag);
+                            g_questTransformSources[questId].insert(pre);
+                        }
+                        continue;
+                    }
+
+                    entryMap[entry].emplace_back(questId, flag);
+                }
+            }
+        }
+
+        for (uint32 idx = 0; idx < QUEST_OBJECTIVES_COUNT; ++idx)
+        {
+            int32 const entry = quest->RequiredNpcOrGo[idx];
+            if (entry <= 0 || !quest->RequiredNpcOrGoCount[idx])
+                continue;
+
+            uint32 const flag = 1u << idx;
+            bool const objectiveSpawned = spawnedEntries.count(uint32(entry)) != 0;
+
+            // Real creatures standing in for the objective: ordinary kill targets, so index
+            // them and let the scan engage them.
+            std::vector<uint32> credits;
+            if (!objectiveSpawned)
+            {
+                auto addCredit = [&credits, &spawnedEntries](uint32 source)
+                {
+                    if (spawnedEntries.count(source) &&
+                        std::find(credits.begin(), credits.end(), source) == credits.end())
+                        credits.push_back(source);
+                };
+
+                if (auto it = objectiveKillSources.find(uint32(entry)); it != objectiveKillSources.end())
+                    for (uint32 source : it->second)
+                        addCredit(source);
+
+                // A reactor that only acts on the trigger when it dies has to be killed, so it
+                // belongs in the scan's target set even though nothing names it a credit source.
+                if (auto it = deathAnchors.find(uint32(entry)); it != deathAnchors.end())
+                    for (uint32 source : it->second)
+                        addCredit(source);
+
+                for (uint32 source : credits)
+                    entryMap[int32(source)].emplace_back(questId, flag);
+
+                if (!credits.empty())
+                    g_questKillSources[questId][idx] = credits;
+            }
+
+            if (!srcSpell)
+                continue;
+
+            bool summoned = false;
+            for (uint8 e = 0; e < MAX_SPELL_EFFECTS; ++e)
+                if (srcSpell->Effects[e].Effect == SPELL_EFFECT_SUMMON &&
+                    srcSpell->Effects[e].MiscValue == entry)
+                    summoned = true;
+
+            // Spell focus wins: it is the only anchor the core itself enforces, and it applies
+            // whether or not the item is what puts the objective in the world - a spawned
+            // objective can still need the item used at a focus to credit it.
+            if (srcSpell->RequiresSpellFocus)
+            {
+                g_questSummonAnchors[questId][idx].focusId = srcSpell->RequiresSpellFocus;
+                g_questSummonAnchors[questId][idx].summonsObjective = summoned;
+                if (!objectiveSpawned)
+                    for (uint32 goEntry : focusObjects[srcSpell->RequiresSpellFocus])
+                        entryMap[-int32(goEntry)].emplace_back(questId, flag);
+                continue;
+            }
+
+            if (!summoned || objectiveSpawned)
+                continue;
+
+            // Otherwise a creature anchor, most explicit source first. A kill source doubles as
+            // one: whatever grants the credit is by definition what the summon has to be beside.
+            uint32 anchor = 0;
+            if (auto it = spellNearCreature.find(srcSpellId);
+                it != spellNearCreature.end() && spawnedEntries.count(it->second))
+                anchor = it->second;
+
+            if (!anchor)
+                if (auto it = smartAnchorHints.find(uint32(entry)); it != smartAnchorHints.end())
+                    for (uint32 hint : it->second)
+                        if (spawnedEntries.count(hint))
+                        {
+                            anchor = hint;
+                            break;
+                        }
+
+            if (!anchor && !credits.empty())
+                anchor = credits.front();
+
+            if (!anchor)
+                continue;
+
+            bool const killAnchor = std::find(credits.begin(), credits.end(), anchor) != credits.end();
+            g_questSummonAnchors[questId][idx].creature = anchor;
+            g_questSummonAnchors[questId][idx].killAnchor = killAnchor;
+            g_questSummonAnchors[questId][idx].summonsObjective = true;
+            if (!killAnchor)
+                entryMap[int32(anchor)].emplace_back(questId, flag);
+        }
+    }
+
+    FileSpawnPositions(entryMap);
+    FileObjectiveEntries(entryMap);
+}
+
+std::vector<int32> const& GetQuestObjectiveEntries(uint32 questId, uint32 objectiveFlag)
+{
+    static std::vector<int32> const empty;
+    auto quest = g_questObjectiveEntries.find(questId);
+    if (quest == g_questObjectiveEntries.end())
+        return empty;
+
+    auto flag = quest->second.find(objectiveFlag);
+    return flag != quest->second.end() ? flag->second : empty;
+}
+
+std::vector<GuidPosition> const& GetEntrySpawns(int32 entry, uint32 mapId)
+{
+    static std::vector<GuidPosition> const empty;
+    auto it = g_entrySpawns.find(entry);
+    if (it == g_entrySpawns.end())
+        return empty;
+
+    auto onMap = it->second.find(mapId);
+    return onMap != it->second.end() ? onMap->second : empty;
+}
+
+std::vector<int32> const& GetQuestEnderEntries(uint32 questId)
+{
+    static std::vector<int32> const empty;
+    auto it = g_questEnderEntries.find(questId);
+    return it != g_questEnderEntries.end() ? it->second : empty;
+}
+
+std::unordered_set<uint32> const& GetQuestTransformSources(uint32 questId)
+{
+    static std::unordered_set<uint32> const empty;
+    auto it = g_questTransformSources.find(questId);
+    return it != g_questTransformSources.end() ? it->second : empty;
+}
+
+QuestSummonAnchor GetQuestSummonAnchor(uint32 questId, uint32 objectiveIdx)
+{
+    if (objectiveIdx >= QUEST_OBJECTIVES_COUNT)
+        return {};
+
+    auto it = g_questSummonAnchors.find(questId);
+    return it != g_questSummonAnchors.end() ? it->second[objectiveIdx] : QuestSummonAnchor{};
+}
+
+std::vector<QuestCraftReagent> const& GetQuestItemReagents(uint32 questId)
+{
+    static std::vector<QuestCraftReagent> const empty;
+    auto it = g_questItemReagents.find(questId);
+    return it != g_questItemReagents.end() ? it->second : empty;
+}
+
+bool IsQuestExtraItemWanted(Player* bot, Quest const* quest, uint32 itemId)
+{
+    if (!bot || !quest || !itemId)
+        return false;
+
+    for (uint8 i = 0; i < QUEST_SOURCE_ITEM_IDS_COUNT; ++i)
+    {
+        if (quest->ItemDrop[i] != itemId)
+            continue;
+
+        uint32 const need = quest->ItemDropQuantity[i];
+        return !need || bot->GetItemCount(itemId, false) < need;
+    }
+
+    for (QuestCraftReagent const& reagent : GetQuestItemReagents(quest->GetQuestId()))
+    {
+        if (reagent.item != itemId)
+            continue;
+
+        // Spent per use, so hold a buffer instead of a single cast's worth.
+        return bot->GetItemCount(itemId, false) < reagent.count * REAGENT_STOCK_CASTS;
+    }
+
+    return false;
+}
+
+std::vector<QuestCraftReagent> const& GetQuestCraftReagents(uint32 questId, uint32 itemObjectiveIdx)
+{
+    static std::vector<QuestCraftReagent> const empty;
+    if (itemObjectiveIdx >= QUEST_ITEM_OBJECTIVES_COUNT)
+        return empty;
+
+    auto it = g_questCraftReagents.find(questId);
+    return it != g_questCraftReagents.end() ? it->second[itemObjectiveIdx] : empty;
+}
+
+uint32 GetQuestCraftItem(uint32 questId, uint32 itemObjectiveIdx)
+{
+    if (itemObjectiveIdx >= QUEST_ITEM_OBJECTIVES_COUNT)
+        return 0;
+
+    auto it = g_questCraftItems.find(questId);
+    return it != g_questCraftItems.end() ? it->second[itemObjectiveIdx] : 0;
+}
+
+std::vector<uint32> const& GetQuestKillSources(uint32 questId, uint32 objectiveIdx)
+{
+    static std::vector<uint32> const empty;
+    if (objectiveIdx >= QUEST_OBJECTIVES_COUNT)
+        return empty;
+
+    auto it = g_questKillSources.find(questId);
+    return it != g_questKillSources.end() ? it->second[objectiveIdx] : empty;
 }
 
 // Selects all questgivers for a specific level (range).

--- a/src/Ai/Base/Value/QuestValues.h
+++ b/src/Ai/Base/Value/QuestValues.h
@@ -7,6 +7,9 @@
 #ifndef PLAYERBOTS_QUESTVALUES_H
 #define PLAYERBOTS_QUESTVALUES_H
 
+#include <unordered_set>
+#include <vector>
+
 #include "NamedObjectContext.h"
 #include "TravelMgr.h"
 #include "Value.h"
@@ -92,6 +95,69 @@ public:
 
     questGiverMap Calculate() override;
 };
+
+// Quest objective spawn index.
+// Everything below is built by BuildQuestObjectiveSpawns and read-only afterwards.
+
+// Single-threaded, before any bot reads it.
+void BuildQuestObjectiveSpawns();
+
+// Entries satisfying one objective of a quest, keyed by objective bit (objective1..4, then
+// item objectives at QUEST_OBJECTIVES_COUNT + i). Negative = gameobject. Empty if the quest
+// has none.
+std::vector<int32> const& GetQuestObjectiveEntries(uint32 questId, uint32 objectiveFlag);
+
+// Spawn positions of one entry on one map.
+std::vector<GuidPosition> const& GetEntrySpawns(int32 entry, uint32 mapId);
+
+// Creatures and gameobjects the quest turns in at. Negative = gameobject.
+std::vector<int32> const& GetQuestEnderEntries(uint32 questId);
+
+// Creature entries this quest's provided item transforms into the creature that carries a
+// required drop (SmartAI SPELLHIT -> UPDATE_TEMPLATE). Empty for the vast majority of quests.
+std::unordered_set<uint32> const& GetQuestTransformSources(uint32 questId);
+
+// Where an objective mob with no spawn row has to be conjured with the quest's provided item:
+// beside a spell-focus gameobject, which the core enforces, or beside a creature, which only the
+// summoned trigger's own script enforces. Both zero for an ordinary objective.
+struct QuestSummonAnchor
+{
+    uint32 focusId{0};
+    uint32 creature{0};
+    // The anchor is also the kill target, so the item has to land before the fight starts.
+    bool killAnchor{false};
+    // The item's spell summons the objective itself. When it does not, the objective is an
+    // ordinary spawned mob and its presence must not suppress a re-use.
+    bool summonsObjective{false};
+};
+
+QuestSummonAnchor GetQuestSummonAnchor(uint32 questId, uint32 objectiveIdx);
+
+// Spawned creatures to kill for this objective when the entry the quest names is not killable
+// itself: a credit marker some other mob credits on death, or one that does not exist until a
+// mob summons it. Empty for an ordinary objective.
+std::vector<uint32> const& GetQuestKillSources(uint32 questId, uint32 objectiveIdx);
+
+// Reagents a craft objective's required item is made from, when that item drops nowhere. Empty
+// for an ordinary looted objective. Indexed by item objective, not by objectiveIdx.
+struct QuestCraftReagent
+{
+    uint32 item{0};
+    uint32 count{0};
+};
+
+std::vector<QuestCraftReagent> const& GetQuestCraftReagents(uint32 questId, uint32 itemObjectiveIdx);
+
+// The item whose on-use spell crafts this objective's required item. 0 if it is not a craft
+// objective. The reagents do not name it: it is only the carrier when it consumes itself.
+uint32 GetQuestCraftItem(uint32 questId, uint32 itemObjectiveIdx);
+
+// Reagents the quest's provided item consumes per use. Empty if it consumes nothing.
+std::vector<QuestCraftReagent> const& GetQuestItemReagents(uint32 questId);
+
+// True while the bot still wants `itemId` for `quest` on grounds RequiredItemId does not cover:
+// a quest-only ItemDrop, or a reagent the provided item spends.
+bool IsQuestExtraItemWanted(Player* bot, Quest const* quest, uint32 itemId);
 
 // All questgivers that have a quest for the bot.
 class ActiveQuestGiversValue : public CalculatedValue<std::vector<GuidPosition>>

--- a/src/Ai/World/Rpg/Action/NewRpgAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.cpp
@@ -211,30 +211,28 @@ bool TellRpgStatusAction::Execute(Event event)
     return false;
 }
 
-bool StartRpgDoQuestAction::Execute(Event event)
-{
-    Player* owner = event.getOwner();
-    if (!owner)
-        return false;
-
-    std::string const text = event.getParam();
-    PlayerbotChatHandler ch(owner);
-    uint32 questId = ch.extractQuestId(text);
-    Quest const* quest = sObjectMgr->GetQuestTemplate(questId);
-    if (quest)
-    {
-        botAI->rpgInfo.ChangeToDoQuest(questId, quest);
-        bot->Whisper("Start to do quest " + std::to_string(questId), LANG_UNIVERSAL, owner);
-        return true;
-    }
-    bot->Whisper("Invalid quest " + text, LANG_UNIVERSAL, owner);
-    return false;
-}
-
 bool NewRpgStatusUpdateAction::Execute(Event /*event*/)
 {
     NewRpgInfo& info = botAI->rpgInfo;
     NewRpgStatus status = info.GetStatus();
+
+    // Grinding pulls the bot onto random XP mobs instead of the objective, so RPG_DO_QUEST runs
+    // without it - except in the POI fallback.
+    auto const* doQuest = std::get_if<NewRpgInfo::DoQuest>(&info.data);
+    if (doQuest && !doQuest->poiFallback)
+    {
+        if (botAI->HasStrategy("grind", BOT_STATE_NON_COMBAT))
+        {
+            botAI->ChangeStrategy("-grind", BOT_STATE_NON_COMBAT);
+            info.grindSuppressed = true;
+        }
+    }
+    else if (info.grindSuppressed)
+    {
+        botAI->ChangeStrategy("+grind", BOT_STATE_NON_COMBAT);
+        info.grindSuppressed = false;
+    }
+
     switch (status)
     {
         case RPG_IDLE:
@@ -422,214 +420,6 @@ bool NewRpgWanderNpcAction::Execute(Event /*event*/)
     }
 
     return true;
-}
-
-bool NewRpgDoQuestAction::Execute(Event /*event*/)
-{
-    if (SearchQuestGiverAndAcceptOrReward())
-        return true;
-
-    NewRpgInfo& info = botAI->rpgInfo;
-    auto* dataPtr = std::get_if<NewRpgInfo::DoQuest>(&info.data);
-    if (!dataPtr)
-        return false;
-    auto& data = *dataPtr;
-    uint32 questId = data.questId;
-    uint8 questStatus = bot->GetQuestStatus(questId);
-    switch (questStatus)
-    {
-        case QUEST_STATUS_INCOMPLETE:
-            return DoIncompleteQuest(data);
-        case QUEST_STATUS_COMPLETE:
-            return DoCompletedQuest(data);
-        default:
-            break;
-    }
-    info.ChangeToIdle();
-    return true;
-}
-
-bool NewRpgDoQuestAction::DoIncompleteQuest(NewRpgInfo::DoQuest& data)
-{
-    uint32 questId = data.questId;
-    if (data.pos != WorldPosition())
-    {
-        /// @TODO: extract to a new function
-        int32 currentObjective = data.objectiveIdx;
-        // check if the objective has completed
-        Quest const* quest = sObjectMgr->GetQuestTemplate(questId);
-        QuestStatusData const& q_status = bot->getQuestStatusMap().at(questId);
-        bool completed = true;
-        if (currentObjective < QUEST_OBJECTIVES_COUNT)
-        {
-            if (q_status.CreatureOrGOCount[currentObjective] < quest->RequiredNpcOrGoCount[currentObjective])
-                completed = false;
-        }
-        else if (currentObjective < QUEST_OBJECTIVES_COUNT + QUEST_ITEM_OBJECTIVES_COUNT)
-        {
-            if (q_status.ItemCount[currentObjective - QUEST_OBJECTIVES_COUNT] <
-                quest->RequiredItemCount[currentObjective - QUEST_OBJECTIVES_COUNT])
-                completed = false;
-        }
-        // the current objective is completed, clear and find a new objective later
-        if (completed)
-        {
-            data.lastReachPOI = 0;
-            data.pos = WorldPosition();
-            data.objectiveIdx = 0;
-        }
-    }
-    if (data.pos == WorldPosition())
-    {
-        std::vector<POIInfo> poiInfo;
-        if (!GetQuestPOIPosAndObjectiveIdx(questId, poiInfo))
-        {
-            // can't find a poi pos to go, stop doing quest for now
-            botAI->rpgInfo.ChangeToIdle();
-            return true;
-        }
-        uint32 rndIdx = urand(0, poiInfo.size() - 1);
-        G3D::Vector2 nearestPoi = poiInfo[rndIdx].pos;
-        int32 objectiveIdx = poiInfo[rndIdx].objectiveIdx;
-
-        float dx = nearestPoi.x, dy = nearestPoi.y;
-
-        // z = MAX_HEIGHT as we do not know accurate z
-        float dz = std::max(bot->GetMap()->GetHeight(dx, dy, MAX_HEIGHT), bot->GetMap()->GetWaterLevel(dx, dy));
-
-        // double check for GetQuestPOIPosAndObjectiveIdx
-        if (dz == INVALID_HEIGHT || dz == VMAP_INVALID_HEIGHT_VALUE)
-            return false;
-
-        WorldPosition pos(bot->GetMapId(), dx, dy, dz);
-        data.lastReachPOI = 0;
-        data.pos = pos;
-        data.objectiveIdx = objectiveIdx;
-    }
-
-    if (bot->GetDistance(data.pos) > 10.0f && !data.lastReachPOI)
-    {
-        if (MoveFarTo(data.pos))
-            return true;
-        // Long-range sampler couldn't land a candidate — nudge the
-        // bot a short distance so the next tick retries from a
-        // different position instead of sitting idle.
-        return MoveRandomNear(10.0f);
-    }
-    // Now we are near the quest objective
-    // kill mobs and looting quest should be done automatically by grind strategy
-
-    if (!data.lastReachPOI)
-    {
-        data.lastReachPOI = getMSTime();
-        return true;
-    }
-    // stayed at this POI for more than 5 minutes
-    if (GetMSTimeDiffToNow(data.lastReachPOI) >= poiStayTime)
-    {
-        bool hasProgression = false;
-        int32 currentObjective = data.objectiveIdx;
-        // check if the objective has progression
-        Quest const* quest = sObjectMgr->GetQuestTemplate(questId);
-        QuestStatusData const& q_status = bot->getQuestStatusMap().at(questId);
-        if (currentObjective < QUEST_OBJECTIVES_COUNT)
-        {
-            if (q_status.CreatureOrGOCount[currentObjective] != 0 && quest->RequiredNpcOrGoCount[currentObjective])
-                hasProgression = true;
-        }
-        else if (currentObjective < QUEST_OBJECTIVES_COUNT + QUEST_ITEM_OBJECTIVES_COUNT)
-        {
-            if (q_status.ItemCount[currentObjective - QUEST_OBJECTIVES_COUNT] != 0 &&
-                quest->RequiredItemCount[currentObjective - QUEST_OBJECTIVES_COUNT])
-                hasProgression = true;
-        }
-        if (!hasProgression)
-        {
-            // we has reach the poi for more than 5 mins but no progession
-            // may not be able to complete this quest, marked as abandoned
-            /// @TODO: It may be better to make lowPriorityQuest a global set shared by all bots (or saved in db)
-            botAI->lowPriorityQuest.insert(questId);
-            botAI->rpgStatistic.questAbandoned++;
-            LOG_DEBUG("playerbots", "[New RPG] {} marked as abandoned quest {}", bot->GetName(), questId);
-            botAI->rpgInfo.ChangeToIdle();
-            return true;
-        }
-        // clear and select another poi later
-        data.lastReachPOI = 0;
-        data.pos = WorldPosition();
-        data.objectiveIdx = 0;
-        return true;
-    }
-
-    // At the POI: keep the bot actively placed but avoid large
-    // random 20yd hops that look like pacing back and forth. A small
-    // ~8yd wander reads as the bot looking around while grind/loot
-    // strategies do their work.
-    return MoveRandomNear(8.0f);
-}
-
-bool NewRpgDoQuestAction::DoCompletedQuest(NewRpgInfo::DoQuest& data)
-{
-    uint32 questId = data.questId;
-    Quest const* quest = data.quest;
-
-    if (data.objectiveIdx != -1)
-    {
-        // if quest is completed, back to poi with -1 idx to reward
-        BroadcastHelper::BroadcastQuestUpdateComplete(botAI, bot, quest);
-        botAI->rpgStatistic.questCompleted++;
-        std::vector<POIInfo> poiInfo;
-        if (!GetQuestPOIPosAndObjectiveIdx(questId, poiInfo, true))
-        {
-            // can't find a poi pos to reward, stop doing quest for now
-            botAI->rpgInfo.ChangeToIdle();
-            return false;
-        }
-        assert(poiInfo.size() > 0);
-        // now we get the place to get rewarded
-        float dx = poiInfo[0].pos.x, dy = poiInfo[0].pos.y;
-        // z = MAX_HEIGHT as we do not know accurate z
-        float dz = std::max(bot->GetMap()->GetHeight(dx, dy, MAX_HEIGHT), bot->GetMap()->GetWaterLevel(dx, dy));
-
-        // double check for GetQuestPOIPosAndObjectiveIdx
-        if (dz == INVALID_HEIGHT || dz == VMAP_INVALID_HEIGHT_VALUE)
-            return false;
-
-        WorldPosition pos(bot->GetMapId(), dx, dy, dz);
-        data.lastReachPOI = 0;
-        data.pos = pos;
-        data.objectiveIdx = -1;
-    }
-
-    if (data.pos == WorldPosition())
-        return false;
-
-    if (bot->GetDistance(data.pos) > 10.0f && !data.lastReachPOI)
-    {
-        if (MoveFarTo(data.pos))
-            return true;
-        return MoveRandomNear(10.0f);
-    }
-
-    // Now we are near the qoi of reward
-    // the quest should be rewarded by SearchQuestGiverAndAcceptOrReward
-    if (!data.lastReachPOI)
-    {
-        data.lastReachPOI = getMSTime();
-        return true;
-    }
-    // stayed at this POI for more than 5 minutes
-    if (GetMSTimeDiffToNow(data.lastReachPOI) >= poiStayTime)
-    {
-        // e.g. Can not reward quest to gameobjects
-        /// @TODO: It may be better to make lowPriorityQuest a global set shared by all bots (or saved in db)
-        botAI->lowPriorityQuest.insert(questId);
-        botAI->rpgStatistic.questAbandoned++;
-        LOG_DEBUG("playerbots", "[New RPG] {} marked as abandoned quest {}", bot->GetName(), questId);
-        botAI->rpgInfo.ChangeToIdle();
-        return true;
-    }
-    return false;
 }
 
 bool NewRpgTravelFlightAction::Execute(Event /*event*/)

--- a/src/Ai/World/Rpg/Action/NewRpgAction.h
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.h
@@ -36,14 +36,6 @@ private:
     void WhisperStatusChange(Player* owner, std::string const& statusName);
 };
 
-class StartRpgDoQuestAction : public Action
-{
-public:
-    StartRpgDoQuestAction(PlayerbotAI* botAI) : Action(botAI, "start rpg do quest") {}
-
-    bool Execute(Event event) override;
-};
-
 class NewRpgStatusUpdateAction : public NewRpgBaseAction
 {
 public:
@@ -97,19 +89,6 @@ public:
     bool Execute(Event event) override;
 
     const uint32 npcStayTime = 8 * 1000;
-};
-
-class NewRpgDoQuestAction : public NewRpgBaseAction
-{
-public:
-    NewRpgDoQuestAction(PlayerbotAI* botAI) : NewRpgBaseAction(botAI, "new rpg do quest") {}
-    bool Execute(Event event) override;
-
-protected:
-    bool DoIncompleteQuest(NewRpgInfo::DoQuest& data);
-    bool DoCompletedQuest(NewRpgInfo::DoQuest& data);
-
-    const uint32 poiStayTime = 5 * 60 * 1000;
 };
 
 class NewRpgTravelFlightAction : public NewRpgBaseAction

--- a/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp
@@ -695,6 +695,8 @@ bool NewRpgBaseAction::SearchQuestGiverAndAcceptOrReward()
             ForceToWait(5000);
             return true;
         }
+        LOG_DEBUG("playerbots", "[New RPG] {} questgiver {} at {} yd not interactable yet, closing in",
+                  bot->GetName(), npcOrGo.ToString(), uint32(bot->GetDistance(object)));
         return MoveWorldObjectTo(npcOrGo);
     }
     return false;
@@ -863,14 +865,13 @@ bool NewRpgBaseAction::GetQuestPOIPosAndObjectiveIdx(uint32 questId, std::vector
                 continue;
 
             float dz = std::max(bot->GetMap()->GetHeight(dx, dy, MAX_HEIGHT), bot->GetMap()->GetWaterLevel(dx, dy));
-
             if (dz == INVALID_HEIGHT || dz == VMAP_INVALID_HEIGHT_VALUE)
-                continue;
+                dz = bot->GetPositionZ();
 
             if (bot->GetZoneId() != bot->GetMap()->GetZoneId(bot->GetPhaseMask(), dx, dy, dz))
                 continue;
 
-            poiInfo.push_back({{dx, dy}, qPoi.ObjectiveIndex});
+            poiInfo.push_back({{dx, dy}, qPoi.ObjectiveIndex, dz});
         }
 
         if (poiInfo.empty())
@@ -942,7 +943,7 @@ bool NewRpgBaseAction::GetQuestPOIPosAndObjectiveIdx(uint32 questId, std::vector
         if (bot->GetZoneId() != bot->GetMap()->GetZoneId(bot->GetPhaseMask(), dx, dy, dz))
             continue;
 
-        poiInfo.push_back({{dx, dy}, qPoi.ObjectiveIndex});
+        poiInfo.push_back({{dx, dy}, qPoi.ObjectiveIndex, dz});
     }
 
     if (poiInfo.size() == 0)

--- a/src/Ai/World/Rpg/Action/NewRpgBaseAction.h
+++ b/src/Ai/World/Rpg/Action/NewRpgBaseAction.h
@@ -22,6 +22,7 @@ struct POIInfo
 {
     G3D::Vector2 pos;
     int32 objectiveIdx;
+    float z{0.0f};
 };
 
 /// A base (composition) class for all new rpg actions

--- a/src/Ai/World/Rpg/Action/NewRpgDoQuest.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgDoQuest.cpp
@@ -1,0 +1,1372 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "NewRpgDoQuest.h"
+#include "BroadcastHelper.h"
+#include "CellImpl.h"
+#include "ChatHelper.h"
+#include "Creature.h"
+#include "DatabaseEnv.h"
+#include "G3D/Vector2.h"
+#include "GameObject.h"
+#include "GridNotifiers.h"
+#include "GridNotifiersImpl.h"
+#include "Item.h"
+#include "LastMovementValue.h"
+#include "LootMgr.h"
+#include "LootObjectStack.h"
+#include "NearestGameObjects.h"
+#include "NewRpgInfo.h"
+#include "ObjectMgr.h"
+#include "Opcodes.h"
+#include "Player.h"
+#include "PlayerbotAI.h"
+#include "PlayerbotAIConfig.h"
+#include "Playerbots.h"
+#include "QuestDef.h"
+#include "Random.h"
+#include "SharedDefines.h"
+#include "SpellAuraDefines.h"
+#include "SpellInfo.h"
+#include "SpellMgr.h"
+#include "Timer.h"
+#include "TravelMgr.h"
+#include "WorldPacket.h"
+#include "WorldSession.h"
+#include <algorithm>
+#include <cfloat>
+#include <unordered_map>
+
+bool StartRpgDoQuestAction::Execute(Event event)
+{
+    Player* owner = event.getOwner();
+    if (!owner)
+        return false;
+
+    std::string const text = event.getParam();
+    PlayerbotChatHandler ch(owner);
+    uint32 questId = ch.extractQuestId(text);
+    Quest const* quest = sObjectMgr->GetQuestTemplate(questId);
+    if (quest)
+    {
+        botAI->rpgInfo.ChangeToDoQuest(questId, quest);
+        bot->Whisper("Start to do quest " + std::to_string(questId), LANG_UNIVERSAL, owner);
+        return true;
+    }
+    bot->Whisper("Invalid quest " + text, LANG_UNIVERSAL, owner);
+    return false;
+}
+
+Unit* NewRpgAttackQuestTargetAction::GetTarget()
+{
+    auto* data = std::get_if<NewRpgInfo::DoQuest>(&botAI->rpgInfo.data);
+    if (!data || !data->targetGuid.IsAnyTypeCreature())
+        return nullptr;
+
+    return botAI->GetUnit(data->targetGuid);
+}
+
+bool NewRpgAttackQuestTargetAction::Execute(Event /*event*/)
+{
+    verbose = false;
+
+    Unit* target = GetTarget();
+    if (!target || !target->IsInWorld() || !target->IsAlive())
+        return false;
+
+    if (bot->IsFriendlyTo(target) || !bot->IsValidAttackTarget(target))
+        return false;
+
+    bot->SetSelection(target->GetGUID());
+    context->GetValue<Unit*>("current target")->Set(target);
+
+    // Halt at commit range even when a later rule defers the attack this
+    // tick - the in-flight spline ends at the mob's exact position.
+    LastMovement& lastMovement = AI_VALUE(LastMovement&, "last movement");
+    bool moveControlled = bot->GetMotionMaster()->GetMotionSlotType(MOTION_SLOT_CONTROLLED) != NULL_MOTION_TYPE;
+    if (bot->isMoving() && lastMovement.priority < MovementPriority::MOVEMENT_COMBAT && !moveControlled)
+    {
+        lastMovement.clear();
+        bot->GetMotionMaster()->Clear(false);
+        bot->StopMoving();
+    }
+
+    if (bot->IsMounted())
+    {
+        bot->Dismount();
+        return true;
+    }
+
+    bool result = Attack(target);
+    LOG_DEBUG("playerbots", "[New RPG] {} attack quest target {} ({}): {}", bot->GetName(), target->GetName(),
+              target->GetGUID().ToString(), result ? "engaged" : "refused");
+    return result;
+}
+
+bool NewRpgDoQuestAction::Execute(Event /*event*/)
+{
+    if (SearchQuestGiverAndAcceptOrReward())
+        return true;
+
+    NewRpgInfo& info = botAI->rpgInfo;
+    auto* dataPtr = std::get_if<NewRpgInfo::DoQuest>(&info.data);
+    if (!dataPtr)
+        return false;
+    auto& data = *dataPtr;
+    uint32 questId = data.questId;
+    uint8 questStatus = bot->GetQuestStatus(questId);
+    switch (questStatus)
+    {
+        case QUEST_STATUS_INCOMPLETE:
+            return DoIncompleteQuest(data);
+        case QUEST_STATUS_COMPLETE:
+            return DoCompletedQuest(data);
+        default:
+            break;
+    }
+    info.ChangeToIdle();
+    return true;
+}
+
+QuestStatusData const* NewRpgDoQuestAction::GetQuestStatus(uint32 questId) const
+{
+    auto const& statusMap = bot->getQuestStatusMap();
+    auto it = statusMap.find(questId);
+    return it == statusMap.end() ? nullptr : &it->second;
+}
+
+bool NewRpgDoQuestAction::IsObjectiveCompleted(NewRpgInfo::DoQuest const& data) const
+{
+    // objectiveIdx is -1 while heading to turn-in. If the quest reverted to incomplete,
+    // report done so a fresh objective is picked instead of indexing arrays with -1.
+    if (data.objectiveIdx < 0)
+        return true;
+
+    Quest const* quest = sObjectMgr->GetQuestTemplate(data.questId);
+    QuestStatusData const* q_status = GetQuestStatus(data.questId);
+    if (!quest || !q_status)
+        return true;
+
+    int32 idx = data.objectiveIdx;
+    if (idx < QUEST_OBJECTIVES_COUNT)
+        return q_status->CreatureOrGOCount[idx] >= quest->RequiredNpcOrGoCount[idx];
+
+    if (idx < QUEST_OBJECTIVES_COUNT + QUEST_ITEM_OBJECTIVES_COUNT)
+        return q_status->ItemCount[idx - QUEST_OBJECTIVES_COUNT] >=
+               quest->RequiredItemCount[idx - QUEST_OBJECTIVES_COUNT];
+
+    return true;
+}
+
+bool NewRpgDoQuestAction::HasObjectiveProgress(NewRpgInfo::DoQuest const& data) const
+{
+    if (data.objectiveIdx < 0)
+        return false;
+
+    Quest const* quest = sObjectMgr->GetQuestTemplate(data.questId);
+    QuestStatusData const* q_status = GetQuestStatus(data.questId);
+    if (!quest || !q_status)
+        return false;
+
+    int32 idx = data.objectiveIdx;
+    if (idx < QUEST_OBJECTIVES_COUNT)
+        return q_status->CreatureOrGOCount[idx] != 0 && quest->RequiredNpcOrGoCount[idx];
+
+    if (idx < QUEST_OBJECTIVES_COUNT + QUEST_ITEM_OBJECTIVES_COUNT)
+        return q_status->ItemCount[idx - QUEST_OBJECTIVES_COUNT] != 0 &&
+               quest->RequiredItemCount[idx - QUEST_OBJECTIVES_COUNT];
+
+    return false;
+}
+
+void NewRpgDoQuestAction::ClearTarget(NewRpgInfo::DoQuest& data)
+{
+    if (data.targetGuid.IsGameObject())
+    {
+        LootObject lootTarget = AI_VALUE(LootObject, "loot target");
+        if (lootTarget.guid == data.targetGuid)
+            context->GetValue<LootObject>("loot target")->Set(LootObject());
+    }
+    data.targetGuid = ObjectGuid::Empty;
+    data.targetPos = WorldPosition();
+    data.targetSince = 0;
+    data.lastEngage = 0;
+}
+
+void NewRpgDoQuestAction::ResetObjectiveSpawn(NewRpgInfo::DoQuest& data)
+{
+    data.spawnGuid = 0;
+    data.pos = WorldPosition();
+    data.objectiveIdx = 0;
+    data.lastReachPOI = 0;
+    data.spawnSince = 0;
+    data.lastScan = 0;
+    data.poiFallback = false;
+    ClearTarget(data);
+}
+
+bool NewRpgDoQuestAction::SelectObjectiveSpawn(NewRpgInfo::DoQuest& data)
+{
+    Quest const* quest = data.quest;
+    QuestStatusData const* q_status = GetQuestStatus(data.questId);
+    if (!quest || !q_status)
+        return false;
+
+    GuidPosition const* best = nullptr;
+    int32 bestObjective = 0;
+    float bestDist = FLT_MAX;
+
+    // Item objectives follow the creature/GO ones at QUEST_OBJECTIVES_COUNT + i, indexed
+    // against whoever drops them, so a quest needing a drop walks to its source mobs.
+    for (int32 idx = 0; idx < QUEST_OBJECTIVES_COUNT + QUEST_ITEM_OBJECTIVES_COUNT; ++idx)
+    {
+        if (idx < QUEST_OBJECTIVES_COUNT)
+        {
+            if (!quest->RequiredNpcOrGo[idx] ||
+                q_status->CreatureOrGOCount[idx] >= quest->RequiredNpcOrGoCount[idx])
+                continue;
+        }
+        else
+        {
+            int32 const item = idx - QUEST_OBJECTIVES_COUNT;
+            if (!quest->RequiredItemId[item] || !quest->RequiredItemCount[item] ||
+                q_status->ItemCount[item] >= quest->RequiredItemCount[item])
+                continue;
+        }
+
+        for (int32 entry : GetQuestObjectiveEntries(data.questId, static_cast<uint32>(1 << idx)))
+        {
+            for (GuidPosition const& pos : GetEntrySpawns(entry, bot->GetMapId()))
+            {
+                if (data.triedSpawns.count(pos.GetRawValue()))
+                    continue;
+
+                float const dist = bot->GetDistance(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ());
+                if (dist < bestDist)
+                {
+                    bestDist = dist;
+                    best = &pos;
+                    bestObjective = idx;
+                }
+            }
+        }
+    }
+
+    if (!best)
+    {
+        if (data.triedSpawns.empty())
+            return false;  // nothing spawned for any incomplete objective on this map
+
+        // every spawn has had its window without progress - let them be retried
+        data.triedSpawns.clear();
+        return true;
+    }
+
+    data.spawnGuid = best->GetRawValue();
+    data.objectiveIdx = bestObjective;
+    data.pos = *best;
+    data.lastReachPOI = 0;
+    data.spawnSince = getMSTime();
+    data.lastScan = 0;
+    return true;
+}
+
+// Objectives whose entries have no spawn row anywhere. Fall back to what the
+// quest's own POI says and let the grind strategy work the area,
+// which is all this action did before it targeted spawns.
+bool NewRpgDoQuestAction::SelectObjectivePoi(NewRpgInfo::DoQuest& data)
+{
+    std::vector<POIInfo> poiInfo;
+    if (!GetQuestPOIPosAndObjectiveIdx(data.questId, poiInfo))
+        return false;
+
+    POIInfo const& poi = poiInfo[urand(0, poiInfo.size() - 1)];
+    data.spawnGuid = 0;
+    data.objectiveIdx = poi.objectiveIdx;
+    data.pos = WorldPosition(bot->GetMapId(), poi.pos.x, poi.pos.y, poi.z);
+    data.poiFallback = true;
+    data.lastReachPOI = 0;
+    data.spawnSince = getMSTime();
+    data.lastScan = 0;
+    return true;
+}
+
+// The turn-in's own spawn point, which the quest POI cannot give: its rows carry x/y only.
+// Same relation the core's `.go quest ender` walks.
+bool NewRpgDoQuestAction::SelectQuestEnder(NewRpgInfo::DoQuest& data)
+{
+    GuidPosition const* best = nullptr;
+    float bestDist = FLT_MAX;
+    for (int32 entry : GetQuestEnderEntries(data.questId))
+    {
+        for (GuidPosition const& pos : GetEntrySpawns(entry, bot->GetMapId()))
+        {
+            if (data.triedSpawns.count(pos.GetRawValue()))
+                continue;
+
+            float const dist = bot->GetDistance(pos.GetPositionX(), pos.GetPositionY(), pos.GetPositionZ());
+            if (dist < bestDist)
+            {
+                bestDist = dist;
+                best = &pos;
+            }
+        }
+    }
+
+    if (!best)
+        return false;
+
+    data.spawnGuid = best->GetRawValue();
+    data.pos = *best;
+    return true;
+}
+
+bool NewRpgDoQuestAction::IsIncompleteObjectiveEntry(NewRpgInfo::DoQuest const& data, uint32 entry) const
+{
+    QuestStatusData const* q_status = GetQuestStatus(data.questId);
+    if (!data.quest || !q_status)
+        return false;
+
+    for (int32 idx = 0; idx < QUEST_OBJECTIVES_COUNT; ++idx)
+        if (data.quest->RequiredNpcOrGo[idx] == int32(entry) &&
+            q_status->CreatureOrGOCount[idx] < data.quest->RequiredNpcOrGoCount[idx])
+            return true;
+
+    return false;
+}
+
+bool NewRpgDoQuestAction::IsWrittenOff(NewRpgInfo::DoQuest const& data, ObjectGuid guid) const
+{
+    auto it = data.visited.find(guid);
+    return it != data.visited.end() && GetMSTimeDiffToNow(it->second) < writeOffTime;
+}
+
+bool NewRpgDoQuestAction::IsValidCreatureTarget(NewRpgInfo::DoQuest const& data, Creature* creature) const
+{
+    if (!creature || !creature->IsInWorld() || !creature->IsAlive())
+        return false;
+
+    if (IsWrittenOff(data, creature->GetGUID()))
+        return false;
+
+    // tapped by someone else - no credit/loot for us
+    if (creature->hasLootRecipient() && !creature->isTappedBy(bot))
+        return false;
+
+    return true;
+}
+
+bool NewRpgDoQuestAction::IsValidGoTarget(NewRpgInfo::DoQuest const& data, GameObject* go) const
+{
+    if (!go || !go->IsInWorld() || !go->isSpawned())
+        return false;
+
+    if (go->GetGoState() != GO_STATE_READY)
+        return false;
+
+    if (IsWrittenOff(data, go->GetGUID()))
+        return false;
+
+    return true;
+}
+
+bool NewRpgDoQuestAction::HasNeededQuestItem(GameObject* go) const
+{
+    GameObjectQuestItemList const* items = sObjectMgr->GetGameObjectQuestItemList(go->GetEntry());
+    if (!items)
+        return false;
+
+    for (uint32 itemId : *items)
+        if (LootObject::IsNeededForQuest(bot, itemId))
+            return true;
+
+    return false;
+}
+
+// Yield the tick while loot is pending, bounded: nothing guarantees the pipeline finishes,
+// and a corpse that despawned leaves "loot target" set with nothing able to clear it.
+bool NewRpgDoQuestAction::HoldForLoot(NewRpgInfo::DoQuest& data)
+{
+    // The loot pipeline runs at higher relevance, so "loot target" is already committed.
+    if (AI_VALUE(LootObject, "loot target").IsEmpty())
+    {
+        data.lootHoldSince = 0;
+        return false;
+    }
+
+    if (!data.lootHoldSince)
+        data.lootHoldSince = getMSTime();
+
+    return GetMSTimeDiffToNow(data.lootHoldSince) < lootHoldTime;
+}
+
+void NewRpgDoQuestAction::WriteOffTarget(NewRpgInfo::DoQuest& data)
+{
+    if (data.targetGuid)
+        data.visited[data.targetGuid] = getMSTime();
+    ClearTarget(data);
+}
+
+WorldObject* NewRpgDoQuestAction::ScanEntryObjectives(NewRpgInfo::DoQuest const& data, float scanRange) const
+{
+    QuestStatusData const* q_status = GetQuestStatus(data.questId);
+    if (!q_status)
+        return nullptr;
+
+    WorldObject* nearest = nullptr;
+    float nearestDist = scanRange;
+    auto keepNearest = [&](WorldObject* obj)
+    {
+        float const dist = bot->GetDistance(obj);
+        if (dist < nearestDist)
+        {
+            nearestDist = dist;
+            nearest = obj;
+        }
+    };
+
+    // Every incomplete objective, not just the one being walked to - a mob of another is
+    // free progress. Collected first so all of them cost one sweep.
+    std::vector<uint32> creatureEntries;
+    std::vector<uint32> goEntries;
+    for (int32 idx = 0; idx < QUEST_OBJECTIVES_COUNT; ++idx)
+    {
+        int32 const entry = data.quest->RequiredNpcOrGo[idx];
+        if (!entry || q_status->CreatureOrGOCount[idx] >= data.quest->RequiredNpcOrGoCount[idx])
+            continue;
+
+        if (entry > 0)
+        {
+            // The objective entry plus anything that has to die in its place: a marker the
+            // quest names is never spawned itself, so hunting its entry alone finds nothing.
+            creatureEntries.push_back(uint32(entry));
+            std::vector<uint32> const& sources = GetQuestKillSources(data.questId, uint32(idx));
+            creatureEntries.insert(creatureEntries.end(), sources.begin(), sources.end());
+        }
+        else
+        {
+            goEntries.push_back(static_cast<uint32>(-entry));
+        }
+    }
+
+    if (!creatureEntries.empty())
+    {
+        std::list<Creature*> creatures;
+        bot->GetCreatureListWithEntryInGrid(creatures, creatureEntries, scanRange);
+        for (Creature* creature : creatures)
+            if (IsValidCreatureTarget(data, creature))
+                keepNearest(creature);
+    }
+
+    if (!goEntries.empty())
+    {
+        std::list<GameObject*> gos;
+        bot->GetGameObjectListWithEntryInGrid(gos, goEntries, scanRange);
+        for (GameObject* go : gos)
+            if (IsValidGoTarget(data, go))
+                keepNearest(go);
+    }
+
+    return nearest;
+}
+
+WorldObject* NewRpgDoQuestAction::ScanItemObjective(NewRpgInfo::DoQuest const& data, float scanRange) const
+{
+    std::vector<int32> const* craftSources = nullptr;
+    if (!GetQuestCraftReagents(data.questId, uint32(data.objectiveIdx) - QUEST_OBJECTIVES_COUNT).empty())
+        craftSources = &GetQuestObjectiveEntries(data.questId, 1u << data.objectiveIdx);
+
+    WorldObject* nearest = nullptr;
+    float nearestDist = scanRange;
+    auto keepNearest = [&](WorldObject* obj)
+    {
+        float const dist = bot->GetDistance(obj);
+        if (dist < nearestDist)
+        {
+            nearestDist = dist;
+            nearest = obj;
+        }
+    };
+
+    std::unordered_set<uint32> const& transformSources = GetQuestTransformSources(data.questId);
+    std::unordered_map<uint32, bool> questLoot;
+    std::list<Unit*> units;
+    Acore::AnyUnitInObjectRangeCheck check(bot, scanRange);
+    Acore::UnitListSearcher<Acore::AnyUnitInObjectRangeCheck> searcher(bot, units, check);
+    Cell::VisitObjects(bot, searcher, scanRange);
+    for (Unit* unit : units)
+    {
+        Creature* creature = unit->ToCreature();
+        if (!creature || !IsValidCreatureTarget(data, creature))
+            continue;
+
+        // Either it drops what we need, or the quest item turns it into something
+        // that does (GetQuestTransformSources), or it carries a craft reagent.
+        uint32 lootId = creature->GetCreatureTemplate()->lootid;
+        bool const dropsReagent =
+            craftSources && std::find(craftSources->begin(), craftSources->end(),
+                                      int32(creature->GetEntry())) != craftSources->end();
+        bool dropsWanted = false;
+        if (!dropsReagent && lootId)
+        {
+            auto cached = questLoot.find(lootId);
+            if (cached == questLoot.end())
+                cached = questLoot.emplace(lootId, LootTemplates_Creature.HaveQuestLootForPlayer(lootId, bot)).first;
+
+            dropsWanted = cached->second;
+        }
+
+        if (!dropsReagent && !dropsWanted && !transformSources.count(creature->GetEntry()))
+            continue;
+
+        keepNearest(creature);
+    }
+
+    std::list<GameObject*> gos;
+    AnyGameObjectInObjectRangeCheck goCheck(bot, scanRange);
+    Acore::GameObjectListSearcher<AnyGameObjectInObjectRangeCheck> goSearcher(bot, gos, goCheck);
+    Cell::VisitObjects(bot, goSearcher, scanRange);
+    for (GameObject* go : gos)
+        if (IsValidGoTarget(data, go) && HasNeededQuestItem(go))
+            keepNearest(go);
+
+    return nearest;
+}
+
+bool NewRpgDoQuestAction::ScanForObjectiveTarget(NewRpgInfo::DoQuest& data, float maxDist)
+{
+    if (!data.quest)
+        return false;
+
+    // Item objectives name no source entry, so they scan by loot predicate, not by entry.
+    // Clamped to sightDistance: the bot cannot act on anything further out.
+    float const scanRange = std::min({maxDist, objectiveScanRange, sPlayerbotAIConfig.sightDistance});
+    WorldObject* target = data.objectiveIdx < QUEST_OBJECTIVES_COUNT ? ScanEntryObjectives(data, scanRange)
+                                                                     : ScanItemObjective(data, scanRange);
+    if (!target)
+        return false;
+
+    data.targetGuid = target->GetGUID();
+    data.targetPos = WorldPosition(bot->GetMapId(), target->GetPositionX(), target->GetPositionY(),
+                                   target->GetPositionZ());
+    data.targetSince = 0;
+    LOG_DEBUG("playerbots", "[New RPG] {} found quest target {} (dist {}) for quest {} objective {}",
+              bot->GetName(), data.targetGuid.ToString(), bot->GetDistance(target), data.questId,
+              data.objectiveIdx);
+    return true;
+}
+
+bool NewRpgDoQuestAction::EngageTarget(NewRpgInfo::DoQuest& data)
+{
+    if (bot->IsInCombat())
+    {
+        data.targetSince = getMSTime();
+        return false;
+    }
+
+    if (data.lastEngage && GetMSTimeDiffToNow(data.lastEngage) > 5000)
+        data.targetSince = getMSTime();
+    data.lastEngage = getMSTime();
+
+    if (data.targetGuid.IsAnyTypeCreature())
+    {
+        Unit* unit = botAI->GetUnit(data.targetGuid);
+        Creature* creature = unit ? unit->ToCreature() : nullptr;
+        if (!creature || !creature->IsAlive())
+        {
+            // Killed or despawned - rescan. Queue the corpse first.
+            if (creature)
+                AI_VALUE(LootObjectStack*, "available loot")->Add(data.targetGuid);
+            ClearTarget(data);
+            return true;
+        }
+
+        if (creature->hasLootRecipient() && !creature->isTappedBy(bot))
+        {
+            WriteOffTarget(data);
+            return true;
+        }
+
+        if (!data.targetSince)
+            data.targetSince = getMSTime();
+        else if (GetMSTimeDiffToNow(data.targetSince) >= targetEngageTimeout)
+        {
+            // unreachable, or the attack action keeps refusing it - don't chase forever
+            LOG_DEBUG("playerbots", "[New RPG] {} wrote off quest target {} for quest {}",
+                      bot->GetName(), data.targetGuid.ToString(), data.questId);
+            WriteOffTarget(data);
+            return true;
+        }
+
+        return EngageCreature(data, creature);
+    }
+
+    if (data.targetGuid.IsGameObject())
+    {
+        GameObject* go = botAI->GetGameObject(data.targetGuid);
+        if (!go || !go->isSpawned())
+        {
+            // opened/used (by us or others) or despawned - rescan
+            ClearTarget(data);
+            return true;
+        }
+
+        if (!data.targetSince)
+            data.targetSince = getMSTime();
+        else if (GetMSTimeDiffToNow(data.targetSince) >= targetEngageTimeout)
+        {
+            LOG_DEBUG("playerbots", "[New RPG] {} wrote off quest target {} for quest {}",
+                      bot->GetName(), data.targetGuid.ToString(), data.questId);
+            WriteOffTarget(data);
+            return true;
+        }
+
+        return EngageGameObject(data, go);
+    }
+
+    ClearTarget(data);
+    return true;
+}
+
+bool NewRpgDoQuestAction::EngageCreature(NewRpgInfo::DoQuest& data, Creature* creature)
+{
+    // Cast objective: takes precedence over talk/attack.
+    if (IsIncompleteObjectiveEntry(data, creature->GetEntry()))
+        if (Item* castItem = GetCastQuestItem(data))
+            return EngageCastTarget(data, creature, castItem);
+
+    // Transform objective: the item has to be used before the kill. Afterwards the
+    // transformed mob is an ordinary target and falls through below.
+    if (data.quest && GetQuestTransformSources(data.questId).count(creature->GetEntry()))
+        if (Item* item = bot->GetItemByEntry(data.quest->GetSrcItemId()))
+            return EngageTransformTarget(data, creature, item);
+
+    // Friendly objective NPC -> talk-to credit, not a kill.
+    if (!bot->IsValidAttackTarget(creature))
+        return EngageTalkTarget(data, creature);
+
+    // Re-anchor only when the mob really moved
+    if (creature->GetExactDist(data.targetPos) > 10.0f)
+        data.targetPos = WorldPosition(bot->GetMapId(), creature->GetPositionX(), creature->GetPositionY(),
+                                       creature->GetPositionZ());
+
+    float const dist = bot->GetDistance(creature);
+
+    // En-route re-target. Each switch needs a 2x improvement in distance, so two
+    // near-equidistant mobs can't ping-pong. The displaced mob is not written off.
+    if (dist > engageRange && (!data.lastScan || GetMSTimeDiffToNow(data.lastScan) >= scanInterval))
+    {
+        data.lastScan = getMSTime();
+        ObjectGuid const held = data.targetGuid;
+        if (ScanForObjectiveTarget(data, dist * 0.5f) && data.targetGuid != held)
+        {
+            data.lastEngage = 0;
+            LOG_DEBUG("playerbots", "[New RPG] {} switched quest target {} -> {} for quest {}",
+                      bot->GetName(), held.ToString(), data.targetGuid.ToString(), data.questId);
+            return true;
+        }
+    }
+
+    // LOS is part of the commit condition: while it is blocked, keep closing in rather
+    // than retrying an attack that cannot land.
+    if (dist > engageRange || !bot->IsWithinLOSInMap(creature))
+    {
+        if (MoveFarTo(data.targetPos))
+            return true;
+        // Same fallback the talk/cast/transform approaches take: a target the sampler cannot
+        // path to must not pin the bot in place. Nudging it re-samples from somewhere else
+        // next tick, and targetEngageTimeout retires the target if that never helps.
+        return MoveRandomNear(10.0f);
+    }
+
+    return botAI->DoSpecificAction("new rpg attack quest target", Event(), true);
+}
+
+bool NewRpgDoQuestAction::EngageGameObject(NewRpgInfo::DoQuest& data, GameObject* go)
+{
+    if (bot->GetDistance(go) > INTERACTION_DISTANCE - 2.0f)
+    {
+        if (bot->isMoving())
+            return false;
+        return MoveTo(bot->GetMapId(), go->GetPositionX(), go->GetPositionY(), go->GetPositionZ(),
+                      false, false, false, false);
+    }
+
+    if (bot->IsMounted())
+    {
+        bot->Dismount();
+        return true;
+    }
+    if (bot->GetShapeshiftForm() != FORM_NONE)
+    {
+        bot->RemoveAurasByType(SPELL_AURA_MOD_SHAPESHIFT);
+        return true;
+    }
+
+    // Lootable chest: hand it to the loot pipeline. Progress comes from the quest items in
+    // the loot - the core grants a gameobject credit only for goobers.
+    LootObject lootObj(bot, go->GetGUID());
+    if (go->GetGoType() == GAMEOBJECT_TYPE_CHEST && !lootObj.IsEmpty())
+    {
+        LootObject currentTarget = AI_VALUE(LootObject, "loot target");
+        bool keepCurrent = !currentTarget.IsEmpty() && currentTarget.IsLootPossible(bot) &&
+                           AI_VALUE2(float, "distance", "loot target") <= sPlayerbotAIConfig.lootDistance;
+        if (currentTarget.guid != go->GetGUID() && !keepCurrent)
+            context->GetValue<LootObject>("loot target")->Set(LootObject(bot, go->GetGUID()));
+        return AI_VALUE(LootObjectStack*, "available loot")->Add(go->GetGUID());
+    }
+
+    // One attempt then write off: Use() credits goobers directly (KillCreditGO), while
+    // buttons and quest chests credit only through a linked trap or their loot.
+    WorldPacket packet(CMSG_GAMEOBJ_USE, 8);
+    packet << go->GetGUID();
+    bot->GetSession()->HandleGameObjectUseOpcode(packet);
+    LOG_DEBUG("playerbots", "[New RPG] {} used quest gameobject {} for quest {}",
+              bot->GetName(), go->GetEntry(), data.questId);
+    WriteOffTarget(data);
+    return true;
+}
+
+bool NewRpgDoQuestAction::EngageTalkTarget(NewRpgInfo::DoQuest& data, Creature* creature)
+{
+    // Claim the tick rather than yielding on isMoving like the GO path: yielding lets a
+    // competing strategy pull the bot off a talk target it cannot attack.
+    if (bot->GetDistance(creature) > INTERACTION_DISTANCE - 1.0f)
+    {
+        if (MoveFarTo(data.targetPos))
+            return true;
+        return MoveRandomNear(5.0f);
+    }
+
+    if (bot->IsMounted())
+    {
+        bot->Dismount();
+        return true;
+    }
+
+    // TalkedToCreature grants the SPEAKTO credit directly. The gossip handler's own call is
+    // commented out (NPCHandler.cpp), so opening a gossip menu would credit nothing.
+    bot->SetFacingToObject(creature);
+    bot->TalkedToCreature(creature->GetEntry(), creature->GetGUID());
+    LOG_DEBUG("playerbots", "[New RPG] {} talked to quest npc {} for quest {}",
+              bot->GetName(), creature->GetEntry(), data.questId);
+    WriteOffTarget(data);
+    return true;
+}
+
+void NewRpgDoQuestAction::BuildCaches()
+{
+    IsCastQuest(0);
+    GetQuestAreaTrigger(0);
+}
+
+bool NewRpgDoQuestAction::IsCastQuest(uint32 questId)
+{
+    // One query, cached for the process: the raw CAST bit is gone from the Quest object
+    // at runtime, so it has to come from the DB column.
+    static std::unordered_set<uint32> const castQuests = []
+    {
+        std::unordered_set<uint32> s;
+        if (QueryResult result =
+                WorldDatabase.Query("SELECT ID FROM quest_template_addon WHERE (SpecialFlags & 0x20) <> 0"))
+            do
+            {
+                s.insert((*result)[0].Get<uint32>());
+            } while (result->NextRow());
+        return s;
+    }();
+
+    return castQuests.count(questId) != 0;
+}
+
+Item* NewRpgDoQuestAction::GetCastQuestItem(NewRpgInfo::DoQuest const& data)
+{
+    if (!IsCastQuest(data.questId) || !data.quest)
+        return nullptr;
+
+    uint32 itemId = data.quest->GetSrcItemId();
+    if (!itemId)
+        return nullptr;
+
+    return bot->GetItemByEntry(itemId);
+}
+
+uint32 NewRpgDoQuestAction::GetItemUseSpell(Item* item)
+{
+    for (uint8 i = 0; i < MAX_ITEM_PROTO_SPELLS; ++i)
+        if (item->GetTemplate()->Spells[i].SpellId > 0)
+            return item->GetTemplate()->Spells[i].SpellId;
+
+    return 0;
+}
+
+bool NewRpgDoQuestAction::EngageTransformTarget(NewRpgInfo::DoQuest& data, Creature* creature, Item* item)
+{
+    // From range, unlike EngageCastTarget: combat pauses this engine, so a bot that walked
+    // into melee would kill the mob untransformed.
+    if (bot->GetDistance(creature) > transformCastRange || !bot->IsWithinLOSInMap(creature))
+    {
+        if (MoveFarTo(data.targetPos))
+            return true;
+        return MoveRandomNear(10.0f);
+    }
+
+    if (bot->IsMounted())
+    {
+        bot->Dismount();
+        return true;
+    }
+
+    // Same cooldown hold as EngageCastTarget. Hold the target rather than write it off;
+    // targetEngageTimeout is the backstop if the cast never lands.
+    uint32 const spellId = GetItemUseSpell(item);
+    if (spellId && bot->HasSpellItemCooldown(spellId, item->GetEntry()))
+        return true;
+
+    // Not written off: the creature keeps its guid, SmartAI turns it into the entry that
+    // carries the drop, and the next tick engages it as an ordinary kill/loot target.
+    bot->SetFacingToObject(creature);
+    botAI->ImbueItem(item, creature);
+    LOG_DEBUG("playerbots", "[New RPG] {} used quest item {} to transform npc {} for quest {}",
+              bot->GetName(), item->GetEntry(), creature->GetEntry(), data.questId);
+    return true;
+}
+
+bool NewRpgDoQuestAction::EngageCastTarget(NewRpgInfo::DoQuest& data, Creature* creature, Item* item)
+{
+    if (bot->GetDistance(creature) > INTERACTION_DISTANCE - 1.0f)
+    {
+        if (MoveFarTo(data.targetPos))
+            return true;
+        return MoveRandomNear(5.0f);
+    }
+
+    if (bot->IsMounted())
+    {
+        bot->Dismount();
+        return true;
+    }
+
+    uint32 const spellId = GetItemUseSpell(item);
+    if (spellId && bot->HasSpellItemCooldown(spellId, item->GetEntry()))
+        return true;
+
+    // The item's SPELL_EFFECT_KILL_CREDIT (or scripted credit) is what advances the
+    // objective. A mis-cast is retried when the write-off list clears on progress.
+    bot->SetFacingToObject(creature);
+    botAI->ImbueItem(item, creature);
+    LOG_DEBUG("playerbots", "[New RPG] {} used quest item {} on npc {} for quest {}",
+              bot->GetName(), item->GetEntry(), creature->GetEntry(), data.questId);
+    WriteOffTarget(data);
+    return true;
+}
+
+bool NewRpgDoQuestAction::DoCraftObjective(NewRpgInfo::DoQuest& data)
+{
+    if (data.objectiveIdx < QUEST_OBJECTIVES_COUNT || !data.quest)
+        return false;
+
+    uint32 const itemIdx = uint32(data.objectiveIdx) - QUEST_OBJECTIVES_COUNT;
+    std::vector<QuestCraftReagent> const& craft = GetQuestCraftReagents(data.questId, itemIdx);
+    if (craft.empty() || IsObjectiveCompleted(data))
+        return false;
+
+    for (QuestCraftReagent const& reagent : craft)
+        if (bot->GetItemCount(reagent.item, false) < reagent.count)
+            return false;
+
+    Item* item = bot->GetItemByEntry(GetQuestCraftItem(data.questId, itemIdx));
+    if (!item)
+        return false;
+
+    uint32 const spellId = GetItemUseSpell(item);
+    if (!spellId || bot->HasSpellItemCooldown(spellId, item->GetEntry()))
+        return false;
+
+    if (data.lastItemUse && GetMSTimeDiffToNow(data.lastItemUse) < QuestItemUseGrace(spellId))
+        return true;
+
+    if (bot->IsNonMeleeSpellCast(false))
+        return true;
+
+    botAI->ImbueItem(item);
+    data.lastItemUse = getMSTime();
+    LOG_DEBUG("playerbots", "[New RPG] {} used quest item {} to craft for quest {}", bot->GetName(),
+              item->GetEntry(), data.questId);
+    return true;
+}
+
+WorldObject* NewRpgDoQuestAction::SelectSummonAnchor(NewRpgInfo::DoQuest const& data,
+                                                     QuestSummonAnchor const& anchor) const
+{
+    if (anchor.focusId)
+        return FindFocusAnchor(anchor.focusId);
+
+    if (!anchor.killAnchor)
+        return FindCreatureAnchor(anchor.creature, summonCreatureAnchorRange);
+
+    // Kill sources are alternates of one another, so take whichever the bot reached,
+    // skipping the one it already used the item on so the fight can follow.
+    Creature* best = nullptr;
+    float nearest = summonKillAnchorRange;
+    for (uint32 entry : GetQuestKillSources(data.questId, uint32(data.objectiveIdx)))
+    {
+        Creature* candidate = FindCreatureAnchor(entry, summonKillAnchorRange);
+        if (!candidate || candidate->GetGUID() == data.lastSummonAnchor)
+            continue;
+
+        float const dist = bot->GetDistance(candidate);
+        if (dist < nearest)
+        {
+            nearest = dist;
+            best = candidate;
+        }
+    }
+
+    return best;
+}
+
+bool NewRpgDoQuestAction::DoSummonObjective(NewRpgInfo::DoQuest& data, QuestSummonAnchor const& anchor)
+{
+    if (data.objectiveIdx < 0 || data.objectiveIdx >= QUEST_OBJECTIVES_COUNT || !data.quest)
+        return false;
+
+    if ((!anchor.focusId && !anchor.creature) || IsObjectiveCompleted(data))
+        return false;
+
+    Item* item = bot->GetItemByEntry(data.quest->GetSrcItemId());
+    if (!item)
+        return false;
+
+    uint32 const spellId = GetItemUseSpell(item);
+    if (!spellId)
+        return false;
+
+    for (QuestCraftReagent const& reagent : GetQuestItemReagents(data.questId))
+        if (bot->GetItemCount(reagent.item, false) < reagent.count)
+            return false;
+
+    // Re-summoning replaces a trigger before its timer fires, but only suppress while it is
+    // still near the fight - engaging a kill-anchor walks away from where it was planted.
+    int32 const summoned = data.quest->RequiredNpcOrGo[data.objectiveIdx];
+    if (anchor.summonsObjective && summoned > 0 &&
+        FindCreatureAnchor(uint32(summoned), summonTriggerNearRange))
+        return false;
+
+    // Hold for the whole cast
+    if (data.lastItemUse && GetMSTimeDiffToNow(data.lastItemUse) < QuestItemUseGrace(spellId))
+        return true;
+
+    if (bot->IsNonMeleeSpellCast(false))
+        return true;
+
+    if (bot->HasSpellItemCooldown(spellId, item->GetEntry()))
+        return false;
+
+    WorldObject* target = SelectSummonAnchor(data, anchor);
+    if (!target)
+        return false;
+
+    if (bot->IsMounted())
+    {
+        bot->Dismount();
+        return true;
+    }
+
+    bot->SetFacingToObject(target);
+    botAI->ImbueItem(item);
+    data.lastItemUse = getMSTime();
+    data.lastSummonAnchor = target->GetGUID();
+    LOG_DEBUG("playerbots", "[New RPG] {} used quest item {} at anchor {} to summon for quest {}",
+              bot->GetName(), item->GetEntry(), target->GetEntry(), data.questId);
+    return true;
+}
+
+GameObject* NewRpgDoQuestAction::FindFocusAnchor(uint32 focusId) const
+{
+    GameObject* found = nullptr;
+    float nearest = FLT_MAX;
+
+    // Only objects already close enough to cast at, so this stays a small grid visit
+    // rather than an objectiveScanRange sweep on every summon quest tick.
+    std::list<GameObject*> gos;
+    AnyGameObjectInObjectRangeCheck goCheck(bot, summonAnchorScanRange);
+    Acore::GameObjectListSearcher<AnyGameObjectInObjectRangeCheck> goSearcher(bot, gos, goCheck);
+    Cell::VisitObjects(bot, goSearcher, summonAnchorScanRange);
+    for (GameObject* go : gos)
+    {
+        if (!go->isSpawned() || go->GetGoType() != GAMEOBJECT_TYPE_SPELL_FOCUS ||
+            go->GetGOInfo()->spellFocus.focusId != focusId)
+            continue;
+
+        // GameObjectFocusCheck - the rule the core casts by - accepts the caster at half the
+        // template's dist. A yard of margin so a cast that starts in range also finishes there.
+        float const useRange = std::max(float(go->GetGOInfo()->spellFocus.dist) / 2.0f - 1.0f, 2.0f);
+        float const dist = bot->GetDistance(go);
+        if (dist <= useRange && dist < nearest)
+        {
+            nearest = dist;
+            found = go;
+        }
+    }
+
+    return found;
+}
+
+Creature* NewRpgDoQuestAction::FindCreatureAnchor(uint32 entry, float range) const
+{
+    Creature* found = nullptr;
+    float nearest = range;
+
+    std::list<Creature*> creatures;
+    bot->GetCreatureListWithEntryInGrid(creatures, entry, std::max(range, summonAnchorScanRange));
+    for (Creature* creature : creatures)
+    {
+        if (!creature->IsInWorld() || !creature->IsAlive())
+            continue;
+
+        float const dist = bot->GetDistance(creature);
+        if (dist < nearest)
+        {
+            nearest = dist;
+            found = creature;
+        }
+    }
+
+    return found;
+}
+
+uint32 NewRpgDoQuestAction::QuestItemUseGrace(uint32 spellId)
+{
+    SpellInfo const* info = sSpellMgr->GetSpellInfo(spellId);
+    return std::max<uint32>(2000, (info ? info->CalcCastTime() : 0) + 1000);
+}
+
+uint32 NewRpgDoQuestAction::GetQuestAreaTrigger(uint32 questId)
+{
+    // ObjectMgr indexes trigger -> quest only, so read the reverse straight off the table it
+    // loads from. DoExploreObjective re-checks the trigger and the quest flag at use time.
+    static std::unordered_map<uint32, uint32> const questToTrigger = []
+    {
+        std::unordered_map<uint32, uint32> m;
+        if (QueryResult result = WorldDatabase.Query("SELECT id, quest FROM areatrigger_involvedrelation ORDER BY id"))
+            do
+            {
+                m[(*result)[1].Get<uint32>()] = (*result)[0].Get<uint32>();
+            } while (result->NextRow());
+        return m;
+    }();
+
+    auto it = questToTrigger.find(questId);
+    return it == questToTrigger.end() ? 0 : it->second;
+}
+
+bool NewRpgDoQuestAction::DoExploreObjective(NewRpgInfo::DoQuest& data)
+{
+    Quest const* quest = data.quest;
+    if (!quest || !quest->HasSpecialFlag(QUEST_SPECIAL_FLAGS_EXPLORATION_OR_EVENT))
+        return false;
+
+    // Explored is a separate completion requirement from the objective counts. Once set,
+    // whatever remains is a scripted event we can't drive - leave it to the quest budget.
+    QuestStatusData const* q_status = GetQuestStatus(data.questId);
+    if (!q_status || q_status->Explored)
+        return false;
+
+    uint32 triggerId = GetQuestAreaTrigger(data.questId);
+    if (!triggerId)
+        return false;  // event quest, not an area-trigger explore
+
+    AreaTrigger const* at = sObjectMgr->GetAreaTrigger(triggerId);
+    if (!at || at->map != bot->GetMapId())
+        return false;
+
+    // HandleAreaTriggerOpcode re-validates the radius and calls AreaExploredOrEventHappens.
+    if (bot->IsInAreaTriggerRadius(at, 0.0f))
+    {
+        WorldPacket p(CMSG_AREATRIGGER);
+        p << triggerId;
+        p.rpos(0);
+        bot->GetSession()->HandleAreaTriggerOpcode(p);
+        LOG_DEBUG("playerbots", "[New RPG] {} fired area trigger {} for quest {}",
+                  bot->GetName(), triggerId, data.questId);
+        return true;
+    }
+
+    WorldPosition pos(at->map, at->x, at->y, at->z);
+    if (bot->GetDistance(pos) > 10.0f)
+    {
+        if (MoveFarTo(pos))
+            return true;
+        return MoveRandomNear(10.0f);
+    }
+    // Near the center but not yet inside a small/box trigger - inch in.
+    return MoveRandomNear(5.0f);
+}
+
+bool NewRpgDoQuestAction::DoIncompleteQuest(NewRpgInfo::DoQuest& data)
+{
+    uint32 questId = data.questId;
+
+    if (data.pos != WorldPosition() && IsObjectiveCompleted(data))
+    {
+        // Sweep nearby corpses into the loot stack before departing.
+        botAI->DoSpecificAction("add all loot", Event(), true);
+        data.triedSpawns.clear();
+        data.visited.clear();
+        ResetObjectiveSpawn(data);
+    }
+
+    // Bounded: a chest the pipeline reports as lootable but refuses to open would
+    // otherwise pin the bot here for the rest of the run.
+    if (HoldForLoot(data))
+        return false;
+
+    // Whole-quest budget: the spawn rotation below never gives up on its own, so this is
+    // what releases a bot from a quest it cannot finish.
+    if (botAI->rpgInfo.HasStatusPersisted(questStayTime))
+    {
+        /// @TODO: It may be better to make lowPriorityQuest a global set shared by all bots (or saved in db)
+        botAI->lowPriorityQuest.insert(questId);
+        botAI->rpgStatistic.questAbandoned++;
+        LOG_DEBUG("playerbots", "[New RPG] {} marked as abandoned quest {} (quest budget)", bot->GetName(), questId);
+        botAI->rpgInfo.ChangeToIdle();
+        return true;
+    }
+
+    if (data.pos == WorldPosition())
+    {
+        if (!SelectObjectiveSpawn(data))
+        {
+            // An unmet explore objective has no spawn, so try it before giving up.
+            if (DoExploreObjective(data))
+                return true;
+            // No spawn point for any objective - walk the POI and grind it instead.
+            if (SelectObjectivePoi(data))
+            {
+                LOG_DEBUG("playerbots", "[New RPG] {} quest {} objective {}: no spawn indexed, POI fallback",
+                          bot->GetName(), questId, data.objectiveIdx);
+                return true;
+            }
+            LOG_DEBUG("playerbots", "[New RPG] {} gave up quest {}: no spawn and no POI on map {}",
+                      bot->GetName(), questId, bot->GetMapId());
+            botAI->rpgInfo.ChangeToIdle();
+            return true;
+        }
+        LOG_DEBUG("playerbots", "[New RPG] {} quest {} heading to objective {} spawn at {} yd",
+                  bot->GetName(), questId, data.objectiveIdx, uint32(bot->GetDistance(data.pos)));
+        return true;
+    }
+
+    // No-progress backstop, measured from when this spawn was picked, not from arrival:
+    // a bot that cannot path to it never arrives.
+    if (data.spawnSince && GetMSTimeDiffToNow(data.spawnSince) >= poiStayTime)
+    {
+        LOG_DEBUG("playerbots", "[New RPG] {} quest {} objective {}: {} after {} s at this spawn, {} tried",
+                  bot->GetName(), questId, data.objectiveIdx,
+                  HasObjectiveProgress(data) ? "progress" : "nothing", poiStayTime / 1000, data.triedSpawns.size());
+
+        if (!HasObjectiveProgress(data))
+        {
+            // dry (or unreachable) spawn: move on to the next nearest one. The quest
+            // budget above is what eventually gives up on the quest entirely.
+            if (data.spawnGuid)
+                data.triedSpawns.insert(data.spawnGuid);
+        }
+        else
+        {
+            // The area works, so let dry spawns be retried and drop the write-offs with
+            // them: `visited` stops a bot re-chasing what it just failed on, it is not a
+            // whole-quest blacklist.
+            data.triedSpawns.clear();
+            data.visited.clear();
+        }
+        ResetObjectiveSpawn(data);
+        return true;
+    }
+
+    QuestSummonAnchor const anchor = data.objectiveIdx >= 0
+                                         ? GetQuestSummonAnchor(data.questId, uint32(data.objectiveIdx))
+                                         : QuestSummonAnchor{};
+
+    // A kill-anchor must be used on before it is fought: the scan targets it because it
+    // grants the credit, and engaging first means fighting it un-primed.
+    if (anchor.killAnchor && DoSummonObjective(data, anchor))
+        return true;
+
+    if (data.targetGuid)
+        return EngageTarget(data);
+
+    // Throttled scan - runs during the approach too, so targets en route are engaged
+    // instead of walked past.
+    if (!data.lastScan || GetMSTimeDiffToNow(data.lastScan) >= scanInterval)
+    {
+        data.lastScan = getMSTime();
+        if (ScanForObjectiveTarget(data, objectiveScanRange))
+            return true;
+    }
+
+    if (DoCraftObjective(data))
+        return true;
+
+    // Nothing of the objective in range - if it is conjured at an anchor, use the item here.
+    // After the scan so anything already summoned is killed first, and before the walk below
+    // so the anchor drives the last stretch.
+    if (DoSummonObjective(data, anchor))
+        return true;
+
+    if (bot->GetDistance(data.pos) > 10.0f)
+    {
+        if (MoveFarTo(data.pos))
+            return true;
+        // Long-range sampler found no candidate - nudge the bot so the next tick
+        // retries from a different position instead of sitting idle.
+        return MoveRandomNear(10.0f);
+    }
+
+    // Give the destination one scan window before writing it off. The throttled scan above
+    // has not necessarily run since arrival, and the cell may only just have loaded.
+    if (!data.lastReachPOI)
+    {
+        data.lastReachPOI = getMSTime();
+        return true;
+    }
+
+    if (GetMSTimeDiffToNow(data.lastReachPOI) < scanInterval)
+        return true;
+
+    // A POI has no spawn point to retire and nothing better to move to - stay and let the
+    // grind strategy work the area until the no-progress window above rotates to another one.
+    if (data.poiFallback)
+        return MoveRandomNear(8.0f);
+
+    // Standing on the spawn point with nothing in range: it is dead or empty, so take the
+    // next nearest rather than waiting out poiStayTime here.
+    LOG_DEBUG("playerbots", "[New RPG] {} quest {} objective {}: arrived, nothing in range - next spawn",
+              bot->GetName(), questId, data.objectiveIdx);
+    data.triedSpawns.insert(data.spawnGuid);
+    ResetObjectiveSpawn(data);
+    return true;
+}
+
+bool NewRpgDoQuestAction::DoCompletedQuest(NewRpgInfo::DoQuest& data)
+{
+    uint32 questId = data.questId;
+    Quest const* quest = data.quest;
+
+    if (data.objectiveIdx != -1)
+    {
+        // Same sweep as the objective-complete transition: the walk to the turn-in
+        // starts immediately and outruns the random "add all loot" trigger.
+        botAI->DoSpecificAction("add all loot", Event(), true);
+        ClearTarget(data);
+        // Nothing left to grind for - the walk to the turn-in must not be interrupted by
+        // "attack anything", which outranks this action.
+        data.poiFallback = false;
+        // if quest is completed, back to poi with -1 idx to reward
+        BroadcastHelper::BroadcastQuestUpdateComplete(botAI, bot, quest);
+        botAI->rpgStatistic.questCompleted++;
+        data.lastReachPOI = 0;
+        data.objectiveIdx = -1;
+        // Clear the objective's spawn point and its write-offs: from here they track the
+        // turn-in's spawn points instead.
+        data.spawnGuid = 0;
+        data.pos = WorldPosition();
+        data.triedSpawns.clear();
+    }
+
+    // Re-entered whenever a turn-in destination is retired below, so an entry with several
+    // spawn points works through them instead of waiting out the clock at the first.
+    if (data.pos == WorldPosition())
+    {
+        if (SelectQuestEnder(data))
+        {
+            LOG_DEBUG("playerbots", "[New RPG] {} quest {} complete, turn-in at ender spawn {} yd away ({} tried)",
+                      bot->GetName(), questId, uint32(bot->GetDistance(data.pos)), data.triedSpawns.size());
+        }
+        else
+        {
+            std::vector<POIInfo> poiInfo;
+            if (!GetQuestPOIPosAndObjectiveIdx(questId, poiInfo, true))
+            {
+                // can't find a poi pos to reward, stop doing quest for now
+                LOG_DEBUG("playerbots", "[New RPG] {} quest {} complete but no turn-in on map {}: "
+                          "{} ender entries indexed ({} spawns tried), no POI either",
+                          bot->GetName(), questId, bot->GetMapId(), GetQuestEnderEntries(questId).size(),
+                          data.triedSpawns.size());
+                botAI->rpgInfo.ChangeToIdle();
+                return false;
+            }
+            assert(poiInfo.size() > 0);
+            // now we get the place to get rewarded
+            data.pos = WorldPosition(bot->GetMapId(), poiInfo[0].pos.x, poiInfo[0].pos.y, poiInfo[0].z);
+            LOG_DEBUG("playerbots", "[New RPG] {} quest {} complete, turn-in POI {} yd away ({} ender entries, "
+                      "{} spawns tried)",
+                      bot->GetName(), questId, uint32(bot->GetDistance(data.pos)),
+                      GetQuestEnderEntries(questId).size(), data.triedSpawns.size());
+        }
+    }
+
+    // Only for a POI destination, whose z is a guess: quest_poi carries x/y only, and
+    // GetQuestPOIPosAndObjectiveIdx falls back to the bot's own height when the POI's grid is
+    // not resident. Arrival is a 3D check and MoveFarTo's stuck recovery teleports to this
+    // exact point, so a stale height strands the bot. A spawn point already has the real z.
+    if (!data.spawnGuid)
+    {
+        float const groundZ = std::max(bot->GetMap()->GetHeight(data.pos.GetPositionX(), data.pos.GetPositionY(),
+                                                                MAX_HEIGHT),
+                                       bot->GetMap()->GetWaterLevel(data.pos.GetPositionX(), data.pos.GetPositionY()));
+        if (groundZ != INVALID_HEIGHT && groundZ != VMAP_INVALID_HEIGHT_VALUE && groundZ != data.pos.GetPositionZ())
+            data.pos = WorldPosition(bot->GetMapId(), data.pos.GetPositionX(), data.pos.GetPositionY(), groundZ);
+    }
+
+    // Same gate as DoIncompleteQuest: don't start the walk to the turn-in while lootable
+    // corpses are pending nearby.
+    if (HoldForLoot(data))
+        return false;
+
+    if (bot->GetDistance(data.pos) > 10.0f && !data.lastReachPOI)
+    {
+        if (MoveFarTo(data.pos))
+            return true;
+        return MoveRandomNear(10.0f);
+    }
+
+    // Now we are near the qoi of reward
+    // the quest should be rewarded by SearchQuestGiverAndAcceptOrReward
+    if (!data.lastReachPOI)
+    {
+        data.lastReachPOI = getMSTime();
+        LOG_DEBUG("playerbots", "[New RPG] {} reached turn-in for quest {}, waiting on the hand-in",
+                  bot->GetName(), questId);
+        return true;
+    }
+    // Standing at an ender spawn point with nobody handing the quest in: it is empty (dead,
+    // despawned, or only put in the world by a script). Retire it and try the next one
+    if (data.spawnGuid && GetMSTimeDiffToNow(data.lastReachPOI) >= enderWaitTime)
+    {
+        LOG_DEBUG("playerbots", "[New RPG] {} nobody took quest {} at this ender spawn, trying the next",
+                  bot->GetName(), questId);
+        data.triedSpawns.insert(data.spawnGuid);
+        data.spawnGuid = 0;
+        data.pos = WorldPosition();
+        data.lastReachPOI = 0;
+        return true;
+    }
+
+    // stayed at this POI for more than 5 minutes
+    if (GetMSTimeDiffToNow(data.lastReachPOI) >= poiStayTime)
+    {
+        // e.g. Can not reward quest to gameobjects
+        /// @TODO: It may be better to make lowPriorityQuest a global set shared by all bots (or saved in db)
+        botAI->lowPriorityQuest.insert(questId);
+        botAI->rpgStatistic.questAbandoned++;
+        LOG_DEBUG("playerbots", "[New RPG] {} marked as abandoned quest {}", bot->GetName(), questId);
+        botAI->rpgInfo.ChangeToIdle();
+        return true;
+    }
+    return false;
+}

--- a/src/Ai/World/Rpg/Action/NewRpgDoQuest.h
+++ b/src/Ai/World/Rpg/Action/NewRpgDoQuest.h
@@ -1,0 +1,146 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_NEWRPGDOQUEST_H
+#define PLAYERBOTS_NEWRPGDOQUEST_H
+
+#include "AttackAction.h"
+#include "NewRpgBaseAction.h"
+#include "NewRpgInfo.h"
+#include "PlayerbotAI.h"
+#include "QuestValues.h"
+
+class Creature;
+class GameObject;
+class Item;
+class WorldObject;
+struct QuestStatusData;
+
+// Distance at which the do-quest engine stops closing in and opens combat.
+constexpr float NEW_RPG_ENGAGE_RANGE = 30.0f;
+
+class StartRpgDoQuestAction : public Action
+{
+public:
+    StartRpgDoQuestAction(PlayerbotAI* botAI) : Action(botAI, "start rpg do quest") {}
+
+    bool Execute(Event event) override;
+};
+
+class NewRpgAttackQuestTargetAction : public AttackAction
+{
+public:
+    NewRpgAttackQuestTargetAction(PlayerbotAI* botAI) : AttackAction(botAI, "new rpg attack quest target") {}
+
+    bool Execute(Event event) override;
+    Unit* GetTarget() override;
+};
+
+class NewRpgDoQuestAction : public NewRpgBaseAction
+{
+public:
+    NewRpgDoQuestAction(PlayerbotAI* botAI) : NewRpgBaseAction(botAI, "new rpg do quest") {}
+    bool Execute(Event event) override;
+
+    // Warm the static caches at load: IsCastQuest runs a blocking query.
+    static void BuildCaches();
+
+protected:
+    bool DoIncompleteQuest(NewRpgInfo::DoQuest& data);
+    bool DoCompletedQuest(NewRpgInfo::DoQuest& data);
+
+    /* objective bookkeeping */
+    // nullptr when the quest left the log mid-tick; .at() would throw.
+    QuestStatusData const* GetQuestStatus(uint32 questId) const;
+    bool IsObjectiveCompleted(NewRpgInfo::DoQuest const& data) const;
+    bool HasObjectiveProgress(NewRpgInfo::DoQuest const& data) const;
+    void ResetObjectiveSpawn(NewRpgInfo::DoQuest& data);
+    void ClearTarget(NewRpgInfo::DoQuest& data);
+
+    /* objective navigation - DB spawn points; POI is only the turn-in location */
+    bool SelectObjectiveSpawn(NewRpgInfo::DoQuest& data);
+    // Last resort when no objective of this quest has a spawn point to walk to.
+    bool SelectObjectivePoi(NewRpgInfo::DoQuest& data);
+    // Where the quest turns in, by spawn point rather than POI.
+    bool SelectQuestEnder(NewRpgInfo::DoQuest& data);
+
+    /* seek & engage */
+    bool ScanForObjectiveTarget(NewRpgInfo::DoQuest& data, float maxDist);
+    // Nearest valid creature/GO of any incomplete creature-or-GO objective, else nullptr.
+    WorldObject* ScanEntryObjectives(NewRpgInfo::DoQuest const& data, float scanRange) const;
+    // Nearest creature/GO holding what an item objective needs, else nullptr.
+    WorldObject* ScanItemObjective(NewRpgInfo::DoQuest const& data, float scanRange) const;
+    bool EngageTarget(NewRpgInfo::DoQuest& data);
+    bool EngageCreature(NewRpgInfo::DoQuest& data, Creature* creature);
+    bool EngageTalkTarget(NewRpgInfo::DoQuest& data, Creature* creature);
+    bool EngageCastTarget(NewRpgInfo::DoQuest& data, Creature* creature, Item* item);
+    // Use the quest item on a creature that a SmartAI SPELLHIT transform turns into the one
+    // carrying the required drop (see GetQuestTransformSources).
+    bool EngageTransformTarget(NewRpgInfo::DoQuest& data, Creature* creature, Item* item);
+    bool EngageGameObject(NewRpgInfo::DoQuest& data, GameObject* go);
+    // First on-use spell of an item, 0 if it has none.
+    static uint32 GetItemUseSpell(Item* item);
+    // Hold after using a quest item: its cast time plus a tick of slack.
+    static uint32 QuestItemUseGrace(uint32 spellId);
+
+    /* cast objective: credit needs the item's spell, which talk/kill credit never uses */
+    // True when an incomplete creature objective of this quest names `entry` itself - not a
+    // kill source or drop source standing in for it.
+    bool IsIncompleteObjectiveEntry(NewRpgInfo::DoQuest const& data, uint32 entry) const;
+    Item* GetCastQuestItem(NewRpgInfo::DoQuest const& data);
+    // Raw quest_template_addon.SpecialFlags & 0x20: ObjectMgr ORs KILL|CAST|SPEAKTO onto
+    // every creature-objective quest at load, so the runtime flag is unusable.
+    static bool IsCastQuest(uint32 questId);
+
+    /* craft objective: the required item is made from a looted reagent */
+    bool DoCraftObjective(NewRpgInfo::DoQuest& data);
+
+    /* summon objective: the mob has no spawn - the quest item conjures it beside an anchor */
+    bool DoSummonObjective(NewRpgInfo::DoQuest& data, QuestSummonAnchor const& anchor);
+    // The live anchor to use the item at - spell focus, plain creature, or kill source.
+    WorldObject* SelectSummonAnchor(NewRpgInfo::DoQuest const& data, QuestSummonAnchor const& anchor) const;
+    // Nearest spell-focus of `focusId` already within casting range, else nullptr.
+    GameObject* FindFocusAnchor(uint32 focusId) const;
+    Creature* FindCreatureAnchor(uint32 entry, float range) const;
+
+    /* explore objective: area-trigger backed, so it navigates and fires rather than engages */
+    bool DoExploreObjective(NewRpgInfo::DoQuest& data);
+    // Reverse quest -> area trigger. ObjectMgr only indexes trigger -> quest. 0 = no trigger.
+    static uint32 GetQuestAreaTrigger(uint32 questId);
+    void WriteOffTarget(NewRpgInfo::DoQuest& data);
+    // Written off recently enough to still skip. Expires after writeOffTime.
+    bool IsWrittenOff(NewRpgInfo::DoQuest const& data, ObjectGuid guid) const;
+    bool IsValidCreatureTarget(NewRpgInfo::DoQuest const& data, Creature* creature) const;
+    bool IsValidGoTarget(NewRpgInfo::DoQuest const& data, GameObject* go) const;
+    bool HasNeededQuestItem(GameObject* go) const;
+    bool HoldForLoot(NewRpgInfo::DoQuest& data);
+
+    const uint32 lootHoldTime = 15 * 1000;
+    const uint32 poiStayTime = 5 * 60 * 1000;
+    // Standing at an ender spawn: the questgiver search runs every tick at 80 yd, so if nothing
+    // has taken the quest by now the spot is empty and the next spawn point is worth a try.
+    const uint32 enderWaitTime = 30 * 1000;
+    // A written-off target comes back after one destination window: by then the tap has
+    // lapsed, the mob has respawned, or the bot stands somewhere else entirely.
+    const uint32 writeOffTime = poiStayTime;
+    // Whole-quest budget: the spawn rotation never gives up on its own.
+    const uint32 questStayTime = 30 * 60 * 1000;
+    const uint32 scanInterval = 2 * 1000;
+    // Ceiling only; ScanForObjectiveTarget clamps to sightDistance.
+    const float objectiveScanRange = 150.0f;
+    const uint32 targetEngageTimeout = 45 * 1000;
+    const float engageRange = NEW_RPG_ENGAGE_RANGE;
+    // Inside the shortest transform spell's range, outside the usual aggro pull.
+    const float transformCastRange = 30.0f;
+    // Past half of any spell-focus template's dist, which is the core's own casting rule.
+    const float summonAnchorScanRange = 25.0f;
+    const float summonCreatureAnchorRange = 5.0f;
+    // The item has to land before the mob aggroes; combat pauses this engine.
+    const float summonKillAnchorRange = 30.0f;
+    const float summonTriggerNearRange = 12.0f;
+};
+
+#endif

--- a/src/Ai/World/Rpg/NewRpgInfo.cpp
+++ b/src/Ai/World/Rpg/NewRpgInfo.cpp
@@ -172,6 +172,11 @@ std::string NewRpgInfo::ToString()
             out << "\npoiPos: " << arg.pos.GetMapId() << " " << arg.pos.GetPositionX() << " "
                 << arg.pos.GetPositionY() << " " << arg.pos.GetPositionZ();
             out << "\nlastReachPOI: " << (arg.lastReachPOI ? GetMSTimeDiffToNow(arg.lastReachPOI) : 0);
+            out << " spawnSince: " << (arg.spawnSince ? GetMSTimeDiffToNow(arg.spawnSince) : 0);
+            out << "\nspawnGuid: " << (arg.poiFallback ? "poi fallback" : std::to_string(arg.spawnGuid))
+                << " triedSpawns: " << arg.triedSpawns.size();
+            out << "\ntarget: " << (arg.targetGuid ? arg.targetGuid.ToString() : "none");
+            out << "\nvisited: " << arg.visited.size();
         }
         else if constexpr (std::is_same_v<T, TravelFlight>)
         {

--- a/src/Ai/World/Rpg/NewRpgInfo.h
+++ b/src/Ai/World/Rpg/NewRpgInfo.h
@@ -51,6 +51,33 @@ struct NewRpgInfo
         int32 objectiveIdx{0};
         WorldPosition pos{};
         uint32 lastReachPOI{0};
+        uint32 spawnSince{0};
+        ObjectGuid targetGuid{};
+        WorldPosition targetPos{};
+        uint32 lastScan{0};
+        uint32 targetSince{0};
+        // Last tick EngageTarget actually ran. Combat pauses the non-combat engine, so a
+        // large gap means the targetSince window overlapped a fight - restart it rather
+        // than write off a still-valid target.
+        uint32 lastEngage{0};
+        // Targets written off, and when.
+        std::unordered_map<ObjectGuid, uint32> visited;
+        // When the quest loop started yielding to the loot pipeline; 0 = not holding.
+        uint32 lootHoldSince{0};
+        // Spawn point currently headed for (GuidPosition raw value); 0 = none picked.
+        uint64 spawnGuid{0};
+        // Spawn points found empty, or that ran a full poiStayTime without progress.
+        // Cleared on progress, or once every spawn has been tried.
+        std::unordered_set<uint64> triedSpawns;
+        // When the quest item was last used. Shared by every path that uses one, so a use
+        // is never re-issued while the previous cast is still in flight.
+        uint32 lastItemUse{0};
+        // Which creature anchor it was used at - a kill-anchor gets the item once and is
+        // then fought, rather than topped up every grace window.
+        ObjectGuid lastSummonAnchor{};
+        // Walking a quest POI instead of a spawn point, because no objective of this quest
+        // has one. The grind strategy stays on while it is set - that is what kills there.
+        bool poiFallback{false};
     };
     // RPG_TRAVEL_FLIGHT
     struct TravelFlight
@@ -75,6 +102,8 @@ struct NewRpgInfo
     };
 
     uint32 startT{0};  // start timestamp of the current status
+
+    bool grindSuppressed{false};
 
     // MOVE_FAR
     float nearestMoveFarDis{FLT_MAX};

--- a/src/Mgr/Item/LootObjectStack.cpp
+++ b/src/Mgr/Item/LootObjectStack.cpp
@@ -9,6 +9,7 @@
 #include "Object.h"
 #include "ObjectAccessor.h"
 #include "Playerbots.h"
+#include "QuestValues.h"
 #include "Unit.h"
 
 #define MAX_LOOT_OBJECT_COUNT 200
@@ -244,6 +245,10 @@ bool LootObject::IsNeededForQuest(Player* bot, uint32 itemId)
 
             return true;
         }
+
+        // ItemDrops and use-reagents: needed for the quest, but named by no RequiredItemId.
+        if (IsQuestExtraItemWanted(bot, qInfo, itemId))
+            return true;
     }
 
     return false;

--- a/src/Mgr/Item/LootObjectStack.h
+++ b/src/Mgr/Item/LootObjectStack.h
@@ -42,7 +42,6 @@ public:
     uint32 reqSkillValue;
     uint32 reqItem;
 
-private:
     static bool IsNeededForQuest(Player* bot, uint32 itemId);
 };
 

--- a/src/Script/Playerbots.cpp
+++ b/src/Script/Playerbots.cpp
@@ -12,12 +12,14 @@
 #include "DatabaseEnv.h"
 #include "DatabaseLoader.h"
 #include "GuildTaskMgr.h"
+#include "NewRpgDoQuest.h"
 #include "PlayerScript.h"
 #include "PlayerbotAIConfig.h"
 #include "PlayerbotCommandScript.h"
 #include "PlayerbotGuildMgr.h"
 #include "PlayerbotSpellRepository.h"
 #include "PlayerbotWorldThreadProcessor.h"
+#include "QuestValues.h"
 #include "RandomPlayerbotMgr.h"
 #include "ScriptMgr.h"
 #include "cmath"
@@ -361,7 +363,21 @@ public:
         LOG_INFO("server.loading", ">> Loaded playerbots config in {} ms", GetMSTimeDiffToNow(oldMSTime));
         LOG_INFO("server.loading", " ");
 
+        // Everything below builds bot-only indexes; a disabled module should build none.
+        if (!sPlayerbotAIConfig.enabled)
+        {
+            LOG_INFO("server.loading", "Playerbots disabled by config - skipping bot indexes");
+            return;
+        }
+
         PlayerbotSpellRepository::Instance().Initialize();
+
+        LOG_INFO("server.loading", "Loading quest objective spawn index...");
+        uint32 questIndexMSTime = getMSTime();
+        BuildQuestObjectiveSpawns();
+        NewRpgDoQuestAction::BuildCaches();
+        LOG_INFO("server.loading", ">> Loaded quest objective spawn index in {} ms",
+                 GetMSTimeDiffToNow(questIndexMSTime));
 
         LOG_INFO("server.loading", "Playerbots World Thread Processor initialized");
     }


### PR DESCRIPTION
## Pull Request Description

`RPG_DO_QUEST` never executed a quest objective. It walked to the quest's POI, switched the grind strategy on and let credit happen as a side effect of killing whatever stood there, which works for a kill objective in an open field and for nothing else. A bot could not talk to an NPC for credit, use a quest item on a mob, loot a chest it was sent to, craft what a quest asked for, walk into an explore trigger or summon the mob that has no spawn at all.

The state becomes an objective engine: it reads what the objective actually requires and performs it.

- **Kill and collect.** The objective's own mobs, plus the entries that stand in for them: a credit marker that is never spawned itself but is credited by another mob's death, and creatures that only exist once something summons them.
- **Talk-to credit.** The bot approaches and hands in the interaction instead of attacking the NPC.
- **Cast objectives.** The quest's provided item, used on a creature that an *incomplete* objective names, which is the only way that credit is granted. (`quest_template_addon.SpecialFlags & 0x20` is read raw, because `ObjectMgr` ORs `KILL|CAST|SPEAKTO` onto every creature-objective quest at load.)
- **Transform sources.** Where the required drop lives on a creature that exists only after a SmartAI `SPELLHIT -> UPDATE_TEMPLATE` turns another one into it, the item goes on the source first.
- **Craft objectives.** The required item is not looted anywhere; the reagents are looted and the carrier item used.
- **Explore objectives.** Navigate the quest's area trigger and fire it.
- **Summon objectives.** The objective mob has no spawn row. The provided item conjures it beside a spell-focus gameobject, beside a plain creature anchor, or on a kill anchor that must be primed before the fight starts.
- **Turn-in.** Resolved through the creature/GO quest-involved relation, and rotated: an ender spawn where nobody takes the quest for 30 s is retired and the next one tried, then the POI, then the quest is given up.

A load-time index feeds every one of these kinds, built from the quest, loot and spawn tables. For a quest that does not use a kind the tables come back empty and the branch falls through.

Finding the objective falls out of the same index, and fixes the old navigation as a side effect.
The state now walks to the objective's **spawn positions** rather than its POI, because `quest_poi_points` carries x/y only: a POI over a cave or a building resolves to the terrain above it.
Every 2 s the bot scans for a match of *any* incomplete objective of the quest, so targets en route are engaged instead of walked past.
Matches hand off to the attack path, the loot pipeline (chests) or a one-shot `GAMEOBJ_USE` (goobers), with per-objective `visited` / `triedSpawns` sets, an engage timeout that pauses while the bot is in combat, and the existing no-progress abandon carried across laps. Objectives the index cannot resolve keep the old POI-plus-grind behaviour unchanged.

Verified locally with a scripted integration suite (a solo quest ladder and a multi-hundred-case quest lifecycle run) plus manual observation; the suite is not part of this PR.

## Feature Evaluation

- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

**Minimum logic.**

Everything derivable from static DB content is resolved once at startup: `BuildQuestObjectiveSpawns()` walks the quest templates, the creature/GO loot templates and the creature/GO spawn rows, and produces read-only tables (objective → entries, entry → spawn positions per map, quest → ender entries, plus the transform/kill/craft/summon source tables). It runs single-threaded in `PlayerbotsWorldScript::OnAfterConfigLoad` before the first bot ticks and logs its own duration. After that every lookup a bot makes is a hash lookup into a vector.

**Cost across many bots.**

Per tick the state machine is the one that was already there (quest status, objective completion, distance to destination), plus:

- one throttled scan, `scanInterval` 2 s, ranged at `min(150, AiPlayerbot.SightDistance)`. Creature and GO objectives use an entry-filtered grid search; item objectives use a unit sweep plus a gameobject sweep, with a per-`lootid` memo of `HaveQuestLootForPlayer`.
- no scan at all while a target is held. `EngageTarget` short-circuits, and it returns immediately while `bot->IsInCombat()`, so a fighting bot runs no do-quest logic.

## How to Test the Changes

Default config is enough: `AiPlayerbot.EnableNewRpgStrategy = 1` and `AiPlayerbot.RpgStatusProbWeight.DoQuest = 60` are the shipped values.

1. Start the server with random bots enabled and watch the loading log for `>> Loaded quest objective spawn index in N ms`. With playerbots disabled by config the line must not appear at all.
2. Enable debug logging for the `playerbots` category and follow a levelling bot; the state logs `[New RPG] <bot> quest <id> heading to objective <n> spawn at <d> yd`, target acquisition, spawn rotation and abandon reasons.
3. Watch the objective kinds. Kill and collect are the easy ones. The interesting cases are a talk-to objective (the bot walks up and interacts instead of attacking), a quest that hands out an item to use on a mob, a chest or goober objective, an explore objective, and a quest whose objective mob has no spawn and must be summoned. A bot on a kill/collect quest should also move to the next spawn point after 5 min without progress instead of standing on a dry one.
4. Watch a turn-in: the bot should walk to the questgiver's spawn point (not the POI) and hand in. Quests whose ender is a gameobject, a barrel or a crate say, should now complete instead of stalling.
5. Regression check on the parts this touches outside the rpg state. Normal looting (quest chests, corpse loot), mounting and dismounting while travelling.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

Bots need more code to do quests properly, but the runtime impact stays minimal. What recurs is one grid scan every 2 s per bot inside `RPG_DO_QUEST`; the index is built once at load, and a bot in any other state pays a single `std::get_if` on the rpg payload in `CheckMountStateAction`.

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

`RPG_DO_QUEST` is a default state of the new rpg strategy, so every bot that picks it behaves differently: it navigates to objective spawn points instead of the POI and actively engages objectives. Bots not in that state are unaffected. When the index cannot resolve an objective the state falls back to the previous POI-plus-grind behaviour.

- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [x] Yes (**explain below**)

## AI Assistance

Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)

AI assistance (Claude) was used for exploring core/DB behaviour, for drafting and refactoring parts of the implementation, and for this description.
The design decisions, the DB research behind the index, the debugging and the in-game validation are mine. Every line was reviewed and revised by hand across several passes, and the behaviour was verified in my local server.

## Code Provenance / Attribution

Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots, MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)

Nothing is ported from another project. Roughly 230 lines of `NewRpgDoQuest.cpp` are moved unchanged or lightly adapted from `NewRpgAction.cpp` in this module.

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note).
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers

- **Known limits, unchanged by this PR.** The do-quest engine is inert while the bot is in combat (it lives in the non-combat engine, same as before), so using an item mid-fight is not possible yet. Some quest types are still unsupported, escort quests among them. Navigation between zones and continents is where it was; I know someone else is working on that.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added RPG quest automation for finding objectives, engaging targets, using quest items, crafting, summoning, exploration, looting, and completing turn-ins.
  - Added support for attacking quest targets directly and recognizing additional quest-required items.
  - Improved handling of quest objective locations and fallback navigation.

- **Bug Fixes**
  - Bots now avoid unnecessary mounting near loot and quest objectives.
  - Quest-related grind behavior is better controlled while completing objectives.
  - Improved detection of interactable quest objects and reward locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->