### PR TITLE
Test staging

### DIFF
--- a/src/Ai/Base/Actions/ChooseTargetActions.cpp
+++ b/src/Ai/Base/Actions/ChooseTargetActions.cpp
@@ -92,12 +92,9 @@ bool AttackAnythingAction::Execute(Event event)
     {
         if (Unit* grindTarget = GetTarget())
         {
-            if (char const* grindName = grindTarget->GetName().c_str())
-            {
-                context->GetValue<ObjectGuid>("pull target")->Set(grindTarget->GetGUID());
-                bot->GetMotionMaster()->Clear();
-                // bot->StopMoving();
-            }
+            context->GetValue<ObjectGuid>("pull target")->Set(grindTarget->GetGUID());
+            bot->GetMotionMaster()->Clear();
+            // bot->StopMoving();
         }
     }
 

--- a/src/Ai/Base/Actions/LfgActions.cpp
+++ b/src/Ai/Base/Actions/LfgActions.cpp
@@ -172,7 +172,7 @@ bool LfgJoinAction::JoinLFG()
 
 bool LfgRoleCheckAction::Execute(Event /*event*/)
 {
-    if (Group* group = bot->GetGroup())
+    if (bot->GetGroup())
     {
         uint32 newRoles = GetRoles();
         // if (currentRoles == newRoles)

--- a/src/Ai/Base/Actions/LfgActions.cpp
+++ b/src/Ai/Base/Actions/LfgActions.cpp
@@ -274,6 +274,15 @@ bool LfgLeaveAction::Execute(Event /*event*/)
     if (sLFGMgr->GetState(bot->GetGUID()) > LFG_STATE_QUEUED)
         return false;
 
+    // Don't drop a queue we deliberately joined. The "seldom" tick (RandomTrigger, ~300s)
+    // otherwise pulls random bots straight back out, so LFGQueue::CheckCompatibility never
+    // sees a role-complete pool that holds still long enough to form a group. Turning
+    // RandomBotJoinLfg off still lets whoever is mid-queue fall through and leave.
+    // Config bool is tested first so the O(currentBots) IsRandomBot() scan is skipped
+    // whenever the feature is disabled.
+    if (sPlayerbotAIConfig.randomBotJoinLfg && RandomPlayerbotMgr::instance().IsRandomBot(bot))
+        return false;
+
     WorldPacket* packet = new WorldPacket(CMSG_LFG_LEAVE);
     bot->GetSession()->QueuePacket(packet);
     // sLFGMgr->LeaveLfg(bot->GetGUID());

--- a/src/Ai/Base/Actions/MovementActions.h
+++ b/src/Ai/Base/Actions/MovementActions.h
@@ -86,16 +86,12 @@ private:
 class FleeAction : public MovementAction
 {
 public:
-    FleeAction(PlayerbotAI* botAI, float distance = sPlayerbotAIConfig.spellDistance)
-        : MovementAction(botAI, "flee"), distance(distance)
+    FleeAction(PlayerbotAI* botAI) : MovementAction(botAI, "flee")
     {
     }
 
     bool Execute(Event event) override;
     bool isUseful() override;
-
-private:
-    float distance;
 };
 
 class FleeWithPetAction : public MovementAction

--- a/src/Ai/Base/Actions/NonCombatActions.cpp
+++ b/src/Ai/Base/Actions/NonCombatActions.cpp
@@ -7,6 +7,8 @@
 #include "NonCombatActions.h"
 #include "Event.h"
 #include "Playerbots.h"
+#include <algorithm>
+#include <cmath>
 
 namespace
 {
@@ -45,22 +47,16 @@ bool DrinkAction::Execute(Event event)
 
         if (bot->isMoving())
         {
+            bot->GetMotionMaster()->Clear(false);
             bot->StopMoving();
-            // botAI->SetNextCheckDelay(sPlayerbotAIConfig->globalCoolDown);
-            // return false;
         }
         bot->SetStandState(UNIT_STAND_STATE_SIT);
         botAI->InterruptSpell();
 
-        // float hp = bot->GetHealthPercent();
-        float mp = bot->GetPowerPct(POWER_MANA);
-        float p = mp;
         float delay;
 
-        if (!bot->InBattleground())
-            delay = 18000.0f * (100 - p) / 100.0f;
-        else
-            delay = 12000.0f * (100 - p) / 100.0f;
+        // 25990 restores 5% per 2s tick; wait whole ticks so the drink finishes.
+        delay = std::max(1.0f, std::ceil((100.0f - bot->GetPowerPct(POWER_MANA)) / 5.0f)) * 2 * IN_MILLISECONDS;
 
         botAI->SetNextCheckDelay(delay);
 
@@ -104,23 +100,17 @@ bool EatAction::Execute(Event event)
 
         if (bot->isMoving())
         {
+            bot->GetMotionMaster()->Clear(false);
             bot->StopMoving();
-            // botAI->SetNextCheckDelay(sPlayerbotAIConfig.globalCoolDown);
-            // return false;
         }
 
         bot->SetStandState(UNIT_STAND_STATE_SIT);
         botAI->InterruptSpell();
 
-        float hp = bot->GetHealthPct();
-        // float mp = bot->HasMana() ? bot->GetPowerPercent() : 0.f;
-        float p = hp;
         float delay;
 
-        if (!bot->InBattleground())
-            delay = 18000.0f * (100 - p) / 100.0f;
-        else
-            delay = 12000.0f * (100 - p) / 100.0f;
+        // 25990 restores 5% per 2s tick; wait whole ticks so the meal finishes.
+        delay = std::max(1.0f, std::ceil((100.0f - bot->GetHealthPct()) / 5.0f)) * 2 * IN_MILLISECONDS;
 
         botAI->SetNextCheckDelay(delay);
 

--- a/src/Ai/Base/Strategy/WaitForAttackStrategy.cpp
+++ b/src/Ai/Base/Strategy/WaitForAttackStrategy.cpp
@@ -41,7 +41,7 @@ bool WaitForAttackStrategy::ShouldWait(PlayerbotAI* botAI)
             AiObjectContext* context = botAI->GetAiObjectContext();
             time_t combatStartTime = context->GetValue<time_t>("combat start time")->Get();
 
-            if (bot->IsInCombat())
+            if (botAI->GetState() == BOT_STATE_COMBAT)
             {
                 if (combatStartTime == 0)
                 {
@@ -49,13 +49,7 @@ bool WaitForAttackStrategy::ShouldWait(PlayerbotAI* botAI)
                     context->GetValue<time_t>("combat start time")->Set(combatStartTime);
                 }
 
-                time_t elapsedTime = time(nullptr) - combatStartTime;
-                return elapsedTime < GetWaitTime(botAI);
-            }
-            else
-            {
-                if (combatStartTime != 0)
-                    context->GetValue<time_t>("combat start time")->Set(0);
+                return time(nullptr) - combatStartTime < GetWaitTime(botAI);
             }
         }
     }

--- a/src/Ai/Base/Value/LootValues.h
+++ b/src/Ai/Base/Value/LootValues.h
@@ -25,7 +25,8 @@ public:
 };
 
 //                   itemId, entry
-typedef std::unordered_map<uint32, int32> DropMap;
+// Multi: one item has many droppers.
+typedef std::unordered_multimap<uint32, int32> DropMap;
 
 // Returns the loot map of all entries
 class DropMapValue : public SingleCalculatedValue<DropMap*>

--- a/src/Ai/Base/Value/NearestGameObjects.h
+++ b/src/Ai/Base/Value/NearestGameObjects.h
@@ -45,7 +45,7 @@ protected:
 
 private:
     float range;
-    bool ignoreLos;
+    [[maybe_unused]] bool ignoreLos;  // unused while the LOS filter in Calculate() stays commented out
 };
 
 class NearestTrapWithDamageValue : public ObjectGuidListCalculatedValue

--- a/src/Ai/Base/Value/QuestValues.cpp
+++ b/src/Ai/Base/Value/QuestValues.cpp
@@ -5,9 +5,11 @@
  */
 
 #include "QuestValues.h"
+
 #include "MapMgr.h"
 #include "Playerbots.h"
 #include "SharedValueContext.h"
+#include <array>
 
 // What kind of a relation does this entry have with this quest.
 entryQuestRelationMap EntryQuestRelationMapValue::Calculate()
@@ -60,17 +62,34 @@ void FindQuestObjectData::GetObjectiveEntries()
     relationMap = GAI_VALUE(entryQuestRelationMap, "entry quest relation");
 }
 
+// Every entry a spawn point can hold: the base from `creature`, plus up to two
+// `creature_multispawn` alternates rolled between on respawn. 0 = no alternate.
+static std::array<uint32, 3> SpawnEntries(CreatureData const& creData)
+{
+    return { creData.id, creData.id2, creData.id3 };
+}
+
 // Data worker. Checks for a specific creature what quest they are needed for and puts them in the proper place in the
 // quest map.
 void FindQuestObjectData::operator()(CreatureData const& creData)
 {
-    uint32 entry = creData.id;
-
-    for (auto& relation : relationMap[entry])
+    // The GuidPosition keeps the spawn's base entry, which can disagree with the alternate it
+    // is filed under. It resolves by spawnId, and consumers read the map key.
+    for (uint32 entry : SpawnEntries(creData))
     {
-        uint32 questId = relation.first;
-        uint32 flag = relation.second;
-        data[questId][flag][entry].push_back(GuidPosition(creData));
+        if (!entry)
+            continue;
+
+        auto relations = relationMap.find(int32(entry));
+        if (relations == relationMap.end())
+            continue;
+
+        for (auto& relation : relations->second)
+        {
+            uint32 questId = relation.first;
+            uint32 flag = relation.second;
+            data[questId][flag][entry].push_back(GuidPosition(creData));
+        }
     }
 }
 

