### PR TITLE
BWL Bot Strategies: warlock pack focus and technician spread for trash

### DIFF
--- a/src/Ai/Raid/BWL/BWLActionContext.h
+++ b/src/Ai/Raid/BWL/BWLActionContext.h
@@ -29,6 +29,8 @@ public:
 
         creators["bwl use hourglass sand"] = &RaidBwlActionContext::bwl_use_hourglass_sand;
         creators["bwl nefarian fear ward"] = &RaidBwlActionContext::bwl_nefarian_fear_ward;
+        creators["bwl attack warlock pack anchor"] = &RaidBwlActionContext::bwl_attack_warlock_pack_anchor;
+        creators["bwl technician spread"] = &RaidBwlActionContext::bwl_technician_spread;
         creators["bwl death talon wyrmguard tank move away"] = &RaidBwlActionContext::bwl_death_talon_wyrmguard_tank_move_away;
         creators["bwl death talon wyrmguard ranged move away"] = &RaidBwlActionContext::bwl_death_talon_wyrmguard_ranged_move_away;
     }
@@ -43,6 +45,8 @@ private:
     static Action* bwl_vaelastrasz_move_away(PlayerbotAI* ai) { return new BwlVaelastraszMoveAwayAction(ai); }
     static Action* bwl_use_hourglass_sand(PlayerbotAI* ai) { return new BwlUseHourglassSandAction(ai); }
     static Action* bwl_nefarian_fear_ward(PlayerbotAI* ai) { return new BwlNefarianFearWardAction(ai); }
+    static Action* bwl_attack_warlock_pack_anchor(PlayerbotAI* ai) { return new BwlAttackWarlockPackAnchorAction(ai); }
+    static Action* bwl_technician_spread(PlayerbotAI* ai) { return new BwlTechnicianSpreadAction(ai); }
     static Action* bwl_death_talon_wyrmguard_tank_move_away(PlayerbotAI* ai) { return new BwlDeathTalonWyrmguardTankMoveAwayAction(ai); }
     static Action* bwl_death_talon_wyrmguard_ranged_move_away(PlayerbotAI* ai) { return new BwlDeathTalonWyrmguardRangedMoveAwayAction(ai); }
 };

--- a/src/Ai/Raid/BWL/BWLActions.cpp
+++ b/src/Ai/Raid/BWL/BWLActions.cpp
@@ -9,6 +9,7 @@
 #include "Playerbots.h"
 #include "RaidBossHelpers.h"
 #include "RtiTargetValue.h"
+#include "Timer.h"
 
 using namespace BlackwingLairHelpers;
 
@@ -284,6 +285,93 @@ bool BwlNefarianFearWardAction::Execute(Event /*event*/)
 }
 
 // Trash
