### PR TITLE
fix(dungeons): stop the generic cc strategy from firing in 5-man dung…

### DIFF
--- a/src/Ai/Base/Trigger/GenericTriggers.cpp
+++ b/src/Ai/Base/Trigger/GenericTriggers.cpp
@@ -577,7 +577,23 @@ bool IsNotFacingTargetTrigger::IsActive()
 
 bool HasCcTargetTrigger::IsActive()
 {
-    return AI_VALUE2(Unit*, "cc target", getName()) && !AI_VALUE2(Unit*, "current cc target", getName());
+    Unit* rtiCcTarget = nullptr;
+    if (botAI->IsInNonRaidDungeon())
+    {
+        rtiCcTarget = AI_VALUE(Unit*, "rti cc target");
+        if (!rtiCcTarget)
+            return false;
+    }
+
+    return IsCcTargetFree(AI_VALUE2(Unit*, "cc target", getName()), rtiCcTarget);
+}
+
+bool HasCcTargetTrigger::IsCcTargetFree(Unit* ccTarget, Unit* rtiCcTarget)
+{
+    if (!ccTarget || (rtiCcTarget && ccTarget != rtiCcTarget))
+        return false;
+
+    return !AI_VALUE2(Unit*, "current cc target", getName());
 }
 
 bool NoMovementTrigger::IsActive() { return !AI_VALUE2(bool, "moving", "self target"); }

--- a/src/Ai/Base/Trigger/GenericTriggers.h
+++ b/src/Ai/Base/Trigger/GenericTriggers.h
@@ -686,6 +686,9 @@ public:
     HasCcTargetTrigger(PlayerbotAI* botAI, std::string const name) : Trigger(botAI, name) {}
 
     bool IsActive() override;
+
+protected:
+    bool IsCcTargetFree(Unit* ccTarget, Unit* rtiCcTarget);
 };
 
 class NoMovementTrigger : public Trigger

--- a/src/Ai/Base/Trigger/RtiTriggers.cpp
+++ b/src/Ai/Base/Trigger/RtiTriggers.cpp
@@ -30,7 +30,7 @@ bool RtiCcTrigger::IsActive()
 
     Unit* ccTarget = AI_VALUE2(Unit*, "cc target", getName());
     if (ccTarget && ccTarget == rtiCcTarget)
-        return HasCcTargetTrigger::IsActive();
+        return IsCcTargetFree(ccTarget, rtiCcTarget);
 
     return botAI->CanCastSpell(getName(), rtiCcTarget);
 }

--- a/src/Ai/Class/Mage/Strategy/FireMageStrategy.cpp
+++ b/src/Ai/Class/Mage/Strategy/FireMageStrategy.cpp
@@ -56,6 +56,23 @@ void FireMageStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
             }
         )
     );
+
+    triggers.push_back(
+        new TriggerNode(
+            "enemy too close for spell",
+            {
+                NextAction("dragon's breath", ACTION_INTERRUPT + 1)
+            }
+        )
+    );
+    triggers.push_back(
+        new TriggerNode(
+            "enemy is close",
+            {
+                NextAction("blast wave", ACTION_INTERRUPT)
+            }
+        )
+    );
 }
 
 // Combat strategy to run to melee for Dragon's Breath and Blast Wave

--- a/src/Ai/Class/Mage/Strategy/FrostFireMageStrategy.cpp
+++ b/src/Ai/Class/Mage/Strategy/FrostFireMageStrategy.cpp
@@ -54,4 +54,21 @@ void FrostFireMageStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
             }
         )
     );
+
+    triggers.push_back(
+        new TriggerNode(
+            "enemy too close for spell",
+            {
+                NextAction("dragon's breath", ACTION_INTERRUPT + 1)
+            }
+        )
+    );
+    triggers.push_back(
+        new TriggerNode(
+            "enemy is close",
+            {
+                NextAction("blast wave", ACTION_INTERRUPT)
+            }
+        )
+    );
 }