--- a/src/Ai/Dungeon/Seth/SethActions.cpp
+++ b/src/Ai/Dungeon/Seth/SethActions.cpp
@@ -9,6 +9,7 @@
 #include "RaidBossHelpers.h"
 #include "SethData.h"
 #include <array>
+#include <cmath>
 
 using namespace SethData;
 
@@ -154,7 +155,7 @@ bool TalonKingIkissRangedStayNearVictimOfBossAction::Execute(Event /*event*/)
         false, false, MovementPriority::MOVEMENT_COMBAT, true, false);
 }
 
-bool TalonKingIkissLosArcaneExplosionAction::Execute(Event event)
+bool TalonKingIkissLosArcaneExplosionAction::Execute(Event /*event*/)
 {
     Position const& pillarCenter = PILLAR_CENTER;
     float const botAngle = pillarCenter.GetAngle(bot);

--- a/src/Ai/Dungeon/Seth/SethActions.h
+++ b/src/Ai/Dungeon/Seth/SethActions.h
@@ -13,48 +13,48 @@
 class TimeLostControllerMarkCharmingTotemWithSkullAction : public Action
 {
 public:
-    TimeLostControllerMarkCharmingTotemWithSkullAction(
-        PlayerbotAI* botAI) : Action(botAI, "time-lost controller mark charming totem with skull") {}
+    TimeLostControllerMarkCharmingTotemWithSkullAction(PlayerbotAI* botAI)
+        : Action(botAI, "time-lost controller mark charming totem with skull") {}
     bool Execute(Event event) override;
 };
 
 class SethekkProphetSetTremorTotemAction : public Action
 {
 public:
-    SethekkProphetSetTremorTotemAction(
-        PlayerbotAI* botAI) : Action(botAI, "sethekk prophet set tremor totem") {}
+    SethekkProphetSetTremorTotemAction(PlayerbotAI* botAI)
+        : Action(botAI, "sethekk prophet set tremor totem") {}
     bool Execute(Event event) override;
 };
 
 class DarkweaverSythMarkElementalsWithSkullAction : public Action
 {
 public:
-    DarkweaverSythMarkElementalsWithSkullAction(
-        PlayerbotAI* botAI) : Action(botAI, "darkweaver syth mark elementals with skull") {}
+    DarkweaverSythMarkElementalsWithSkullAction(PlayerbotAI* botAI)
+        : Action(botAI, "darkweaver syth mark elementals with skull") {}
     bool Execute(Event event) override;
 };
 
 class AnzuAlternateMarksOnBossAction : public Action
 {
 public:
-    AnzuAlternateMarksOnBossAction(
-        PlayerbotAI* botAI) : Action(botAI, "anzu alternate marks on boss") {}
+    AnzuAlternateMarksOnBossAction(PlayerbotAI* botAI)
+        : Action(botAI, "anzu alternate marks on boss") {}
     bool Execute(Event event) override;
 };
 
 class AnzuCastHealOverTimeSpellOnBirdSpiritAction : public Action
 {
 public:
-    AnzuCastHealOverTimeSpellOnBirdSpiritAction(
-        PlayerbotAI* botAI) : Action(botAI, "anzu cast heal over time spell on bird spirit") {}
+    AnzuCastHealOverTimeSpellOnBirdSpiritAction(PlayerbotAI* botAI)
+        : Action(botAI, "anzu cast heal over time spell on bird spirit") {}
     bool Execute(Event event) override;
 };
 
 class TalonKingIkissTankMoveBossToPillarPositionAction : public MovementAction
 {
 public:
-    TalonKingIkissTankMoveBossToPillarPositionAction(
-        PlayerbotAI* botAI) : MovementAction(botAI, "talon king ikiss tank move boss to pillar position") {}
+    TalonKingIkissTankMoveBossToPillarPositionAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "talon king ikiss tank move boss to pillar position") {}
     bool Execute(Event event) override;
 
 private:
@@ -64,16 +64,16 @@ private:
 class TalonKingIkissRangedStayNearVictimOfBossAction : public MovementAction
 {
 public:
-    TalonKingIkissRangedStayNearVictimOfBossAction(
-        PlayerbotAI* botAI) : MovementAction(botAI, "talon king ikiss ranged stay near victim of boss") {}
+    TalonKingIkissRangedStayNearVictimOfBossAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "talon king ikiss ranged stay near victim of boss") {}
     bool Execute(Event event) override;
 };
 
 class TalonKingIkissLosArcaneExplosionAction : public MovementAction
 {
 public:
-    TalonKingIkissLosArcaneExplosionAction(
-        PlayerbotAI* botAI) : MovementAction(botAI, "talon king ikiss los arcane explosion") {}
+    TalonKingIkissLosArcaneExplosionAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "talon king ikiss los arcane explosion") {}
     bool Execute(Event event) override;
 
 private:
@@ -84,8 +84,8 @@ private:
 class TalonKingIkissMoveToWithinLosAction : public MovementAction
 {
 public:
-    TalonKingIkissMoveToWithinLosAction(
-        PlayerbotAI* botAI) : MovementAction(botAI, "talon king ikiss move to within los") {}
+    TalonKingIkissMoveToWithinLosAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "talon king ikiss move to within los") {}
     bool Execute(Event event) override;
 };
 

--- a/src/Ai/Dungeon/Seth/SethMultipliers.h
+++ b/src/Ai/Dungeon/Seth/SethMultipliers.h
@@ -12,32 +12,32 @@
 class SethekkProphetSetTremorTotemMultiplier : public Multiplier
 {
 public:
-    SethekkProphetSetTremorTotemMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "sethekk prophet set tremor totem") {}
+    SethekkProphetSetTremorTotemMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "sethekk prophet set tremor totem") {}
     float GetValue(Action* action) override;
 };
 
 class AnzuControlSpellCastingWithSpellBombMultiplier : public Multiplier
 {
 public:
-    AnzuControlSpellCastingWithSpellBombMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "anzu control spell casting with spell bomb") {}
+    AnzuControlSpellCastingWithSpellBombMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "anzu control spell casting with spell bomb") {}
     float GetValue(Action* action) override;
 };
 
 class TalonKingIkissDelayBloodlustAndHeroismMultiplier : public Multiplier
 {
 public:
-    TalonKingIkissDelayBloodlustAndHeroismMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "talon king ikiss delay bloodlust and heroism") {}
+    TalonKingIkissDelayBloodlustAndHeroismMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "talon king ikiss delay bloodlust and heroism") {}
     float GetValue(Action* action) override;
 };
 
 class TalonKingIkissControlMovementMultiplier : public Multiplier
 {
 public:
-    TalonKingIkissControlMovementMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "talon king ikiss control movement") {}
+    TalonKingIkissControlMovementMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "talon king ikiss control movement") {}
     float GetValue(Action* action) override;
 };
 

--- a/src/Ai/Dungeon/Seth/SethStrategy.h
+++ b/src/Ai/Dungeon/Seth/SethStrategy.h
@@ -8,6 +8,8 @@
 #define PLAYERBOTS_SETHSTRATEGY_H
 
 #include "Strategy.h"
+#include <string>
+#include <vector>
 
 class TbcDungeonSethekkHallsStrategy : public Strategy
 {

--- a/src/Ai/Dungeon/Seth/SethTriggers.h
+++ b/src/Ai/Dungeon/Seth/SethTriggers.h
@@ -12,72 +12,72 @@
 class TimeLostControllerDropsCharmingTotemTrigger : public Trigger
 {
 public:
-    TimeLostControllerDropsCharmingTotemTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "time-lost controller drops charming totem") {}
+    TimeLostControllerDropsCharmingTotemTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "time-lost controller drops charming totem") {}
     bool IsActive() override;
 };
 
 class SethekkProphetCastsFearTrigger : public Trigger
 {
 public:
-    SethekkProphetCastsFearTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "sethekk prophet casts fear") {}
+    SethekkProphetCastsFearTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "sethekk prophet casts fear") {}
     bool IsActive() override;
 };
 
 class DarkweaverSythBossSummonsElementalsTrigger : public Trigger
 {
 public:
-    DarkweaverSythBossSummonsElementalsTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "darkweaver syth boss summons elementals") {}
+    DarkweaverSythBossSummonsElementalsTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "darkweaver syth boss summons elementals") {}
     bool IsActive() override;
 };
 
 class AnzuEncounterHasTwoPhasesTrigger : public Trigger
 {
 public:
-    AnzuEncounterHasTwoPhasesTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "anzu encounter has two phases") {}
+    AnzuEncounterHasTwoPhasesTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "anzu encounter has two phases") {}
     bool IsActive() override;
 };
 
 class AnzuBirdSpiritsProvideBuffsTrigger : public Trigger
 {
 public:
-    AnzuBirdSpiritsProvideBuffsTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "anzu bird spirits provide buffs") {}
+    AnzuBirdSpiritsProvideBuffsTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "anzu bird spirits provide buffs") {}
     bool IsActive() override;
 };
 
 class TalonKingIkissBossEngagedByTankTrigger : public Trigger
 {
 public:
-    TalonKingIkissBossEngagedByTankTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "talon king ikiss boss engaged by tank") {}
+    TalonKingIkissBossEngagedByTankTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "talon king ikiss boss engaged by tank") {}
     bool IsActive() override;
 };
 
 class TalonKingIkissRangedPrepareForArcaneExplosionTrigger : public Trigger
 {
 public:
-    TalonKingIkissRangedPrepareForArcaneExplosionTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "talon king ikiss ranged prepare for arcane explosion") {}
+    TalonKingIkissRangedPrepareForArcaneExplosionTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "talon king ikiss ranged prepare for arcane explosion") {}
     bool IsActive() override;
 };
 
 class TalonKingIkissBossCastingArcaneExplosionTrigger : public Trigger
 {
 public:
-    TalonKingIkissBossCastingArcaneExplosionTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "talon king ikiss boss casting arcane explosion") {}
+    TalonKingIkissBossCastingArcaneExplosionTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "talon king ikiss boss casting arcane explosion") {}
     bool IsActive() override;
 };
 
 class TalonKingIkissBossOutOfLosTrigger : public Trigger
 {
 public:
-    TalonKingIkissBossOutOfLosTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "talon king ikiss boss out of los") {}
+    TalonKingIkissBossOutOfLosTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "talon king ikiss boss out of los") {}
     bool IsActive() override;
 };
 