+
+static constexpr float BWL_TRASH_SEARCH_RANGE = 35.0f;
+// The technicians' Bomb (22334) splashes 5 yards around where it lands, so a
+// 6-yard gap is all it takes to keep one bomb off the rest of the raid.
+static constexpr float TECHNICIAN_SPREAD_DISTANCE = 6.0f;
+// ...tolerating a couple of neighbours inside the gap: repelling until every
+// raider is isolated pushes the back half out of cast range. Only a genuine
+// clump moves, so a bomb catches three raiders at worst.
+static constexpr uint32 TECHNICIAN_SPREAD_TOLERATED_NEIGHBOURS = 2;
+// One committed step at a time: recomputing the repulsion every tick against
+// neighbours who are also mid-step degrades the settle into a constant zigzag.
+static constexpr uint32 TECHNICIAN_SPREAD_MOVE_COOLDOWN_MS = 1500;
+
+bool BwlAttackWarlockPackAnchorAction::Execute(Event /*event*/)
+{
+    // Hold a live warlock once acquired; reassignment waits until it dies.
+    if (IsTargetingLiveWarlock(botAI))
+        return false;
+
+    // Melee split evenly across the live warlocks so several die at once;
+    // ranged just burn the nearest one from wherever they spread to.
+    Creature* anchor = PlayerbotAI::IsMelee(bot)
+        ? FindAssignedWarlock(bot, BWL_TRASH_SEARCH_RANGE)
+        : FindNearestInCombat(bot, BlackwingLairNPCs::NPC_BLACKWING_WARLOCK, BWL_TRASH_SEARCH_RANGE);
+    if (!anchor)
+        return false;
+
+    return Attack(anchor);
+}
+
+bool BwlTechnicianSpreadAction::Execute(Event /*event*/)
+{
+    uint32 const now = getMSTime();
+    if (_lastMoveMs && now - _lastMoveMs < TECHNICIAN_SPREAD_MOVE_COOLDOWN_MS)
+        return false;
+
+    // Weighted repulsion from nearby group members (same approach as the
+    // Vaelastrasz Burning Adrenaline spread): closer = stronger push.
+    float fleeX = 0.0f;
+    float fleeY = 0.0f;
+    uint32 neighbours = 0;
+
+    const Group* group = bot->GetGroup();
+    if (!group)
+        return false;
+
+    for (const GroupReference* gref = group->GetFirstMember(); gref; gref = gref->next())
+    {
+        Player* p = gref->GetSource();
+        if (!p || p == bot || !p->IsAlive() || p->GetMapId() != bot->GetMapId())
+            continue;
+
+        // Only space out from others who are also spreading (ranged/healers).
+        // Melee are intentionally stacked on the warlocks; repelling from them
+        // just chases the raid around and never lets ranged settle.
+        if (PlayerbotAI::IsMelee(p))
+            continue;
+
+        float dist = bot->GetDistance2d(p);
+        if (dist < TECHNICIAN_SPREAD_DISTANCE && dist > 0.1f)
+        {
+            ++neighbours;
+            float weight = 1.0f - dist / TECHNICIAN_SPREAD_DISTANCE;
+            fleeX += (bot->GetPositionX() - p->GetPositionX()) / dist * weight;
+            fleeY += (bot->GetPositionY() - p->GetPositionY()) / dist * weight;
+        }
+    }
+
+    // Every step taken here is a cast interrupted; bots that are already
+    // spread enough stay put and keep casting.
+    if (neighbours <= TECHNICIAN_SPREAD_TOLERATED_NEIGHBOURS)
+        return false;
+
+    float fleeLen = sqrt(fleeX * fleeX + fleeY * fleeY);
+    if (fleeLen < 0.1f)
+        return false;
+
+    float moveX = bot->GetPositionX() + (fleeX / fleeLen) * INCREMENTAL_MOVE_STEP_DISTANCE;
+    float moveY = bot->GetPositionY() + (fleeY / fleeLen) * INCREMENTAL_MOVE_STEP_DISTANCE;
+
+    if (!MoveTo(bot->GetMapId(), moveX, moveY, bot->GetPositionZ(), false, false,
+                false, false, MovementPriority::MOVEMENT_COMBAT, true))
+        return false;
+
+    _lastMoveMs = now;
+    return true;
+}
 
 static constexpr float WYRMGUARD_SAFE_DISTANCE = 16.0f;
 

--- a/src/Ai/Raid/BWL/BWLActions.h
+++ b/src/Ai/Raid/BWL/BWLActions.h
@@ -76,6 +76,23 @@ public:
 
 // Trash
 
