### PR TITLE
Rename, Move, and Modify RaidBossHelpers

### DIFF
--- a/src/Ai/Dungeon/Seth/SethActions.cpp
+++ b/src/Ai/Dungeon/Seth/SethActions.cpp
@@ -5,12 +5,13 @@
  */
 
 #include "SethActions.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "SethData.h"
 #include <array>
 
 using namespace SethData;
+using namespace EncounterHelpers;
 
 bool TimeLostControllerMarkCharmingTotemWithSkullAction::Execute(Event /*event*/)
 {

--- a/src/Ai/Dungeon/Seth/SethMultipliers.cpp
+++ b/src/Ai/Dungeon/Seth/SethMultipliers.cpp
@@ -5,18 +5,19 @@
  */
 
 #include "SethMultipliers.h"
+#include "EncounterHelpers.h"
 #include "FollowActions.h"
 #include "GenericSpellActions.h"
 #include "HunterActions.h"
 #include "MageActions.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "ReachTargetActions.h"
 #include "SethActions.h"
 #include "SethData.h"
 #include "ShamanActions.h"
 
 using namespace SethData;
+using namespace EncounterHelpers;
 
 float SethekkProphetSetTremorTotemMultiplier::GetValue(Action* action)
 {
@@ -52,7 +53,7 @@ float AnzuControlSpellCastingWithSpellBombMultiplier::GetValue(Action* action)
         return 0.0f;
 
     // For healer
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (mainTank && mainTank->GetHealthPct() > 50.0f)
         return 0.0f;
 

--- a/src/Ai/Dungeon/Seth/SethTriggers.cpp
+++ b/src/Ai/Dungeon/Seth/SethTriggers.cpp
@@ -5,11 +5,12 @@
  */
 
 #include "SethTriggers.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "SethData.h"
 
 using namespace SethData;
+using namespace EncounterHelpers;
 
 bool TimeLostControllerDropsCharmingTotemTrigger::IsActive()
 {

--- a/src/Ai/Raid/BT/BTActions.cpp
+++ b/src/Ai/Raid/BT/BTActions.cpp
@@ -7,11 +7,12 @@
 #include "BTActions.h"
 #include "BTHelpers.h"
 #include "CreatureAI.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include <vector>
 
 using namespace BlackTempleHelpers;
+using namespace EncounterHelpers;
 
 // General
 
@@ -94,7 +95,7 @@ bool HighWarlordNajentusMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!najentus)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -292,9 +293,9 @@ bool SupremusMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (hunters.empty())
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
-    Player* firstAssistTank = GetGroupAssistTank(botAI, bot, 0);
-    Player* secondAssistTank = GetGroupAssistTank(botAI, bot, 1);
+    Player* mainTank = GetGroupMainTank(bot);
+    Player* firstAssistTank = GetGroupAssistTank(bot, 0);
+    Player* secondAssistTank = GetGroupAssistTank(bot, 1);
 
     Player* misdirectTarget = nullptr;
     if (bot == hunters[0] && mainTank)
@@ -541,7 +542,7 @@ bool TeronGorefiendMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!gorefiend)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -816,7 +817,7 @@ bool GurtoggBloodboilMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!group)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -956,7 +957,7 @@ bool ReliquaryOfSoulsMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!desire && !anger)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -1143,7 +1144,7 @@ bool MotherShahrazMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!shahraz)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -1368,7 +1369,7 @@ bool IllidariCouncilMisdirectBossesToTanksAction::Execute(Event /*event*/)
         councilTarget = AI_VALUE2(Unit*, "find target", "lady malande");
         for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
         {
-            if (Player* member = GetGroupAssistTank(botAI, bot, 0))
+            if (Player* member = GetGroupAssistTank(bot, 0))
             {
                 tankTarget = member;
                 break;
@@ -1380,7 +1381,7 @@ bool IllidariCouncilMisdirectBossesToTanksAction::Execute(Event /*event*/)
         councilTarget = AI_VALUE2(Unit*, "find target", "gathios the shatterer");
         for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
         {
-            if (Player* member = GetGroupMainTank(botAI, bot))
+            if (Player* member = GetGroupMainTank(bot))
             {
                 tankTarget = member;
                 break;
@@ -1392,7 +1393,7 @@ bool IllidariCouncilMisdirectBossesToTanksAction::Execute(Event /*event*/)
         councilTarget = AI_VALUE2(Unit*, "find target", "veras darkshadow");
         for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
         {
-            if (Player* member = GetGroupAssistTank(botAI, bot, 1))
+            if (Player* member = GetGroupAssistTank(bot, 1))
             {
                 tankTarget = member;
                 break;
@@ -1431,7 +1432,7 @@ bool IllidariCouncilMainTankPositionGathiosAction::Execute(Event /*event*/)
     if (MarkTargetWithSquare(bot, gathios))
         return true;
 
-    SetRtiTarget(botAI, "square", gathios);
+    SetRtiTarget(botAI, "square");
 
     if (AI_VALUE(Unit*, "current target") != gathios)
         return Attack(gathios);
@@ -1504,7 +1505,7 @@ bool IllidariCouncilFirstAssistTankFocusMalandeAction::Execute(Event /*event*/)
     if (MarkTargetWithStar(bot, malande))
         return true;
 
-    SetRtiTarget(botAI, "star", malande);
+    SetRtiTarget(botAI, "star");
 
     if (AI_VALUE(Unit*, "current target") != malande)
         return Attack(malande);
@@ -1528,14 +1529,14 @@ bool IllidariCouncilSecondAssistTankPositionDarkshadowAction::Execute(Event /*ev
     if (MarkTargetWithCircle(bot, darkshadow))
         return true;
 
-    SetRtiTarget(botAI, "circle", darkshadow);
+    SetRtiTarget(botAI, "circle");
 
     if (AI_VALUE(Unit*, "current target") != darkshadow)
         return Attack(darkshadow);
 
     if (darkshadow->GetVictim() == bot)
     {
-        Player* mainTank = GetGroupMainTank(botAI, bot);
+        Player* mainTank = GetGroupMainTank(bot);
         if (!mainTank)
             return false;
 
@@ -1573,7 +1574,7 @@ bool IllidariCouncilMageTankPositionZerevorAction::Execute(Event /*event*/)
     if (MarkTargetWithTriangle(bot, zerevor))
         return true;
 
-    SetRtiTarget(botAI, "triangle", zerevor);
+    SetRtiTarget(botAI, "triangle");
 
     if (AI_VALUE(Unit*, "current target") != zerevor)
         return Attack(zerevor);
@@ -1711,7 +1712,7 @@ bool IllidariCouncilAssignDpsTargetsAction::Execute(Event /*event*/)
 
     if (shouldAttackMalande)
     {
-        SetRtiTarget(botAI, "star", malande);
+        SetRtiTarget(botAI, "star");
 
         if (AI_VALUE(Unit*, "current target") != malande)
             return Attack(malande);
@@ -1720,14 +1721,14 @@ bool IllidariCouncilAssignDpsTargetsAction::Execute(Event /*event*/)
              darkshadow && !darkshadow->HasAura(
                 static_cast<uint32>(BlackTempleSpells::SPELL_VANISH)))
     {
-        SetRtiTarget(botAI, "circle", darkshadow);
+        SetRtiTarget(botAI, "circle");
 
         if (AI_VALUE(Unit*, "current target") != darkshadow)
             return Attack(darkshadow);
     }
     else if (Unit* gathios = AI_VALUE2(Unit*, "find target", "gathios the shatterer"))
     {
-        SetRtiTarget(botAI, "square", gathios);
+        SetRtiTarget(botAI, "square");
 
         if (AI_VALUE(Unit*, "current target") != gathios)
             return Attack(gathios);
@@ -1799,8 +1800,8 @@ bool IllidanStormrageMisdirectToTankAction::TryMisdirectToFlameTanks(Group* grou
     if (!eastFlame || !westFlame || eastFlame == westFlame)
         return false;
 
-    Player* firstAssistTank = GetGroupAssistTank(botAI, bot, 0);
-    Player* secondAssistTank = GetGroupAssistTank(botAI, bot, 1);
+    Player* firstAssistTank = GetGroupAssistTank(bot, 0);
+    Player* secondAssistTank = GetGroupAssistTank(bot, 1);
     if (!firstAssistTank || !secondAssistTank)
         return false;
 

--- a/src/Ai/Raid/BT/BTHelpers.cpp
+++ b/src/Ai/Raid/BT/BTHelpers.cpp
@@ -5,8 +5,10 @@
  */
 
 #include "BTHelpers.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
+
+using namespace EncounterHelpers;
 
 namespace BlackTempleHelpers
 {
@@ -104,7 +106,7 @@ std::unordered_map<ObjectGuid, TankPositionState> shahrazTankStep;
 
 TankPositionState GetShahrazTankPositionState(PlayerbotAI* botAI, Player* bot)
 {
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return TankPositionState::Unknown;
 

--- a/src/Ai/Raid/BT/BTMultipliers.cpp
+++ b/src/Ai/Raid/BT/BTMultipliers.cpp
@@ -8,66 +8,51 @@
 #include "BTActions.h"
 #include "BTHelpers.h"
 #include "ChooseTargetActions.h"
-#include "DKActions.h"
-#include "DruidActions.h"
-#include "DruidBearActions.h"
 #include "DruidShapeshiftActions.h"
+#include "EncounterHelpers.h"
 #include "FollowActions.h"
 #include "HunterActions.h"
 #include "MageActions.h"
-#include "PaladinActions.h"
 #include "PriestActions.h"
 #include "ReachTargetActions.h"
 #include "RogueActions.h"
 #include "ShamanActions.h"
-#include "WarlockActions.h"
-#include "WarriorActions.h"
 #include "WipeAction.h"
+#include <array>
+#include <ctime>
 
 using namespace BlackTempleHelpers;
+using namespace EncounterHelpers;
 
-static bool IsDpsCooldownAction(Action* action)
+// General
+
+// Illidan is handled separately
+float BlackTempleDelayDpsCooldownsMultiplier::GetValue(Action* action)
 {
-    return dynamic_cast<CastHeroismAction*>(action) ||
-           dynamic_cast<CastBloodlustAction*>(action) ||
-           dynamic_cast<CastMetamorphosisAction*>(action) ||
-           dynamic_cast<CastAdrenalineRushAction*>(action) ||
-           dynamic_cast<CastBladeFlurryAction*>(action) ||
-           dynamic_cast<CastIcyVeinsAction*>(action) ||
-           dynamic_cast<CastColdSnapAction*>(action) ||
-           dynamic_cast<CastArcanePowerAction*>(action) ||
-           dynamic_cast<CastPresenceOfMindAction*>(action) ||
-           dynamic_cast<CastCombustionAction*>(action) ||
-           dynamic_cast<CastRapidFireAction*>(action) ||
-           dynamic_cast<CastReadinessAction*>(action) ||
-           dynamic_cast<CastAvengingWrathAction*>(action) ||
-           dynamic_cast<CastElementalMasteryAction*>(action) ||
-           dynamic_cast<CastFeralSpiritAction*>(action) ||
-           dynamic_cast<CastFireElementalTotemAction*>(action) ||
-           dynamic_cast<CastFireElementalTotemMeleeAction*>(action) ||
-           dynamic_cast<CastForceOfNatureAction*>(action) ||
-           dynamic_cast<CastArmyOfTheDeadAction*>(action) ||
-           dynamic_cast<CastSummonGargoyleAction*>(action) ||
-           dynamic_cast<CastBerserkingAction*>(action) ||
-           dynamic_cast<CastBloodFuryAction*>(action);
-}
-
-// High Warlord Naj'entus
-
-float HighWarlordNajentusDelayDpsCooldownsMultiplier::GetValue(Action* action)
-{
-    Unit* najentus = AI_VALUE2(Unit*, "find target", "high warlord naj'entus");
-    if (!najentus || najentus->GetHealthPct() < 95.0f)
+    if (!IsDpsCooldownAction(bot, action))
         return 1.0f;
 
-    if (IsDpsCooldownAction(action) ||
-        (botAI->IsDps(bot) && dynamic_cast<UseTrinketAction*>(action)))
+    static constexpr std::array BlackTempleBosses = {
+        "gathios the shatterer", "mother shahraz", "essence of suffering", "gurtogg bloodboil",
+        "teron gorefiend", "supremus", "high warlord naj'entus" };
+
+    Unit* boss = nullptr;
+    for (const char* name : BlackTempleBosses)
     {
-        return 0.0f;
+        if (Unit* candidate = AI_VALUE2(Unit*, "find target", name))
+        {
+            boss = candidate;
+            break;
+        }
     }
+
+    if (boss && boss->GetHealthPct() > 95.0f)
+        return 0.0f;
 
     return 1.0f;
 }
+
+// High Warlord Naj'entus
 
 float HighWarlordNajentusDisableCombatFormationMoveMultiplier::GetValue(Action* action)
 {
@@ -84,21 +69,6 @@ float HighWarlordNajentusDisableCombatFormationMoveMultiplier::GetValue(Action* 
 }
 
 // Supremus
-
-float SupremusDelayDpsCooldownsMultiplier::GetValue(Action* action)
-{
-    Unit* supremus = AI_VALUE2(Unit*, "find target", "supremus");
-    if (!supremus || supremus->GetHealthPct() < 95.0f)
-        return 1.0f;
-
-    if (IsDpsCooldownAction(action) ||
-        (botAI->IsDps(bot) && dynamic_cast<UseTrinketAction*>(action)))
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
-}
 
 float SupremusFocusOnAvoidanceInPhase2Multiplier::GetValue(Action* action)
 {
@@ -134,21 +104,6 @@ float SupremusHitboxIsBuggedMultiplier::GetValue(Action* action)
 }
 
 // Teron Gorefiend
-
-float TeronGorefiendDelayDpsCooldownsMultiplier::GetValue(Action* action)
-{
-    Unit* gorefiend = AI_VALUE2(Unit*, "find target", "teron gorefiend");
-    if (!gorefiend || gorefiend->GetHealthPct() < 95.0f)
-        return 1.0f;
-
-    if (IsDpsCooldownAction(action) ||
-        (botAI->IsDps(bot) && dynamic_cast<UseTrinketAction*>(action)))
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
-}
 
 float TeronGorefiendControlMovementMultiplier::GetValue(Action* action)
 {
@@ -230,21 +185,6 @@ float TeronGorefiendDisableAttackingConstructsMultiplier::GetValue(Action* actio
 
 // Gurtogg Bloodboil
 
-float GurtoggBloodboilDelayDpsCooldownsMultiplier::GetValue(Action* action)
-{
-    Unit* gurtogg = AI_VALUE2(Unit*, "find target", "gurtogg bloodboil");
-    if (!gurtogg || gurtogg->GetHealthPct() < 95.0f)
-        return 1.0f;
-
-    if (IsDpsCooldownAction(action) ||
-        (botAI->IsDps(bot) && dynamic_cast<UseTrinketAction*>(action)))
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
-}
-
 float GurtoggBloodboilControlMovementMultiplier::GetValue(Action* action)
 {
     if (!AI_VALUE2(Unit*, "find target", "gurtogg bloodboil"))
@@ -276,21 +216,6 @@ float GurtoggBloodboilControlMovementMultiplier::GetValue(Action* action)
 
 // Reliquary of Souls
 
-float ReliquaryOfSoulsDelayDpsCooldownsMultiplier::GetValue(Action* action)
-{
-    Unit* suffering = AI_VALUE2(Unit*, "find target", "essence of suffering");
-    if (!suffering || suffering->GetHealthPct() < 95.0f)
-        return 1.0f;
-
-    if (IsDpsCooldownAction(action) ||
-        (botAI->IsDps(bot) && dynamic_cast<UseTrinketAction*>(action)))
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
-}
-
 float ReliquaryOfSoulsDontWasteHealingMultiplier::GetValue(Action* action)
 {
     if (!AI_VALUE2(Unit*, "find target", "essence of suffering"))
@@ -314,21 +239,6 @@ float ReliquaryOfSoulsDontWasteHealingMultiplier::GetValue(Action* action)
 }
 
 // Mother Shahraz
-
-float MotherShahrazDelayDpsCooldownsMultiplier::GetValue(Action* action)
-{
-    Unit* shahraz = AI_VALUE2(Unit*, "find target", "mother shahraz");
-    if (!shahraz || shahraz->GetHealthPct() < 90.0f)
-        return 1.0f;
-
-    if (IsDpsCooldownAction(action) ||
-        (botAI->IsDps(bot) && dynamic_cast<UseTrinketAction*>(action)))
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
-}
 
 float MotherShahrazControlMovementMultiplier::GetValue(Action* action)
 {
@@ -371,47 +281,22 @@ float MotherShahrazBotsWithFatalAttractionOnlyRunAwayMultiplier::GetValue(Action
 
 // Illidari Council
 
-float IllidariCouncilDelayDpsCooldownsMultiplier::GetValue(Action* action)
-{
-    Unit* gathios = AI_VALUE2(Unit*, "find target", "gathios the shatterer");
-    if (!gathios || gathios->GetHealthPct() < 90.0f)
-        return 1.0f;
-
-    if (IsDpsCooldownAction(action) ||
-        (botAI->IsDps(bot) && dynamic_cast<UseTrinketAction*>(action)))
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
-}
-
 float IllidariCouncilDisableTankActionsMultiplier::GetValue(Action* action)
 {
-    if (!botAI->IsTank(bot) ||
-        !AI_VALUE2(Unit*, "find target", "gathios the shatterer"))
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
+        return 1.0f;
+
+    if (!PlayerbotAI::IsTank(bot))
+        return 1.0f;
+
+    if (!dynamic_cast<TankAssistAction*>(action) &&
+        !IsTauntAction(bot, action) && !IsAoeThreatAction(bot, action))
     {
         return 1.0f;
     }
 
-    if (bot->GetVictim() != nullptr && dynamic_cast<TankAssistAction*>(action))
+    if (AI_VALUE2(Unit*, "find target", "gathios the shatterer"))
         return 0.0f;
-
-    if (dynamic_cast<CastTauntAction*>(action) ||
-        dynamic_cast<CastChallengingShoutAction*>(action) ||
-        dynamic_cast<CastShockwaveAction*>(action) ||
-        dynamic_cast<CastCleaveAction*>(action) ||
-        dynamic_cast<CastGrowlAction*>(action) ||
-        dynamic_cast<CastSwipeBearAction*>(action) ||
-        dynamic_cast<CastChallengingRoarAction*>(action) ||
-        dynamic_cast<CastHandOfReckoningAction*>(action) ||
-        dynamic_cast<CastRighteousDefenseAction*>(action) ||
-        dynamic_cast<CastDarkCommandAction*>(action) ||
-        dynamic_cast<CastDeathAndDecayAction*>(action) ||
-        dynamic_cast<CastBloodBoilAction*>(action))
-    {
-        return 0.0f;
-    }
 
     return 1.0f;
 }
@@ -546,27 +431,27 @@ float IllidariCouncilWaitForDpsMultiplier::GetValue(Action* action)
 
 float IllidanStormrageDelayDpsCooldownsMultiplier::GetValue(Action* action)
 {
+    if (!IsDpsCooldownAction(bot, action))
+        return 1.0f;
+
     Unit* illidan = AI_VALUE2(Unit*, "find target", "illidan stormrage");
     if (!illidan)
         return 1.0f;
 
-    if (illidan->GetHealthPct() > 62.0f &&
+    if (illidan->GetHealthPct() <= 62.0f)
+        return 1.0f;
+
+    if (bot->getClass() == CLASS_SHAMAN &&
         (dynamic_cast<CastHeroismAction*>(action) ||
          dynamic_cast<CastBloodlustAction*>(action)))
     {
         return 0.0f;
     }
 
-    if (illidan->GetHealthPct() <= 62.0f || illidan->GetHealthPct() > 95.0f)
+    if (illidan->GetHealthPct() > 95.0f)
         return 1.0f;
 
-    if (IsDpsCooldownAction(action) ||
-        (botAI->IsDps(bot) && dynamic_cast<UseTrinketAction*>(action)))
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
+    return 0.0f;
 }
 
 float IllidanStormrageControlTankActionsMultiplier::GetValue(Action* action)
@@ -616,7 +501,7 @@ float IllidanStormrageControlTankActionsMultiplier::GetValue(Action* action)
 
 float IllidanStormrageDisableDefaultTargetingMultiplier::GetValue(Action* action)
 {
-    if (bot->GetVictim() == nullptr)
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
         return 1.0f;
 
     Unit* illidan = AI_VALUE2(Unit*, "find target", "illidan stormrage");

--- a/src/Ai/Raid/BT/BTMultipliers.h
+++ b/src/Ai/Raid/BT/BTMultipliers.h
@@ -11,11 +11,11 @@
 
 // High Warlord Naj'entus
 
-class HighWarlordNajentusDelayDpsCooldownsMultiplier : public Multiplier
+class BlackTempleDelayDpsCooldownsMultiplier : public Multiplier
 {
 public:
-    HighWarlordNajentusDelayDpsCooldownsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "high warlord naj'entus delay dps cooldowns multiplier") {}
+    BlackTempleDelayDpsCooldownsMultiplier(
+        PlayerbotAI* botAI) : Multiplier(botAI, "black temple delay dps cooldowns multiplier") {}
     float GetValue(Action* action) override;
 };
 
@@ -28,14 +28,6 @@ public:
 };
 
 // Supremus
-
-class SupremusDelayDpsCooldownsMultiplier : public Multiplier
-{
-public:
-    SupremusDelayDpsCooldownsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "supremus delay dps cooldowns multiplier") {}
-    float GetValue(Action* action) override;
-};
 
 class SupremusFocusOnAvoidanceInPhase2Multiplier : public Multiplier
 {
@@ -54,14 +46,6 @@ public:
 };
 
 // Teron Gorefiend
-
-class TeronGorefiendDelayDpsCooldownsMultiplier : public Multiplier
-{
-public:
-    TeronGorefiendDelayDpsCooldownsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "teron gorefiend delay dps cooldowns multiplier") {}
-    float GetValue(Action* action) override;
-};
 
 class TeronGorefiendControlMovementMultiplier : public Multiplier
 {
@@ -97,14 +81,6 @@ public:
 
 // Gurtogg Bloodboil
 
-class GurtoggBloodboilDelayDpsCooldownsMultiplier : public Multiplier
-{
-public:
-    GurtoggBloodboilDelayDpsCooldownsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "gurtogg bloodboil delay dps cooldowns multiplier") {}
-    float GetValue(Action* action) override;
-};
-
 class GurtoggBloodboilControlMovementMultiplier : public Multiplier
 {
 public:
@@ -115,14 +91,6 @@ public:
 
 // Reliquary of Souls
 
-class ReliquaryOfSoulsDelayDpsCooldownsMultiplier : public Multiplier
-{
-public:
-    ReliquaryOfSoulsDelayDpsCooldownsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "reliquary of souls delay dps cooldowns multiplier") {}
-    float GetValue(Action* action) override;
-};
-
 class ReliquaryOfSoulsDontWasteHealingMultiplier : public Multiplier
 {
 public:
@@ -132,14 +100,6 @@ public:
 };
 
 // Mother Shahraz
-
-class MotherShahrazDelayDpsCooldownsMultiplier : public Multiplier
-{
-public:
-    MotherShahrazDelayDpsCooldownsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "mother shahraz delay dps cooldowns multiplier") {}
-    float GetValue(Action* action) override;
-};
 
 class MotherShahrazControlMovementMultiplier : public Multiplier
 {
@@ -158,14 +118,6 @@ public:
 };
 
 // Illidari Council
-
-class IllidariCouncilDelayDpsCooldownsMultiplier : public Multiplier
-{
-public:
-    IllidariCouncilDelayDpsCooldownsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "illidari council delay dps cooldowns multiplier") {}
-    float GetValue(Action* action) override;
-};
 
 class IllidariCouncilDisableTankActionsMultiplier : public Multiplier
 {

--- a/src/Ai/Raid/BT/BTStrategy.cpp
+++ b/src/Ai/Raid/BT/BTStrategy.cpp
@@ -205,37 +205,33 @@ void RaidBlackTempleStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 
 void RaidBlackTempleStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
 {
+    // General
+    multipliers.push_back(new BlackTempleDelayDpsCooldownsMultiplier(botAI));
+
     // High Warlord Naj'entus
-    multipliers.push_back(new HighWarlordNajentusDelayDpsCooldownsMultiplier(botAI));
     multipliers.push_back(new HighWarlordNajentusDisableCombatFormationMoveMultiplier(botAI));
 
     // Supremus
-    multipliers.push_back(new SupremusDelayDpsCooldownsMultiplier(botAI));
     multipliers.push_back(new SupremusFocusOnAvoidanceInPhase2Multiplier(botAI));
     multipliers.push_back(new SupremusHitboxIsBuggedMultiplier(botAI));
 
     // Teron Gorefiend
-    multipliers.push_back(new TeronGorefiendDelayDpsCooldownsMultiplier(botAI));
     multipliers.push_back(new TeronGorefiendControlMovementMultiplier(botAI));
     multipliers.push_back(new TeronGorefiendMarkedBotOnlyMoveToDieMultiplier(botAI));
     multipliers.push_back(new TeronGorefiendSpiritsAttackOnlyShadowyConstructsMultiplier(botAI));
     multipliers.push_back(new TeronGorefiendDisableAttackingConstructsMultiplier(botAI));
 
     // Gurtogg Bloodboil
-    multipliers.push_back(new GurtoggBloodboilDelayDpsCooldownsMultiplier(botAI));
     multipliers.push_back(new GurtoggBloodboilControlMovementMultiplier(botAI));
 
     // Reliquary of Souls
-    multipliers.push_back(new ReliquaryOfSoulsDelayDpsCooldownsMultiplier(botAI));
     multipliers.push_back(new ReliquaryOfSoulsDontWasteHealingMultiplier(botAI));
 
     // Mother Shahraz
-    multipliers.push_back(new MotherShahrazDelayDpsCooldownsMultiplier(botAI));
     multipliers.push_back(new MotherShahrazControlMovementMultiplier(botAI));
     multipliers.push_back(new MotherShahrazBotsWithFatalAttractionOnlyRunAwayMultiplier(botAI));
 
     // Illidari Council
-    multipliers.push_back(new IllidariCouncilDelayDpsCooldownsMultiplier(botAI));
     multipliers.push_back(new IllidariCouncilDisableTankActionsMultiplier(botAI));
     multipliers.push_back(new IllidariCouncilControlMovementMultiplier(botAI));
     multipliers.push_back(new IllidariCouncilControlMisdirectionMultiplier(botAI));

--- a/src/Ai/Raid/BT/BTTriggers.cpp
+++ b/src/Ai/Raid/BT/BTTriggers.cpp
@@ -8,11 +8,12 @@
 #include "AiFactory.h"
 #include "BTActions.h"
 #include "BTHelpers.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "SharedDefines.h"
 
 using namespace BlackTempleHelpers;
+using namespace EncounterHelpers;
 
 // General
 

--- a/src/Ai/Raid/BWL/BWLActions.cpp
+++ b/src/Ai/Raid/BWL/BWLActions.cpp
@@ -6,11 +6,12 @@
 
 #include "BWLActions.h"
 #include "BWLHelpers.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "RtiTargetValue.h"
 
 using namespace BlackwingLairHelpers;
+using namespace EncounterHelpers;
 
 static constexpr float INCREMENTAL_MOVE_STEP_DISTANCE = 3.0f;
 
@@ -117,7 +118,7 @@ bool BwlRazorgoreMarkBossAction::Execute(Event /*event*/)
             if (MarkTargetWithMoon(bot, boss))
                 return true;
 
-            SetRtiTarget(botAI, "moon", boss);
+            SetRtiTarget(botAI, "moon");
 
             if (AI_VALUE(Unit*, "current target") != boss)
                 return Attack(boss);

--- a/src/Ai/Raid/Gruul/GruulActions.cpp
+++ b/src/Ai/Raid/Gruul/GruulActions.cpp
@@ -6,12 +6,13 @@
 
 #include "GruulActions.h"
 #include "CreatureAI.h"
+#include "EncounterHelpers.h"
 #include "GruulHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "Unit.h"
 
 using namespace GruulsLairHelpers;
+using namespace EncounterHelpers;
 
 // High King Maulgar Actions
 
@@ -25,7 +26,7 @@ bool HighKingMaulgarMainTankAttackMaulgarAction::Execute(Event /*event*/)
     if (MarkTargetWithSquare(bot, maulgar))
         return true;
 
-    SetRtiTarget(botAI, "square", maulgar);
+    SetRtiTarget(botAI, "square");
 
     if (AI_VALUE(Unit*, "current target") != maulgar)
         return Attack(maulgar);
@@ -62,7 +63,7 @@ bool HighKingMaulgarFirstAssistTankAttackOlmAction::Execute(Event /*event*/)
     if (MarkTargetWithCircle(bot, olm))
         return true;
 
-    SetRtiTarget(botAI, "circle", olm);
+    SetRtiTarget(botAI, "circle");
 
     if (AI_VALUE(Unit*, "current target") != olm)
         return Attack(olm);
@@ -99,7 +100,7 @@ bool HighKingMaulgarSecondAssistTankAttackBlindeyeAction::Execute(Event /*event*
     if (MarkTargetWithStar(bot, blindeye))
         return true;
 
-    SetRtiTarget(botAI, "star", blindeye);
+    SetRtiTarget(botAI, "star");
 
     if (AI_VALUE(Unit*, "current target") != blindeye)
         return Attack(blindeye);
@@ -136,7 +137,7 @@ bool HighKingMaulgarMageTankAttackKroshAction::Execute(Event /*event*/)
     if (MarkTargetWithTriangle(bot, krosh))
         return true;
 
-    SetRtiTarget(botAI, "triangle", krosh);
+    SetRtiTarget(botAI, "triangle");
 
     if (krosh->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_SPELL_SHIELD)) &&
         botAI->CanCastSpell("spellsteal", krosh))
@@ -194,7 +195,7 @@ bool HighKingMaulgarMoonkinTankAttackKigglerAction::Execute(Event /*event*/)
     if (MarkTargetWithDiamond(bot, kiggler))
         return true;
 
-    SetRtiTarget(botAI, "diamond", kiggler);
+    SetRtiTarget(botAI, "diamond");
 
     if (AI_VALUE(Unit*, "current target") != kiggler)
         return Attack(kiggler);
@@ -222,7 +223,7 @@ bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithStar(bot, blindeye))
             return true;
 
-        SetRtiTarget(botAI, "star", blindeye);
+        SetRtiTarget(botAI, "star");
 
         if (AI_VALUE(Unit*, "current target") != blindeye)
             return Attack(blindeye);
@@ -236,7 +237,7 @@ bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithCircle(bot, olm))
             return true;
 
-        SetRtiTarget(botAI, "circle", olm);
+        SetRtiTarget(botAI, "circle");
 
         if (AI_VALUE(Unit*, "current target") != olm)
             return Attack(olm);
@@ -251,7 +252,7 @@ bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithTriangle(bot, krosh))
             return true;
 
-        SetRtiTarget(botAI, "triangle", krosh);
+        SetRtiTarget(botAI, "triangle");
 
         if (AI_VALUE(Unit*, "current target") != krosh)
             return Attack(krosh);
@@ -265,7 +266,7 @@ bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithDiamond(bot, kiggler))
             return true;
 
-        SetRtiTarget(botAI, "diamond", kiggler);
+        SetRtiTarget(botAI, "diamond");
 
         if (AI_VALUE(Unit*, "current target") != kiggler)
             return Attack(kiggler);
@@ -279,7 +280,7 @@ bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithSquare(bot, maulgar))
             return true;
 
-        SetRtiTarget(botAI, "square", maulgar);
+        SetRtiTarget(botAI, "square");
 
         if (AI_VALUE(Unit*, "current target") != maulgar)
             return Attack(maulgar);
@@ -420,14 +421,14 @@ bool HighKingMaulgarMisdirectOgresToTanksAction::Execute(Event /*event*/)
     if (hunterIndex == 0)
     {
         ogreTarget = AI_VALUE2(Unit*, "find target", "blindeye the seer");
-        tankTarget = GetGroupAssistTank(botAI, bot, 1);
+        tankTarget = GetGroupAssistTank(bot, 1);
     }
     else if (hunterIndex == 1)
     {
         ogreTarget = AI_VALUE2(Unit*, "find target", "olm the summoner");
         for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
         {
-            if (Player* member = GetGroupAssistTank(botAI, bot, 0))
+            if (Player* member = GetGroupAssistTank(bot, 0))
             {
                 tankTarget = member;
                 break;

--- a/src/Ai/Raid/Hyjal/HyjalActions.cpp
+++ b/src/Ai/Raid/Hyjal/HyjalActions.cpp
@@ -5,12 +5,13 @@
  */
 
 #include "HyjalActions.h"
+#include "EncounterHelpers.h"
 #include "HyjalHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "Timer.h"
 
 using namespace HyjalSummitHelpers;
+using namespace EncounterHelpers;
 
 // General
 
@@ -77,7 +78,7 @@ bool RageWinterchillMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!winterchill)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -226,7 +227,7 @@ bool AnetheronMisdirectBossAndInfernalsToTanksAction::Execute(Event /*event*/)
 
     if (anetheron->GetHealthPct() > 95.0f)
     {
-        Player* mainTank = GetGroupMainTank(botAI, bot);
+        Player* mainTank = GetGroupMainTank(bot);
         if (!mainTank)
             return false;
 
@@ -241,7 +242,7 @@ bool AnetheronMisdirectBossAndInfernalsToTanksAction::Execute(Event /*event*/)
     if (Unit* infernal = AI_VALUE2(Unit*, "find target", "towering infernal");
         infernal && infernal->GetHealthPct() > 50.0f)
     {
-        Player* firstAssistTank = GetGroupAssistTank(botAI, bot, 0);
+        Player* firstAssistTank = GetGroupAssistTank(bot, 0);
         if (!firstAssistTank)
             return false;
 
@@ -266,7 +267,7 @@ bool AnetheronMainTankPositionBossAction::Execute(Event /*event*/)
     if (MarkTargetWithSquare(bot, anetheron))
         return true;
 
-    SetRtiTarget(botAI, "square", anetheron);
+    SetRtiTarget(botAI, "square");
 
     if (AI_VALUE(Unit*, "current target") != anetheron)
         return Attack(anetheron);
@@ -398,7 +399,7 @@ bool AnetheronFirstAssistTankPickUpInfernalsAction::Execute(Event /*event*/)
     if (MarkTargetWithDiamond(bot, infernal))
         return true;
 
-    SetRtiTarget(botAI, "diamond", infernal);
+    SetRtiTarget(botAI, "diamond");
 
     if (AI_VALUE(Unit*, "current target") != infernal)
         return Attack(infernal);
@@ -435,7 +436,7 @@ bool AnetheronAssignDpsPriorityAction::Execute(Event /*event*/)
 
     if (botAI->IsMelee(bot))
     {
-        SetRtiTarget(botAI, "square", anetheron);
+        SetRtiTarget(botAI, "square");
 
         if (AI_VALUE(Unit*, "current target") != anetheron)
             return Attack(anetheron);
@@ -455,10 +456,10 @@ bool AnetheronAssignDpsPriorityAction::Execute(Event /*event*/)
         if (anetheron->GetHealthPct() > 10.0f && botAI->IsRangedDps(bot) &&
             bot->GetDistance2d(infernal) < 50.0f)
         {
-            if (Player* firstAssistTank = GetGroupAssistTank(botAI, bot, 0);
+            if (Player* firstAssistTank = GetGroupAssistTank(bot, 0);
                 !firstAssistTank || infernal->GetVictim() == firstAssistTank)
             {
-                SetRtiTarget(botAI, "diamond", infernal);
+                SetRtiTarget(botAI, "diamond");
 
                 if (AI_VALUE(Unit*, "current target") != infernal)
                     return Attack(infernal);
@@ -467,7 +468,7 @@ bool AnetheronAssignDpsPriorityAction::Execute(Event /*event*/)
     }
     else if (botAI->IsRangedDps(bot))
     {
-        SetRtiTarget(botAI, "square", anetheron);
+        SetRtiTarget(botAI, "square");
 
         if (AI_VALUE(Unit*, "current target") != anetheron)
             return Attack(anetheron);
@@ -484,7 +485,7 @@ bool KazrogalMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!kazrogal)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -551,7 +552,7 @@ bool KazrogalMainTankPositionBossAction::Execute(Event /*event*/)
 // To spread cleave damage
 bool KazrogalAssistTanksMoveInFrontOfBossAction::Execute(Event /*event*/)
 {
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -714,7 +715,7 @@ bool AzgalorMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!azgalor)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -739,7 +740,7 @@ bool AzgalorMainTankPositionBossAction::Execute(Event /*event*/)
     if (MarkTargetWithStar(bot, azgalor))
         return true;
 
-    SetRtiTarget(botAI, "star", azgalor);
+    SetRtiTarget(botAI, "star");
 
     if (AI_VALUE(Unit*, "current target") != azgalor)
         return Attack(azgalor);
@@ -827,7 +828,7 @@ bool AzgalorMeleeGetOutOfFireAndSwapTargetsAction::Execute(Event /*event*/)
     constexpr float singleTickMoveAwayDist = 6.0f;
     if (!IsInRainOfFire(bot, RAIN_OF_FIRE_RADIUS + singleTickMoveAwayDist))
     {
-        SetRtiTarget(botAI, "star", azgalor);
+        SetRtiTarget(botAI, "star");
         return false;
     }
 
@@ -836,11 +837,11 @@ bool AzgalorMeleeGetOutOfFireAndSwapTargetsAction::Execute(Event /*event*/)
 
     if (!desiredTarget)
     {
-        SetRtiTarget(botAI, "star", azgalor);
+        SetRtiTarget(botAI, "star");
         return MoveAway(azgalor, 5.0f);
     }
 
-    SetRtiTarget(botAI, "circle", desiredTarget);
+    SetRtiTarget(botAI, "circle");
 
     if (!bot->IsWithinMeleeRange(desiredTarget))
     {
@@ -869,7 +870,7 @@ bool AzgalorWaitAtSafePositionAction::Execute(Event /*event*/)
     if (!azgalor)
         return false;
 
-    SetRtiTarget(botAI, "star", azgalor);
+    SetRtiTarget(botAI, "star");
 
     const Position& position = AZGALOR_DOOMGUARD_POSITION;
     constexpr float moveDist = 10.0f;
@@ -919,7 +920,7 @@ bool AzgalorFirstAssistTankPositionDoomguardAction::Execute(Event /*event*/)
         if (MarkTargetWithCircle(bot, doomguard))
             return true;
 
-        SetRtiTarget(botAI, "circle", doomguard);
+        SetRtiTarget(botAI, "circle");
 
         if (AI_VALUE(Unit*, "current target") != doomguard)
             return Attack(doomguard);
@@ -970,7 +971,7 @@ bool AzgalorRangedDpsPrioritizeDoomguardsAction::Execute(Event /*event*/)
         if (Unit* doomguard = AI_VALUE2(Unit*, "find target", "lesser doomguard");
             doomguard && bot->GetDistance2d(doomguard) < 65.0f)
         {
-            SetRtiTarget(botAI, "circle", doomguard);
+            SetRtiTarget(botAI, "circle");
 
             if (AI_VALUE(Unit*, "current target") != doomguard)
                 return Attack(doomguard);
@@ -978,7 +979,7 @@ bool AzgalorRangedDpsPrioritizeDoomguardsAction::Execute(Event /*event*/)
     }
     else
     {
-        SetRtiTarget(botAI, "star", azgalor);
+        SetRtiTarget(botAI, "star");
 
         if (AI_VALUE(Unit*, "current target") != azgalor)
             return Attack(azgalor);
@@ -995,7 +996,7 @@ bool ArchimondeMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!archimonde)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -1052,7 +1053,7 @@ bool ArchimondeCastFearImmunitySpellAction::Execute(Event /*event*/)
 
 bool ArchimondeCastFearImmunitySpellAction::CastFearWardOnMainTank()
 {
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (mainTank && botAI->CanCastSpell("fear ward", mainTank))
         return botAI->CastSpell("fear ward", mainTank);
 
@@ -1078,7 +1079,7 @@ bool ArchimondeSpreadToAvoidAirBurstAction::Execute(Event /*event*/)
     if (!archimonde)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (mainTank && bot != mainTank)
     {
         const float distanceToMainTank = bot->GetDistance2d(mainTank);

--- a/src/Ai/Raid/Hyjal/HyjalMultipliers.cpp
+++ b/src/Ai/Raid/Hyjal/HyjalMultipliers.cpp
@@ -9,16 +9,17 @@
 #include "ChooseTargetActions.h"
 #include "DKActions.h"
 #include "DruidBearActions.h"
+#include "EncounterHelpers.h"
 #include "HunterActions.h"
 #include "HyjalActions.h"
 #include "HyjalHelpers.h"
 #include "PaladinActions.h"
-#include "RaidBossHelpers.h"
 #include "ReachTargetActions.h"
 #include "ShamanActions.h"
 #include "WarriorActions.h"
 
 using namespace HyjalSummitHelpers;
+using namespace EncounterHelpers;
 
 // Without this multiplier, Bloodlust/Heroism will not be available for
 // bosses because it will be used on cooldown during trash waves
@@ -265,7 +266,7 @@ float AzgalorMeleeDpsControlAvoidanceMultiplier::GetValue(Action* action)
             return 0.0f;
     }
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank || !GET_PLAYERBOT_AI(mainTank))
         return 1.0f;
 

--- a/src/Ai/Raid/Hyjal/HyjalTriggers.cpp
+++ b/src/Ai/Raid/Hyjal/HyjalTriggers.cpp
@@ -6,12 +6,13 @@
 
 #include "HyjalTriggers.h"
 #include "AiFactory.h"
+#include "EncounterHelpers.h"
 #include "HyjalActions.h"
 #include "HyjalHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 
 using namespace HyjalSummitHelpers;
+using namespace EncounterHelpers;
 
 // General
 
@@ -226,7 +227,7 @@ bool AzgalorMainTankIsPositioningBossTrigger::IsActive()
     if (!azgalor || azgalor->GetVictim() == bot)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank || !GET_PLAYERBOT_AI(mainTank) || botAI->IsMainTank(bot))
         return false;
 
@@ -278,7 +279,7 @@ bool AzgalorDoomguardsMustBeControlledTrigger::IsActive()
     if (botAI->IsAssistTankOfIndex(bot, 1, true))
     {
         // Trigger for second assist tank only if first assist tank has Doom
-        Player* firstAssistTank = GetGroupAssistTank(botAI, bot, 0);
+        Player* firstAssistTank = GetGroupAssistTank(bot, 0);
         if (firstAssistTank &&
             !firstAssistTank->HasAura(static_cast<uint32>(HyjalSummitSpells::SPELL_DOOM)))
             return false;

--- a/src/Ai/Raid/Hyjal/Util/HyjalHelpers.cpp
+++ b/src/Ai/Raid/Hyjal/Util/HyjalHelpers.cpp
@@ -5,10 +5,12 @@
  */
 
 #include "HyjalHelpers.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "Timer.h"
 #include <algorithm>
+
+using namespace EncounterHelpers;
 
 namespace HyjalSummitHelpers
 {
@@ -165,7 +167,7 @@ std::unordered_map<ObjectGuid, bool> isBelowManaThreshold;
 
 TankPositionState GetKazrogalTankPositionState(PlayerbotAI* botAI, Player* bot)
 {
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return TankPositionState::Unknown;
 
@@ -206,7 +208,7 @@ RainOfFireData* GetActiveAzgalorRainOfFire(uint32 instanceId)
 
 TankPositionState GetAzgalorTankPositionState(PlayerbotAI* botAI, Player* bot)
 {
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return TankPositionState::Unknown;
 

--- a/src/Ai/Raid/Hyjal/Util/HyjalScripts.cpp
+++ b/src/Ai/Raid/Hyjal/Util/HyjalScripts.cpp
@@ -6,16 +6,17 @@
 
 #include "AllCreatureScript.h"
 #include "DynamicObjectScript.h"
+#include "EncounterHelpers.h"
 #include "HyjalHelpers.h"
 #include "ObjectAccessor.h"
 #include "Player.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "ScriptMgr.h"
 #include "Spell.h"
 #include "Timer.h"
 
 using namespace HyjalSummitHelpers;
+using namespace EncounterHelpers;
 
 static Player* GetFirstPlayerSpellTarget(Spell* spell, Unit* caster)
 {
@@ -40,7 +41,7 @@ static bool ShouldInterruptForArchimondeAirBurst(PlayerbotAI* botAI, Player* bot
     if (!target)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank || bot == mainTank)
         return false;
 

--- a/src/Ai/Raid/Kara/KaraActions.cpp
+++ b/src/Ai/Raid/Kara/KaraActions.cpp
@@ -5,13 +5,14 @@
  */
 
 #include "KaraActions.h"
+#include "EncounterHelpers.h"
 #include "KaraHelpers.h"
 #include "PlayerbotTextMgr.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include <array>
 
 using namespace KaraHelpers;
+using namespace EncounterHelpers;
 
 // General
 
@@ -102,7 +103,7 @@ bool KarazhanCastFearProtectionSpellAction::Execute(Event /*event*/)
 
 bool KarazhanCastFearProtectionSpellAction::CastFearWardOnMainTank()
 {
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank || mainTank->HasAura(Id(KaraSpells::SPELL_FEAR_WARD)))
         return false;
 

--- a/src/Ai/Raid/Kara/KaraTriggers.cpp
+++ b/src/Ai/Raid/Kara/KaraTriggers.cpp
@@ -5,12 +5,13 @@
  */
 
 #include "KaraTriggers.h"
+#include "EncounterHelpers.h"
 #include "KaraActions.h"
 #include "KaraHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 
 using namespace KaraHelpers;
+using namespace EncounterHelpers;
 
 // General
 

--- a/src/Ai/Raid/Mag/MagActions.cpp
+++ b/src/Ai/Raid/Mag/MagActions.cpp
@@ -6,13 +6,14 @@
 
 #include "MagActions.h"
 #include "Creature.h"
+#include "EncounterHelpers.h"
 #include "MagHelpers.h"
 #include "ObjectAccessor.h"
 #include "ObjectGuid.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 
 using namespace MagtheridonHelpers;
+using namespace EncounterHelpers;
 
 bool MagtheridonMainTankAttackFirstThreeChannelersAction::Execute(Event /*event*/)
 {
@@ -23,7 +24,7 @@ bool MagtheridonMainTankAttackFirstThreeChannelersAction::Execute(Event /*event*
         if (MarkTargetWithSquare(bot, channelerSquare))
             return true;
 
-        SetRtiTarget(botAI, "square", channelerSquare);
+        SetRtiTarget(botAI, "square");
     }
     else if (Creature* channelerStar = GetChanneler(bot, WEST_CHANNELER))
     {
@@ -31,7 +32,7 @@ bool MagtheridonMainTankAttackFirstThreeChannelersAction::Execute(Event /*event*
         if (MarkTargetWithStar(bot, channelerStar))
             return true;
 
-        SetRtiTarget(botAI, "star", channelerStar);
+        SetRtiTarget(botAI, "star");
     }
     else if (Creature* channelerCircle = GetChanneler(bot, EAST_CHANNELER))
     {
@@ -39,7 +40,7 @@ bool MagtheridonMainTankAttackFirstThreeChannelersAction::Execute(Event /*event*
         if (MarkTargetWithCircle(bot, channelerCircle))
             return true;
 
-        SetRtiTarget(botAI, "circle", channelerCircle);
+        SetRtiTarget(botAI, "circle");
     }
 
     if (channelerTarget && AI_VALUE(Unit*, "current target") != channelerTarget)
@@ -72,7 +73,7 @@ bool MagtheridonFirstAssistTankAttackNWChannelerAction::Execute(Event /*event*/)
     if (MarkTargetWithDiamond(bot, channelerDiamond))
         return true;
 
-    SetRtiTarget(botAI, "diamond", channelerDiamond);
+    SetRtiTarget(botAI, "diamond");
 
     if (AI_VALUE(Unit*, "current target") != channelerDiamond)
         return Attack(channelerDiamond);
@@ -108,7 +109,7 @@ bool MagtheridonSecondAssistTankAttackNEChannelerAction::Execute(Event /*event*/
     if (MarkTargetWithTriangle(bot, channelerTriangle))
         return true;
 
-    SetRtiTarget(botAI, "triangle", channelerTriangle);
+    SetRtiTarget(botAI, "triangle");
 
     if (AI_VALUE(Unit*, "current target") != channelerTriangle)
         return Attack(channelerTriangle);
@@ -163,7 +164,7 @@ bool MagtheridonMisdirectHellfireChannelersToMainTankAction::Execute(Event /*eve
         }
     }
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
 
     Creature* targetChanneler = nullptr;
     if (hunterIndex == 0)
@@ -194,7 +195,7 @@ bool MagtheridonAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithSquare(bot, channelerSquare))
             return true;
 
-        SetRtiTarget(botAI, "square", channelerSquare);
+        SetRtiTarget(botAI, "square");
 
         if (AI_VALUE(Unit*, "current target") != channelerSquare)
             return Attack(channelerSquare);
@@ -204,7 +205,7 @@ bool MagtheridonAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithStar(bot, channelerStar))
             return true;
 
-        SetRtiTarget(botAI, "star", channelerStar);
+        SetRtiTarget(botAI, "star");
 
         if (AI_VALUE(Unit*, "current target") != channelerStar)
             return Attack(channelerStar);
@@ -214,7 +215,7 @@ bool MagtheridonAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithCircle(bot, channelerCircle))
             return true;
 
-        SetRtiTarget(botAI, "circle", channelerCircle);
+        SetRtiTarget(botAI, "circle");
 
         if (AI_VALUE(Unit*, "current target") != channelerCircle)
             return Attack(channelerCircle);
@@ -224,7 +225,7 @@ bool MagtheridonAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithDiamond(bot, channelerDiamond))
             return true;
 
-        SetRtiTarget(botAI, "diamond", channelerDiamond);
+        SetRtiTarget(botAI, "diamond");
 
         if (AI_VALUE(Unit*, "current target") != channelerDiamond)
             return Attack(channelerDiamond);
@@ -234,14 +235,14 @@ bool MagtheridonAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithTriangle(bot, channelerTriangle))
             return true;
 
-        SetRtiTarget(botAI, "triangle", channelerTriangle);
+        SetRtiTarget(botAI, "triangle");
 
         if (AI_VALUE(Unit*, "current target") != channelerTriangle)
             return Attack(channelerTriangle);
     }
     else if (Unit* magtheridon = AI_VALUE2(Unit*, "find target", "magtheridon"))
     {
-        SetRtiTarget(botAI, "cross", magtheridon);
+        SetRtiTarget(botAI, "cross");
 
         if (AI_VALUE(Unit*, "current target") != magtheridon)
             return Attack(magtheridon);
@@ -326,7 +327,7 @@ bool MagtheridonMainTankPositionBossAction::Execute(Event /*event*/)
     if (MarkTargetWithCross(bot, magtheridon))
         return true;
 
-    SetRtiTarget(botAI, "cross", magtheridon);
+    SetRtiTarget(botAI, "cross");
 
     if (AI_VALUE(Unit*, "current target") != magtheridon)
         return Attack(magtheridon);

--- a/src/Ai/Raid/Mag/MagTriggers.cpp
+++ b/src/Ai/Raid/Mag/MagTriggers.cpp
@@ -5,11 +5,12 @@
  */
 
 #include "MagTriggers.h"
+#include "EncounterHelpers.h"
 #include "MagHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 
 using namespace MagtheridonHelpers;
+using namespace EncounterHelpers;
 
 bool MagtheridonFirstThreeChannelersEngagedByMainTankTrigger::IsActive()
 {

--- a/src/Ai/Raid/SSC/SSCActions.cpp
+++ b/src/Ai/Raid/SSC/SSCActions.cpp
@@ -7,15 +7,16 @@
 #include "SSCActions.h"
 #include "AiFactory.h"
 #include "Corpse.h"
+#include "EncounterHelpers.h"
 #include "LootAction.h"
 #include "LootObjectStack.h"
 #include "ObjectAccessor.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "RtiTargetValue.h"
 #include "SSCHelpers.h"
 
 using namespace SerpentShrineCavernHelpers;
+using namespace EncounterHelpers;
 
 // General
 
@@ -152,7 +153,7 @@ bool HydrossTheUnstablePositionFrostTankAction::Execute(Event /*event*/)
         if (MarkTargetWithSquare(bot, hydross))
             return true;
 
-        SetRtiTarget(botAI, "square", hydross);
+        SetRtiTarget(botAI, "square");
 
         if (AI_VALUE(Unit*, "current target") != hydross)
             return Attack(hydross);
@@ -234,7 +235,7 @@ bool HydrossTheUnstablePositionNatureTankAction::Execute(Event /*event*/)
         if (MarkTargetWithTriangle(bot, hydross))
             return true;
 
-        SetRtiTarget(botAI, "triangle", hydross);
+        SetRtiTarget(botAI, "triangle");
 
         if (AI_VALUE(Unit*, "current target") != hydross)
             return Attack(hydross);
@@ -309,7 +310,7 @@ bool HydrossTheUnstablePrioritizeElementalAddsAction::Execute(Event /*event*/)
         if (MarkTargetWithSkull(bot, waterElemental))
             return true;
 
-        SetRtiTarget(botAI, "skull", waterElemental);
+        SetRtiTarget(botAI, "skull");
 
         if (AI_VALUE(Unit*, "current target") != waterElemental)
             return Attack(waterElemental);
@@ -319,7 +320,7 @@ bool HydrossTheUnstablePrioritizeElementalAddsAction::Execute(Event /*event*/)
         if (MarkTargetWithSkull(bot, natureElemental))
             return true;
 
-        SetRtiTarget(botAI, "skull", natureElemental);
+        SetRtiTarget(botAI, "skull");
 
         if (AI_VALUE(Unit*, "current target") != natureElemental)
             return Attack(natureElemental);
@@ -354,7 +355,7 @@ bool HydrossTheUnstableMisdirectBossToTankAction::Execute(Event /*event*/)
 bool HydrossTheUnstableMisdirectBossToTankAction::TryMisdirectToFrostTank(
     Unit* hydross)
 {
-    Player* frostTank = GetGroupMainTank(botAI, bot);
+    Player* frostTank = GetGroupMainTank(bot);
     if (!frostTank)
         return false;
 
@@ -373,7 +374,7 @@ bool HydrossTheUnstableMisdirectBossToTankAction::TryMisdirectToFrostTank(
 bool HydrossTheUnstableMisdirectBossToTankAction::TryMisdirectToNatureTank(
     Unit* hydross)
 {
-    Player* natureTank = GetGroupAssistTank(botAI, bot, 0);
+    Player* natureTank = GetGroupAssistTank(bot, 0);
     if (!natureTank)
         return false;
 
@@ -601,9 +602,9 @@ bool TheLurkerBelowSpreadRangedInArcAction::Execute(Event /*event*/)
 // the first 3 will each pick up 1 Guardian
 bool TheLurkerBelowTanksPickUpAddsAction::Execute(Event /*event*/)
 {
-    Player* mainTank = GetGroupMainTank(botAI, bot);
-    Player* firstAssistTank = GetGroupAssistTank(botAI, bot, 0);
-    Player* secondAssistTank = GetGroupAssistTank(botAI, bot, 1);
+    Player* mainTank = GetGroupMainTank(bot);
+    Player* firstAssistTank = GetGroupAssistTank(bot, 0);
+    Player* secondAssistTank = GetGroupAssistTank(bot, 1);
     if (!mainTank || !firstAssistTank || !secondAssistTank)
         return false;
 
@@ -642,7 +643,7 @@ bool TheLurkerBelowTanksPickUpAddsAction::Execute(Event /*event*/)
             if (MarkTargetWithIcon(bot, guardian, rtiIndices[i]))
                 return true;
 
-            SetRtiTarget(botAI, rtiNames[i], guardian);
+            SetRtiTarget(botAI, rtiNames[i]);
 
             if (AI_VALUE(Unit*, "current target") != guardian)
                 return Attack(guardian);
@@ -720,7 +721,7 @@ bool LeotherasTheBlindDemonFormTankAttackBossAction::Execute(Event /*event*/)
         if (MarkTargetWithSquare(bot, leotherasDemon))
             return true;
 
-        SetRtiTarget(botAI, "square", leotherasDemon);
+        SetRtiTarget(botAI, "square");
 
         if (botAI->CanCastSpell("searing pain", leotherasDemon))
             return botAI->CastSpell("searing pain", leotherasDemon);
@@ -986,7 +987,7 @@ bool LeotherasTheBlindFinalPhaseAssignDpsPriorityAction::Execute(Event /*event*/
     if (MarkTargetWithStar(bot, leotherasHuman))
         return true;
 
-    SetRtiTarget(botAI, "star", leotherasHuman);
+    SetRtiTarget(botAI, "star");
 
     if (AI_VALUE(Unit*, "current target") != leotherasHuman)
         return Attack(leotherasHuman);
@@ -1026,7 +1027,7 @@ bool LeotherasTheBlindMisdirectBossToDemonFormTankAction::Execute(Event /*event*
 
     Player* targetTank = GetLeotherasDemonFormTank(bot);
     if (!targetTank)
-        targetTank = GetGroupMainTank(botAI, bot);
+        targetTank = GetGroupMainTank(bot);
 
     if (!targetTank)
         return false;
@@ -1102,7 +1103,7 @@ bool FathomLordKarathressMainTankPositionBossAction::Execute(Event /*event*/)
     if (MarkTargetWithTriangle(bot, karathress))
         return true;
 
-    SetRtiTarget(botAI, "triangle", karathress);
+    SetRtiTarget(botAI, "triangle");
 
     if (AI_VALUE(Unit*, "current target") != karathress)
         return Attack(karathress);
@@ -1140,7 +1141,7 @@ bool FathomLordKarathressFirstAssistTankPositionCaribdisAction::Execute(Event /*
     if (MarkTargetWithDiamond(bot, caribdis))
         return true;
 
-    SetRtiTarget(botAI, "diamond", caribdis);
+    SetRtiTarget(botAI, "diamond");
 
     if (AI_VALUE(Unit*, "current target") != caribdis)
         return Attack(caribdis);
@@ -1177,7 +1178,7 @@ bool FathomLordKarathressSecondAssistTankPositionSharkkisAction::Execute(Event /
     if (MarkTargetWithStar(bot, sharkkis))
         return true;
 
-    SetRtiTarget(botAI, "star", sharkkis);
+    SetRtiTarget(botAI, "star");
 
     if (AI_VALUE(Unit*, "current target") != sharkkis)
         return Attack(sharkkis);
@@ -1214,7 +1215,7 @@ bool FathomLordKarathressThirdAssistTankPositionTidalvessAction::Execute(Event /
     if (MarkTargetWithCircle(bot, tidalvess))
         return true;
 
-    SetRtiTarget(botAI, "circle", tidalvess);
+    SetRtiTarget(botAI, "circle");
 
     if (AI_VALUE(Unit*, "current target") != tidalvess)
         return Attack(tidalvess);
@@ -1304,17 +1305,17 @@ bool FathomLordKarathressMisdirectBossesToTanksAction::Execute(Event /*event*/)
     if (hunterIndex == 0)
     {
         bossTarget = AI_VALUE2(Unit*, "find target", "fathom-guard caribdis");
-        tankTarget = GetGroupAssistTank(botAI, bot, 0);
+        tankTarget = GetGroupAssistTank(bot, 0);
     }
     else if (hunterIndex == 1)
     {
         bossTarget = AI_VALUE2(Unit*, "find target", "fathom-guard tidalvess");
-        tankTarget = GetGroupAssistTank(botAI, bot, 2);
+        tankTarget = GetGroupAssistTank(bot, 2);
     }
     else if (hunterIndex == 2)
     {
         bossTarget = AI_VALUE2(Unit*, "find target", "fathom-guard sharkkis");
-        tankTarget = GetGroupAssistTank(botAI, bot, 1);
+        tankTarget = GetGroupAssistTank(bot, 1);
     }
 
     if (!bossTarget || !tankTarget)
@@ -1340,7 +1341,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithSkull(bot, totem))
             return true;
 
-        SetRtiTarget(botAI, "skull", totem);
+        SetRtiTarget(botAI, "skull");
 
         if (AI_VALUE(Unit*, "current target") != totem)
             return Attack(totem);
@@ -1363,7 +1364,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithCircle(bot, tidalvess))
             return true;
 
-        SetRtiTarget(botAI, "circle", tidalvess);
+        SetRtiTarget(botAI, "circle");
 
         if (AI_VALUE(Unit*, "current target") != tidalvess)
             return Attack(tidalvess);
@@ -1378,7 +1379,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithDiamond(bot, caribdis))
             return true;
 
-        SetRtiTarget(botAI, "diamond", caribdis);
+        SetRtiTarget(botAI, "diamond");
 
         const Position& position = CARIBDIS_RANGED_DPS_POSITION;
         if (bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY()) > 2.0f)
@@ -1400,7 +1401,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithStar(bot, sharkkis))
             return true;
 
-        SetRtiTarget(botAI, "star", sharkkis);
+        SetRtiTarget(botAI, "star");
 
         if (AI_VALUE(Unit*, "current target") != sharkkis)
             return Attack(sharkkis);
@@ -1415,7 +1416,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithCross(bot, fathomSporebat))
             return true;
 
-        SetRtiTarget(botAI, "cross", fathomSporebat);
+        SetRtiTarget(botAI, "cross");
 
         if (AI_VALUE(Unit*, "current target") != fathomSporebat)
             return Attack(fathomSporebat);
@@ -1429,7 +1430,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithSquare(bot, fathomLurker))
             return true;
 
-        SetRtiTarget(botAI, "square", fathomLurker);
+        SetRtiTarget(botAI, "square");
 
         if (AI_VALUE(Unit*, "current target") != fathomLurker)
             return Attack(fathomLurker);
@@ -1444,7 +1445,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithTriangle(bot, karathress))
             return true;
 
-        SetRtiTarget(botAI, "triangle", karathress);
+        SetRtiTarget(botAI, "triangle");
 
         if (AI_VALUE(Unit*, "current target") != karathress)
             return Attack(karathress);
@@ -1471,7 +1472,7 @@ bool MorogrimTidewalkerMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!tidewalker)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -1740,7 +1741,7 @@ bool LadyVashjPhase1SpreadRangedInArcAction::Execute(Event /*event*/)
 // For absorbing Shock Burst
 bool LadyVashjSetGroundingTotemInMainTankGroupAction::Execute(Event /*event*/)
 {
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -1761,7 +1762,7 @@ bool LadyVashjMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!vashj)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -1781,7 +1782,7 @@ bool LadyVashjStaticChargeMoveAwayFromGroupAction::Execute(Event /*event*/)
         return false;
 
     // If the main tank has Static Charge, other group members should move away
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (mainTank && bot != mainTank && mainTank->HasAura(SPELL_STATIC_CHARGE))
     {
         float currentDistance = bot->GetExactDist2d(mainTank);
@@ -1917,7 +1918,7 @@ bool LadyVashjAssignPhase2AndPhase3DpsPriorityAction::Execute(Event /*event*/)
                 if (MarkTargetWithDiamond(bot, vashj))
                     return true;
 
-                SetRtiTarget(botAI, "diamond", vashj);
+                SetRtiTarget(botAI, "diamond");
                 targets = { vashj };
             }
             else if (botAI->HasCheat(BotCheatMask::raid) &&
@@ -1988,7 +1989,7 @@ bool LadyVashjMisdirectStriderToFirstAssistTankAction::Execute(Event /*event*/)
     if (!strider)
         return false;
 
-    Player* firstAssistTank = GetGroupAssistTank(botAI, bot, 0);
+    Player* firstAssistTank = GetGroupAssistTank(bot, 0);
     if (!firstAssistTank || strider->GetVictim() == firstAssistTank)
         return false;
 
@@ -2081,7 +2082,7 @@ bool LadyVashjTeleportToTaintedElementalAction::Execute(Event /*event*/)
         if (MarkTargetWithStar(bot, tainted))
             return true;
 
-        SetRtiTarget(botAI, "star", tainted);
+        SetRtiTarget(botAI, "star");
         return Attack(tainted);
     }
 

--- a/src/Ai/Raid/SSC/SSCHelpers.cpp
+++ b/src/Ai/Raid/SSC/SSCHelpers.cpp
@@ -9,7 +9,6 @@
 #include "Creature.h"
 #include "ObjectAccessor.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 
 namespace SerpentShrineCavernHelpers
 {

--- a/src/Ai/Raid/SSC/SSCTriggers.cpp
+++ b/src/Ai/Raid/SSC/SSCTriggers.cpp
@@ -7,14 +7,15 @@
 #include "SSCTriggers.h"
 #include "AiFactory.h"
 #include "Corpse.h"
+#include "EncounterHelpers.h"
 #include "LootObjectStack.h"
 #include "ObjectAccessor.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "SSCActions.h"
 #include "SSCHelpers.h"
 
 using namespace SerpentShrineCavernHelpers;
+using namespace EncounterHelpers;
 
 // General
 bool SerpentShrineCavernBotIsNotInCombatTrigger::IsActive()
@@ -150,9 +151,9 @@ bool TheLurkerBelowBossIsSubmergedTrigger::IsActive()
     if (!lurker || lurker->getStandState() != UNIT_STAND_STATE_SUBMERGED)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
-    Player* firstAssistTank = GetGroupAssistTank(botAI, bot, 0);
-    Player* secondAssistTank = GetGroupAssistTank(botAI, bot, 1);
+    Player* mainTank = GetGroupMainTank(bot);
+    Player* firstAssistTank = GetGroupAssistTank(bot, 0);
+    Player* secondAssistTank = GetGroupAssistTank(bot, 1);
 
     if (!mainTank || !firstAssistTank || !secondAssistTank)
         return false;

--- a/src/Ai/Raid/TK/TKActions.cpp
+++ b/src/Ai/Raid/TK/TKActions.cpp
@@ -6,16 +6,17 @@
 
 #include "TKActions.h"
 #include "AiFactory.h"
+#include "EncounterHelpers.h"
 #include "EquipAction.h"
 #include "LootAction.h"
 #include "LootObjectStack.h"
 #include "ObjectAccessor.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "TKHelpers.h"
 #include "TKKaelthasBossAI.h"
 
 using namespace TempestKeepHelpers;
+using namespace EncounterHelpers;
 
 // Trash
 
@@ -48,7 +49,7 @@ bool AlarMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!alar)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (mainTank && botAI->CanCastSpell("misdirection", mainTank))
         return botAI->CastSpell("misdirection", mainTank);
 
@@ -70,7 +71,7 @@ bool AlarBossTanksMoveBetweenPlatformsAction::Execute(Event /*event*/)
     if (MarkTargetWithStar(bot, alar))
         return true;
 
-    SetRtiTarget(botAI, "star", alar);
+    SetRtiTarget(botAI, "star");
 
     int8 locationIndex = GetAlarCurrentLocationIndex(alar);
     if (locationIndex == LOCATION_NONE)
@@ -140,7 +141,7 @@ bool AlarMeleeDpsMoveBetweenPlatformsAction::Execute(Event /*event*/)
     if (!alar)
         return false;
 
-    SetRtiTarget(botAI, "star", alar);
+    SetRtiTarget(botAI, "star");
 
     int8 locationIndex = GetAlarCurrentLocationIndex(alar);
     if (locationIndex == LOCATION_NONE)
@@ -235,7 +236,7 @@ bool AlarAssistTanksPickUpEmbersAction::HandlePhase1Embers(Unit* alar)
         if (MarkTargetWithSquare(bot, ember))
             return true;
 
-        SetRtiTarget(botAI, "square", ember);
+        SetRtiTarget(botAI, "square");
 
         if (AI_VALUE(Unit*, "current target") != ember)
             return Attack(ember);
@@ -294,7 +295,7 @@ bool AlarAssistTanksPickUpEmbersAction::HandlePhase2Embers()
         if (MarkTargetWithSquare(bot, firstEmber))
             return true;
 
-        SetRtiTarget(botAI, "square", firstEmber);
+        SetRtiTarget(botAI, "square");
 
         if (firstEmber->GetVictim() != bot)
         {
@@ -310,12 +311,12 @@ bool AlarAssistTanksPickUpEmbersAction::HandlePhase2Embers()
                 return MoveFromGroup(safeDistance);
         }
     }
-    else if (GetSecondEmberTank(botAI) == bot && secondEmber)
+    else if (GetSecondEmberTank(bot) == bot && secondEmber)
     {
         if (MarkTargetWithCircle(bot, secondEmber))
             return true;
 
-        SetRtiTarget(botAI, "circle", secondEmber);
+        SetRtiTarget(botAI, "circle");
 
         if (secondEmber->GetVictim() != bot)
         {
@@ -349,7 +350,7 @@ bool AlarRangedDpsPrioritizeEmbersAction::Execute(Event /*event*/)
             return MoveAway(firstEmber, safeDistance - bot->GetDistance2d(firstEmber));
         }
 
-        SetRtiTarget(botAI, "square", firstEmber);
+        SetRtiTarget(botAI, "square");
         if (AI_VALUE(Unit*, "current target") != firstEmber)
             return Attack(firstEmber);
     }
@@ -362,13 +363,13 @@ bool AlarRangedDpsPrioritizeEmbersAction::Execute(Event /*event*/)
             return MoveAway(secondEmber, safeDistance - bot->GetDistance2d(secondEmber));
         }
 
-        SetRtiTarget(botAI, "circle", secondEmber);
+        SetRtiTarget(botAI, "circle");
         if (AI_VALUE(Unit*, "current target") != secondEmber)
             return Attack(secondEmber);
     }
     else if (Unit* alar = AI_VALUE2(Unit*, "find target", "al'ar"))
     {
-        SetRtiTarget(botAI, "star", alar);
+        SetRtiTarget(botAI, "star");
         if (AI_VALUE(Unit*, "current target") != alar)
             return Attack(alar);
     }
@@ -482,15 +483,15 @@ bool AlarSwapTanksOnBossAction::Execute(Event /*event*/)
 
     if (alar->GetHealth() == alar->GetMaxHealth())
     {
-        SetRtiTarget(botAI, "star", alar);
+        SetRtiTarget(botAI, "star");
         if (AI_VALUE(Unit*, "current target") != alar)
             return Attack(alar);
     }
 
-    Player* secondEmberTank = GetSecondEmberTank(botAI);
+    Player* secondEmberTank = GetSecondEmberTank(bot);
     if (secondEmberTank && secondEmberTank != bot)
     {
-        SetRtiTarget(botAI, "star", alar);
+        SetRtiTarget(botAI, "star");
         if (AI_VALUE(Unit*, "current target") != alar)
             return Attack(alar);
         else if (alar->GetVictim() != bot)
@@ -895,14 +896,14 @@ bool HighAstromancerSolarianTargetSolariumPriestsAction::Execute(Event /*event*/
         if (MarkTargetWithSquare(bot, targetPriest))
             return true;
 
-        SetRtiTarget(botAI, "square", targetPriest);
+        SetRtiTarget(botAI, "square");
     }
     else
     {
         if (MarkTargetWithStar(bot, targetPriest))
             return true;
 
-        SetRtiTarget(botAI, "star", targetPriest);
+        SetRtiTarget(botAI, "star");
     }
 
     if (AI_VALUE(Unit*, "current target") != targetPriest)
@@ -972,7 +973,7 @@ Unit* HighAstromancerSolarianTargetSolariumPriestsAction::AssignSolariumPriestsT
 
 bool HighAstromancerSolarianCastFearWardOnMainTankAction::Execute(Event /*event*/)
 {
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (mainTank && botAI->CanCastSpell("fear ward", mainTank))
         return botAI->CastSpell("fear ward", mainTank);
 
@@ -1035,7 +1036,7 @@ bool KaelthasSunstriderMisdirectAdvisorsToTanksAction::Execute(Event /*event*/)
     else if (hunterIndex == 1)
     {
         advisorTarget = AI_VALUE2(Unit*, "find target", "master engineer telonicus");
-        tankTarget = GetGroupAssistTank(botAI, bot, 0);
+        tankTarget = GetGroupAssistTank(bot, 0);
     }
 
     if (!advisorTarget ||
@@ -1065,7 +1066,7 @@ bool KaelthasSunstriderMainTankPositionSanguinarAction::Execute(Event /*event*/)
     if (MarkTargetWithStar(bot, sanguinar))
         return true;
 
-    SetRtiTarget(botAI, "star", sanguinar);
+    SetRtiTarget(botAI, "star");
 
     if (AI_VALUE(Unit*, "current target") != sanguinar)
         return Attack(sanguinar);
@@ -1094,7 +1095,7 @@ bool KaelthasSunstriderMainTankPositionSanguinarAction::Execute(Event /*event*/)
 
 bool KaelthasSunstriderCastFearWardOnSanguinarTankAction::Execute(Event /*event*/)
 {
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (mainTank && botAI->CanCastSpell("fear ward", mainTank))
         return botAI->CastSpell("fear ward", mainTank);
 
@@ -1110,7 +1111,7 @@ bool KaelthasSunstriderWarlockTankPositionCapernianAction::Execute(Event /*event
     if (MarkTargetWithCircle(bot, capernian))
         return true;
 
-    SetRtiTarget(botAI, "circle", capernian);
+    SetRtiTarget(botAI, "circle");
 
     if (AI_VALUE(Unit*, "current target") != capernian &&
         botAI->CanCastSpell("searing pain", capernian) &&
@@ -1273,7 +1274,7 @@ bool KaelthasSunstriderFirstAssistTankPositionTelonicusAction::Execute(Event /*e
     if (MarkTargetWithTriangle(bot, telonicus))
         return true;
 
-    SetRtiTarget(botAI, "triangle", telonicus);
+    SetRtiTarget(botAI, "triangle");
 
     if (AI_VALUE(Unit*, "current target") != telonicus)
         return Attack(telonicus);
@@ -1355,7 +1356,7 @@ bool KaelthasSunstriderAssignAdvisorDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithSquare(bot, thaladred))
             return true;
 
-        SetRtiTarget(botAI, "square", thaladred);
+        SetRtiTarget(botAI, "square");
 
         if (AI_VALUE(Unit*, "current target") != thaladred)
             return Attack(thaladred);
@@ -1370,7 +1371,7 @@ bool KaelthasSunstriderAssignAdvisorDpsPriorityAction::Execute(Event /*event*/)
         capernian && !capernian->HasUnitFlag(UNIT_FLAG_NON_ATTACKABLE) &&
         !capernian->HasAura(SPELL_PERMANENT_FEIGN_DEATH))
     {
-        SetRtiTarget(botAI, "circle", capernian);
+        SetRtiTarget(botAI, "circle");
 
         if (AI_VALUE(Unit*, "current target") != capernian)
             return Attack(capernian);
@@ -1384,7 +1385,7 @@ bool KaelthasSunstriderAssignAdvisorDpsPriorityAction::Execute(Event /*event*/)
     if (sanguinar && !sanguinar->HasUnitFlag(UNIT_FLAG_NON_ATTACKABLE) &&
         !sanguinar->HasAura(SPELL_PERMANENT_FEIGN_DEATH))
     {
-        SetRtiTarget(botAI, "star", sanguinar);
+        SetRtiTarget(botAI, "star");
 
         if (AI_VALUE(Unit*, "current target") != sanguinar)
             return Attack(sanguinar);
@@ -1398,7 +1399,7 @@ bool KaelthasSunstriderAssignAdvisorDpsPriorityAction::Execute(Event /*event*/)
     if (telonicus && !telonicus->HasUnitFlag(UNIT_FLAG_NON_ATTACKABLE) &&
         !telonicus->HasAura(SPELL_PERMANENT_FEIGN_DEATH))
     {
-        SetRtiTarget(botAI, "triangle", telonicus);
+        SetRtiTarget(botAI, "triangle");
         if (AI_VALUE(Unit*, "current target") != telonicus)
             return Attack(telonicus);
 
@@ -1455,7 +1456,7 @@ bool KaelthasSunstriderManageAdvisorDpsTimerAction::Execute(Event /*event*/)
 bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*event*/)
 {
     if (botAI->IsAssistTank(bot))
-        SetRtiTarget(botAI, "moon", nullptr);
+        SetRtiTarget(botAI, "moon");
 
     // Priority 0: Everybody other than the main tank needs to stay away from the axe
     // But this applies to assist tanks only after they get aggro on the mace, dagger, or sword
@@ -1487,7 +1488,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
             if (MarkTargetWithSkull(bot, staff))
                 return true;
 
-            SetRtiTarget(botAI, "skull", staff);
+            SetRtiTarget(botAI, "skull");
 
             if (AI_VALUE(Unit*, "current target") != staff)
                 return Attack(staff);
@@ -1498,7 +1499,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
             if (MarkTargetWithSkull(bot, mace))
                 return true;
 
-            SetRtiTarget(botAI, "skull", mace);
+            SetRtiTarget(botAI, "skull");
 
             if (AI_VALUE(Unit*, "current target") != mace)
                 return Attack(mace);
@@ -1509,7 +1510,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
             if (MarkTargetWithSkull(bot, sword))
                 return true;
 
-            SetRtiTarget(botAI, "skull", sword);
+            SetRtiTarget(botAI, "skull");
 
             if (AI_VALUE(Unit*, "current target") != sword)
                 return Attack(sword);
@@ -1520,7 +1521,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
             if (MarkTargetWithSkull(bot, dagger))
                 return true;
 
-            SetRtiTarget(botAI, "skull", dagger);
+            SetRtiTarget(botAI, "skull");
 
             if (AI_VALUE(Unit*, "current target") != dagger)
                 return Attack(dagger);
@@ -1528,7 +1529,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
         // Priority 5: Devastation - ranged only (Diamond--marked in other method by main tank)
         else if (axe && botAI->IsRangedDps(bot))
         {
-            SetRtiTarget(botAI, "diamond", axe);
+            SetRtiTarget(botAI, "diamond");
 
             if (AI_VALUE(Unit*, "current target") != axe)
                 return Attack(axe);
@@ -1539,7 +1540,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
             if (MarkTargetWithSkull(bot, longbow))
                 return true;
 
-            SetRtiTarget(botAI, "skull", longbow);
+            SetRtiTarget(botAI, "skull");
 
             if (AI_VALUE(Unit*, "current target") != longbow)
                 return Attack(longbow);
@@ -1550,7 +1551,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
             if (MarkTargetWithSkull(bot, shield))
                 return true;
 
-            SetRtiTarget(botAI, "skull", shield);
+            SetRtiTarget(botAI, "skull");
 
             if (AI_VALUE(Unit*, "current target") != shield)
                 return Attack(shield);
@@ -1569,7 +1570,7 @@ bool KaelthasSunstriderMoveDevastationAwayAction::Execute(Event /*event*/)
     if (MarkTargetWithDiamond(bot, axe))
         return true;
 
-    SetRtiTarget(botAI, "diamond", axe);
+    SetRtiTarget(botAI, "diamond");
 
     if (AI_VALUE(Unit*, "current target") != axe)
         return Attack(axe);
@@ -1804,7 +1805,7 @@ bool KaelthasSunstriderMainTankPositionBossAction::Execute(Event /*event*/)
     if (MarkTargetWithStar(bot, kaelthas))
         return true;
 
-    SetRtiTarget(botAI, "star", kaelthas);
+    SetRtiTarget(botAI, "star");
 
     if (AI_VALUE(Unit*, "current target") != kaelthas)
         return Attack(kaelthas);
@@ -1895,7 +1896,7 @@ bool KaelthasSunstriderHandlePhoenixesAndEggsAction::AssistTanksPickUpPhoenixes(
         if (MarkTargetWithSquare(bot, targetPhoenix))
             return true;
 
-        SetRtiTarget(botAI, "square", targetPhoenix);
+        SetRtiTarget(botAI, "square");
     }
     else if (botAI->IsAssistTankOfIndex(bot, 1, true) && phoenixes.size() >= 2)
     {
@@ -1904,7 +1905,7 @@ bool KaelthasSunstriderHandlePhoenixesAndEggsAction::AssistTanksPickUpPhoenixes(
         if (MarkTargetWithCircle(bot, targetPhoenix))
             return true;
 
-        SetRtiTarget(botAI, "circle", targetPhoenix);
+        SetRtiTarget(botAI, "circle");
     }
 
     if (!targetPhoenix)
@@ -1934,7 +1935,7 @@ bool KaelthasSunstriderHandlePhoenixesAndEggsAction::NonTanksDestroyEggsAndAvoid
             if (MarkTargetWithDiamond(bot, phoenixEgg))
                 return true;
 
-            SetRtiTarget(botAI, "diamond", phoenixEgg);
+            SetRtiTarget(botAI, "diamond");
 
             if (AI_VALUE(Unit*, "current target") != phoenixEgg)
                 return Attack(phoenixEgg);
@@ -2043,7 +2044,7 @@ bool KaelthasSunstriderBreakThroughShockBarrierAction::Execute(Event /*event*/)
     }
     else if (AI_VALUE(Unit*, "current target") != kaelthas)
     {
-        SetRtiTarget(botAI, "star", kaelthas);
+        SetRtiTarget(botAI, "star");
         return Attack(kaelthas);
     }
 

--- a/src/Ai/Raid/TK/TKTriggers.cpp
+++ b/src/Ai/Raid/TK/TKTriggers.cpp
@@ -5,13 +5,14 @@
  */
 
 #include "TKTriggers.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "TKActions.h"
 #include "TKHelpers.h"
 #include "TKKaelthasBossAI.h"
 
 using namespace TempestKeepHelpers;
+using namespace EncounterHelpers;
 
 // Trash
 
@@ -295,7 +296,7 @@ bool KaelthasSunstriderSanguinarCastsBellowingRoarTrigger::IsActive()
         kaelAI->GetPhase() != PHASE_ALL_ADVISORS)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank || mainTank->HasAura(SPELL_FEAR_WARD))
         return false;
 

--- a/src/Ai/Raid/TK/Util/TKHelpers.cpp
+++ b/src/Ai/Raid/TK/Util/TKHelpers.cpp
@@ -5,10 +5,12 @@
  */
 
 #include "TKHelpers.h"
+#include "EncounterHelpers.h"
 #include "LootObjectStack.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "TKActions.h"
+
+using namespace EncounterHelpers;
 
 namespace TempestKeepHelpers
 {
@@ -288,10 +290,10 @@ std::pair<Unit*, Unit*> GetFirstTwoEmbersOfAlar(PlayerbotAI* botAI)
     return { firstEmber, secondEmber };
 }
 
-Player* GetSecondEmberTank(PlayerbotAI* botAI)
+Player* GetSecondEmberTank(Player* bot)
 {
-    Player* mainTank = GetGroupMainTank(botAI, botAI->GetBot());
-    Player* assistTank = GetGroupAssistTank(botAI, botAI->GetBot(), 0);
+    Player* mainTank = GetGroupMainTank(bot);
+    Player* assistTank = GetGroupAssistTank(bot, 0);
 
     bool mainTankHasMelt = mainTank && mainTank->HasAura(SPELL_MELT_ARMOR);
     bool assistTankHasMelt = assistTank && assistTank->HasAura(SPELL_MELT_ARMOR);

--- a/src/Ai/Raid/TK/Util/TKHelpers.h
+++ b/src/Ai/Raid/TK/Util/TKHelpers.h
@@ -133,7 +133,7 @@ namespace TempestKeepHelpers
     void GetClosestPlatformAndGround(
         const Position& botPos, int8& closestPlatform, Position& ground);
     std::pair<Unit*, Unit*> GetFirstTwoEmbersOfAlar(PlayerbotAI* botAI);
-    Player* GetSecondEmberTank(PlayerbotAI* botAI);
+    Player* GetSecondEmberTank(Player* bot);
 
     // Void Reaver
     extern const Position VOID_REAVER_TANK_POSITION;

--- a/src/Ai/Raid/ZA/ZAActions.cpp
+++ b/src/Ai/Raid/ZA/ZAActions.cpp
@@ -5,11 +5,12 @@
  */
 
 #include "ZAActions.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "ZAHelpers.h"
 
 using namespace ZulAmanHelpers;
+using namespace EncounterHelpers;
 
 // Trash
 
@@ -38,7 +39,7 @@ bool AkilzonMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!akilzon)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -97,7 +98,7 @@ bool AkilzonMoveToEyeOfTheStormAction::Execute(Event /*event*/)
 {
     Player* target = GetElectricalStormTarget(bot);
     if (!target && !botAI->IsMainTank(bot))
-        target = GetGroupMainTank(botAI, bot);
+        target = GetGroupMainTank(bot);
 
     if (target && bot->GetExactDist2d(target) > 2.0f)
     {
@@ -137,7 +138,7 @@ bool NalorakkMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!nalorakk)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -244,7 +245,7 @@ bool JanalaiMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!janalai)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -387,7 +388,7 @@ bool HalazziMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!halazzi)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -410,7 +411,7 @@ bool HalazziMainTankPositionBossAction::Execute(Event /*event*/)
     if (MarkTargetWithStar(bot, halazzi))
         return true;
 
-    SetRtiTarget(botAI, "star", halazzi);
+    SetRtiTarget(botAI, "star");
 
     if (AI_VALUE(Unit*, "current target") != halazzi)
         return Attack(halazzi);
@@ -446,7 +447,7 @@ bool HalazziFirstAssistTankAttackSpiritLynxAction::Execute(Event /*event*/)
         if (MarkTargetWithCircle(bot, lynx))
             return true;
 
-        SetRtiTarget(botAI, "circle", lynx);
+        SetRtiTarget(botAI, "circle");
 
         if (AI_VALUE(Unit*, "current target") != lynx)
             return Attack(lynx);
@@ -458,7 +459,7 @@ bool HalazziFirstAssistTankAttackSpiritLynxAction::Execute(Event /*event*/)
     }
     else if (Unit* halazzi = AI_VALUE2(Unit*, "find target", "halazzi"))
     {
-        SetRtiTarget(botAI, "star", halazzi);
+        SetRtiTarget(botAI, "star");
 
         if (AI_VALUE(Unit*, "current target") != halazzi)
             return Attack(halazzi);
@@ -497,7 +498,7 @@ bool HalazziAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithSkull(bot, totem))
             return true;
 
-        SetRtiTarget(botAI, "skull", totem);
+        SetRtiTarget(botAI, "skull");
 
         if (AI_VALUE(Unit*, "current target") != totem)
             return Attack(totem);
@@ -508,7 +509,7 @@ bool HalazziAssignDpsPriorityAction::Execute(Event /*event*/)
     // Target priority 2: Halazzi
     if (Unit* halazzi = AI_VALUE2(Unit*, "find target", "halazzi"))
     {
-        SetRtiTarget(botAI, "star", halazzi);
+        SetRtiTarget(botAI, "star");
 
         if (AI_VALUE(Unit*, "current target") != halazzi)
             return Attack(halazzi);
@@ -526,7 +527,7 @@ bool HexLordMalacrassMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!malacrass)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -581,7 +582,7 @@ bool HexLordMalacrassAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithSkull(bot, priorityTarget))
             return true;
 
-        SetRtiTarget(botAI, "skull", priorityTarget);
+        SetRtiTarget(botAI, "skull");
     }
 
     return false;
@@ -646,7 +647,7 @@ bool ZuljinMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!zuljin)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 

--- a/src/Ai/Raid/ZA/ZAMultipliers.cpp
+++ b/src/Ai/Raid/ZA/ZAMultipliers.cpp
@@ -8,6 +8,7 @@
 #include "ChooseTargetActions.h"
 #include "DKActions.h"
 #include "DruidBearActions.h"
+#include "EncounterHelpers.h"
 #include "FollowActions.h"
 #include "GenericSpellActions.h"
 #include "HunterActions.h"
@@ -15,7 +16,6 @@
 #include "PaladinActions.h"
 #include "Playerbots.h"
 #include "PriestActions.h"
-#include "RaidBossHelpers.h"
 #include "ReachTargetActions.h"
 #include "RogueActions.h"
 #include "ShamanActions.h"
@@ -25,6 +25,7 @@
 #include "ZAHelpers.h"
 
 using namespace ZulAmanHelpers;
+using namespace EncounterHelpers;
 
 // Akil'zon <Eagle Avatar>
 

--- a/src/Ai/Raid/ZA/ZATriggers.cpp
+++ b/src/Ai/Raid/ZA/ZATriggers.cpp
@@ -5,12 +5,13 @@
  */
 
 #include "ZATriggers.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "ZAActions.h"
 #include "ZAHelpers.h"
 
 using namespace ZulAmanHelpers;
+using namespace EncounterHelpers;
 
 // Trash
 

--- a/src/Util/EncounterHelpers.cpp
+++ b/src/Util/EncounterHelpers.cpp
@@ -10,6 +10,7 @@
 #include "DruidActions.h"
 #include "DruidBearActions.h"
 #include "DruidCatActions.h"
+#include "GenericSpellActions.h"
 #include "GridNotifiers.h"
 #include "GridNotifiersImpl.h"
 #include "HunterActions.h"
@@ -287,58 +288,86 @@ bool IsDpsCooldownAction(Player* bot, Action* action)
     if (dynamic_cast<UseTrinketAction*>(action))
         return true;
 
+    bool isClassCooldown = false;
     switch (bot->getClass())
     {
         case CLASS_DEATH_KNIGHT:
-            return dynamic_cast<CastSummonGargoyleAction*>(action) ||
+            isClassCooldown = dynamic_cast<CastSummonGargoyleAction*>(action) ||
                 dynamic_cast<CastDeathchillAction*>(action) ||
                 dynamic_cast<CastEmpowerRuneWeaponAction*>(action) ||
                 dynamic_cast<CastArmyOfTheDeadAction*>(action);
+            break;
 
         case CLASS_DRUID:
-            return dynamic_cast<CastStarfallAction*>(action) ||
+            isClassCooldown = dynamic_cast<CastStarfallAction*>(action) ||
                 dynamic_cast<CastForceOfNatureAction*>(action) ||
                 dynamic_cast<CastBerserkAction*>(action);
+            break;
 
         case CLASS_HUNTER:
-            return dynamic_cast<CastKillCommandAction*>(action) ||
+            isClassCooldown = dynamic_cast<CastKillCommandAction*>(action) ||
                 dynamic_cast<CastRapidFireAction*>(action) ||
                 dynamic_cast<CastReadinessAction*>(action) ||
                 dynamic_cast<CastBestialWrathAction*>(action);
+            break;
 
         case CLASS_MAGE:
-            return dynamic_cast<CastArcanePowerAction*>(action) ||
+            isClassCooldown = dynamic_cast<CastArcanePowerAction*>(action) ||
                 dynamic_cast<CastCombustionAction*>(action) ||
                 dynamic_cast<CastIcyVeinsAction*>(action) ||
                 dynamic_cast<CastMirrorImageAction*>(action) ||
                 dynamic_cast<CastColdSnapAction*>(action) ||
                 dynamic_cast<CastPresenceOfMindAction*>(action);
+            break;
 
         case CLASS_SHAMAN:
-            return dynamic_cast<CastElementalMasteryAction*>(action) ||
+            isClassCooldown = dynamic_cast<CastElementalMasteryAction*>(action) ||
                 dynamic_cast<CastFeralSpiritAction*>(action) ||
                 dynamic_cast<CastFireElementalTotemAction*>(action) ||
                 dynamic_cast<CastFireElementalTotemMeleeAction*>(action);
+            break;
 
         case CLASS_PALADIN:
-            return dynamic_cast<CastAvengingWrathAction*>(action);
+            isClassCooldown = dynamic_cast<CastAvengingWrathAction*>(action);
+            break;
 
         case CLASS_ROGUE:
-            return dynamic_cast<CastKillingSpreeAction*>(action) ||
+            isClassCooldown = dynamic_cast<CastKillingSpreeAction*>(action) ||
                 dynamic_cast<CastBladeFlurryAction*>(action) ||
                 dynamic_cast<CastAdrenalineRushAction*>(action) ||
                 dynamic_cast<CastColdBloodAction*>(action);
+            break;
 
         case CLASS_WARLOCK:
-            return dynamic_cast<CastMetamorphosisAction*>(action);
+            isClassCooldown = dynamic_cast<CastMetamorphosisAction*>(action);
+            break;
 
         case CLASS_WARRIOR:
-            return dynamic_cast<CastDeathWishAction*>(action) ||
+            isClassCooldown = dynamic_cast<CastDeathWishAction*>(action) ||
                 dynamic_cast<CastBladestormAction*>(action) ||
                 dynamic_cast<CastRecklessnessAction*>(action);
+            break;
 
         default:
-            return false; // Priest =(
+            break; // Priest =(
+    }
+
+    if (isClassCooldown)
+        return true;
+
+    switch (bot->getRace())
+    {
+        case RACE_BLOODELF:
+            return dynamic_cast<CastArcaneTorrentAction*>(action);
+
+        case RACE_ORC:
+            return dynamic_cast<CastBloodFuryAction*>(action);
+
+        case RACE_TROLL:
+            return dynamic_cast<CastBerserkingAction*>(action);
+
+        default:
+            return false;
     }
 }
 

--- a/src/Util/EncounterHelpers.cpp
+++ b/src/Util/EncounterHelpers.cpp
@@ -4,12 +4,28 @@
  * or (at your option) any later version.
  */
 
-#include "RaidBossHelpers.h"
+#include "EncounterHelpers.h"
 #include "CellImpl.h"
+#include "DKActions.h"
+#include "DruidActions.h"
+#include "DruidBearActions.h"
+#include "DruidCatActions.h"
 #include "GridNotifiers.h"
 #include "GridNotifiersImpl.h"
+#include "HunterActions.h"
+#include "MageActions.h"
+#include "PaladinActions.h"
 #include "Playerbots.h"
+#include "RogueActions.h"
 #include "RtiTargetValue.h"
+#include "ShamanActions.h"
+#include "WarlockActions.h"
+#include "WarriorActions.h"
+#include <list>
+
+namespace EncounterHelpers
+
+{
 
 // Functions to mark targets with raid target icons
 // Note that these functions do not allow the player to change the icon during the encounter
@@ -88,20 +104,14 @@ bool ClearTargetIcon(Player* bot, uint8 iconId)
     return false;
 }
 
-// For bots to set their raid target icon to the specified icon on the specified target
-void SetRtiTarget(PlayerbotAI* botAI, const std::string& rtiName, Unit* target)
+// For bots to set their raid target icon to the specified icon
+void SetRtiTarget(PlayerbotAI* botAI, std::string const& rtiName)
 {
-    if (!target)
-        return;
+    Value<std::string>* rtiValue =
+        botAI->GetAiObjectContext()->GetValue<std::string>("rti");
 
-    std::string currentRti = botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Get();
-    Unit* currentTarget = botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Get();
-
-    if (currentRti != rtiName || currentTarget != target)
-    {
-        botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Set(rtiName);
-        botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Set(target);
-    }
+    if (rtiValue->Get() != rtiName)
+        rtiValue->Set(rtiName);
 }
 
 // Return the first alive bot in the specified instance map for purposes of assigning
@@ -128,13 +138,13 @@ bool IsMechanicTrackerBot(Player* bot, uint32 mapId)
 }
 
 // Requires the main tank to be alive
-Player* GetGroupMainTank(PlayerbotAI* botAI, Player* bot)
+Player* GetGroupMainTank(Player* bot)
 {
     Group* group = bot->GetGroup();
     if (!group)
         return nullptr;
 
-    ObjectGuid const mainTankGuid = botAI->GetMainTankGuid(group);
+    ObjectGuid const mainTankGuid = PlayerbotAI::GetMainTankGuid(group);
     if (mainTankGuid.IsEmpty())
         return nullptr;
 
@@ -149,13 +159,13 @@ Player* GetGroupMainTank(PlayerbotAI* botAI, Player* bot)
 }
 
 // Returns the alive assist tank of the specified index (0 = first, 1 = second, etc.)
-Player* GetGroupAssistTank(PlayerbotAI* botAI, Player* bot, uint8 index)
+Player* GetGroupAssistTank(Player* bot, uint8 index)
 {
     Group* group = bot->GetGroup();
     if (!group)
         return nullptr;
 
-    ObjectGuid const mainTankGuid = botAI->GetMainTankGuid(group);
+    ObjectGuid const mainTankGuid = PlayerbotAI::GetMainTankGuid(group);
     if (mainTankGuid.IsEmpty())
         return nullptr;
 
@@ -165,7 +175,7 @@ Player* GetGroupAssistTank(PlayerbotAI* botAI, Player* bot, uint8 index)
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
         Player* member = ref->GetSource();
-        if (!member || !member->IsAlive() || !botAI->IsTank(member) ||
+        if (!member || !member->IsAlive() || !PlayerbotAI::IsTank(member) ||
             member->GetGUID() == mainTankGuid)
         {
             continue;
@@ -259,4 +269,135 @@ std::vector<Position> GetDynamicObjectPositions(Player* bot, float searchRadius,
     }
 
     return dynObjs;
+}
+
+// This function is primarily for use in multipliers during encounters where it is desirable
+// for bots to save cooldowns for particular phases (or for a bit after the pull)
+bool IsDpsCooldownAction(Player* bot, Action* action)
+{
+    if (bot->getClass() == CLASS_SHAMAN && // Before dps gate to capture Resto
+        (dynamic_cast<CastBloodlustAction*>(action) || dynamic_cast<CastHeroismAction*>(action)))
+    {
+        return true;
+    }
+
+    if (!PlayerbotAI::IsDps(bot))
+        return false;
+
+    if (dynamic_cast<UseTrinketAction*>(action))
+        return true;
+
+    switch (bot->getClass())
+    {
+        case CLASS_DEATH_KNIGHT:
+            return dynamic_cast<CastSummonGargoyleAction*>(action) ||
+                dynamic_cast<CastDeathchillAction*>(action) ||
+                dynamic_cast<CastEmpowerRuneWeaponAction*>(action) ||
+                dynamic_cast<CastArmyOfTheDeadAction*>(action);
+
+        case CLASS_DRUID:
+            return dynamic_cast<CastStarfallAction*>(action) ||
+                dynamic_cast<CastForceOfNatureAction*>(action) ||
+                dynamic_cast<CastBerserkAction*>(action);
+
+        case CLASS_HUNTER:
+            return dynamic_cast<CastKillCommandAction*>(action) ||
+                dynamic_cast<CastRapidFireAction*>(action) ||
+                dynamic_cast<CastReadinessAction*>(action) ||
+                dynamic_cast<CastBestialWrathAction*>(action);
+
+        case CLASS_MAGE:
+            return dynamic_cast<CastArcanePowerAction*>(action) ||
+                dynamic_cast<CastCombustionAction*>(action) ||
+                dynamic_cast<CastIcyVeinsAction*>(action) ||
+                dynamic_cast<CastMirrorImageAction*>(action) ||
+                dynamic_cast<CastColdSnapAction*>(action) ||
+                dynamic_cast<CastPresenceOfMindAction*>(action);
+
+        case CLASS_SHAMAN:
+            return dynamic_cast<CastElementalMasteryAction*>(action) ||
+                dynamic_cast<CastFeralSpiritAction*>(action) ||
+                dynamic_cast<CastFireElementalTotemAction*>(action) ||
+                dynamic_cast<CastFireElementalTotemMeleeAction*>(action);
+
+        case CLASS_PALADIN:
+            return dynamic_cast<CastAvengingWrathAction*>(action);
+
+        case CLASS_ROGUE:
+            return dynamic_cast<CastKillingSpreeAction*>(action) ||
+                dynamic_cast<CastBladeFlurryAction*>(action) ||
+                dynamic_cast<CastAdrenalineRushAction*>(action) ||
+                dynamic_cast<CastColdBloodAction*>(action);
+
+        case CLASS_WARLOCK:
+            return dynamic_cast<CastMetamorphosisAction*>(action);
+
+        case CLASS_WARRIOR:
+            return dynamic_cast<CastDeathWishAction*>(action) ||
+                dynamic_cast<CastBladestormAction*>(action) ||
+                dynamic_cast<CastRecklessnessAction*>(action);
+
+        default:
+            return false; // Priest =(
+    }
+}
+
+bool IsTauntAction(Player* bot, Action* action)
+{
+    if (!PlayerbotAI::IsTank(bot))
+        return false;
+
+    switch (bot->getClass())
+    {
+        case CLASS_DEATH_KNIGHT:
+            return dynamic_cast<CastDarkCommandAction*>(action) ||
+                dynamic_cast<CastDeathGripAction*>(action);
+
+        case CLASS_DRUID:
+            return dynamic_cast<CastGrowlAction*>(action) ||
+                dynamic_cast<CastChallengingRoarAction*>(action);
+
+        case CLASS_PALADIN:
+            return dynamic_cast<CastHandOfReckoningAction*>(action) ||
+                dynamic_cast<CastRighteousDefenseAction*>(action);
+
+        case CLASS_WARRIOR:
+            return dynamic_cast<CastTauntAction*>(action) ||
+                dynamic_cast<CastChallengingShoutAction*>(action);
+
+        default:
+            return false;
+    }
+}
+
+// These abilities can be particularly problematic on the pull for a council-type boss
+bool IsAoeThreatAction(Player* bot, Action* action)
+{
+    if (!PlayerbotAI::IsTank(bot))
+        return false;
+
+    switch (bot->getClass())
+    {
+        case CLASS_DEATH_KNIGHT:
+            return dynamic_cast<CastDeathAndDecayAction*>(action) ||
+                dynamic_cast<CastPestilenceAction*>(action) ||
+                dynamic_cast<CastBloodBoilAction*>(action);
+
+        case CLASS_DRUID:
+            return dynamic_cast<CastSwipeBearAction*>(action);
+
+        case CLASS_PALADIN:
+            return dynamic_cast<CastAvengersShieldAction*>(action) ||
+                dynamic_cast<CastConsecrationAction*>(action);
+
+        case CLASS_WARRIOR:
+            return dynamic_cast<CastThunderClapAction*>(action) ||
+                dynamic_cast<CastShockwaveAction*>(action) ||
+                dynamic_cast<CastCleaveAction*>(action);
+
+        default:
+            return false;
+    }
+}
+
 }

--- a/src/Util/EncounterHelpers.h
+++ b/src/Util/EncounterHelpers.h
@@ -4,11 +4,22 @@
  * or (at your option) any later version.
  */
 
-#ifndef PLAYERBOTS_RAIDBOSSHELPERS_H
-#define PLAYERBOTS_RAIDBOSSHELPERS_H
+#ifndef PLAYERBOTS_ENCOUNTERHELPERS_H
+#define PLAYERBOTS_ENCOUNTERHELPERS_H
 
-#include "AiObject.h"
-#include "Unit.h"
+#include "Common.h"
+#include "Position.h"
+#include <string>
+#include <vector>
+
+class Action;
+class Player;
+class PlayerbotAI;
+class Unit;
+
+namespace EncounterHelpers
+
+{
 
 bool MarkTargetWithIcon(Player* bot, Unit* target, uint8 iconId);
 bool MarkTargetWithSkull(Player* bot, Unit* target);
@@ -20,12 +31,17 @@ bool MarkTargetWithTriangle(Player* bot, Unit* target);
 bool MarkTargetWithCross(Player* bot, Unit* target);
 bool MarkTargetWithMoon(Player* bot, Unit* target);
 bool ClearTargetIcon(Player* bot, uint8 iconId);
-void SetRtiTarget(PlayerbotAI* botAI, const std::string& rtiName, Unit* target);
+void SetRtiTarget(PlayerbotAI* botAI, std::string const& rtiName);
 bool IsMechanicTrackerBot(Player* bot, uint32 mapId);
-Player* GetGroupMainTank(PlayerbotAI* botAI, Player* bot);
-Player* GetGroupAssistTank(PlayerbotAI* botAI, Player* bot, uint8 index);
+Player* GetGroupMainTank(Player* bot);
+Player* GetGroupAssistTank(Player* bot, uint8 index);
 Unit* GetFirstAliveUnitByEntry(PlayerbotAI* botAI, uint32 entry);
 Player* GetNearestPlayerInRadius(Player* bot, float radius);
 std::vector<Position> GetDynamicObjectPositions(Player* bot, float searchRadius, uint32 spellId);
+bool IsDpsCooldownAction(Player* bot, Action* action);
+bool IsTauntAction(Player* bot, Action* action);
+bool IsAoeThreatAction(Player* bot, Action* action);
+
+}
 
 #endif


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

Since RaidBossHelpers is also used for dungeons and trash strategies, I've renamed it EncounterHelpers and moved it to the /src/Util/ folder. I wrapped the functions in a new EncounterHelpers namespace and then updated includes and namespace usage where any relevant functions are used.

Other changes:

- Added boolean functions for IsDpsCooldownAction, IsTauntAction, and IsAoeThreatAction for usage in multipliers. This can cut down a lot on includes in multiplier files in addition to making the code cleaner. I implemented them for Black Temple as an example since BT was already using the constituent actions, and I intend to use them in other strategies as well going forward.
- Cleaned up SetRtiTarget, as half the function was inoperative, and removed a parameter and updated call sites. I eventually intend to get rid of forcing RTI changes entirely and probably doing away with this helper at that point.
- Removed unneeded PlayerbotAI* botAI parameters from GetGroupMainTank and GetGroupAssistTank and updated call sites accordingly


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

Minimum logic is described above. Should be no relevant impact on processing cost, absent a tiny bit of improved efficiency with the BT multipliers.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

Right now, the only potential functional regression would be in BT so if there are problems noticed there it would be worth flagging.

## Impact Assessment
<!--
As a generic test, pmon checks before and after your edits are helpful. To standardize the measurement, set the configs
BotActiveAlone = 100 & botActiveAloneSmartScale = 0. After server boot, enable the monitor `playerbot pmon toggle`
right after the bots finished logging-in, and run the stack command `playerbot pmon stack` 5 minutes after that.
The last "Total" line is the main result to look for.
-->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [x] Yes (**explain below**)

I've never really understood this question, but this does require using the namespace for the helpers going forward (either with using namespace like me because I'm lazy or each time you call a function from the helper file). It's necessary though as the file grows to cordon off all the classless functions.


## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

Assistance with modifying SetRtiTarget

## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/Ai/Base/Actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated.
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