--- a/src/Ai/Dungeon/TbcDungeonActionContext.h
+++ b/src/Ai/Dungeon/TbcDungeonActionContext.h
@@ -8,7 +8,7 @@
 #define PLAYERBOTS_TBCDUNGEONACTIONCONTEXT_H
 
 #include "ACActionContext.h"
-#include "SethActionContext.h"
 #include "MechActionContext.h"
+#include "SethActionContext.h"
 
 #endif

--- a/src/Ai/Dungeon/TbcDungeonTriggerContext.h
+++ b/src/Ai/Dungeon/TbcDungeonTriggerContext.h
@@ -8,7 +8,7 @@
 #define PLAYERBOTS_TBCDUNGEONTRIGGERCONTEXT_H
 
 #include "ACTriggerContext.h"
-#include "SethTriggerContext.h"
 #include "MechTriggerContext.h"
+#include "SethTriggerContext.h"
 
 #endif

--- a/src/Ai/Raid/Kara/KaraActions.cpp
+++ b/src/Ai/Raid/Kara/KaraActions.cpp
@@ -9,7 +9,14 @@
 #include "PlayerbotTextMgr.h"
 #include "Playerbots.h"
 #include "RaidBossHelpers.h"
+#include <algorithm>
 #include <array>
+#include <cmath>
+#include <ctime>
+#include <limits>
+#include <list>
+#include <map>
+#include <string>
 
 using namespace KaraHelpers;
 