+class BwlAttackWarlockPackAnchorAction : public AttackAction
+{
+public:
+    BwlAttackWarlockPackAnchorAction(PlayerbotAI* botAI) : AttackAction(botAI, "bwl attack warlock pack anchor") {}
+    bool Execute(Event event) override;
+};
+
+class BwlTechnicianSpreadAction : public MovementAction
+{
+public:
+    BwlTechnicianSpreadAction(PlayerbotAI* botAI) : MovementAction(botAI, "bwl technician spread") {}
+    bool Execute(Event event) override;
+
+private:
+    uint32 _lastMoveMs = 0;
+};
+
 class BwlDeathTalonWyrmguardTankMoveAwayAction : public MovementAction
 {
 public:

--- a/src/Ai/Raid/BWL/BWLHelpers.cpp
+++ b/src/Ai/Raid/BWL/BWLHelpers.cpp
@@ -6,7 +6,11 @@
 
 #include "BWLHelpers.h"
 #include "AiObjectContext.h"
+#include "Creature.h"
 #include "Group.h"
+
+#include <algorithm>
+#include <vector>
 
 namespace BlackwingLairHelpers
 {
@@ -56,5 +60,75 @@ namespace BlackwingLairHelpers
         }
 
         return false;
+    }
+
+    Creature* FindNearestInCombat(const Player* bot, BlackwingLairNPCs entry, float range)
+    {
+        std::list<Creature*> creatures;
+        bot->GetCreatureListWithEntryInGrid(creatures, static_cast<uint32>(entry), range);
+
+        Creature* nearest = nullptr;
+        float nearestDist = range;
+        for (Creature* creature : creatures)
+        {
+            if (!creature->IsAlive() || !creature->IsInCombat())
+                continue;
+
+            float dist = bot->GetDistance2d(creature);
+            if (dist < nearestDist)
+            {
+                nearestDist = dist;
+                nearest = creature;
+            }
+        }
+        return nearest;
+    }
+
+    // Melee split as evenly as possible across the live warlocks instead of
+    // piling the nearest. A bot claims a warlock by its ordinal among the
+    // group's alive dps, both lists GUID-ordered, so every bot derives the
+    // same split without shared state.
+    Creature* FindAssignedWarlock(Player* bot, float range)
+    {
+        std::list<Creature*> creatures;
+        bot->GetCreatureListWithEntryInGrid(creatures,
+            static_cast<uint32>(BlackwingLairNPCs::NPC_BLACKWING_WARLOCK), range);
+
+        std::vector<Creature*> warlocks;
+        for (Creature* creature : creatures)
+            if (creature->IsAlive() && creature->IsInCombat())
+                warlocks.push_back(creature);
+
+        if (warlocks.empty())
+            return nullptr;
+
+        std::sort(warlocks.begin(), warlocks.end(),
+            [](Creature const* a, Creature const* b) { return a->GetGUID() < b->GetGUID(); });
+
+        uint32 ordinal = 0;
+        if (Group* group = bot->GetGroup())
+        {
+            for (GroupReference* gref = group->GetFirstMember(); gref; gref = gref->next())
+            {
+                Player* member = gref->GetSource();
+                if (!member || member == bot || !member->IsAlive() || member->GetMapId() != bot->GetMapId())
+                    continue;
+                if (!PlayerbotAI::IsDps(member) || !(member->GetGUID() < bot->GetGUID()))
+                    continue;
+                ++ordinal;
+            }
+        }
+
+        return warlocks[ordinal % warlocks.size()];
+    }
+
+    // Steady-state fast path shared by the warlock pack trigger, action and
+    // multiplier: the bot's own target proving a live warlock is in the fight
+    // makes their grid searches redundant.
+    bool IsTargetingLiveWarlock(PlayerbotAI* botAI)
+    {
+        Unit* current = botAI->GetAiObjectContext()->GetValue<Unit*>("current target")->Get();
+        return current && current->IsAlive() && current->IsInCombat() &&
+               current->GetEntry() == static_cast<uint32>(BlackwingLairNPCs::NPC_BLACKWING_WARLOCK);
     }
 }

--- a/src/Ai/Raid/BWL/BWLHelpers.h
+++ b/src/Ai/Raid/BWL/BWLHelpers.h
@@ -43,13 +43,18 @@ namespace BlackwingLairHelpers
     enum class BlackwingLairNPCs : uint32
     {
         // Trash
-        NPC_DEATH_TALON_WYRMGUARD = 12460
+        NPC_DEATH_TALON_WYRMGUARD = 12460,
+        NPC_BLACKWING_TECHNICIAN = 13996,
+        NPC_BLACKWING_WARLOCK = 12459
     };
 
     bool IsActiveSuppressionDeviceInRange(const GameObject* go, const Player* bot);
     bool AreRazorgoreEggsAlive(PlayerbotAI* botAI);
     bool IsRazorgoreOffTank(Player* bot);
     bool IsNonBABotNearPosition(const Player* bot, Position const& position, float distance);
+    Creature* FindNearestInCombat(const Player* bot, BlackwingLairNPCs entry, float range);
+    Creature* FindAssignedWarlock(Player* bot, float range);
+    bool IsTargetingLiveWarlock(PlayerbotAI* botAI);
 }
 
 #endif