--- a/src/Ai/Class/Mage/Strategy/GenericMageStrategy.cpp
+++ b/src/Ai/Class/Mage/Strategy/GenericMageStrategy.cpp
@@ -168,14 +168,6 @@ void MageBoostStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 void MageCcStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
     triggers.push_back(new TriggerNode("polymorph", { NextAction("polymorph", 30.0f) }));
-
-    Player* bot = botAI->GetBot();
-    int tab = AiFactory::GetPlayerSpecTab(bot);
-    if (tab == MAGE_TAB_FIRE)
-    {
-        triggers.push_back(new TriggerNode("enemy too close for spell", {NextAction("dragon's breath", ACTION_INTERRUPT + 1)}));
-        triggers.push_back(new TriggerNode("enemy is close", {NextAction("blast wave", ACTION_INTERRUPT)}));
-    }
 }
 
 void MageAoeStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -12,6 +12,7 @@
 #include "CheckMountStateAction.h"
 #include "Common.h"
 #include "CreatureData.h"
+#include "DBCStores.h"
 #include "EmoteAction.h"
 #include "Engine.h"
 #include "EventProcessor.h"
@@ -1763,6 +1764,12 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
         out << "Added " << strategyName << " instance strategy";
         TellMasterNoFacing(out.str());
     }
+}
+
+bool PlayerbotAI::IsInNonRaidDungeon() const
+{
+    MapEntry const* mapEntry = sMapStore.LookupEntry(bot->GetMapId());
+    return mapEntry && mapEntry->IsNonRaidDungeon();
 }
 
 bool PlayerbotAI::HasTargetExclusions() const

--- a/src/Bot/PlayerbotAI.h
+++ b/src/Bot/PlayerbotAI.h
@@ -410,6 +410,7 @@ public:
     std::vector<std::string> GetStrategies(BotState type);
     Strategy* GetStrategy(std::string const name, BotState type);
     void ApplyInstanceStrategies(uint32 mapId, bool tellMaster = false);
+    bool IsInNonRaidDungeon() const;
     bool HasTargetExclusions() const;
     void EvaluateHealerDpsStrategy();
     bool ContainsStrategy(StrategyType type);


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

Bots in dungeons break CC. One bot sheeps a mob, the next bot hits it, sheep heals the mob, mage keeps
spamming sheep. In 5 man dungeons I've never seen CC be useful, as it is simply not yet supported in a generic way
with the "cc" combat strat.

So this PR turns off the generic `cc` strategy while a bot is in a 5-man.

I did it by having `Engine::Init()` skip strategies that say they're suppressed:

```cpp
Strategy* strategy = i->second;
if (strategy->IsSuppressed())
    continue;
```

and one implementation on the base class:

```cpp
bool Strategy::IsSuppressed() { return botAI->IsInNonRaidDungeon() && getName() == "cc"; }
```

Nothing gets added to or removed from the engine, which matters for a few reasons:

* Open world, raids and BGs behave exactly like they do now.
* `co +cc` / `co -cc` still work normally and the saved strategy string is never touched, so a master's
  setting can't get clobbered.
* Instance strategies (`tbc-mgt`, `wotlk-uk`, etc) have their own CC triggers under their own names, so
  a dungeon script that wants a sheep still gets one.
* No new call sites needed. `Init()` already runs on login, on strategy changes, on combat state flips,
  and after a far teleport through `Reset(true)`.

Second thing in here: Dragon's Breath and Blast Wave move out of `MageCcStrategy` into
`FireMageStrategy` and `FrostFireMageStrategy`. They're panic buttons for when something is in your
face, not crowd control, and they were fire-spec only anyway. `AiFactory` adds `fire`/`frostfire` for
the same spec the old `MAGE_TAB_FIRE` check tested, so the same bots end up with the same triggers.

What actually goes quiet in a 5-man:

| Class | Spells |
|---------|--------------------------------------|
| Mage | Polymorph |
| Priest | Shackle Undead |
| Paladin | Turn Undead |
| Hunter | Scare Beast, Freezing Trap |
| Rogue | Stealth into Sap |
| Druid | Cyclone, Hibernate, Entangling Roots |
| Warlock | Banish, Fear |

Warrior, Shaman and DK don't have a `cc` strategy so nothing changes for them.

Heads up on one thing: Banish and Cyclone make the target immune to damage, so bots can't actually break
those two. My reasoning above doesn't really cover them. I still think they're not worth casting in a
5-man, but if you'd rather I leave them alone I can.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

Minimum logic: one `continue` in the `Engine::Init()` loop, one virtual on `Strategy`, and one map check
on `PlayerbotAI`. 48 lines added across 8 files, 5 of those lines in `src/Bot`. No new members, no new
state to keep in sync, no config read, nothing added to the trigger or action tables.

I originally wrote this the obvious way, pulling `cc` off the engine on the way into a dungeon and
putting it back on the way out. That needed two bools, five call sites, and a fix in
`PlayerbotRepository::Save` so the suppression didn't get written into the bot's saved strategy list. It
was more code and it had a bug where a bot logging in inside a dungeon could get its saved `-cc`
overwritten. This version has neither problem.

Cost: nothing on the tick path. `IsSuppressed()` is only called from `Engine::Init()`, and the tick path
(`UpdateAIInternal` -> `DoNextAction` -> `currentEngine->DoNextAction()`) never calls `Init()`. A bot
sitting in a dungeon pays nothing per tick.

Per `Init()` it's one call per strategy, so about 15-20 on a combat engine. I put the cheap check first
on purpose: `IsInNonRaidDungeon()` is `sMapStore.LookupEntry(id)`, a bounds check and an array read, no
allocation. Outside a dungeon it stops there and never calls `getName()`, which is where most bots are
most of the time. Inside a dungeon you also get one short string per strategy for the name compare.

For context, `Init()` already deletes and reallocates every `TriggerNode` and `Multiplier` on the
engine, so 18 array reads on top of that isn't going to show up.

`Init()` doesn't run any more often than it did before. It fires on login, on each combat/non-combat/dead
engine switch, on `co +x` / `-x`, on spec change or randomize, and after a far teleport. I specifically
did not add an `Init()` call in `HandleTeleportAck`, because `Reset(true)` a few lines down already
re-inits all three engines and doing it twice per teleport would be wasteful with a lot of random bots
zipping around.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

You need a mage in the party, and humanoid mobs since that's what Polymorph works on.

1. Outdoors, pull a humanoid pack. Mage should sheep one. `co ?` shows `cc`.
2. Go into any 5-man and pull a humanoid pack. No sheep. `co ?` still shows `cc`, because the strategy
   is still on the engine, it's just not doing anything.
3. Leave and pull outdoors again. Sheep comes back on its own, no `co +cc`, no relog.
4. Do step 1 again inside a raid and inside a BG. Should be identical to current test-staging.
5. Master settings: `co -cc` outside, zone into a dungeon, zone out, `cc` should still be off. Then
   `co +cc` outside, log out inside a dungeon, log back in, leave, `cc` should still be on. This is the
   case my first attempt got wrong so it's worth checking.
6. Heroic is the same map type so it behaves the same. Quick spot check.
7. As fire or frostfire mage, let something get in melee range in a dungeon. Dragon's Breath and Blast
   Wave should still go off.

## Impact Assessment
<!--
As a generic test, pmon checks before and after your edits are helpful. To standardize the measurement, set the configs
BotActiveAlone = 100 & botActiveAloneSmartScale = 0. After server boot, enable the monitor `playerbot pmon toggle`
right after the bots finished logging-in, and run the stack command `playerbot pmon stack` 5 minutes after that.
The last "Total" line is the main result to look for.
-->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

