### PR TITLE
Use a hash set for currentBots instead of a linked list

### DIFF
--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -310,7 +310,9 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 /*elapsed*/, bool /*minimal*/)
     }
 
     GetBots();
-    std::list<uint32> availableBots = currentBots;
+    // Copied deliberately: ProcessBot() erases from currentBots while this is
+    // being iterated below, so the loops must run over a snapshot.
+    std::unordered_set<uint32> availableBots = currentBots;
     uint32 availableBotCount = availableBots.size();
     uint32 onlineBotCount = playerBots.size();
 
@@ -739,7 +741,7 @@ uint32 RandomPlayerbotMgr::AddRandomBots()
             if (GetEventValue(charInfo.guid, "add") ||
                 GetEventValue(charInfo.guid, "logout") ||
                 GetPlayerBot(charInfo.guid) ||
-                std::find(currentBots.begin(), currentBots.end(), charInfo.guid) != currentBots.end() ||
+                currentBots.contains(charInfo.guid) ||
                 (sPlayerbotAIConfig.disableDeathKnightLogin && charInfo.rClass == CLASS_DEATH_KNIGHT))
             {
                 return false;
@@ -752,7 +754,7 @@ uint32 RandomPlayerbotMgr::AddRandomBots()
 
             SetEventValue(charInfo.guid, "add", 1, add_time);
             SetEventValue(charInfo.guid, "logout", 0, 0);
-            currentBots.push_back(charInfo.guid);
+            currentBots.insert(charInfo.guid);
 
             return true;
         };
@@ -1351,7 +1353,7 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
                 LOG_DEBUG("playerbots", "Bot #{}: log out", bot);
 
             SetEventValue(bot, "add", 0, 0);
-            currentBots.remove(bot);
+            currentBots.erase(bot);
 
             if (player)
                 LogoutPlayerBot(botGUID);
@@ -1434,7 +1436,7 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
         LOG_DEBUG("playerbots", "Bot #{} {}:{} <{}>: log out", bot, IsAlliance(player->getRace()) ? "A" : "H",
                   player->GetLevel(), player->GetName().c_str());
         LogoutPlayerBot(botGUID);
-        currentBots.remove(bot);
+        currentBots.erase(bot);
         SetEventValue(bot, "logout", 1,
                       urand(sPlayerbotAIConfig.minRandomBotInWorldTime, sPlayerbotAIConfig.maxRandomBotInWorldTime));
         return true;
@@ -2120,10 +2122,7 @@ bool RandomPlayerbotMgr::IsRandomBot(ObjectGuid::LowType bot)
     if (!sPlayerbotAIConfig.IsInRandomAccountList(sCharacterCache->GetCharacterAccountIdByGuid(guid)))
         return false;
 
-    if (std::find(currentBots.begin(), currentBots.end(), bot) != currentBots.end())
-        return true;
-
-    return false;
+    return currentBots.contains(bot);
 }
 
 bool RandomPlayerbotMgr::IsAddclassBot(Player* bot)
@@ -2188,7 +2187,7 @@ void RandomPlayerbotMgr::GetBots()
             Field* fields = result->Fetch();
             uint32 bot = fields[0].Get<uint32>();
             if (GetEventValue(bot, "add"))
-                currentBots.push_back(bot);
+                currentBots.insert(bot);
 
             if (currentBots.size() >= maxAllowedBotCount)
                 break;
@@ -2657,7 +2656,7 @@ void RandomPlayerbotMgr::OnPlayerLogin(Player* player)
 void RandomPlayerbotMgr::OnPlayerLoginError(uint32 bot)
 {
     SetEventValue(bot, "add", 0, 0);
-    currentBots.remove(bot);
+    currentBots.erase(bot);
 }
 
 Player* RandomPlayerbotMgr::GetRandomPlayer()

--- a/src/Bot/RandomPlayerbotMgr.h
+++ b/src/Bot/RandomPlayerbotMgr.h
@@ -7,13 +7,13 @@
 #ifndef PLAYERBOTS_RANDOMPLAYERBOTMGR_H
 #define PLAYERBOTS_RANDOMPLAYERBOTMGR_H
 
-#include <unordered_set>
-
 #include "NewRpgInfo.h"
 #include "ObjectGuid.h"
 #include "PlayerbotMgr.h"
 #include "GameTime.h"
 #include "PlayerbotCommandServer.h"