@@ -41,8 +48,7 @@ bool KarazhanResetEncounterStatesAction::Execute(Event /*event*/)
 
     if (!AI_VALUE2(Unit*, "find target", "the big bad wolf"))
     {
-        Action* wolfAction = botAI->GetAiObjectContext()->GetAction(
-            "big bad wolf little red riding hood run away");
+        Action* wolfAction = context->GetAction("big bad wolf little red riding hood run away");
         if (wolfAction &&
             static_cast<BigBadWolfLittleRedRidingHoodRunAwayAction*>(wolfAction)->ResetRunIndex())
         {
@@ -55,24 +61,21 @@ bool KarazhanResetEncounterStatesAction::Execute(Event /*event*/)
         if (isMechanicTracker && netherspiteDpsWaitTimer.erase(instanceId) > 0)
             reset = true;
 
-        Action* redAction = botAI->GetAiObjectContext()->GetAction(
-            "netherspite block red beam");
+        Action* redAction = context->GetAction("netherspite block red beam");
         if (redAction &&
             static_cast<NetherspiteBlockRedBeamAction*>(redAction)->ResetRedBeamState())
         {
             reset = true;
         }
 
-        Action* blueAction = botAI->GetAiObjectContext()->GetAction(
-            "netherspite block blue beam");
+        Action* blueAction = context->GetAction("netherspite block blue beam");
         if (blueAction &&
             static_cast<NetherspiteBlockBlueBeamAction*>(blueAction)->ResetBlueBeamState())
         {
             reset = true;
         }
 
-        Action* greenAction = botAI->GetAiObjectContext()->GetAction(
-            "netherspite block green beam");
+        Action* greenAction = context->GetAction("netherspite block green beam");
         if (greenAction &&
             static_cast<NetherspiteBlockGreenBeamAction*>(greenAction)->ResetGreenBeamState())
         {
@@ -900,7 +903,6 @@ bool NetherspiteAvoidBeamAndVoidZoneAction::Execute(Event /*event*/)
         return false;
 
     constexpr uint8 numAngles = 36;
-    constexpr float maxSearchDist = 30.0f;
     constexpr float stepDist = 0.5f;
     constexpr uint8 numSteps = 56;
 
@@ -950,7 +952,7 @@ bool NetherspiteAvoidBeamAndVoidZoneAction::Execute(Event /*event*/)
 }
 
 bool NetherspiteAvoidBeamAndVoidZoneAction::IsAwayFromBeams(
-     float x, float y, float botX, float botY, const std::vector<BeamAvoid>& beams)
+     float x, float y, float botX, float botY, std::vector<BeamAvoid> const& beams)
 {
     for (auto const& beam : beams)
     {
@@ -1008,21 +1010,21 @@ bool NetherspiteManageTimersAndTrackersAction::Execute(Event /*event*/)
         if (isMechanicTracker && netherspiteDpsWaitTimer.erase(instanceId) > 0)
             didSomething = true;
 
-        Action* redAction = botAI->GetAiObjectContext()->GetAction("netherspite block red beam");
+        Action* redAction = context->GetAction("netherspite block red beam");
         if (redAction &&
             static_cast<NetherspiteBlockRedBeamAction*>(redAction)->ResetRedBeamState())
         {
             didSomething = true;
         }
 
-        Action* blueAction = botAI->GetAiObjectContext()->GetAction("netherspite block blue beam");
+        Action* blueAction = context->GetAction("netherspite block blue beam");
         if (blueAction &&
             static_cast<NetherspiteBlockBlueBeamAction*>(blueAction)->ResetBlueBeamState())
         {
             didSomething = true;
         }
 
-        Action* greenAction = botAI->GetAiObjectContext()->GetAction("netherspite block green beam");
+        Action* greenAction = context->GetAction("netherspite block green beam");
         if (greenAction &&
             static_cast<NetherspiteBlockGreenBeamAction*>(greenAction)->ResetGreenBeamState())
         {
@@ -1543,8 +1545,7 @@ bool NightbaneManageTimersAndTrackersAction::Execute(Event /*event*/)
 
     if (nightbane->GetPositionZ() <= NIGHTBANE_FLIGHT_Z)
     {
-        Action* action = botAI->GetAiObjectContext()->GetAction(
-            "nightbane flight phase stack and move");
+        Action* action = context->GetAction("nightbane flight phase stack and move");
         if (action &&
             static_cast<NightbaneFlightPhaseStackAndMoveAction*>(action)->ResetRainOfBonesHit())
         {

--- a/src/Ai/Raid/Kara/KaraActions.h
+++ b/src/Ai/Raid/Kara/KaraActions.h
@@ -10,20 +10,21 @@
 #include "Action.h"
 #include "AttackAction.h"
 #include "MovementActions.h"
+#include <vector>
 
 class KarazhanResetEncounterStatesAction : public Action
 {
 public:
-    KarazhanResetEncounterStatesAction(
-        PlayerbotAI* botAI) : Action(botAI, "karazhan reset encounter states") {}
+    KarazhanResetEncounterStatesAction(PlayerbotAI* botAI)
+        : Action(botAI, "karazhan reset encounter states") {}
     bool Execute(Event event) override;
 };
 
 class KarazhanCastFearProtectionSpellAction : public Action
 {
 public:
-    KarazhanCastFearProtectionSpellAction(
-        PlayerbotAI* botAI) : Action(botAI, "karazhan cast fear protection spell") {}
+    KarazhanCastFearProtectionSpellAction(PlayerbotAI* botAI)
+        : Action(botAI, "karazhan cast fear protection spell") {}
     bool Execute(Event event) override;
 
 private:
@@ -34,16 +35,16 @@ private:
 class ManaWarpStunCreatureBeforeWarpBreachAction : public AttackAction
 {
 public:
-    ManaWarpStunCreatureBeforeWarpBreachAction(
-        PlayerbotAI* botAI) : AttackAction(botAI, "mana warp stun creature before warp breach") {}
+    ManaWarpStunCreatureBeforeWarpBreachAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "mana warp stun creature before warp breach") {}
     bool Execute(Event event) override;
 };
 
 class AttumenTheHuntsmanHandlePhaseOneAction : public AttackAction
 {
 public:
-    AttumenTheHuntsmanHandlePhaseOneAction(
-        PlayerbotAI* botAI) : AttackAction(botAI, "attumen the huntsman handle phase one") {}
+    AttumenTheHuntsmanHandlePhaseOneAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "attumen the huntsman handle phase one") {}
     bool Execute(Event event) override;
 
 private:
@@ -53,8 +54,8 @@ private:
 class AttumenTheHuntsmanHandlePhaseTwoAction : public AttackAction
 {
 public:
-    AttumenTheHuntsmanHandlePhaseTwoAction(
-        PlayerbotAI* botAI) : AttackAction(botAI, "attumen the huntsman handle phase two") {}
+    AttumenTheHuntsmanHandlePhaseTwoAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "attumen the huntsman handle phase two") {}
     bool Execute(Event event) override;
 
 private:
@@ -65,24 +66,24 @@ private:
 class AttumenTheHuntsmanSetDpsTimerAction : public Action
 {
 public:
-    AttumenTheHuntsmanSetDpsTimerAction(
-        PlayerbotAI* botAI) : Action(botAI, "attumen the huntsman set dps timer") {}
+    AttumenTheHuntsmanSetDpsTimerAction(PlayerbotAI* botAI)
+        : Action(botAI, "attumen the huntsman set dps timer") {}
     bool Execute(Event event) override;
 };
 
 class MoroesMarkTargetAction : public Action
 {
 public:
-    MoroesMarkTargetAction(
-        PlayerbotAI* botAI) : Action(botAI, "moroes mark target") {}
+    MoroesMarkTargetAction(PlayerbotAI* botAI)
+        : Action(botAI, "moroes mark target") {}
     bool Execute(Event event) override;
 };
 
 class MaidenOfVirtueTankPositionBossAction : public AttackAction
 {
 public:
-    MaidenOfVirtueTankPositionBossAction(
-        PlayerbotAI* botAI) : AttackAction(botAI, "maiden of virtue tank position boss") {}
+    MaidenOfVirtueTankPositionBossAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "maiden of virtue tank position boss") {}
     bool Execute(Event event) override;
 
 private:
@@ -92,32 +93,32 @@ private:
 class MaidenOfVirtuePositionRangedBetweenPillarsAction : public MovementAction
 {
 public:
-    MaidenOfVirtuePositionRangedBetweenPillarsAction(
-        PlayerbotAI* botAI) : MovementAction(botAI, "maiden of virtue position ranged between pillars") {}
+    MaidenOfVirtuePositionRangedBetweenPillarsAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "maiden of virtue position ranged between pillars") {}
     bool Execute(Event event) override;
 };
 
 class MaidenOfVirtueSetGroundingTotemAction : public Action
 {
 public:
-    MaidenOfVirtueSetGroundingTotemAction(
-        PlayerbotAI* botAI) : Action(botAI, "maiden of virtue set grounding totem") {}
+    MaidenOfVirtueSetGroundingTotemAction(PlayerbotAI* botAI)
+        : Action(botAI, "maiden of virtue set grounding totem") {}
     bool Execute(Event event) override;
 };
 
 class BigBadWolfPositionBossAction : public AttackAction
 {
 public:
-    BigBadWolfPositionBossAction(
-        PlayerbotAI* botAI) : AttackAction(botAI, "big bad wolf position boss") {}
+    BigBadWolfPositionBossAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "big bad wolf position boss") {}
     bool Execute(Event event) override;
 };
 
 class BigBadWolfLittleRedRidingHoodRunAwayAction : public MovementAction
 {
 public:
-    BigBadWolfLittleRedRidingHoodRunAwayAction(
-        PlayerbotAI* botAI) : MovementAction(botAI, "big bad wolf little red riding hood run away") {}
+    BigBadWolfLittleRedRidingHoodRunAwayAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "big bad wolf little red riding hood run away") {}
     bool Execute(Event event) override;
     bool ResetRunIndex()
     {
@@ -134,96 +135,96 @@ private:
 class RomuloAndJulianneMarkTargetAction : public Action
 {
 public:
-    RomuloAndJulianneMarkTargetAction(
-        PlayerbotAI* botAI) : Action(botAI, "romulo and julianne mark target") {}
+    RomuloAndJulianneMarkTargetAction(PlayerbotAI* botAI)
+        : Action(botAI, "romulo and julianne mark target") {}
     bool Execute(Event event) override;
 };
 
 class WizardOfOzMarkTargetAction : public Action
 {
 public:
-    WizardOfOzMarkTargetAction(
-        PlayerbotAI* botAI) : Action(botAI, "wizard of oz mark target") {}
+    WizardOfOzMarkTargetAction(PlayerbotAI* botAI)
+        : Action(botAI, "wizard of oz mark target") {}
     bool Execute(Event event) override;
 };
 
 class WizardOfOzScorchStrawmanAction : public Action
 {
 public:
-    WizardOfOzScorchStrawmanAction(
-        PlayerbotAI* botAI) : Action(botAI, "wizard of oz scorch strawman") {}
+    WizardOfOzScorchStrawmanAction(PlayerbotAI* botAI)
+        : Action(botAI, "wizard of oz scorch strawman") {}
     bool Execute(Event event) override;
 };
 
 class TheCuratorMarkAstralFlareAction : public Action
 {
 public:
-    TheCuratorMarkAstralFlareAction(
-        PlayerbotAI* botAI) : Action(botAI, "the curator mark astral flare") {}
+    TheCuratorMarkAstralFlareAction(PlayerbotAI* botAI)
+        : Action(botAI, "the curator mark astral flare") {}
     bool Execute(Event event) override;
 };
 
 class TheCuratorPositionBossAction : public AttackAction
 {
 public:
-    TheCuratorPositionBossAction(
-        PlayerbotAI* botAI) : AttackAction(botAI, "the curator position boss") {}
+    TheCuratorPositionBossAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "the curator position boss") {}
     bool Execute(Event event) override;
 };
 
 class TheCuratorSpreadRangedAction : public MovementAction
 {
 public:
-    TheCuratorSpreadRangedAction(
-        PlayerbotAI* botAI) : MovementAction(botAI, "the curator spread ranged") {}
+    TheCuratorSpreadRangedAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "the curator spread ranged") {}
     bool Execute(Event event) override;
 };
 
 class TerestianIllhoofMarkTargetAction : public Action
 {
 public:
-    TerestianIllhoofMarkTargetAction(
-        PlayerbotAI* botAI) : Action(botAI, "terestian illhoof mark target") {}
+    TerestianIllhoofMarkTargetAction(PlayerbotAI* botAI)
+        : Action(botAI, "terestian illhoof mark target") {}
     bool Execute(Event event) override;
 };
 
 class ShadeOfAranRunAwayFromArcaneExplosionAction : public MovementAction
 {
 public:
-    ShadeOfAranRunAwayFromArcaneExplosionAction(
-        PlayerbotAI* botAI) : MovementAction(botAI, "shade of aran run away from arcane explosion") {}
+    ShadeOfAranRunAwayFromArcaneExplosionAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "shade of aran run away from arcane explosion") {}
     bool Execute(Event event) override;
 };
 
 class ShadeOfAranStopMovingDuringFlameWreathAction : public MovementAction
 {
 public:
-    ShadeOfAranStopMovingDuringFlameWreathAction(
-        PlayerbotAI* botAI) : MovementAction(botAI, "shade of aran stop moving during flame wreath") {}
+    ShadeOfAranStopMovingDuringFlameWreathAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "shade of aran stop moving during flame wreath") {}
     bool Execute(Event event) override;
 };
 
 class ShadeOfAranMarkConjuredElementalAction : public Action
 {
 public:
-    ShadeOfAranMarkConjuredElementalAction(
-        PlayerbotAI* botAI) : Action(botAI, "shade of aran mark conjured elemental") {}
+    ShadeOfAranMarkConjuredElementalAction(PlayerbotAI* botAI)
+        : Action(botAI, "shade of aran mark conjured elemental") {}
     bool Execute(Event event) override;
 };
 
 class ShadeOfAranRangedMaintainDistanceAction : public MovementAction
 {
 public:
-    ShadeOfAranRangedMaintainDistanceAction(
-        PlayerbotAI* botAI) : MovementAction(botAI, "shade of aran ranged maintain distance") {}
+    ShadeOfAranRangedMaintainDistanceAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "shade of aran ranged maintain distance") {}
     bool Execute(Event event) override;
 };
 
 class NetherspiteBlockRedBeamAction : public MovementAction
 {
 public:
-    NetherspiteBlockRedBeamAction(
-        PlayerbotAI* botAI) : MovementAction(botAI, "netherspite block red beam") {}
+    NetherspiteBlockRedBeamAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "netherspite block red beam") {}
     bool Execute(Event event) override;
     bool ResetRedBeamState()
     {
@@ -246,8 +247,8 @@ private:
 class NetherspiteBlockBlueBeamAction : public MovementAction
 {
 public:
-    NetherspiteBlockBlueBeamAction(
-        PlayerbotAI* botAI) : MovementAction(botAI, "netherspite block blue beam") {}
+    NetherspiteBlockBlueBeamAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "netherspite block blue beam") {}
     bool Execute(Event event) override;
     bool ResetBlueBeamState()
     {
@@ -264,8 +265,8 @@ private:
 class NetherspiteBlockGreenBeamAction : public MovementAction
 {
 public:
-    NetherspiteBlockGreenBeamAction(
-        PlayerbotAI* botAI) : MovementAction(botAI, "netherspite block green beam") {}
+    NetherspiteBlockGreenBeamAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "netherspite block green beam") {}
     bool Execute(Event event) override;
     bool ResetGreenBeamState()
     {
@@ -282,8 +283,8 @@ private:
 class NetherspiteAvoidBeamAndVoidZoneAction : public MovementAction
 {
 public:
-    NetherspiteAvoidBeamAndVoidZoneAction(
-        PlayerbotAI* botAI) : MovementAction(botAI, "netherspite avoid beam and void zone") {}
+    NetherspiteAvoidBeamAndVoidZoneAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "netherspite avoid beam and void zone") {}
     bool Execute(Event event) override;
 
 private:
@@ -295,62 +296,62 @@ private:
         float dirY;
     };
     bool IsAwayFromBeams(
-        float x, float y, float botX, float botY, const std::vector<BeamAvoid>& beams);
+        float x, float y, float botX, float botY, std::vector<BeamAvoid> const& beams);
 };
 
 class NetherspiteBanishPhaseAvoidVoidZoneAction : public MovementAction
 {
 public:
-    NetherspiteBanishPhaseAvoidVoidZoneAction(
-        PlayerbotAI* botAI) : MovementAction(botAI, "netherspite banish phase avoid void zone") {}
+    NetherspiteBanishPhaseAvoidVoidZoneAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "netherspite banish phase avoid void zone") {}
     bool Execute(Event event) override;
 };
 
 class NetherspiteManageTimersAndTrackersAction : public Action
 {
 public:
-    NetherspiteManageTimersAndTrackersAction(
-        PlayerbotAI* botAI) : Action(botAI, "netherspite manage timers and trackers") {}
+    NetherspiteManageTimersAndTrackersAction(PlayerbotAI* botAI)
+        : Action(botAI, "netherspite manage timers and trackers") {}
     bool Execute(Event event) override;
 };
 
 class PrinceMalchezaarEnfeebledBotAvoidHazardAction : public MovementAction
 {
 public:
-    PrinceMalchezaarEnfeebledBotAvoidHazardAction(
-        PlayerbotAI* botAI) : MovementAction(botAI, "prince malchezaar enfeebled bot avoid hazard") {}
+    PrinceMalchezaarEnfeebledBotAvoidHazardAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "prince malchezaar enfeebled bot avoid hazard") {}
     bool Execute(Event event) override;
 };
 
 class PrinceMalchezaarNonTankAvoidInfernalAction : public MovementAction
 {
 public:
-    PrinceMalchezaarNonTankAvoidInfernalAction(
-        PlayerbotAI* botAI) : MovementAction(botAI, "prince malchezaar non tank avoid infernal") {}
+    PrinceMalchezaarNonTankAvoidInfernalAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "prince malchezaar non tank avoid infernal") {}
     bool Execute(Event event) override;
 };
 
 class PrinceMalchezaarTanksPositionBossAction : public AttackAction
 {
 public:
-    PrinceMalchezaarTanksPositionBossAction(
-        PlayerbotAI* botAI) : AttackAction(botAI, "prince malchezaar tanks position boss") {}
+    PrinceMalchezaarTanksPositionBossAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "prince malchezaar tanks position boss") {}
     bool Execute(Event event) override;
 };
 
 class NightbaneGroundPhaseTanksPositionBossAction : public AttackAction
 {
 public:
-    NightbaneGroundPhaseTanksPositionBossAction(
-        PlayerbotAI* botAI) : AttackAction(botAI, "nightbane ground phase tanks position boss") {}
+    NightbaneGroundPhaseTanksPositionBossAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "nightbane ground phase tanks position boss") {}
     bool Execute(Event event) override;
 };
 
 class NightbaneGroundPhaseCoordinateRangedMovementAction : public MovementAction
 {
 public:
-    NightbaneGroundPhaseCoordinateRangedMovementAction(
-        PlayerbotAI* botAI) : MovementAction(botAI, "nightbane ground phase coordinate ranged movement") {}
+    NightbaneGroundPhaseCoordinateRangedMovementAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "nightbane ground phase coordinate ranged movement") {}
     bool Execute(Event event) override;
 
 private:
@@ -361,16 +362,16 @@ private:
 class NightbaneControlPetAggressionAction : public Action
 {
 public:
-    NightbaneControlPetAggressionAction(
-        PlayerbotAI* botAI) : Action(botAI, "nightbane control pet aggression") {}
+    NightbaneControlPetAggressionAction(PlayerbotAI* botAI)
+        : Action(botAI, "nightbane control pet aggression") {}
     bool Execute(Event event) override;
 };
 
 class NightbaneFlightPhaseStackAndMoveAction : public MovementAction
 {
 public:
-    NightbaneFlightPhaseStackAndMoveAction(
-        PlayerbotAI* botAI) : MovementAction(botAI, "nightbane flight phase stack and move") {}
+    NightbaneFlightPhaseStackAndMoveAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "nightbane flight phase stack and move") {}
     bool Execute(Event event) override;
     bool ResetRainOfBonesHit()
     {
@@ -387,16 +388,16 @@ private:
 class NightbaneTeleportBackToTerraceAction : public MovementAction
 {
 public:
-    NightbaneTeleportBackToTerraceAction(
-        PlayerbotAI* botAI) : MovementAction(botAI, "nightbane teleport back to terrace") {}
+    NightbaneTeleportBackToTerraceAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "nightbane teleport back to terrace") {}
     bool Execute(Event event) override;
 };
 
 class NightbaneManageTimersAndTrackersAction : public Action
 {
 public:
-    NightbaneManageTimersAndTrackersAction(
-        PlayerbotAI* botAI) : Action(botAI, "nightbane manage timers and trackers") {}
+    NightbaneManageTimersAndTrackersAction(PlayerbotAI* botAI)
+        : Action(botAI, "nightbane manage timers and trackers") {}
     bool Execute(Event event) override;
 };
 

--- a/src/Ai/Raid/Kara/KaraHelpers.cpp
+++ b/src/Ai/Raid/Kara/KaraHelpers.cpp
@@ -6,13 +6,16 @@
 
 #include "KaraHelpers.h"
 #include "Playerbots.h"