Nothing on the tick path, and `Init()` isn't called any more often than before. The added work scales
with `Init()` calls, not with ticks or party size or number of targets. In a dungeon the engine actually
builds fewer triggers than it does today, since the `cc` ones get skipped.

<!-- TODO(author): drop your pmon before/after here. BotActiveAlone = 100, botActiveAloneSmartScale = 0,
     pmon toggle after login, pmon stack 5 min later, post the last "Total" line for both builds. -->

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

Yes, that's the whole point. By default bots stop casting the spells in the table above while in a
non-raid dungeon. Open world, raids, BGs and arenas are unchanged, and so is every instance strategy.

There's no config option for it right now. I left it as a plain default because a CC the group instantly
breaks is a bug everywhere it happens, not a preference. If you want a toggle I'll add one, see the
notes at the bottom.

- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [x] Yes (**explain below**)

One branch in `Engine::Init()` and one virtual on `Strategy`. Two things I'd want a second opinion on:

1. `Strategy::IsSuppressed()` sounds generic but the only implementation hardcodes `"cc"`, so the base
   class now knows about one specific strategy name. The alternative was a guard clause in all seven
   `*CcStrategy::InitTriggers`, which I had working first. I went with the single place because any
   future `cc` strategy gets it for free, but I'm not attached to it.
2. The `continue` skips the whole strategy, not just its triggers, so it also skips `GetType()`,
   `HasTargetExclusions()`, `InitMultipliers()` and `actionNodeFactories`. I checked all seven `cc`
   strategies and none of them use any of that (all have `: Strategy(botAI) {}` constructors and no
   overrides), so right now it's the same thing. If someone later adds a multiplier or a factory to a
   `cc` strategy it would quietly get dropped.

## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

<!-- TODO(author): reword to match how you actually worked. -->

Yes, for review and cleanup passes.

It went through a few rewrites. First version added and removed the strategy from the engine, which had
the save bug I mentioned above. Second version put a guard clause in each of the seven cc strategies,
which worked but was seven copies of the same line. Third is what's here. A perf pass after that caught
a redundant `Engine::Init()` I'd added in `HandleTeleportAck` and got the `&&` in `IsSuppressed()` the
right way round so the cheap check runs first.

I went through the call sites myself for the frequency and cost claims above rather than taking them on
faith.

## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->

<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/Ai/Base/Actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated. <!-- n/a, no new dialogue -->
- - [x] New source files use the GPLv2 header. <!-- n/a, no new files -->
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->

8 files, +48 / -8:

| File | What |
|---|---|
| `src/Bot/Engine/Engine.cpp` | skip suppressed strategies in `Init()` |
| `src/Bot/Engine/Strategy/Strategy.h` | `virtual bool IsSuppressed();` |
| `src/Bot/Engine/Strategy/Strategy.cpp` | the one line implementation |
| `src/Bot/PlayerbotAI.h` / `.cpp` | `IsInNonRaidDungeon()` and the `DBCStores.h` include |
| `src/Ai/Class/Mage/Strategy/GenericMageStrategy.cpp` | Dragon's Breath / Blast Wave out |
| `src/Ai/Class/Mage/Strategy/FireMageStrategy.cpp` | and in |
| `src/Ai/Class/Mage/Strategy/FrostFireMageStrategy.cpp` | same |

On the map check, `MapEntry::IsNonRaidDungeon()` is `map_type == MAP_INSTANCE`. That's per map, not per
difficulty, so heroics are covered by the same check and raids, BGs and arenas are excluded.

If you want this behind a config, I'd suggest:

```
AiPlayerbot.DungeonSuppressedStrategies = "cc"
```

and have `IsSuppressed()` check that set instead of the literal. That gets the hardcoded `"cc"` out of
`Strategy` too, and an empty string gives you current behavior back. Happy to push that if you'd prefer
it.

Also happy to split the mage Dragon's Breath / Blast Wave bit into its own PR if you'd rather look at
them separately, it stands on its own either way.