+
+#include <unordered_set>
 
 struct BattlegroundInfo
 {

--- a/src/Bot/RandomPlayerbotMgr.h
+++ b/src/Bot/RandomPlayerbotMgr.h
@@ -249,10 +249,6 @@ private:
     std::map<uint32, std::map<uint32, std::vector<WorldLocation>>> rpgLocsCacheLevel;
     std::map<TeamId, std::map<BattlegroundTypeId, std::vector<uint32>>> BattleMastersCache;
     std::unordered_map<uint32, BotEventCache> eventCache;
-    // Membership is tested on virtually every bot interaction (see IsRandomBot),
-    // so this is a hash set rather than a sequence container. It also makes the
-    // no-duplicates invariant structural instead of relying on callers to check
-    // before inserting.
     std::unordered_set<uint32> currentBots;
     uint32 bgBotsCount;
     uint32 playersLevel;

--- a/src/Bot/RandomPlayerbotMgr.h
+++ b/src/Bot/RandomPlayerbotMgr.h
@@ -7,6 +7,8 @@
 #ifndef PLAYERBOTS_RANDOMPLAYERBOTMGR_H
 #define PLAYERBOTS_RANDOMPLAYERBOTMGR_H
 
+#include <unordered_set>
+
 #include "NewRpgInfo.h"
 #include "ObjectGuid.h"
 #include "PlayerbotMgr.h"
@@ -247,7 +249,11 @@ private:
     std::map<uint32, std::map<uint32, std::vector<WorldLocation>>> rpgLocsCacheLevel;
     std::map<TeamId, std::map<BattlegroundTypeId, std::vector<uint32>>> BattleMastersCache;
     std::unordered_map<uint32, BotEventCache> eventCache;
-    std::list<uint32> currentBots;
+    // Membership is tested on virtually every bot interaction (see IsRandomBot),
+    // so this is a hash set rather than a sequence container. It also makes the
+    // no-duplicates invariant structural instead of relying on callers to check
+    // before inserting.
+    std::unordered_set<uint32> currentBots;
     uint32 bgBotsCount;
     uint32 playersLevel;
 


### PR DESCRIPTION
## Pull Request Description

`RandomPlayerbotMgr::currentBots` changes from `std::list<uint32>` to `std::unordered_set<uint32>`.

`IsRandomBot(ObjectGuid::LowType)` tested membership with `std::find` over that list — a linear scan
of ~3200 linked-list nodes, with a likely cache miss per node. Profiling put it at **3.91% of total
server CPU** (3.89% self), with instruction-level annotation attributing **99.72% of its samples to
the four-instruction traversal loop**:

```
 0.06 :  cmpl  %ebp, 0x10(%rax)    ; load node value
99.72 :  je    <found>
 0.00 :  movq  (%rax), %rax        ; node = node->next
 0.00 :  cmpq  %rbx, %rax
```

After the change, at matched battleground population: **3.91% -> 0.08%**.

Also makes the three `currentBots.remove()` calls O(1) instead of O(n), and makes the no-duplicates
invariant structural rather than something callers maintain by checking before insertion.

## Feature Evaluation

- **Minimum logic:** none added — a container swap. Every operation used is membership test, insert,
  erase, size or empty; all O(1) on `unordered_set`, O(n) on `std::list`. No new branches or state.
- **Processing cost across many bots:** strictly reduced, and the saving scales with bot count. Old
  cost was O(bots) per membership test; new cost is constant. There is no population at which the
  new version is slower.

## How to Test the Changes

1. Run to a **settled** bot population — not during ramp-up, login churn distorts the numbers.
2. `perf record -F 99 -g -p $(pgrep -x worldserver) -- sleep 90`
3. `perf report --stdio --no-children -g none | grep IsRandomBot`
4. Apply, rebuild, restart, settle to the **same** bot count and battleground occupancy, repeat.

Expected: `IsRandomBot(unsigned int)` falls from a few percent to ~zero. Structural check:
`objdump -d --demangle worldserver` on that symbol — the `movq (%rax), %rax` traversal loop is gone,
replaced by a `div`-based bucket lookup.

### Test environment

| | |
|---|---|
| CPU | AMD EPYC 7502, 16 vCPU (1 thread/core), 256 MiB L3 |
| RAM | 32 GB |
| OS / kernel | Linux Mint 22.3, kernel 7.0.0-28 |
| Compiler | clang 18.1.3, `-O2 -g -DNDEBUG` (RelWithDebInfo), static scripts/modules |
| AzerothCore | ceeb3116e (2026-07-24) |
| MySQL | 8.0.46 |
| Modules | mod-playerbots, mod-bg-auto-queue, mod-cfbg, mod-ah-bot-plus, mod-ale, mod-dungeon-clear, mod-llm-chatter |

Relevant config:

```
AiPlayerbot.MaxRandomBots = 3600      MapUpdate.Threads = 12
AiPlayerbot.MinRandomBots = 600       MapUpdateInterval = 10
AiPlayerbot.BotActiveAlone = 25       MinWorldUpdateTime = 1
AiPlayerbot.RandomBotsPerInterval = 60  Visibility.Distance.Continents = 100
```

Population during both captures: ~3200 random bots in world, ~2300 of them in battlegrounds.

CPU is worth noting specifically for this change: the cost being removed is a cache miss per
linked-list node, so cache hierarchy and memory latency determine how much of this saving transfers
to other hardware. A machine with a smaller working set relative to cache, or fewer bots, would see
proportionally less.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - [x] **No, not at all** — it reduces it, and the reduction grows with bot count.

- Does this change modify default bot behavior?
    - [x] **No** — one nuance, stated rather than hidden: a hash set does not preserve insertion
      order, and `UpdateAIInternal()` stops once its quota is met, so order decides which bots are
      serviced during a backlog. Behaviour is unchanged because eligibility comes from each bot's own
      randomised `"update"` timer, not position — `ProcessBot()` returns false for bots not yet due
      and those consume no quota. Ordering only breaks ties among already-due bots, and anything not
      serviced this tick stays due for the next.

- Does this change add new decision branches or increase maintenance complexity?
    - [x] **No** — removes two `std::find` call sites; the uniqueness invariant callers maintained by
      hand is now enforced by the container.

## AI Assistance

- [x] **Yes**

Used for interpreting the `perf` and `objdump` output, and for drafting this description.

I've spent a fair amount of my career doing low-level debugging — kernel-mode drivers, crash dump
analysis, that sort of thing — so reading the code isn't the hard part (at least when I remember to
wear my reading glasses).  What's changed is the speed at which I can work through dense disassembly
listings and profiler tables, and that's where the assistance is genuinely useful.