+#include <algorithm>
+#include <limits>
+#include <list>
 
 namespace KaraHelpers
 {
 
 // General
 
-bool IsSafePosition(float x, float y, const std::vector<Unit*>& hazards, float hazardRadius)
+bool IsSafePosition(float x, float y, std::vector<Unit*> const& hazards, float hazardRadius)
 {
     for (Unit* hazard : hazards)
     {

--- a/src/Ai/Raid/Kara/KaraHelpers.h
+++ b/src/Ai/Raid/Kara/KaraHelpers.h
@@ -7,13 +7,18 @@
 #ifndef PLAYERBOTS_KARAHELPERS_H
 #define PLAYERBOTS_KARAHELPERS_H
 
-#include "AiObject.h"
+#include "Common.h"
+#include "ObjectGuid.h"
 #include "Position.h"
-#include "Unit.h"
 #include <array>
 #include <ctime>
+#include <tuple>
 #include <type_traits>
 #include <unordered_map>
+#include <vector>
+
+class Player;
+class Unit;
 
 namespace KaraHelpers
 {
@@ -88,7 +93,7 @@ enum class KaraNpcs : uint32
 
 // General
 inline constexpr uint32 KARA_MAP_ID = 532;
-bool IsSafePosition (float x, float y, const std::vector<Unit*>& hazards, float hazardRadius);
+bool IsSafePosition (float x, float y, std::vector<Unit*> const& hazards, float hazardRadius);
 
 // Attumen the Huntsman
 inline Position const ATTUMEN_TANK_POSITION = { -11123.762f, -1926.619f, 49.215f };

--- a/src/Ai/Raid/Kara/KaraMultipliers.cpp
+++ b/src/Ai/Raid/Kara/KaraMultipliers.cpp
@@ -22,6 +22,7 @@
 #include "RogueActions.h"
 #include "ShamanActions.h"
 #include "WarriorActions.h"
+#include <ctime>
 
 using namespace KaraHelpers;
 
@@ -74,6 +75,9 @@ float AttumenTheHuntsmanDisableAutomaticTargetingMultiplier::GetValue(Action* ac
 
 float AttumenTheHuntsmanStayStackedMultiplier::GetValue(Action* action)
 {
+    if (PlayerbotAI::IsTank(bot))
+        return 1.0f;
+
     if (dynamic_cast<AttackAction*>(action) ||
         dynamic_cast<AttumenTheHuntsmanHandlePhaseTwoAction*>(action))
     {

--- a/src/Ai/Raid/Kara/KaraMultipliers.h
+++ b/src/Ai/Raid/Kara/KaraMultipliers.h
@@ -12,160 +12,160 @@
 class KarazhanSetTremorTotemMultiplier : public Multiplier
 {
 public:
-    KarazhanSetTremorTotemMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "karazhan set tremor totem") {}
+    KarazhanSetTremorTotemMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "karazhan set tremor totem") {}
     float GetValue(Action* action) override;
 };
 
 class AttumenTheHuntsmanDisableAutomaticTargetingMultiplier : public Multiplier
 {
 public:
-    AttumenTheHuntsmanDisableAutomaticTargetingMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "attumen the huntsman disable automatic targeting") {}
+    AttumenTheHuntsmanDisableAutomaticTargetingMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "attumen the huntsman disable automatic targeting") {}
     float GetValue(Action* action) override;
 };
 
 class AttumenTheHuntsmanStayStackedMultiplier : public Multiplier
 {
 public:
-    AttumenTheHuntsmanStayStackedMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "attumen the huntsman stay stacked") {}
+    AttumenTheHuntsmanStayStackedMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "attumen the huntsman stay stacked") {}
     float GetValue(Action* action) override;
 };
 
 class AttumenTheHuntsmanWaitForDpsMultiplier : public Multiplier
 {
 public:
-    AttumenTheHuntsmanWaitForDpsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "attumen the huntsman wait for dps") {}
+    AttumenTheHuntsmanWaitForDpsMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "attumen the huntsman wait for dps") {}
     float GetValue(Action* action) override;
 };
 
 class MaidenOfVirtueDisableCombatFormationMoveMultiplier : public Multiplier
 {
 public:
-    MaidenOfVirtueDisableCombatFormationMoveMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "maiden of virtue disable combat formation move") {}
+    MaidenOfVirtueDisableCombatFormationMoveMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "maiden of virtue disable combat formation move") {}
     float GetValue(Action* action) override;
 };
 
 class MaidenOfVirtueSetGroundingTotemMultiplier : public Multiplier
 {
 public:
-    MaidenOfVirtueSetGroundingTotemMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "maiden of virtue set grounding totem") {}
+    MaidenOfVirtueSetGroundingTotemMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "maiden of virtue set grounding totem") {}
     float GetValue(Action* action) override;
 };
 
 class TheCuratorDisableTankAssistMultiplier : public Multiplier
 {
 public:
-    TheCuratorDisableTankAssistMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "the curator disable tank assist") {}
+    TheCuratorDisableTankAssistMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "the curator disable tank assist") {}
     float GetValue(Action* action) override;
 };
 
 class TheCuratorDisableCombatFormationMoveMultiplier : public Multiplier
 {
 public:
-    TheCuratorDisableCombatFormationMoveMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "the curator disable combat formation move") {}
+    TheCuratorDisableCombatFormationMoveMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "the curator disable combat formation move") {}
     float GetValue(Action* action) override;
 };
 
 class TheCuratorDelayBloodlustAndHeroismMultiplier : public Multiplier
 {
 public:
-    TheCuratorDelayBloodlustAndHeroismMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "the curator delay bloodlust and heroism") {}
+    TheCuratorDelayBloodlustAndHeroismMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "the curator delay bloodlust and heroism") {}
     float GetValue(Action* action) override;
 };
 
 class TerestianIllhoofDontDotFiendishImpsMultiplier : public Multiplier
 {
 public:
-    TerestianIllhoofDontDotFiendishImpsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "terestian illhoof don't dot fiendish imps") {}
+    TerestianIllhoofDontDotFiendishImpsMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "terestian illhoof don't dot fiendish imps") {}
     float GetValue(Action* action) override;
 };
 
 class ShadeOfAranArcaneExplosionRunAwayMultiplier : public Multiplier
 {
 public:
-    ShadeOfAranArcaneExplosionRunAwayMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "shade of aran arcane explosion run away") {}
+    ShadeOfAranArcaneExplosionRunAwayMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "shade of aran arcane explosion run away") {}
     float GetValue(Action* action) override;
 };
 
 class ShadeOfAranFlameWreathDisableMovementMultiplier : public Multiplier
 {
 public:
-    ShadeOfAranFlameWreathDisableMovementMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "shade of aran flame wreath disable movement") {}
+    ShadeOfAranFlameWreathDisableMovementMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "shade of aran flame wreath disable movement") {}
     float GetValue(Action* action) override;
 };
 
 class NetherspiteKeepBlockingBeamMultiplier : public Multiplier
 {
 public:
-    NetherspiteKeepBlockingBeamMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "netherspite keep blocking beam") {}
+    NetherspiteKeepBlockingBeamMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "netherspite keep blocking beam") {}
     float GetValue(Action* action) override;
 };
 
 class NetherspiteWaitForDpsMultiplier : public Multiplier
 {
 public:
-    NetherspiteWaitForDpsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "netherspite wait for dps") {}
+    NetherspiteWaitForDpsMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "netherspite wait for dps") {}
     float GetValue(Action* action) override;
 };
 
 class PrinceMalchezaarEnfeebleMultiplier : public Multiplier
 {
 public:
-    PrinceMalchezaarEnfeebleMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "prince malchezaar enfeeble") {}
+    PrinceMalchezaarEnfeebleMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "prince malchezaar enfeeble") {}
     float GetValue(Action* action) override;
 };
 
 class PrinceMalchezaarDelayBloodlustAndHeroismMultiplier : public Multiplier
 {
 public:
-    PrinceMalchezaarDelayBloodlustAndHeroismMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "prince malchezaar delay bloodlust and heroism") {}
+    PrinceMalchezaarDelayBloodlustAndHeroismMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "prince malchezaar delay bloodlust and heroism") {}
     float GetValue(Action* action) override;
 };
 
 class NightbaneDisablePetsMultiplier : public Multiplier
 {
 public:
-    NightbaneDisablePetsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "nightbane disable pets") {}
+    NightbaneDisablePetsMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "nightbane disable pets") {}
     float GetValue(Action* action) override;
 };
 
 class NightbaneWaitForDpsMultiplier : public Multiplier
 {
 public:
-    NightbaneWaitForDpsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "nightbane wait for dps") {}
+    NightbaneWaitForDpsMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "nightbane wait for dps") {}
     float GetValue(Action* action) override;
 };
 
 class NightbaneDisableAvoidAoeMultiplier : public Multiplier
 {
 public:
-    NightbaneDisableAvoidAoeMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "nightbane disable avoid aoe") {}
+    NightbaneDisableAvoidAoeMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "nightbane disable avoid aoe") {}
     float GetValue(Action* action) override;
 };
 
 class NightbaneDisableMovementMultiplier : public Multiplier
 {
 public:
-    NightbaneDisableMovementMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "nightbane disable movement") {}
+    NightbaneDisableMovementMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "nightbane disable movement") {}
     float GetValue(Action* action) override;
 };
 

--- a/src/Ai/Raid/Kara/KaraStrategy.cpp
+++ b/src/Ai/Raid/Kara/KaraStrategy.cpp
@@ -8,7 +8,6 @@
 #include "AiObjectContext.h"
 #include "KaraHelpers.h"
 #include "KaraMultipliers.h"
-#include "PlayerbotAI.h"
 #include "Playerbots.h"
 
 void RaidKarazhanStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)

--- a/src/Ai/Raid/Kara/KaraStrategy.h
+++ b/src/Ai/Raid/Kara/KaraStrategy.h
@@ -8,6 +8,8 @@
 #define PLAYERBOTS_KARASTRATEGY_H
 
 #include "Strategy.h"