--- a/src/Ai/Raid/BWL/BWLMultipliers.cpp
+++ b/src/Ai/Raid/BWL/BWLMultipliers.cpp
@@ -88,3 +88,29 @@ float VaelastraszBurningAdrenalineMultiplier::GetValue(Action* action)
 
     return 1.0f;
 }
+
+static constexpr float BWL_TRASH_SEARCH_RANGE = 35.0f;
+
+float WarlockPackFocusMultiplier::GetValue(Action* action)
+{
+    // The pack-anchor action locks dps onto a live warlock; zero the generic
+    // target pickers so the summoned felguards cannot drag a bot off it.
+    // Cheapest exits first: this runs for every queued action of every bot,
+    // so the action-type filter goes ahead of the warlock grid search.
+    if (!dynamic_cast<DpsAssistAction*>(action) &&
+        !dynamic_cast<DpsAoeAction*>(action) &&
+        !dynamic_cast<AggressiveTargetAction*>(action) &&
+        !dynamic_cast<AttackAnythingAction*>(action))
+        return 1.0f;
+
+    if (!PlayerbotAI::IsDps(bot))
+        return 1.0f;
+
+    if (IsTargetingLiveWarlock(botAI))
+        return 0.0f;
+
+    if (!FindNearestInCombat(bot, BlackwingLairNPCs::NPC_BLACKWING_WARLOCK, BWL_TRASH_SEARCH_RANGE))
+        return 1.0f;
+
+    return 0.0f;
+}

--- a/src/Ai/Raid/BWL/BWLMultipliers.h
+++ b/src/Ai/Raid/BWL/BWLMultipliers.h
@@ -33,4 +33,12 @@ public:
     float GetValue(Action* action) override;
 };
 
+class WarlockPackFocusMultiplier : public Multiplier
+{
+public:
+    WarlockPackFocusMultiplier(
+        PlayerbotAI* botAI) : Multiplier(botAI, "warlock pack focus multiplier") {}
+    float GetValue(Action* action) override;
+};
+
 #endif

--- a/src/Ai/Raid/BWL/BWLStrategy.cpp
+++ b/src/Ai/Raid/BWL/BWLStrategy.cpp
@@ -36,6 +36,10 @@ void RaidBwlStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(new TriggerNode("bwl nefarian fear ward", {
         NextAction("bwl nefarian fear ward", ACTION_RAID) }));
 
+    triggers.push_back(new TriggerNode("bwl warlock pack anchor", {
+        NextAction("bwl attack warlock pack anchor", ACTION_RAID + 1) }));
+    triggers.push_back(new TriggerNode("bwl technician spread", {
+        NextAction("bwl technician spread", ACTION_RAID) }));
     triggers.push_back(new TriggerNode("bwl death talon wyrmguard tank", {
         NextAction("bwl death talon wyrmguard tank move away", ACTION_RAID) }));
     triggers.push_back(new TriggerNode("bwl death talon wyrmguard ranged", {
@@ -47,4 +51,5 @@ void RaidBwlStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
     multipliers.push_back(new RazorgoreTankMultiplier(botAI));
     multipliers.push_back(new VaelastraszTankMultiplier(botAI));
     multipliers.push_back(new VaelastraszBurningAdrenalineMultiplier(botAI));
+    multipliers.push_back(new WarlockPackFocusMultiplier(botAI));
 }

--- a/src/Ai/Raid/BWL/BWLTriggerContext.h
+++ b/src/Ai/Raid/BWL/BWLTriggerContext.h
@@ -28,6 +28,8 @@ public:
         creators["bwl affliction bronze"] = &RaidBwlTriggerContext::bwl_affliction_bronze;
         creators["bwl wild magic"] = &RaidBwlTriggerContext::bwl_wild_magic;
         creators["bwl nefarian fear ward"] = &RaidBwlTriggerContext::bwl_nefarian_fear_ward;
+        creators["bwl warlock pack anchor"] = &RaidBwlTriggerContext::bwl_warlock_pack_anchor;
+        creators["bwl technician spread"] = &RaidBwlTriggerContext::bwl_technician_spread;
         creators["bwl death talon wyrmguard tank"] = &RaidBwlTriggerContext::bwl_death_talon_wyrmguard_tank;
         creators["bwl death talon wyrmguard ranged"] = &RaidBwlTriggerContext::bwl_death_talon_wyrmguard_ranged;
     }
@@ -42,6 +44,8 @@ private:
     static Trigger* bwl_affliction_bronze(PlayerbotAI* ai) { return new BwlAfflictionBronzeTrigger(ai); }
     static Trigger* bwl_wild_magic(PlayerbotAI* ai) { return new BwlWildMagicTrigger(ai); }
     static Trigger* bwl_nefarian_fear_ward(PlayerbotAI* ai) { return new BwlNefarianFearWardTrigger(ai); }
+    static Trigger* bwl_warlock_pack_anchor(PlayerbotAI* ai) { return new BwlWarlockPackAnchorTrigger(ai); }
+    static Trigger* bwl_technician_spread(PlayerbotAI* ai) { return new BwlTechnicianSpreadTrigger(ai); }
     static Trigger* bwl_death_talon_wyrmguard_tank(PlayerbotAI* ai) { return new BwlDeathTalonWyrmguardTankTrigger(ai); }
     static Trigger* bwl_death_talon_wyrmguard_ranged(PlayerbotAI* ai) { return new BwlDeathTalonWyrmguardRangedTrigger(ai); }
 };

