### PR TITLE
Fix selfbot trading and trade cancellations

### DIFF
--- a/src/Ai/Base/Actions/TradeStatusAction.cpp
+++ b/src/Ai/Base/Actions/TradeStatusAction.cpp
@@ -19,39 +19,47 @@
 
 bool TradeStatusAction::Execute(Event event)
 {
+    if (IsSelfBot(bot))
+        return false;
+
+    if (!bot->GetSession())
+        return false;
+
     Player* trader = bot->GetTrader();
-    Player* master = GetMaster();
     if (!trader)
         return false;
 
-    PlayerbotAI* traderBotAI = GET_PLAYERBOT_AI(trader);
+    bool const traderIsGameClientPlayer = IsRealPlayer(trader) || IsSelfBot(trader);
+    Player* master = GetMaster();
 
-    // Allow the master and group members to trade
-    if (trader != master && !traderBotAI && (!bot->GetGroup() || !bot->GetGroup()->IsMember(trader->GetGUID())))
+    // Bots refuse to trade with a person (whether active or selfbotting) who is neither their
+    // master nor a group member. Bot traders (other than selfbots) are handled further down.
+    if (trader != master && traderIsGameClientPlayer &&
+        (!bot->GetGroup() || !bot->GetGroup()->IsMember(trader->GetGUID())))
     {
         bot->Whisper(PlayerbotTextMgr::instance().GetBotTextOrDefault(
                          "trade_busy_now", "I'm kind of busy now", {}),
                      LANG_UNIVERSAL, trader);
+        CancelTrade();
         return false;
     }
 
-    if (sPlayerbotAIConfig.enableRandomBotTrading == 0 && (sRandomPlayerbotMgr.IsRandomBot(bot)|| sRandomPlayerbotMgr.IsAddclassBot(bot)))
+    if (sPlayerbotAIConfig.enableRandomBotTrading == 0 &&
+        (sRandomPlayerbotMgr.IsRandomBot(bot)|| sRandomPlayerbotMgr.IsAddclassBot(bot)))
     {
         bot->Whisper(PlayerbotTextMgr::instance().GetBotTextOrDefault(
                          "trade_disabled", "Trading is disabled", {}),
                      LANG_UNIVERSAL, trader);
+        CancelTrade();
         return false;
     }
 
-    // Allow trades from group members or bots
+    // Bots also refuse their own master when ungrouped and security withholds full access.
     if ((!bot->GetGroup() || !bot->GetGroup()->IsMember(trader->GetGUID())) &&
         (trader != master || !botAI->GetSecurity()->CheckLevelFor(PLAYERBOT_SECURITY_ALLOW_ALL, true, master)) &&
-        !traderBotAI)
+        traderIsGameClientPlayer)
     {
-        WorldPacket p;
-        uint32 status = 0;
-        p << status;
-        bot->GetSession()->HandleCancelTradeOpcode(p);
+        CancelTrade();
         return false;
     }
 
@@ -60,7 +68,9 @@ bool TradeStatusAction::Execute(Event event)
     uint32 status;
     p >> status;
 
-    if (status == TRADE_STATUS_TRADE_ACCEPT || (status == TRADE_STATUS_BACK_TO_TRADE && trader->GetTradeData() && trader->GetTradeData()->IsAccepted()))
+    if (status == TRADE_STATUS_TRADE_ACCEPT ||
+        (status == TRADE_STATUS_BACK_TO_TRADE &&
+         trader->GetTradeData() && trader->GetTradeData()->IsAccepted()))
     {
         WorldPacket p;
         uint32 status = 0;
@@ -95,9 +105,7 @@ bool TradeStatusAction::Execute(Event event)
 
                 CraftData& craftData = AI_VALUE(CraftData&, "craft");
                 if (!craftData.IsEmpty() && craftData.IsRequired(itemId))
-                {
                     craftData.AddObtained(itemId, count);
-                }
 
                 GuildTaskMgr::instance().CheckItemTask(itemId, count, trader, bot);
             }