+#include <string>
+#include <vector>
 
 class RaidKarazhanStrategy : public Strategy
 {

--- a/src/Ai/Raid/Kara/KaraTriggers.h
+++ b/src/Ai/Raid/Kara/KaraTriggers.h
@@ -12,303 +12,303 @@
 class KarazhanBotIsNotInCombatTrigger : public Trigger
 {
 public:
-    KarazhanBotIsNotInCombatTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "karazhan bot is not in combat") {}
+    KarazhanBotIsNotInCombatTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "karazhan bot is not in combat") {}
     bool IsActive() override;
 };
 
 class KarazhanEnemiesCastFearTrigger : public Trigger
 {
 public:
-    KarazhanEnemiesCastFearTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "karazhan enemies cast fear") {}
+    KarazhanEnemiesCastFearTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "karazhan enemies cast fear") {}
     bool IsActive() override;
 };
 
 class ManaWarpIsAboutToExplodeTrigger : public Trigger
 {
 public:
-    ManaWarpIsAboutToExplodeTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "mana warp is about to explode") {}
+    ManaWarpIsAboutToExplodeTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "mana warp is about to explode") {}
     bool IsActive() override;
 };
 
 class AttumenTheHuntsmanPhaseOneActiveTrigger : public Trigger
 {
 public:
-    AttumenTheHuntsmanPhaseOneActiveTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "attumen the huntsman phase one active") {}
+    AttumenTheHuntsmanPhaseOneActiveTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "attumen the huntsman phase one active") {}
     bool IsActive() override;
 };
 
 class AttumenTheHuntsmanPhaseTwoActiveTrigger : public Trigger
 {
 public:
-    AttumenTheHuntsmanPhaseTwoActiveTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "attumen the huntsman phase two active") {}
+    AttumenTheHuntsmanPhaseTwoActiveTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "attumen the huntsman phase two active") {}
     bool IsActive() override;
 };
 
 class AttumenTheHuntsmanPhaseTransitionTrigger : public Trigger
 {
 public:
-    AttumenTheHuntsmanPhaseTransitionTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "attumen the huntsman phase transition") {}
+    AttumenTheHuntsmanPhaseTransitionTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "attumen the huntsman phase transition") {}
     bool IsActive() override;
 };
 
 class MoroesShouldPrioritizeAddsTrigger : public Trigger
 {
 public:
-    MoroesShouldPrioritizeAddsTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "moroes should prioritize adds") {}
+    MoroesShouldPrioritizeAddsTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "moroes should prioritize adds") {}
     bool IsActive() override;
 };
 
 class MaidenOfVirtueBossEngagedByTanksTrigger : public Trigger
 {
 public:
-    MaidenOfVirtueBossEngagedByTanksTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "maiden of virtue boss engaged by tanks") {}
+    MaidenOfVirtueBossEngagedByTanksTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "maiden of virtue boss engaged by tanks") {}
     bool IsActive() override;
 };
 
 class MaidenOfVirtueHolyWrathDealsChainDamageTrigger : public Trigger
 {
 public:
-    MaidenOfVirtueHolyWrathDealsChainDamageTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "maiden of virtue holy wrath deals chain damage") {}
+    MaidenOfVirtueHolyWrathDealsChainDamageTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "maiden of virtue holy wrath deals chain damage") {}
     bool IsActive() override;
 };
 
 class MaidenOfVirtueGroundingTotemConsumesHolyFireTrigger : public Trigger
 {
 public:
-    MaidenOfVirtueGroundingTotemConsumesHolyFireTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "maiden of virtue grounding totem consumes holy fire") {}
+    MaidenOfVirtueGroundingTotemConsumesHolyFireTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "maiden of virtue grounding totem consumes holy fire") {}
     bool IsActive() override;
 };
 
 class BigBadWolfBossEngagedByTankTrigger : public Trigger
 {
 public:
-    BigBadWolfBossEngagedByTankTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "big bad wolf boss engaged by tank") {}
+    BigBadWolfBossEngagedByTankTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "big bad wolf boss engaged by tank") {}
     bool IsActive() override;
 };
 
 class BigBadWolfBossIsChasingLittleRedRidingHoodTrigger : public Trigger
 {
 public:
-    BigBadWolfBossIsChasingLittleRedRidingHoodTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "big bad wolf boss is chasing little red riding hood") {}
+    BigBadWolfBossIsChasingLittleRedRidingHoodTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "big bad wolf boss is chasing little red riding hood") {}
     bool IsActive() override;
 };
 
 class RomuloAndJulianneBothBossesRevivedTrigger : public Trigger
 {
 public:
-    RomuloAndJulianneBothBossesRevivedTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "romulo and julianne both bosses revived") {}
+    RomuloAndJulianneBothBossesRevivedTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "romulo and julianne both bosses revived") {}
     bool IsActive() override;
 };
 
 class WizardOfOzNeedTargetPriorityTrigger : public Trigger
 {
 public:
-    WizardOfOzNeedTargetPriorityTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "wizard of oz need target priority") {}
+    WizardOfOzNeedTargetPriorityTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "wizard of oz need target priority") {}
     bool IsActive() override;
 };
 
 class WizardOfOzStrawmanIsVulnerableToFireTrigger : public Trigger
 {
 public:
-    WizardOfOzStrawmanIsVulnerableToFireTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "wizard of oz strawman is vulnerable to fire") {}
+    WizardOfOzStrawmanIsVulnerableToFireTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "wizard of oz strawman is vulnerable to fire") {}
     bool IsActive() override;
 };
 class TheCuratorAstralFlareSpawnedTrigger : public Trigger
 {
 public:
-    TheCuratorAstralFlareSpawnedTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "the curator astral flare spawned") {}
+    TheCuratorAstralFlareSpawnedTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "the curator astral flare spawned") {}
     bool IsActive() override;
 };
 
 class TheCuratorBossEngagedByTanksTrigger : public Trigger
 {
 public:
-    TheCuratorBossEngagedByTanksTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "the curator boss engaged by tanks") {}
+    TheCuratorBossEngagedByTanksTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "the curator boss engaged by tanks") {}
     bool IsActive() override;
 };
 
 class TheCuratorBossEngagedByRangedTrigger : public Trigger
 {
 public:
-    TheCuratorBossEngagedByRangedTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "the curator boss engaged by ranged") {}
+    TheCuratorBossEngagedByRangedTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "the curator boss engaged by ranged") {}
     bool IsActive() override;
 };
 
 class TerestianIllhoofShouldPrioritizeChainsTrigger : public Trigger
 {
 public:
-    TerestianIllhoofShouldPrioritizeChainsTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "terestian illhoof should prioritize chains") {}
+    TerestianIllhoofShouldPrioritizeChainsTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "terestian illhoof should prioritize chains") {}
     bool IsActive() override;
 };
 
 class ShadeOfAranArcaneExplosionIsCastingTrigger : public Trigger
 {
 public:
-    ShadeOfAranArcaneExplosionIsCastingTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "shade of aran arcane explosion is casting") {}
+    ShadeOfAranArcaneExplosionIsCastingTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "shade of aran arcane explosion is casting") {}
     bool IsActive() override;
 };
 
 class ShadeOfAranFlameWreathIsActiveTrigger : public Trigger
 {
 public:
-    ShadeOfAranFlameWreathIsActiveTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "shade of aran flame wreath is active") {}
+    ShadeOfAranFlameWreathIsActiveTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "shade of aran flame wreath is active") {}
     bool IsActive() override;
 };
 
 class ShadeOfAranConjuredElementalsSummonedTrigger : public Trigger
 {
 public:
-    ShadeOfAranConjuredElementalsSummonedTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "shade of aran conjured elementals summoned") {}
+    ShadeOfAranConjuredElementalsSummonedTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "shade of aran conjured elementals summoned") {}
     bool IsActive() override;
 };
 
 class ShadeOfAranBossCastsCounterspellNearbyTrigger : public Trigger
 {
 public:
-    ShadeOfAranBossCastsCounterspellNearbyTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "shade of aran boss casts counterspell nearby") {}
+    ShadeOfAranBossCastsCounterspellNearbyTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "shade of aran boss casts counterspell nearby") {}
     bool IsActive() override;
 };
 
 class NetherspiteRedBeamIsActiveTrigger : public Trigger
 {
 public:
-    NetherspiteRedBeamIsActiveTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "netherspite red beam is active") {}
+    NetherspiteRedBeamIsActiveTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "netherspite red beam is active") {}
     bool IsActive() override;
 };
 
 class NetherspiteBlueBeamIsActiveTrigger : public Trigger
 {
 public:
-    NetherspiteBlueBeamIsActiveTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "netherspite blue beam is active") {}
+    NetherspiteBlueBeamIsActiveTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "netherspite blue beam is active") {}
     bool IsActive() override;
 };
 
 class NetherspiteGreenBeamIsActiveTrigger : public Trigger
 {
 public:
-    NetherspiteGreenBeamIsActiveTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "netherspite green beam is active") {}
+    NetherspiteGreenBeamIsActiveTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "netherspite green beam is active") {}
     bool IsActive() override;
 };
 
 class NetherspiteBotIsNotBeamBlockerTrigger : public Trigger
 {
 public:
-    NetherspiteBotIsNotBeamBlockerTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "netherspite bot is not beam blocker") {}
+    NetherspiteBotIsNotBeamBlockerTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "netherspite bot is not beam blocker") {}
     bool IsActive() override;
 };
 
 class NetherspiteBossIsBanishedTrigger : public Trigger
 {
 public:
-    NetherspiteBossIsBanishedTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "netherspite boss is banished") {}
+    NetherspiteBossIsBanishedTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "netherspite boss is banished") {}
     bool IsActive() override;
 };
 
 class NetherspiteShouldManageTimersAndTrackersTrigger : public Trigger
 {
 public:
-    NetherspiteShouldManageTimersAndTrackersTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "netherspite should manage timers and trackers") {}
+    NetherspiteShouldManageTimersAndTrackersTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "netherspite should manage timers and trackers") {}
     bool IsActive() override;
 };
 
 class PrinceMalchezaarBotIsEnfeebledTrigger : public Trigger
 {
 public:
-    PrinceMalchezaarBotIsEnfeebledTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "prince malchezaar bot is enfeebled") {}
+    PrinceMalchezaarBotIsEnfeebledTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "prince malchezaar bot is enfeebled") {}
     bool IsActive() override;
 };
 
 class PrinceMalchezaarEngagedByNonTanksTrigger : public Trigger
 {
 public:
-    PrinceMalchezaarEngagedByNonTanksTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "prince malchezaar engaged by non-tanks") {}
+    PrinceMalchezaarEngagedByNonTanksTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "prince malchezaar engaged by non-tanks") {}
     bool IsActive() override;
 };
 
 class PrinceMalchezaarBossEngagedByTanksTrigger : public Trigger
 {
 public:
-    PrinceMalchezaarBossEngagedByTanksTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "prince malchezaar boss engaged by tanks") {}
+    PrinceMalchezaarBossEngagedByTanksTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "prince malchezaar boss engaged by tanks") {}
     bool IsActive() override;
 };
 
 class NightbaneBossEngagedByTanksTrigger : public Trigger
 {
 public:
-    NightbaneBossEngagedByTanksTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "nightbane boss engaged by tanks") {}
+    NightbaneBossEngagedByTanksTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "nightbane boss engaged by tanks") {}
     bool IsActive() override;
 };
 
 class NightbaneGroundPhaseEngagedByRangedTrigger : public Trigger
 {
 public:
-    NightbaneGroundPhaseEngagedByRangedTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "nightbane ground phase engaged by ranged") {}
+    NightbaneGroundPhaseEngagedByRangedTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "nightbane ground phase engaged by ranged") {}
     bool IsActive() override;
 };
 
 class NightbanePetsIgnoreCollisionToChaseFlyingBossTrigger : public Trigger
 {
 public:
-    NightbanePetsIgnoreCollisionToChaseFlyingBossTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "nightbane pets ignore collision to chase flying boss") {}
+    NightbanePetsIgnoreCollisionToChaseFlyingBossTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "nightbane pets ignore collision to chase flying boss") {}
     bool IsActive() override;
 };
 
 class NightbaneBossIsFlyingTrigger : public Trigger
 {
 public:
-    NightbaneBossIsFlyingTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "nightbane boss is flying") {}
+    NightbaneBossIsFlyingTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "nightbane boss is flying") {}
     bool IsActive() override;
 };
 
 class NightbaneBotWentOutOfBoundsTrigger : public Trigger
 {
 public:
-    NightbaneBotWentOutOfBoundsTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "nightbane bot went out of bounds") {}
+    NightbaneBotWentOutOfBoundsTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "nightbane bot went out of bounds") {}
     bool IsActive() override;
 };
 
 class NightbaneShouldManageTimersAndTrackersTrigger : public Trigger
 {
 public:
-    NightbaneShouldManageTimersAndTrackersTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "nightbane should manage timers and trackers") {}
+    NightbaneShouldManageTimersAndTrackersTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "nightbane should manage timers and trackers") {}
     bool IsActive() override;
 };
 