The change itself is essentially a container swap that I completely understand and verified.

## Code Provenance / Attribution

- [x] **No, all code in this PR is original**

## Final Checklist

- [x] Stability is not compromised.
- [x] Performance impact is understood, tested, and acceptable.
- [x] Added logic complexity is justified and explained.
- [x] Any new bot dialogue lines are translated. *(n/a)*
- [x] Any code ported/adapted from another project is attributed. *(n/a)*
- [x] New source files use the GPLv2 header. *(n/a)*
- [x] Documentation updated if needed. *(n/a)*
- [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers

`<unordered_set>` moved to the bottom of the include block as requested.

**On methodology:** the comparison uses **per-symbol shares**, not absolute CPU, because shares
normalise against total work — unrelated config changes were applied to the same test server in the
same restart, so absolute CPU is not comparable between the two profiles. I can state that
`IsRandomBot`'s share collapsed and that the traversal loop is gone from the emitted code; I can't
claim a precise whole-server percentage from this change alone. Both profiles were taken at matched
battleground population, since open-world versus battleground bot distribution changes the profile
substantially.

The snapshot copy in `UpdateAIInternal()` is retained and now commented — `ProcessBot()` erases from
`currentBots` while those loops iterate, so it must run over a snapshot. Defensive, not stylistic.


## Miscellaneous

I've been running the Playerbots fork for just under 8 weeks now, as my friends and I have the WoW
itch again. As it turns out I have just as much fun tuning MySQL, running profilers, and making
some small additions here and there to some of the mods than I do playing the game itself. I've
been investigating and learning about several different areas of the codebase (like full map updates)
to see if there's anything else I can do to squeeze every last bit of CPU with a giant bot population
when I came across the ::list/::find code in RandomPlayerbotMgr in a profiler. I felt this was an
actual worthy contribution to the project as it really does make a measurable impact, hence, this PR.