@@ -109,9 +117,7 @@ bool TradeStatusAction::Execute(Event event)
 
                 CraftData& craftData = AI_VALUE(CraftData&, "craft");
                 if (!craftData.IsEmpty() && craftData.itemId == itemId)
-                {
                     craftData.Crafted(count);
-                }
             }
 
             return true;
@@ -123,7 +129,6 @@ bool TradeStatusAction::Execute(Event event)
             bot->SetFacingToObject(trader);
 
         BeginTrade();
-
         return true;
     }
     return false;
@@ -132,7 +137,7 @@ bool TradeStatusAction::Execute(Event event)
 void TradeStatusAction::BeginTrade()
 {
     Player* trader = bot->GetTrader();
-    if (!trader || GET_PLAYERBOT_AI(bot->GetTrader()))
+    if (!trader || (GET_PLAYERBOT_AI(trader) && !IsSelfBot(trader)))
         return;
 
     WorldPacket p;
@@ -156,13 +161,20 @@ void TradeStatusAction::BeginTrade()
     }
 }
 
+void TradeStatusAction::CancelTrade()
+{
+    WorldPacket p;
+    bot->GetSession()->HandleCancelTradeOpcode(p);
+}
+
 bool TradeStatusAction::CheckTrade()
 {
     Player* trader = bot->GetTrader();
     if (!bot->GetTradeData() || !trader || !trader->GetTradeData())
         return false;
 
-    if (!IsRealPlayer(botAI->GetMaster()) && GET_PLAYERBOT_AI(bot->GetTrader()))
+    if (!botAI->HasGameClientMaster() && GET_PLAYERBOT_AI(bot->GetTrader()) &&
+        !IsSelfBot(bot->GetTrader()))
     {
         for (uint32 slot = 0; slot < TRADE_SLOT_TRADED_COUNT; ++slot)
         {
@@ -185,23 +197,24 @@ bool TradeStatusAction::CheckTrade()
         {
             if (bot->GetGroup() && bot->GetGroup()->IsMember(bot->GetTrader()->GetGUID()) &&
                 botAI->HasGameClientMaster())
+            {
                 botAI->TellMasterNoFacing(PlayerbotTextMgr::instance().GetBotTextOrDefault(
                     "trade_thank_you_player",
                     "Thank you %player",
                     {{"%player", chat->FormatWorldobject(bot->GetTrader())}}));
+            }
             else
+            {
                 bot->Say(PlayerbotTextMgr::instance().GetBotTextOrDefault(
                              "trade_thank_you_player",
                              "Thank you %player",
                              {{"%player", chat->FormatWorldobject(bot->GetTrader())}}),
                          (bot->GetTeamId() == TEAM_ALLIANCE ? LANG_COMMON : LANG_ORCISH));
+            }
         }
         return isGettingItem;
     }
-    if (!bot->GetSession())
-    {
-        return false;
-    }
+
     uint32 accountId = bot->GetSession()->GetAccountId();
     if (!sPlayerbotAIConfig.IsInRandomAccountList(accountId))
     {
@@ -219,14 +232,16 @@ bool TradeStatusAction::CheckTrade()
     int32 botMoney = bot->GetTradeData()->GetMoney() + botItemsMoney;
     int32 playerItemsMoney = CalculateCost(trader, false);
     int32 playerMoney = trader->GetTradeData()->GetMoney() + playerItemsMoney;
-    if (botItemsMoney > 0 && sPlayerbotAIConfig.enableRandomBotTrading == 2 && (sRandomPlayerbotMgr.IsRandomBot(bot)|| sRandomPlayerbotMgr.IsAddclassBot(bot)))
+    if (botItemsMoney > 0 && sPlayerbotAIConfig.enableRandomBotTrading == 2 &&
+        (sRandomPlayerbotMgr.IsRandomBot(bot)|| sRandomPlayerbotMgr.IsAddclassBot(bot)))
     {
         bot->Whisper(PlayerbotTextMgr::instance().GetBotTextOrDefault(
                          "trade_selling_disabled", "Selling is disabled.", {}),
                      LANG_UNIVERSAL, trader);
         return false;
     }
-    if (playerItemsMoney && sPlayerbotAIConfig.enableRandomBotTrading == 3 && (sRandomPlayerbotMgr.IsRandomBot(bot)|| sRandomPlayerbotMgr.IsAddclassBot(bot)))
+    if (playerItemsMoney && sPlayerbotAIConfig.enableRandomBotTrading == 3 &&
+        (sRandomPlayerbotMgr.IsRandomBot(bot)|| sRandomPlayerbotMgr.IsAddclassBot(bot)))
     {
         bot->Whisper(PlayerbotTextMgr::instance().GetBotTextOrDefault(
                          "trade_buying_disabled", "Buying is disabled.", {}),

--- a/src/Ai/Base/Actions/TradeStatusAction.h
+++ b/src/Ai/Base/Actions/TradeStatusAction.h
@@ -21,6 +21,7 @@ public:
 
 private:
     void BeginTrade();
+    void CancelTrade();
     bool CheckTrade();
     int32 CalculateCost(Player* player, bool sell);
 };


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

The general idea is that selfbots should be treated as humans for trading purposes, when before there were several gaps.

- You can actually open a trade window as a selfbot. Before, you could do it only if you made the bot start the trade (like telling them "trade").
- You can take stuff from altbots you are trading with as a selfbot. Before, you could give altbots items or exchange items with them with selfbot on, but a trade would not complete if you did not offer up anything.
- You can't rip off randombots by going into selfbot mode. Before, you could open up a trade with a randombot in your group (by making them initiate the trade since the selfbot was not allowed to), and then you could have them put up any item and as long as you gave an item back, could've been an apple, they'd accept.
- Bots refuse trades from selfbots in the same way that they refuse trades from an active player (e.g., a randombot you aren't grouped with will reject your trade, whether or not you have seflbot on).
- Trying to trade _with_ a selfbot now is like trading with a person. Before, you could open a trade with a selfbot in your group and then as soon as you hit accept the trade would complete.

Also, this PR fixes a bug relating to trade cancellation. Previously, if you had a trade refused by a bot, in most cases you'd be stuck as if you were in an open trade and would not be able to open another because the packet to cancel a trade was never sent. Now, you'll actually get a cancellation so it won't block additional trading. 

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

TradeStatusAction::Execute() immediately returns false for a selfbot. 

A helper, TradeStatusAction::CancelTrade(), was added to send the trade cancellation packet since it's duplicated three times (one of the three already existed, but it was the narrowest path to a trade rejection compared to the two that didn't have the packet).

Otherwise, this is mostly a matter of ensuring that selfbots are included in paths that previously required an active human player.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

1. Selfbot and try to initiate a trade with an altbot. It should open the trade window. Tell your altbot to put up an item for trade. Put up nothing in return and try to accept. The trade should succeed.
2. Selfbot and try to initiate a trade with a randombot in your group. It should open the trade window. Tell the randombot to put up something for trade that isn't gray. Offer them something that isn't gray but is worth very little. Depending on what it is, the bot should tell you either "I don't need this" (if it doesn't want your item at all) or how much additional money it wants for its item (if your item has some but not enough value).
3. Selfbot and try to initiate a trade with a randombot that is not in your group. You should get the message "I'm busy right now" and the trade should be cancelled immediately. You should then be able to attempt another trade (and get that message again) or attempt a trade with a valid partner (like an altbot) and open a window successfully.


## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

The purpose is to have bots treat selfbots like humans instead of other bots with respect to trading.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

Assistance with trying to read the trade code, which I find very confusing, and also identifying the issue causing trades not to be validly cancelled.

## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated.
- - [x] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note).
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