--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -2420,7 +2420,7 @@ void PlayerbotFactory::InitEquipment(bool incremental, bool second_chance)
             bool isTrinketSlot = (slot == EQUIPMENT_SLOT_TRINKET1 || slot == EQUIPMENT_SLOT_TRINKET2);
             calculator.SetExcludeResilience(isTrinketSlot);
 
-            if (Item* oldItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))
+            if (bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot))
                 bot->DestroyItem(INVENTORY_SLOT_BAG_0, slot, true);
 
             std::vector<std::pair<uint32, int32>>& ids = items[slot];

--- a/src/Bot/Factory/RandomPlayerbotFactory.cpp
+++ b/src/Bot/Factory/RandomPlayerbotFactory.cpp
@@ -352,7 +352,7 @@ uint32 RandomPlayerbotFactory::CalculateTotalAccountCount()
         {
             Field* fields = typeCheck->Fetch();
             uint8 accountType = fields[0].Get<uint8>();
-            uint32 count = fields[1].Get<uint32>();
+            uint32 count = static_cast<uint32>(fields[1].Get<uint64>());
 
             if (accountType == 0) existingUnassignedAccounts = count;
             else if (accountType == 1) existingRndBotAccounts = count;

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -264,6 +264,10 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
 
     AllowActivity();
 
+    // If we get attacked, drop the pending delay so the engine can switch to combat.
+    if (nextAICheckDelay && bot->IsInCombat() && currentEngine != engines[BOT_STATE_COMBAT])
+        nextAICheckDelay = 0;
+
     if (!CanUpdateAI())
         return;
 

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -1456,6 +1456,9 @@ void PlayerbotAI::ChangeEngine(BotState type)
 
 void PlayerbotAI::ChangeEngineOnCombat()
 {
+    if (HasStrategy("wait for attack", BOT_STATE_COMBAT))
+        aiObjectContext->GetValue<time_t>("combat start time")->Set(time(nullptr));
+
     if (HasStrategy("stay", BOT_STATE_COMBAT))
     {
         aiObjectContext->GetValue<PositionInfo>("pos", "stay")
@@ -1465,6 +1468,9 @@ void PlayerbotAI::ChangeEngineOnCombat()
 
 void PlayerbotAI::ChangeEngineOnNonCombat()
 {
+    if (HasStrategy("wait for attack", BOT_STATE_COMBAT))
+        aiObjectContext->GetValue<time_t>("combat start time")->Set(0);
+
     if (HasStrategy("stay", BOT_STATE_NON_COMBAT))
     {
         aiObjectContext->GetValue<PositionInfo>("pos", "stay")->Reset();

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -56,8 +56,13 @@
 #include <sstream>
 #include <string>
 
+namespace
+{
 constexpr uint32 SPELL_TITAN_GRIP = 49152;
 constexpr uint32 SPELL_DK_FROST_PRESENCE = 48263;
+constexpr uint32 SPELL_GRAVITY_LAPSE_TK = 39432;
+constexpr uint32 SPELL_GRAVITY_LAPSE_MGT = 44226;
+}
 
 std::vector<std::string> PlayerbotAI::dispel_whitelist = {
     "mutating injection",
@@ -3607,12 +3612,9 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
     // aiObjectContext->GetValue<LastMovement&>("last movement")->Get().Set(nullptr);
     // aiObjectContext->GetValue<time_t>("stay time")->Set(0);
 
-    if (bot->IsFlying() || bot->HasUnitState(UNIT_STATE_IN_FLIGHT))
+    if ((bot->IsFlying() && !bot->HasAura(SPELL_GRAVITY_LAPSE_TK) && !bot->HasAura(SPELL_GRAVITY_LAPSE_MGT)) ||
+        bot->HasUnitState(UNIT_STATE_IN_FLIGHT))
     {
-        // if (!sPlayerbotAIConfig.logInGroupOnly || (bot->GetGroup() && HasGameClientMaster()))
-        //     LOG_DEBUG("playerbots", "Spell cast is flying - target name: {}, spellid: {}, bot name: {}}",
-        //         target->GetName(), spellId, bot->GetName());
-
         return false;
     }
 
@@ -3860,8 +3862,11 @@ bool PlayerbotAI::CastSpell(uint32 spellId, float x, float y, float z, Item* ite
 
     // MotionMaster& mm = *bot->GetMotionMaster();
 
-    if (bot->IsFlying() || bot->HasUnitState(UNIT_STATE_IN_FLIGHT))
+    if ((bot->IsFlying() && !bot->HasAura(SPELL_GRAVITY_LAPSE_TK) && !bot->HasAura(SPELL_GRAVITY_LAPSE_MGT)) ||
+        bot->HasUnitState(UNIT_STATE_IN_FLIGHT))
+    {
         return false;
+    }
 
     // bot->ClearUnitState(UNIT_STATE_CHASE);
     // bot->ClearUnitState(UNIT_STATE_FOLLOW);

--- a/src/Bot/RandomPlayerbotMgr.h
+++ b/src/Bot/RandomPlayerbotMgr.h
@@ -178,7 +178,7 @@ protected:
     void OnBotLoginInternal(Player* const bot) override;
 
 private:
-    RandomPlayerbotMgr() : PlayerbotHolder(), processTicks(0)
+    RandomPlayerbotMgr() : PlayerbotHolder()
     {
         this->playersLevel = sPlayerbotAIConfig.randombotStartingLevel;
 
@@ -242,14 +242,12 @@ private:
     uint32 GetZoneLevel(uint16 mapId, float teleX, float teleY, float teleZ);
     typedef void (RandomPlayerbotMgr::*ConsoleCommandHandler)(Player*);
     std::vector<Player*> players;
-    uint32 processTicks;
 
     // std::map<uint32, std::vector<WorldLocation>> rpgLocsCache;
     std::map<uint32, std::map<uint32, std::vector<WorldLocation>>> rpgLocsCacheLevel;
     std::map<TeamId, std::map<BattlegroundTypeId, std::vector<uint32>>> BattleMastersCache;
     std::unordered_map<uint32, BotEventCache> eventCache;
     std::unordered_set<uint32> currentBots;
-    uint32 bgBotsCount;
     uint32 playersLevel;
 
     // Account lists

--- a/src/Mgr/Move/FleeManager.cpp
+++ b/src/Mgr/Move/FleeManager.cpp
@@ -66,7 +66,7 @@ void FleeManager::calculatePossibleDestinations(std::vector<FleePoint*>& points)
     float botPosY = startPosition.GetPositionY();
     float botPosZ = startPosition.GetPositionZ();
 
-    FleePoint start(botAI, botPosX, botPosY, botPosZ);
+    FleePoint start(botPosX, botPosY, botPosZ);
     calculateDistanceToCreatures(&start);
 
     std::vector<float> enemyOri;
@@ -110,7 +110,7 @@ void FleeManager::calculatePossibleDestinations(std::vector<FleePoint*>& points)
                 if (!bot->IsWithinLOS(x, y, z) || (target && !target->IsWithinLOS(x, y, z)))
                     continue;
 
-                FleePoint* point = new FleePoint(botAI, x, y, z);
+                FleePoint* point = new FleePoint(x, y, z);
                 calculateDistanceToCreatures(point);
 
                 if (ServerFacade::instance().IsDistanceGreaterOrEqualThan(point->minDistance - start.minDistance,

--- a/src/Mgr/Move/FleeManager.h
+++ b/src/Mgr/Move/FleeManager.h
@@ -17,8 +17,7 @@ class PlayerbotAI;
 class FleePoint
 {
 public:
-    FleePoint(PlayerbotAI* botAI, float x, float y, float z)
-        : x(x), y(y), z(z), sumDistance(0.0f), minDistance(0.0f), botAI(botAI)
+    FleePoint(float x, float y, float z) : x(x), y(y), z(z), sumDistance(0.0f), minDistance(0.0f)
     {
     }
 
@@ -28,9 +27,6 @@ public:
 
     float sumDistance;
     float minDistance;
-
-private:
-    PlayerbotAI* botAI;
 };
 
 class FleeManager


### PR DESCRIPTION
Maintenance PR

Changelog:
- Server startup no longer logs a misleading bot-account warning.
- Resting bots now finish eating or drinking in one uninterrupted session.
- Resting bots now respond immediately when combat begins.
- Random bots remain in the Random Dungeon queue long enough for groups to form.
- Tank bots can position normally during the Attumen the Huntsman encounter.
- Bots using wait-for-attack now respect the configured delay after combat begins.
- Bots can cast spells during Kael’thas’s Gravity Lapse.
- Questing bots can find objectives that use alternate creatures at shared spawn locations.
- Questing bots recognize all creatures that can provide required quest items.

AzerothCore fork: https://github.com/kadeshar/azerothcore-wotlk/tree/test-staging