--- a/src/Ai/Raid/BWL/BWLTriggers.cpp
+++ b/src/Ai/Raid/BWL/BWLTriggers.cpp
@@ -87,6 +87,33 @@ bool BwlNefarianFearWardTrigger::IsActive()
 
 // Trash
 
+static constexpr float BWL_TRASH_SEARCH_RANGE = 35.0f;
+
+bool BwlWarlockPackAnchorTrigger::IsActive()
+{
+    // Each warlock's Demon Portal (22372) keeps summoning Enraged Felguards,
+    // and its death despawns its portals, so every dps burns a warlock whenever
+    // one is alive - not the technicians and not the summoned felguards.
+    if (!bot->IsInCombat() || !PlayerbotAI::IsDps(bot))
+        return false;
+
+    if (IsTargetingLiveWarlock(botAI))
+        return true;
+
+    return FindNearestInCombat(bot, BlackwingLairNPCs::NPC_BLACKWING_WARLOCK, BWL_TRASH_SEARCH_RANGE) != nullptr;
+}
+
+bool BwlTechnicianSpreadTrigger::IsActive()
+{
+    // Bomb (22334) is thrown at random raiders; a clumped raid multiplies
+    // every bomb. Melee share their target's reach, so only ranged/healers
+    // spread.
+    if (!bot->IsInCombat() || !PlayerbotAI::IsRanged(bot) || PlayerbotAI::IsTank(bot))
+        return false;
+
+    return FindNearestInCombat(bot, BlackwingLairNPCs::NPC_BLACKWING_TECHNICIAN, BWL_TRASH_SEARCH_RANGE) != nullptr;
+}
+
 bool BwlDeathTalonWyrmguardTankTrigger::IsActive()
 {
     return PlayerbotAI::IsTank(bot) && AI_VALUE2(Unit*, "find target", "death talon wyrmguard");

--- a/src/Ai/Raid/BWL/BWLTriggers.h
+++ b/src/Ai/Raid/BWL/BWLTriggers.h
@@ -70,6 +70,20 @@ public:
 
 // Trash
 
+class BwlWarlockPackAnchorTrigger : public Trigger
+{
+public:
+    BwlWarlockPackAnchorTrigger(PlayerbotAI* botAI) : Trigger(botAI, "bwl warlock pack anchor") {}
+    bool IsActive() override;
+};
+
+class BwlTechnicianSpreadTrigger : public Trigger
+{
+public:
+    BwlTechnicianSpreadTrigger(PlayerbotAI* botAI) : Trigger(botAI, "bwl technician spread") {}
+    bool IsActive() override;
+};
+
 class BwlDeathTalonWyrmguardTankTrigger : public Trigger
 {
 public:


### PR DESCRIPTION
## Pull Request Description

Each Blackwing Warlock (12459) in the BWL trash packs casts Demon Portal (22372) every 30-45s, and each portal summons an Enraged Felguard every 30s until the warlock dies (killing it despawns its portals). Left to the generic target pickers the bots chew on whatever is nearest, so the pack never shrinks while a warlock is alive and the felguards stack up.

Three pieces, all gated on the pack NPCs being in combat within 35 yards:

- Warlock pack anchor: every dps prioritises a live warlock. Melee split evenly across the live warlocks by GUID ordinal, so every bot derives the same split with no shared state and the warlocks fall together. Ranged burn the nearest one.
- Warlock pack focus multiplier: zeroes the generic target pickers for dps while a warlock is alive, so the summoned felguards can't drag anyone off the kill.
- Technician spread: the technicians' Bomb (22334) is thrown at random raiders and splashes 5 yards, so ranged and healers keep a 6-yard gap via weighted repulsion. Only genuine clumps move, and steps are paced to one committed move per bot per 1.5s so the camp repositions deliberately instead of thrashing.

The strategy is only auto-applied inside Blackwing Lair (map 469).

## Feature Evaluation

- Minimum logic: two triggers, one attack action, one movement action and one multiplier, all on existing base classes, plus two grid-search helpers. In the steady state (bot already burning a warlock) all three sites share a cached current-target check and skip the grid search entirely.
- Processing cost: combat and role flags exit first, so bots outside BWL pack combat pay a couple of boolean checks. Grid searches only run for dps actually fighting the pack, and only until a warlock is acquired. Measured numbers under Impact Assessment.

## How to Test the Changes

1. Take a bot raid into BWL and pull any trash pack containing Blackwing Warlocks and Blackwing Technicians.
2. Watch the dps: they should switch to the warlocks on pull, melee spreading across several warlocks rather than piling one, and ignore the summoned felguards until the last warlock drops, at which point normal target picking resumes.
3. Watch the ranged/healers: they should open up roughly 6-yard gaps while technicians are alive. Bots already spaced should stand still and keep casting, only clumps move.
4. The decision trace in Playerbots.log shows the new entries as `bwl warlock pack anchor`, `bwl attack warlock pack anchor` and `bwl technician spread`.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

Measured with the standardized pmon procedure from this template (BotActiveAlone = 100, botActiveAloneSmartScale = 0, 41 fully active bots: a 40-bot raid parked in BWL plus 1 random bot). Parked baseline Total was 38.4s over the 5-minute window (0.361ms avg per AI update). During a full pack fight (18 warlocks, 92 technicians respawned for the test) the average rose to 0.459ms. The new trigger, action and multiplier rank below pmon's visible table floor in both windows, while pre-existing BWL triggers chart at 0.1-0.3%.

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

Only inside BWL, and only while these specific trash NPCs are in combat within 35 yards: dps target selection locks to warlocks and ranged/healers de-clump. Bosses and everything outside map 469 are untouched, and the lock releases itself when the last warlock dies.

- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [x] Yes (**explain below**)

Two trigger nodes and one multiplier added to the existing BWL raid strategy. Self-contained in the BWL raid files, no new config, no changes to shared machinery.

## AI Assistance

Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)

Code generation and log analysis were done with AI assistance (Claude, via Claude Code, co-author trailer on the commit). I reviewed all of it and validated it live across four pack pulls in a 40-bot raid, iterating on what the decision traces showed (the spread pacing and the steady-state early-outs both came out of those traces). The pmon measurements above were run on the final code.

## Code Provenance / Attribution

Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated.
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers

The behaviour claims were checked against the data rather than folklore: the warlock SAI casts Demon Portal (22372) on a 30-45s timer, the portal NPC (14081) summons via serverside aura 22391 triggering 22392 "Summon Enraged Felguard" every 30s, and the warlock's On Just Died script despawns its portals. Bomb (22334) is a 5-yard fire AoE cast at a random hostile per the technician SAI.

The spread started life re-deciding every tick (235 moves in 12 seconds across the camp in the first live trace) and was paced to one committed step per bot per 1.5s after that showed up as visible zigzagging. The early-outs cut roughly 4-5k redundant grid searches per pack and dropped target acquisitions from 45 to 32, since bots now hold an acquired warlock instead of reshuffling when another one dies.

Wyrmguard handling is untouched (#2594 owns that space), and the suppression room hatcher priority is deliberately left out for a separate PR.

-----------------------

Let me know if you prefer more (like this) or less verbosity in PRs etc. As I progress my tooling and understanding of the codebase hopefully I can settle in and help out more confidently. :)
