### PR TITLE
Calculate real BG size for random BG's

### DIFF
--- a/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
+++ b/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
@@ -293,17 +293,17 @@ bool BGJoinAction::shouldJoinBg(BattlegroundQueueTypeId queueTypeId, Battlegroun
     uint32 bgHordePlayerCount = sRandomPlayerbotMgr.BattlegroundData[queueTypeId][bracketId].bgHordePlayerCount;
     uint32 activeBgQueue = sRandomPlayerbotMgr.BattlegroundData[queueTypeId][bracketId].activeBgQueue;
     uint32 bgInstanceCount = sRandomPlayerbotMgr.BattlegroundData[queueTypeId][bracketId].bgInstanceCount;
-    
+
     uint32 maxRequiredAllianceSlots;
     uint32 maxRequiredHordeSlots;
-    
+
     // For random battlegrounds we need to find out the real BG size.
     if (queueTypeId == BATTLEGROUND_QUEUE_RB)
     {
-        // Use the original tempplate size to make the queue pop.
+        // Use the original template size to make the queue pop.
         maxRequiredAllianceSlots = TeamSize * activeBgQueue;
         maxRequiredHordeSlots = TeamSize * activeBgQueue;
-        
+
         // Existing Random BG instances use their real battleground size.
         for (Battleground const* activeBg : sBattlegroundMgr->GetActiveBattlegrounds())
         {
@@ -311,14 +311,14 @@ bool BGJoinAction::shouldJoinBg(BattlegroundQueueTypeId queueTypeId, Battlegroun
                 activeBg->GetBgTypeID() != BATTLEGROUND_RB ||
                 activeBg->GetBracketId() != bracketId)
                 continue;
-            
+
             BattlegroundTypeId realBgTypeId = activeBg->GetBgTypeID(true);
-            
+
             if (realBgTypeId == BATTLEGROUND_RB)
                 continue;
-            
+
             uint32 realTeamSize = activeBg->GetMaxPlayersPerTeam();
-            
+
             maxRequiredAllianceSlots += realTeamSize;
             maxRequiredHordeSlots += realTeamSize;
         }
@@ -327,12 +327,12 @@ bool BGJoinAction::shouldJoinBg(BattlegroundQueueTypeId queueTypeId, Battlegroun
     {
         // Existing behavior for normal battlegrounds.
         maxRequiredAllianceSlots =
-        TeamSize * (activeBgQueue + bgInstanceCount);
-        
+            TeamSize * (activeBgQueue + bgInstanceCount);
+
         maxRequiredHordeSlots =
-        TeamSize * (activeBgQueue + bgInstanceCount);
+            TeamSize * (activeBgQueue + bgInstanceCount);
     }
-    
+
     if (teamId == TEAM_ALLIANCE)
     {
         if ((bgAllianceBotCount + bgAlliancePlayerCount) < maxRequiredAllianceSlots)
@@ -343,7 +343,7 @@ bool BGJoinAction::shouldJoinBg(BattlegroundQueueTypeId queueTypeId, Battlegroun
         if ((bgHordeBotCount + bgHordePlayerCount) < maxRequiredHordeSlots)
             return true;
     }
-    
+
     return false;
 }
 

--- a/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
+++ b/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
@@ -293,18 +293,57 @@ bool BGJoinAction::shouldJoinBg(BattlegroundQueueTypeId queueTypeId, Battlegroun
     uint32 bgHordePlayerCount = sRandomPlayerbotMgr.BattlegroundData[queueTypeId][bracketId].bgHordePlayerCount;
     uint32 activeBgQueue = sRandomPlayerbotMgr.BattlegroundData[queueTypeId][bracketId].activeBgQueue;
     uint32 bgInstanceCount = sRandomPlayerbotMgr.BattlegroundData[queueTypeId][bracketId].bgInstanceCount;
-
+    
+    uint32 maxRequiredAllianceSlots;
+    uint32 maxRequiredHordeSlots;
+    
+    // For random battlegrounds we need to find out the real BG size.
+    if (queueTypeId == BATTLEGROUND_QUEUE_RB)
+    {
+        // Use the original tempplate size to make the queue pop.
+        maxRequiredAllianceSlots = TeamSize * activeBgQueue;
+        maxRequiredHordeSlots = TeamSize * activeBgQueue;
+        
+        // Existing Random BG instances use their real battleground size.
+        for (Battleground const* activeBg : sBattlegroundMgr->GetActiveBattlegrounds())
+        {
+            if (!activeBg ||
+                activeBg->GetBgTypeID() != BATTLEGROUND_RB ||
+                activeBg->GetBracketId() != bracketId)
+                continue;
+            
+            BattlegroundTypeId realBgTypeId = activeBg->GetBgTypeID(true);
+            
+            if (realBgTypeId == BATTLEGROUND_RB)
+                continue;
+            
+            uint32 realTeamSize = activeBg->GetMaxPlayersPerTeam();
+            
+            maxRequiredAllianceSlots += realTeamSize;
+            maxRequiredHordeSlots += realTeamSize;
+        }
+    }
+    else
+    {
+        // Existing behavior for normal battlegrounds.
+        maxRequiredAllianceSlots =
+        TeamSize * (activeBgQueue + bgInstanceCount);
+        
+        maxRequiredHordeSlots =
+        TeamSize * (activeBgQueue + bgInstanceCount);
+    }
+    
     if (teamId == TEAM_ALLIANCE)
     {
-        if ((bgAllianceBotCount + bgAlliancePlayerCount) < TeamSize * (activeBgQueue + bgInstanceCount))
+        if ((bgAllianceBotCount + bgAlliancePlayerCount) < maxRequiredAllianceSlots)
             return true;
     }
     else
     {
-        if ((bgHordeBotCount + bgHordePlayerCount) < TeamSize * (activeBgQueue + bgInstanceCount))
+        if ((bgHordeBotCount + bgHordePlayerCount) < maxRequiredHordeSlots)
             return true;
     }
-
+    
     return false;
 }
 


### PR DESCRIPTION
## Pull Request Description

<!-- Describe what this change does and why it is needed -->

Fixes Random Battleground bot population logic in `BattleGroundJoinAction`.

`BATTLEGROUND_QUEUE_RB` uses `BATTLEGROUND_RB` as its initial template, which has a 10v10 capacity. Once AzerothCore creates the actual Random Battleground instance, however, the real battleground type can be different (for example, `BATTLEGROUND_AV` with a 40-player-per-team capacity).

The existing queue calculation continues to use the Random Battleground template `TeamSize`, causing large Random Battlegrounds to be treated as 10v10. This can result in bots under-populating the actual battleground and incorrectly deciding when additional bots are needed.

This change keeps the existing Random Battleground queue behavior for matches that have not been created yet, but uses the actual battleground instance's `GetMaxPlayersPerTeam()` once a Random Battleground has been created.

No changes are made to `RandomPlayerbotMgr` or to the underlying queue bookkeeping.

## Feature Evaluation

<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->

* Describe the **minimum logic** required to achieve the intended behavior.

  * Keep `BATTLEGROUND_RB` and its existing 10v10 `TeamSize` for Random Battlegrounds that have not yet produced an instance.
  * When an active Random Battleground instance exists, check `GetBgTypeID(true)` to confirm that it has a real battleground type rather than the `BATTLEGROUND_RB` template.
  * Use the existing instance's `GetMaxPlayersPerTeam()` as the required capacity for that Random Battleground instead of the Random Battleground template's 10-player team size.
  * Leave the existing logic unchanged for non-Random Battleground queues.

* Describe the **processing cost** when this logic executes across many bots.

  * The additional work only occurs while evaluating the Random Battleground queue.
  * It iterates over the currently active battleground instances and performs a small number of constant-time checks for each matching Random Battleground.
  * No player or bot iteration, database access, map lookup, allocation, or additional timer is introduced.
  * The loop only runs as part of the existing battleground queue evaluation.

## How to Test the Changes

<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

1. Start the server with the modified `mod-playerbots` module.
2. Queue a real player for a Random Battleground.
3. Allow AzerothCore to create the actual Random Battleground instance.
4. Test with a Random Battleground whose real type has a larger team size than `BATTLEGROUND_RB`, such as Alterac Valley.
5. Verify that bots continue joining the existing Random Battleground until the real battleground's `GetMaxPlayersPerTeam()` capacity is reached rather than stopping at 10 players per team.
6. Verify that a Random Battleground that has not yet been created still uses the existing 10v10 template capacity when deciding whether additional bots are required.
7. Test multiple active Random Battleground instances and verify that each instance uses its own real battleground capacity.
8. Verify that specific/non-Random Battleground queue behavior is unchanged.
9. Verify that bots do not continuously flood the queue after the existing Random Battleground reaches its real capacity.

Expected behavior:

* Before a Random Battleground instance exists, `BATTLEGROUND_RB` remains 10v10 for queue accounting.
* After the instance is created, its real battleground capacity is used.
* A Random AV is therefore treated as 40v40 rather than 10v10.
* Existing non-Random Battleground behavior remains unchanged.

## Impact Assessment

<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->

* Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?

  * [ ] No, not at all
  * [x] Minimal impact (**explain below**)
  * [ ] Moderate impact (**explain below**)

  The additional work is limited to a small iteration over active battleground instances when evaluating `BATTLEGROUND_QUEUE_RB`. It does not add a new timer, player iteration, bot iteration, database query, or map lookup.

* Does this change modify default bot behavior?

  * [ ] No
  * [x] Yes (**explain why**)

  This corrects Random Battleground population behavior by using the actual battleground capacity after an instance is created. Bots will be able to populate larger Random Battlegrounds correctly instead of treating every Random Battleground as 10v10.

* Does this change add new decision branches or increase maintenance complexity?

  * [ ] No
  * [x] Yes (**explain below**)

  A small Random Battleground-specific branch is added to distinguish between an uncreated Random Battleground and an already-created instance with a real battleground type. The existing logic for other battleground types remains unchanged.

## AI Assistance

<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->

Was AI assistance used while working on this change?

* * [ ] No
* * [x] Yes (**explain below**)

<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

AI was used for source-code analysis, reviewing the existing battleground queue and instance accounting, identifying the difference between `BATTLEGROUND_RB` and `GetBgTypeID(true)`, and reviewing the proposed minimal change to `BattleGroundJoinAction`.

The final implementation was manually reviewed against the existing `mod-playerbots` and AzerothCore APIs and was kept limited to the battleground join decision logic.

## Code Provenance / Attribution

<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->

Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
MaNGOS, another module)?

* * [x] No, all code in this PR is original
* * [ ] Yes (**name the project and the original author(s) below**)

<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->

The change uses existing AzerothCore APIs such as `GetBgTypeID(true)` and `GetMaxPlayersPerTeam()`, but no code was copied or ported from another project.

<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/strategy/actions/FishingAction.cpp
-->

## Final Checklist

* * [x] Stability is not compromised.
* * [x] Performance impact is understood, tested, and acceptable.
* * [x] Added logic complexity is justified and explained.
* * [x] Any new bot dialogue lines are translated.
* * [x] Any code ported/adapted from another project is attributed (project + author(s), `Co-authored-by:` trailer + in-file note).
* * [x] New source files use the GPLv2 header.
* * [x] Documentation updated if needed (Conf comments, WiKi commands).
* * [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers

<!-- Anything else that's helpful to review or test your pull request. -->

The change is intentionally limited to `BattleGroundJoinAction.cpp`.

The key behavior is:

* `BATTLEGROUND_RB` remains the initial template and therefore uses its existing 10v10 capacity before an instance exists.
* Once a Random Battleground instance exists, `GetBgTypeID(true)` identifies its real battleground type.
* `GetMaxPlayersPerTeam()` is then used for that active instance, so for example a Random Alterac Valley is treated as 40v40 instead of 10v10.
* The existing player + bot count comparison is preserved to avoid changing the existing queue population behavior.
