### PR TITLE
feat(mgt): add the tbc-mgt strategy for Magisters' Terrace

### DIFF
--- a/src/Ai/Dungeon/DungeonStrategyContext.h
+++ b/src/Ai/Dungeon/DungeonStrategyContext.h
@@ -17,6 +17,7 @@
 #include "HoLStrategy.h"
 #include "HoSStrategy.h"
 #include "MechStrategy.h"
+#include "MgTStrategy.h"
 #include "NexStrategy.h"
 #include "OCStrategy.h"
 #include "PoSStrategy.h"
@@ -41,6 +42,7 @@ class DungeonStrategyContext : public NamedObjectContext<Strategy>
             creators["tbc-seth"] = &DungeonStrategyContext::tbc_seth;       // Auchindoun: Sethekk Halls
             creators["tbc-mech"] = &DungeonStrategyContext::tbc_mech;       // Tempest Keep: The Mechanar
             creators["tbc-ub"] = &DungeonStrategyContext::tbc_ub;           // Coilfang Reservoir: The Underbog
+            creators["tbc-mgt"] = &DungeonStrategyContext::tbc_mgt;         // Magisters' Terrace
 
             // Wrath of the Lich King
             creators["wotlk-uk"] = &DungeonStrategyContext::wotlk_uk;       // Utgarde Keep
@@ -64,6 +66,7 @@ class DungeonStrategyContext : public NamedObjectContext<Strategy>
         static Strategy* tbc_seth(PlayerbotAI* botAI) { return new TbcDungeonSethekkHallsStrategy(botAI); }
         static Strategy* tbc_mech(PlayerbotAI* botAI) { return new TbcDungeonMechanarStrategy(botAI); }
         static Strategy* tbc_ub(PlayerbotAI* botAI) { return new TbcDungeonUnderbogStrategy(botAI); }
+        static Strategy* tbc_mgt(PlayerbotAI* botAI) { return new TbcDungeonMagistersTerraceStrategy(botAI); }
         static Strategy* wotlk_uk(PlayerbotAI* botAI) { return new WotlkDungeonUKStrategy(botAI); }
         static Strategy* wotlk_nex(PlayerbotAI* botAI) { return new WotlkDungeonNexStrategy(botAI); }
         static Strategy* wotlk_an(PlayerbotAI* botAI) { return new WotlkDungeonANStrategy(botAI); }

--- a/src/Ai/Dungeon/MgT/MgTActionContext.h
+++ b/src/Ai/Dungeon/MgT/MgTActionContext.h
@@ -1,0 +1,65 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_MGTACTIONCONTEXT_H
+#define PLAYERBOTS_MGTACTIONCONTEXT_H
+
+#include "Action.h"
+#include "AiObjectContext.h"
+#include "MgTActions.h"
+
+class TbcDungeonMagistersTerraceActionContext : public NamedObjectContext<Action>
+{
+public:
+    TbcDungeonMagistersTerraceActionContext()
+    {
+        creators["mgt kill crystal"] = &TbcDungeonMagistersTerraceActionContext::mgt_kill_crystal;
+        creators["mgt return to room"] = &TbcDungeonMagistersTerraceActionContext::mgt_return_to_room;
+        creators["mgt leave dampening field"] = &TbcDungeonMagistersTerraceActionContext::mgt_leave_dampening_field;
+        creators["mgt close on mage guard"] = &TbcDungeonMagistersTerraceActionContext::mgt_close_on_mage_guard;
+        creators["mgt clear arcane nova"] = &TbcDungeonMagistersTerraceActionContext::mgt_clear_arcane_nova;
+        creators["mgt priority interrupt"] = &TbcDungeonMagistersTerraceActionContext::mgt_priority_interrupt;
+        creators["mgt focus target"] = &TbcDungeonMagistersTerraceActionContext::mgt_focus_target;
+        creators["mgt taunt enraged wretched"] = &TbcDungeonMagistersTerraceActionContext::mgt_taunt_enraged_wretched;
+        creators["mgt delrissa interrupt"] = &TbcDungeonMagistersTerraceActionContext::mgt_delrissa_interrupt;
+        creators["mgt delrissa focus target"] = &TbcDungeonMagistersTerraceActionContext::mgt_delrissa_focus_target;
+        creators["mgt delrissa tremor totem"] = &TbcDungeonMagistersTerraceActionContext::mgt_delrissa_tremor_totem;
+        creators["mgt leave flame strike"] = &TbcDungeonMagistersTerraceActionContext::mgt_leave_flame_strike;
+        creators["mgt leave phoenix burn"] = &TbcDungeonMagistersTerraceActionContext::mgt_leave_phoenix_burn;
+        creators["mgt kael focus target"] = &TbcDungeonMagistersTerraceActionContext::mgt_kael_focus_target;
+        creators["mgt kael interrupt"] = &TbcDungeonMagistersTerraceActionContext::mgt_kael_interrupt;
+        creators["mgt take lapse spot"] = &TbcDungeonMagistersTerraceActionContext::mgt_take_lapse_spot;
+    }
+
+private:
+    static Action* mgt_kill_crystal(PlayerbotAI* botAI) { return new MgTKillCrystalAction(botAI); }
+    static Action* mgt_return_to_room(PlayerbotAI* botAI) { return new MgTReturnToRoomAction(botAI); }
+    static Action* mgt_leave_dampening_field(PlayerbotAI* botAI) { return new MgTLeaveDampeningFieldAction(botAI); }
+    static Action* mgt_close_on_mage_guard(PlayerbotAI* botAI) { return new MgTCloseOnMageGuardAction(botAI); }
+    static Action* mgt_clear_arcane_nova(PlayerbotAI* botAI) { return new MgTClearArcaneNovaAction(botAI); }
+    static Action* mgt_priority_interrupt(PlayerbotAI* botAI) { return new MgTPriorityInterruptAction(botAI); }
+    static Action* mgt_focus_target(PlayerbotAI* botAI) { return new MgTFocusTargetAction(botAI); }
+    static Action* mgt_taunt_enraged_wretched(PlayerbotAI* botAI)
+    {
+        return new MgTTauntEnragedWretchedAction(botAI);
+    }
+    static Action* mgt_delrissa_interrupt(PlayerbotAI* botAI) { return new MgTDelrissaInterruptAction(botAI); }
+    static Action* mgt_delrissa_focus_target(PlayerbotAI* botAI)
+    {
+        return new MgTDelrissaFocusTargetAction(botAI);
+    }
+    static Action* mgt_delrissa_tremor_totem(PlayerbotAI* botAI)
+    {
+        return new MgTDelrissaTremorTotemAction(botAI);
+    }
+    static Action* mgt_leave_flame_strike(PlayerbotAI* botAI) { return new MgTLeaveFlameStrikeAction(botAI); }
+    static Action* mgt_leave_phoenix_burn(PlayerbotAI* botAI) { return new MgTLeavePhoenixBurnAction(botAI); }
+    static Action* mgt_kael_focus_target(PlayerbotAI* botAI) { return new MgTKaelFocusTargetAction(botAI); }
+    static Action* mgt_kael_interrupt(PlayerbotAI* botAI) { return new MgTKaelInterruptAction(botAI); }
+    static Action* mgt_take_lapse_spot(PlayerbotAI* botAI) { return new MgTTakeLapseSpotAction(botAI); }
+};
+
+#endif

--- a/src/Ai/Dungeon/MgT/MgTActions.cpp
+++ b/src/Ai/Dungeon/MgT/MgTActions.cpp
@@ -1,0 +1,191 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "MgTActions.h"
+#include "AiObjectContext.h"
+#include "EncounterHelpers.h"
+#include "MgTShared.h"
+#include "Playerbots.h"
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <vector>
+
+using namespace EncounterHelpers;
+
+bool MgTEscapeAction::Execute(Event)
+{
+    if (IsWaitingForLastMove(MovementPriority::MOVEMENT_COMBAT))
+        return false;
+
+    auto const& spots = AI_VALUE_REF(MagistersTerrace::EscapeSpots, _value);
+    for (MagistersTerrace::EscapeSpot const& spot : spots)
+    {
+        if (MoveTo(bot->GetMapId(), spot.x, spot.y, spot.z, false, false, false, false,
+                   MovementPriority::MOVEMENT_COMBAT, true, false))
+            return true;
+    }
+
+    return false;
+}
+
+bool MgTFocusAction::Execute(Event)
+{
+    Unit* target = botAI->GetUnit(AI_VALUE(ObjectGuid, _value));
+    if (!target)
+        return false;
+
+    if (IsMechanicTrackerBot(bot, MagistersTerrace::MAP_MAGISTERS_TERRACE))
+        MarkTargetWithSkull(bot, target);
+
+    if (AI_VALUE(Unit*, "current target") == target)
+        return false;
+
+    return Attack(target);
+}
+
+bool MgTKillCrystalAction::Execute(Event)
+{
+    Unit* crystal = botAI->GetUnit(AI_VALUE(ObjectGuid, "mgt crystal target"));
+    if (!crystal || AI_VALUE(Unit*, "current target") == crystal)
+        return false;
+
+    return Attack(crystal);
+}
+
+bool MgTReturnToRoomAction::Execute(Event)
+{
+    float x = MagistersTerrace::SELIN_REGROUP_X;
+    float y = bot->GetPositionY();
+    MagistersTerrace::ClampIntoRoom(x, y);
+
+    float const bx = bot->GetPositionX();
+    float const by = bot->GetPositionY();
+    float const bz = bot->GetPositionZ();
+
+    float const dist = bot->GetExactDist2d(x, y);
+    if (dist < 1.0f)
+        return false;
+
+    float const step = std::min(8.0f, dist);
+    float const moveX = bx + ((x - bx) / dist) * step;
+    float const moveY = by + ((y - by) / dist) * step;
+
+    float moveZ = bot->GetMapHeight(moveX, moveY, bz + MagistersTerrace::GROUND_SEARCH_UP, true,
+                                    MagistersTerrace::GROUND_SEARCH_DOWN);
+    if (std::fabs(moveZ - bz) > MagistersTerrace::GROUND_TIER_STEP)
+        moveZ = bz;
+
+    return MoveTo(bot->GetMapId(), moveX, moveY, moveZ, false, false, false, false,
+                  MovementPriority::MOVEMENT_COMBAT, true, false);
+}
+
+bool MgTCloseOnMageGuardAction::Execute(Event)
+{
+    Unit* guard = botAI->GetUnit(AI_VALUE(ObjectGuid, "mgt mage guard target"));
+    if (!guard)
+        return false;
+
+    return ReachCombatTo(guard, 0.0f);
+}
+
+bool MgTPriorityInterruptAction::Execute(Event)
+{
+    Unit* target = botAI->GetUnit(AI_VALUE(ObjectGuid, "mgt interrupt target"));
+    if (!target)
+        return false;
+
+    uint8 const urgency = MagistersTerrace::GetInterruptUrgency(target);
+    if (!urgency)
+        return false;
+
+    return !MagistersTerrace::CastInterrupt(botAI, target, urgency).empty();
+}
+
+bool MgTTauntEnragedWretchedAction::Execute(Event)
+{
+    Unit* wretched = botAI->GetUnit(AI_VALUE(ObjectGuid, "mgt enraged wretched"));
+    if (!wretched)
+        return false;
+
+    for (std::string const& spell : MagistersTerrace::TauntSpellNames())
+    {
+        if (botAI->CanCastSpell(spell, wretched) && botAI->CastSpell(spell, wretched))
+            return true;
+    }
+
+    return false;
+}
+
+bool MgTDelrissaInterruptAction::Execute(Event)
+{
+    auto const& order = AI_VALUE_REF(GuidVector, "mgt delrissa interrupt order");
+    for (ObjectGuid const guid : order)
+    {
+        Unit* target = botAI->GetUnit(guid);
+        if (!target)
+            continue;
+
+        uint8 const urgency = MagistersTerrace::GetRetinueInterruptUrgency(target);
+        if (!urgency)
+            continue;
+
+        if (!MagistersTerrace::CastInterrupt(botAI, target, urgency).empty())
+            return true;
+    }
+
+    return false;
+}
+
+bool MgTDelrissaTremorTotemAction::Execute(Event)
+{
+    return botAI->CanCastSpell("tremor totem", bot) && botAI->CastSpell("tremor totem", bot);
+}
+
+bool MgTKaelInterruptAction::Execute(Event)
+{
+    Unit* target = MagistersTerrace::GetKaelInterruptTarget(bot);
+    if (!target)
+        return false;
+
+    return !MagistersTerrace::CastInterrupt(botAI, target, MagistersTerrace::CONTROL_INTERRUPT_URGENCY).empty();
+}
+
+bool MgTTakeLapseSpotAction::Execute(Event)
+{
+    if (IsWaitingForLastMove(MovementPriority::MOVEMENT_COMBAT))
+        return false;
+
+    MagistersTerrace::LapseWorld world;
+    MagistersTerrace::CollectLapseWorld(bot, world);
+
+    MagistersTerrace::LapseSpot spot = { bot->GetPositionX(), bot->GetPositionY() };
+    MagistersTerrace::LapseSpot station = spot;
+    Unit* kael = MagistersTerrace::GetKaelthas(bot);
+    bool move = false;
+
+    if (MagistersTerrace::GetGravityLapseKite(bot, world, spot, _kite) ||
+        MagistersTerrace::GetGravityLapseDodge(bot, world, spot))
+    {
+        move = true;
+    }
+    else if (MagistersTerrace::GetGravityLapseSpot(bot, world, station) &&
+             !MagistersTerrace::OnLapseStation(bot, kael, station))
+    {
+        move = MagistersTerrace::GetLapseApproach(bot, world, station,
+                                                  MagistersTerrace::LapseThreatened(bot, world), spot);
+    }
+
+    if (!move)
+        return false;
+
+    float z = bot->GetPositionZ();
+    if (kael && MagistersTerrace::IsLapseMeleeSlot(bot))
+        z = kael->GetPositionZ();
+
+    return MoveTo(bot->GetMapId(), spot.x, spot.y, z, false, false, false, false,
+                  MovementPriority::MOVEMENT_COMBAT, true, false);
+}

--- a/src/Ai/Dungeon/MgT/MgTActions.h
+++ b/src/Ai/Dungeon/MgT/MgTActions.h
@@ -1,0 +1,168 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_MGTACTIONS_H
+#define PLAYERBOTS_MGTACTIONS_H
+
+#include "AttackAction.h"
+#include "MgTShared.h"
+#include "MovementActions.h"
+
+class MgTEscapeAction : public MovementAction
+{
+public:
+    MgTEscapeAction(PlayerbotAI* botAI, std::string const name, std::string const value)
+        : MovementAction(botAI, name), _value(value)
+    {
+    }
+
+    bool Execute(Event event) override;
+
+private:
+    std::string const _value;
+};
+
+class MgTLeaveDampeningFieldAction : public MgTEscapeAction
+{
+public:
+    MgTLeaveDampeningFieldAction(PlayerbotAI* botAI)
+        : MgTEscapeAction(botAI, "mgt leave dampening field", "mgt dampening escape")
+    {
+    }
+};
+
+class MgTClearArcaneNovaAction : public MgTEscapeAction
+{
+public:
+    MgTClearArcaneNovaAction(PlayerbotAI* botAI)
+        : MgTEscapeAction(botAI, "mgt clear arcane nova", "mgt nova escape")
+    {
+    }
+};
+
+class MgTLeaveFlameStrikeAction : public MgTEscapeAction
+{
+public:
+    MgTLeaveFlameStrikeAction(PlayerbotAI* botAI)
+        : MgTEscapeAction(botAI, "mgt leave flame strike", "mgt flame strike escape")
+    {
+    }
+};
+
+class MgTLeavePhoenixBurnAction : public MgTEscapeAction
+{
+public:
+    MgTLeavePhoenixBurnAction(PlayerbotAI* botAI)
+        : MgTEscapeAction(botAI, "mgt leave phoenix burn", "mgt phoenix escape")
+    {
+    }
+};
+
+class MgTFocusAction : public AttackAction
+{
+public:
+    MgTFocusAction(PlayerbotAI* botAI, std::string const name, std::string const value)
+        : AttackAction(botAI, name), _value(value)
+    {
+    }
+
+    bool Execute(Event event) override;
+
+private:
+    std::string const _value;
+};
+
+class MgTFocusTargetAction : public MgTFocusAction
+{
+public:
+    MgTFocusTargetAction(PlayerbotAI* botAI) : MgTFocusAction(botAI, "mgt focus target", "mgt focus target") {}
+};
+
+class MgTDelrissaFocusTargetAction : public MgTFocusAction
+{
+public:
+    MgTDelrissaFocusTargetAction(PlayerbotAI* botAI)
+        : MgTFocusAction(botAI, "mgt delrissa focus target", "mgt delrissa focus target")
+    {
+    }
+};
+
+class MgTKaelFocusTargetAction : public MgTFocusAction
+{
+public:
+    MgTKaelFocusTargetAction(PlayerbotAI* botAI)
+        : MgTFocusAction(botAI, "mgt kael focus target", "mgt kael focus target")
+    {
+    }
+};
+
+class MgTKillCrystalAction : public AttackAction
+{
+public:
+    MgTKillCrystalAction(PlayerbotAI* botAI) : AttackAction(botAI, "mgt kill crystal") {}
+    bool Execute(Event event) override;
+};
+
+class MgTReturnToRoomAction : public MovementAction
+{
+public:
+    MgTReturnToRoomAction(PlayerbotAI* botAI) : MovementAction(botAI, "mgt return to room") {}
+    bool Execute(Event event) override;
+};
+
+class MgTCloseOnMageGuardAction : public MovementAction
+{
+public:
+    MgTCloseOnMageGuardAction(PlayerbotAI* botAI) : MovementAction(botAI, "mgt close on mage guard") {}
+    bool Execute(Event event) override;
+};
+
+class MgTPriorityInterruptAction : public Action
+{
+public:
+    MgTPriorityInterruptAction(PlayerbotAI* botAI) : Action(botAI, "mgt priority interrupt") {}
+    bool Execute(Event event) override;
+};
+
+class MgTTauntEnragedWretchedAction : public Action
+{
+public:
+    MgTTauntEnragedWretchedAction(PlayerbotAI* botAI) : Action(botAI, "mgt taunt enraged wretched") {}
+    bool Execute(Event event) override;
+};
+
+class MgTDelrissaInterruptAction : public Action
+{
+public:
+    MgTDelrissaInterruptAction(PlayerbotAI* botAI) : Action(botAI, "mgt delrissa interrupt") {}
+    bool Execute(Event event) override;
+};
+
+class MgTDelrissaTremorTotemAction : public Action
+{
+public:
+    MgTDelrissaTremorTotemAction(PlayerbotAI* botAI) : Action(botAI, "mgt delrissa tremor totem") {}
+    bool Execute(Event event) override;
+};
+
+class MgTKaelInterruptAction : public Action
+{
+public:
+    MgTKaelInterruptAction(PlayerbotAI* botAI) : Action(botAI, "mgt kael interrupt") {}
+    bool Execute(Event event) override;
+};
+
+class MgTTakeLapseSpotAction : public MovementAction
+{
+public:
+    MgTTakeLapseSpotAction(PlayerbotAI* botAI) : MovementAction(botAI, "mgt take lapse spot") {}
+    bool Execute(Event event) override;
+
+private:
+    MagistersTerrace::KiteState _kite;
+};
+
+#endif

--- a/src/Ai/Dungeon/MgT/MgTMultipliers.cpp
+++ b/src/Ai/Dungeon/MgT/MgTMultipliers.cpp
@@ -1,0 +1,233 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "MgTMultipliers.h"
+#include "AiObjectContext.h"
+#include "AttackersValue.h"
+#include "ChooseTargetActions.h"
+#include "FollowActions.h"
+#include "GenericSpellActions.h"
+#include "MgTActions.h"
+#include "MgTShared.h"
+#include "MovementActions.h"
+#include "Playerbots.h"
+#include "ReachTargetActions.h"
+#include "ShamanActions.h"
+
+float MgTCrystalFocusMultiplier::GetValue(Action* action)
+{
+    if (dynamic_cast<MgTKillCrystalAction*>(action))
+        return 1.0f;
+
+    bool const suppressed =
+        dynamic_cast<DpsAssistAction*>(action) ||
+        dynamic_cast<TankAssistAction*>(action) ||
+        dynamic_cast<CastDebuffSpellOnAttackerAction*>(action) ||
+        (action->getThreatType() == Action::ActionThreatType::Aoe && PlayerbotAI::IsDps(bot) &&
+         !dynamic_cast<CastHealingSpellAction*>(action));
+
+    if (!suppressed)
+        return 1.0f;
+
+    if (PlayerbotAI::IsHeal(bot))
+        return 1.0f;
+
+    if (AI_VALUE(ObjectGuid, "mgt crystal target").IsEmpty())
+        return 1.0f;
+
+    return 0.0f;
+}
+
+float MgTFocusOrderMultiplier::GetValue(Action* action)
+{
+    bool const picker =
+        dynamic_cast<DpsAssistAction*>(action) ||
+        dynamic_cast<DpsAoeAction*>(action) ||
+        dynamic_cast<TankAssistAction*>(action);
+
+    bool const drop = !picker && dynamic_cast<DropTargetAction*>(action) != nullptr;
+
+    if (!picker && !drop)
+        return 1.0f;
+
+    if (!bot->IsInCombat())
+        return 1.0f;
+
+    if (PlayerbotAI::IsHeal(bot) || PlayerbotAI::IsTank(bot) || !PlayerbotAI::IsDps(bot))
+        return 1.0f;
+
+    if (!AI_VALUE(ObjectGuid, "mgt crystal target").IsEmpty())
+        return 1.0f;
+
+    ObjectGuid const order = MagistersTerrace::ResolveFocusOrder(botAI);
+    if (order.IsEmpty())
+        return 1.0f;
+
+    if (!drop)
+        return 0.0f;
+
+    Unit* current = AI_VALUE(Unit*, "current target");
+    if (!current || current->GetGUID() != order)
+        return 1.0f;
+    if (!current->IsAlive() || !AttackersValue::IsValidTarget(current, bot))
+        return 1.0f;
+
+    return 0.0f;
+}
+
+float MgTFocusBurstMultiplier::GetValue(Action* action)
+{
+    if (action->getThreatType() != Action::ActionThreatType::Aoe)
+        return 1.0f;
+
+    if (dynamic_cast<CastHealingSpellAction*>(action))
+        return 1.0f;
+
+    if (PlayerbotAI::IsHeal(bot) || !PlayerbotAI::IsDps(bot))
+        return 1.0f;
+
+    switch (MagistersTerrace::ResolveFocusOrderOwner(botAI))
+    {
+        case MagistersTerrace::FocusOrder::Kael:
+        case MagistersTerrace::FocusOrder::Delrissa:
+            return 0.0f;
+        default:
+            return 1.0f;
+    }
+}
+
+float MgTRoomLeashMultiplier::GetValue(Action* action)
+{
+    bool const isFlight =
+        dynamic_cast<FleeAction*>(action) ||
+        dynamic_cast<FleeWithPetAction*>(action) ||
+        dynamic_cast<RunAwayAction*>(action);
+
+    if (!isFlight)
+        return 1.0f;
+
+    if (bot->GetPositionX() > MagistersTerrace::SELIN_SAFE_X + MagistersTerrace::SELIN_FLEE_SLACK)
+        return 1.0f;
+
+    if (!MagistersTerrace::GetSelin(bot))
+        return 1.0f;
+
+    return 0.0f;
+}
+
+float MgTDampeningFieldMultiplier::GetValue(Action* action)
+{
+    bool const isCompeting =
+        dynamic_cast<CombatFormationMoveAction*>(action) ||
+        dynamic_cast<FollowAction*>(action) ||
+        dynamic_cast<AvoidAoeAction*>(action);
+
+    if (!isCompeting)
+        return 1.0f;
+
+    auto const& spots = AI_VALUE_REF(MagistersTerrace::EscapeSpots, "mgt dampening escape");
+    if (spots.empty())
+        return 1.0f;
+
+    return 0.0f;
+}
+
+float MgTDelrissaTremorTotemMultiplier::GetValue(Action* action)
+{
+    bool const isCompeting =
+        dynamic_cast<CastStrengthOfEarthTotemAction*>(action) ||
+        dynamic_cast<CastStoneskinTotemAction*>(action) ||
+        dynamic_cast<CastEarthbindTotemAction*>(action);
+
+    if (!isCompeting)
+        return 1.0f;
+
+    if (!AI_VALUE(bool, "mgt delrissa tremor totem"))
+        return 1.0f;
+
+    return 0.0f;
+}
+
+float MgTFlameStrikeMultiplier::GetValue(Action* action)
+{
+    bool const isCompeting =
+        dynamic_cast<CombatFormationMoveAction*>(action) ||
+        dynamic_cast<FollowAction*>(action) ||
+        dynamic_cast<AvoidAoeAction*>(action);
+
+    if (!isCompeting)
+        return 1.0f;
+
+    auto const& spots = AI_VALUE_REF(MagistersTerrace::EscapeSpots, "mgt flame strike escape");
+    if (spots.empty())
+        return 1.0f;
+
+    return 0.0f;
+}
+
+float MgTGravityLapseMultiplier::GetValue(Action* action)
+{
+    bool const isCompeting =
+        dynamic_cast<CombatFormationMoveAction*>(action) ||
+        dynamic_cast<FollowAction*>(action) ||
+        dynamic_cast<ReachTargetAction*>(action) ||
+        dynamic_cast<CastReachTargetSpellAction*>(action);
+
+    if (!isCompeting)
+        return 1.0f;
+
+    if (!AI_VALUE(bool, "mgt gravity lapse"))
+        return 1.0f;
+
+    return 0.0f;
+}
+
+float MgTKaelUnattackableMultiplier::GetValue(Action* action)
+{
+    bool const suppressed =
+        dynamic_cast<DpsAssistAction*>(action) ||
+        dynamic_cast<TankAssistAction*>(action) ||
+        dynamic_cast<CastDebuffSpellOnAttackerAction*>(action) ||
+        (action->getThreatType() == Action::ActionThreatType::Aoe && PlayerbotAI::IsDps(bot) &&
+         !dynamic_cast<CastHealingSpellAction*>(action));
+
+    if (!suppressed)
+        return 1.0f;
+
+    if (PlayerbotAI::IsHeal(bot))
+        return 1.0f;
+
+    if (!AI_VALUE(bool, "mgt kael unattackable"))
+        return 1.0f;
+
+    return 0.0f;
+}
+
+float MgTPhoenixBurnMultiplier::GetValue(Action* action)
+{
+    bool const isCompeting =
+        dynamic_cast<CombatFormationMoveAction*>(action) ||
+        dynamic_cast<FollowAction*>(action) ||
+        dynamic_cast<AvoidAoeAction*>(action) ||
+        dynamic_cast<ReachTargetAction*>(action) ||
+        dynamic_cast<CastReachTargetSpellAction*>(action);
+
+    if (!isCompeting)
+        return 1.0f;
+
+    MagistersTerrace::PhoenixRing const ring = AI_VALUE(MagistersTerrace::PhoenixRing, "mgt phoenix ring");
+    if (ring != MagistersTerrace::PhoenixRing::None && dynamic_cast<SetBehindTargetAction*>(action))
+        return 0.0f;
+
+    auto const& spots = AI_VALUE_REF(MagistersTerrace::EscapeSpots, "mgt phoenix escape");
+    if (!spots.empty())
+        return 0.0f;
+
+    if (ring == MagistersTerrace::PhoenixRing::Covers)
+        return 0.0f;
+
+    return 1.0f;
+}

--- a/src/Ai/Dungeon/MgT/MgTMultipliers.h
+++ b/src/Ai/Dungeon/MgT/MgTMultipliers.h
@@ -1,0 +1,82 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_MGTMULTIPLIERS_H
+#define PLAYERBOTS_MGTMULTIPLIERS_H
+
+#include "Multiplier.h"
+
+class MgTCrystalFocusMultiplier : public Multiplier
+{
+public:
+    MgTCrystalFocusMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "mgt crystal focus") {}
+    float GetValue(Action* action) override;
+};
+
+class MgTFocusOrderMultiplier : public Multiplier
+{
+public:
+    MgTFocusOrderMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "mgt focus order") {}
+    float GetValue(Action* action) override;
+};
+
+class MgTFocusBurstMultiplier : public Multiplier
+{
+public:
+    MgTFocusBurstMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "mgt focus burst") {}
+    float GetValue(Action* action) override;
+};
+
+class MgTRoomLeashMultiplier : public Multiplier
+{
+public:
+    MgTRoomLeashMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "mgt room leash") {}
+    float GetValue(Action* action) override;
+};
+
+class MgTDampeningFieldMultiplier : public Multiplier
+{
+public:
+    MgTDampeningFieldMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "mgt dampening field") {}
+    float GetValue(Action* action) override;
+};
+
+class MgTDelrissaTremorTotemMultiplier : public Multiplier
+{
+public:
+    MgTDelrissaTremorTotemMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "mgt delrissa tremor totem") {}
+    float GetValue(Action* action) override;
+};
+
+class MgTFlameStrikeMultiplier : public Multiplier
+{
+public:
+    MgTFlameStrikeMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "mgt flame strike") {}
+    float GetValue(Action* action) override;
+};
+
+class MgTPhoenixBurnMultiplier : public Multiplier
+{
+public:
+    MgTPhoenixBurnMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "mgt phoenix burn") {}
+    float GetValue(Action* action) override;
+};
+
+class MgTKaelUnattackableMultiplier : public Multiplier
+{
+public:
+    MgTKaelUnattackableMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "mgt kael unattackable") {}
+    float GetValue(Action* action) override;
+};
+
+class MgTGravityLapseMultiplier : public Multiplier
+{
+public:
+    MgTGravityLapseMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "mgt gravity lapse") {}
+    float GetValue(Action* action) override;
+};
+
+#endif

--- a/src/Ai/Dungeon/MgT/MgTShared.cpp
+++ b/src/Ai/Dungeon/MgT/MgTShared.cpp
@@ -1,0 +1,1927 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "MgTShared.h"
+#include "AiObjectContext.h"
+#include "AttackersValue.h"
+#include "Creature.h"
+#include "EncounterHelpers.h"
+#include "Group.h"
+#include "PlayerbotAIConfig.h"
+#include "Playerbots.h"
+#include "Spell.h"
+#include "SpellInfo.h"
+#include "SpellMgr.h"
+#include "Timer.h"
+#include <algorithm>
+#include <cmath>
+#include <iterator>
+#include <limits>
+#include <list>
+#include <string>
+#include <utility>
+
+using namespace EncounterHelpers;
+
+namespace MagistersTerrace
+{
+namespace
+{
+enum MgTNpcs : uint32
+{
+    NPC_SELIN_FIREHEART         = 24723,
+    NPC_FEL_CRYSTAL             = 24722,
+
+    NPC_SUNBLADE_MAGE_GUARD     = 24683,
+    NPC_SUNBLADE_BLOOD_KNIGHT   = 24684,
+    NPC_SUNBLADE_MAGISTER       = 24685,
+    NPC_SUNBLADE_WARLOCK        = 24686,
+    NPC_SUNBLADE_PHYSICIAN      = 24687,
+    NPC_SUNBLADE_IMP            = 24815,
+
+    NPC_WRETCHED_SKULKER        = 24688,
+    NPC_WRETCHED_BRUISER        = 24689,
+    NPC_WRETCHED_HUSK           = 24690,
+
+    NPC_COILSKAR_WITCH          = 24696,
+    NPC_SISTER_OF_TORMENT       = 24697,
+    NPC_ETHEREUM_SMUGGLER       = 24698,
+};
+
+enum MgTSpells : uint32
+{
+    SPELL_MAGIC_DAMPENING_FIELD = 44475,
+
+    SPELL_HOLY_LIGHT            = 44479,
+    SPELL_HOLY_LIGHT_H          = 46029,
+
+    SPELL_ARCANE_NOVA           = 44644,
+    SPELL_ARCANE_NOVA_H         = 46036,
+
+    SPELL_INCINERATE            = 44519,
+    SPELL_INCINERATE_H          = 46043,
+    SPELL_FROSTBOLT             = 44606,
+    SPELL_FROSTBOLT_H           = 46035,
+
+    SPELL_WRETCHED_FIREBALL     = 44503,
+    SPELL_WRETCHED_FROSTBOLT    = 44504,
+
+    SPELL_DEADLY_EMBRACE        = 44547,
+
+    SPELL_FORKED_LIGHTNING      = 20299,
+    SPELL_FORKED_LIGHTNING_H    = 46150,
+
+    SPELL_DRINK_FEL_INFUSION    = 44505,
+};
+
+enum MgTDelrissaNpcs : uint32
+{
+    NPC_DELRISSA                = 24560,
+
+    NPC_APOKO                   = 24553,
+    NPC_ELLRYS_DUSKHALLOW       = 24558,
+    NPC_YAZZAI                  = 24561,
+    NPC_ZELFAN                  = 24556,
+    NPC_GARAXXAS                = 24555,
+    NPC_KAGANI_NIGHTSTRIKE      = 24557,
+    NPC_WARLORD_SALARIS         = 24559,
+    NPC_ERAMAS_BRIGHTBLAZE      = 24554,
+
+    NPC_HIGH_EXPLOSIVE_SHEEP    = 24715,
+
+    NPC_FIZZLE                  = 24656,
+    NPC_SLIVER                  = 24552,
+};
+
+enum MgTDelrissaSpells : uint32
+{
+    SPELL_FLASH_HEAL            = 17843,
+    SPELL_LESSER_HEALING_WAVE   = 44256,
+    SPELL_SUMMON_IMP            = 44163,
+    SPELL_DELRISSA_FEAR         = 38595,
+    SPELL_POLYMORPH             = 13323,
+
+    SPELL_TREMOR_TOTEM          = 8143,
+};
+
+enum MgTKaelNpcs : uint32
+{
+    NPC_KAEL_THAS               = 24664,
+    NPC_FLAMESTRIKE_TRIGGER     = 24666,
+    NPC_PHOENIX                 = 24674,
+    NPC_PHOENIX_EGG             = 24675,
+    NPC_ARCANE_SPHERE           = 24708,
+};
+
+enum MgTKaelSpells : uint32
+{
+    SPELL_FLAME_STRIKE          = 44190,
+    SPELL_FLAME_STRIKE_H        = 46163,
+
+    SPELL_PHOENIX_BURN          = 44197,
+
+    SPELL_SHOCK_BARRIER         = 46165,
+    SPELL_PYROBLAST             = 36819,
+
+    SPELL_KAEL_FIREBALL         = 44189,
+
+    SPELL_GRAVITY_LAPSE_INITIAL = 44224,
+    SPELL_GRAVITY_LAPSE_DOT     = 44226,
+    SPELL_GRAVITY_LAPSE_FLY     = 44227,
+    SPELL_POWER_FEEDBACK        = 44233,
+};
+
+constexpr char const* SELIN_NAME = "selin fireheart";
+constexpr char const* KAEL_NAME  = "kael'thas sunstrider";
+
+constexpr float ROOM_X_MIN = 218.0f;
+constexpr float ROOM_X_MAX = 260.0f;
+constexpr float ROOM_Y_MIN = -40.0f;
+constexpr float ROOM_Y_MAX = 40.0f;
+
+constexpr float CRYSTAL_SCAN_RANGE = 60.0f;
+
+constexpr float DAMPENING_RADIUS = 5.0f;
+constexpr float DAMPENING_STAND  = DAMPENING_RADIUS + 1.5f;
+constexpr float DAMPENING_CLEAR  = DAMPENING_RADIUS + 4.0f;
+constexpr float DAMPENING_SCAN   = 30.0f;
+
+constexpr float TANK_REJOIN_GAP = 5.0f;
+
+constexpr float GLAIVE_MIN_RANGE = 12.0f;
+constexpr float GLAIVE_MAX_RANGE = 60.0f;
+
+constexpr float NOVA_CLEAR = 16.0f;
+
+constexpr float INTERRUPT_SCAN = 30.0f;
+constexpr float WRETCHED_SCAN  = 40.0f;
+constexpr float FOCUS_SCAN     = 40.0f;
+
+constexpr float ESCAPE_LOS_HEIGHT = 2.0f;
+
+constexpr float PARTY_CENTROID_RANGE = 60.0f;
+
+constexpr float ESCAPE_RADII[] = { 7.0f, 10.0f, 13.0f, 16.0f };
+constexpr uint8 ESCAPE_BEARINGS = 12;
+constexpr float ESCAPE_TRAVEL_WEIGHT = 0.25f;
+constexpr uint8 ESCAPE_KEEP = 5;
+
+constexpr float FLAMESTRIKE_STAND = 7.5f;
+constexpr float FLAMESTRIKE_CLEAR = 10.0f;
+constexpr float FLAMESTRIKE_SCAN  = 40.0f;
+
+constexpr float BURN_DAMAGE  = 8.0f;
+constexpr float BURN_STAND   = 9.0f;
+constexpr float BURN_CLEAR   = 12.0f;
+constexpr float PHOENIX_SCAN = 40.0f;
+
+constexpr float BURN_MELEE_STAND = BURN_DAMAGE + 0.5f;
+constexpr float BURN_MELEE_CLEAR = BURN_DAMAGE + 2.5f;
+constexpr float BURN_MELEE_RADII[] = { 3.0f, 5.0f, 7.0f, 9.0f, 12.0f };
+constexpr uint8 BURN_MELEE_BEARINGS = 16;
+
+constexpr float KAEL_MELEE_RING = 5.0f;
+
+constexpr LapseSpot KAEL_P2      = { 148.54f, 181.13f };
+
+constexpr LapseSpot LAPSE_TANK   = { 148.54f, 177.53f };
+constexpr LapseSpot LAPSE_MELEE[] = {
+    { 151.30f, 178.82f },
+    { 145.78f, 178.82f },
+};
+
+constexpr LapseSpot LAPSE_HEALER = { 148.54f, 167.13f };
+constexpr LapseSpot LAPSE_RANGED[] = {
+    { 137.07f, 164.75f },
+    { 148.54f, 155.13f },
+    { 164.92f, 169.66f },
+};
+
+constexpr float SPHERE_DAMAGE    = 5.0f;
+constexpr float SPHERE_CLEAR     = 8.0f;
+constexpr float SPHERE_SCAN      = 40.0f;
+
+constexpr float LAPSE_PUSH_MAX   = 8.0f;
+
+constexpr float SPHERE_SPEED     = 3.0f;
+constexpr float SPHERE_LEAD      = 2.5f;
+
+constexpr float SPHERE_ALERT     = 9.0f;
+constexpr float SPHERE_TRANSIT   = 6.0f;
+constexpr float SPHERE_ROUTE_SLACK = 0.5f;
+
+constexpr float SPHERE_DODGE_NEAR_RADIUS = 4.0f;
+constexpr float SPHERE_DODGE_RADII[]     = { SPHERE_DODGE_NEAR_RADIUS, 7.0f, 11.0f, 15.0f };
+constexpr uint8 SPHERE_DODGE_BEARINGS    = 16;
+constexpr float SPHERE_DODGE_TRAVEL_COST = 0.25f;
+constexpr float SPHERE_DODGE_MARGIN_CAP    = 6.0f;
+constexpr float SPHERE_DODGE_MARGIN_WEIGHT = 0.5f;
+constexpr float SPHERE_DODGE_MIN_GAIN      = 2.0f;
+
+constexpr float KITE_LEG          = 12.0f;
+constexpr float KITE_TURN_MAGNITUDES[] = { 0.0f, 25.0f, 50.0f, 75.0f,
+                                           100.0f, 125.0f, 150.0f, 175.0f };
+
+constexpr float KITE_PROBE_STEP   = 2.0f;
+constexpr float KITE_PROBE_MAX    = 24.0f;
+
+constexpr float KITE_PASS_CLEAR   = SPHERE_DAMAGE;
+constexpr float KITE_RUNWAY_TIEBREAK = 0.5f;
+constexpr float KITE_COMMIT_BONUS = 3.0f;
+constexpr float KITE_COMMIT_STRAIGHT = 10.0f;
+
+constexpr uint32 KITE_COMMIT_BREAK_MS = 1500;
+
+constexpr float KITE_NORTH_MIN    = 340.0f;
+constexpr float KITE_NORTH_MAX    = 20.0f;
+constexpr float KITE_BOWL_MIN     = 100.0f;
+constexpr float KITE_BOWL_MAX     = 260.0f;
+constexpr float KITE_BOWL_RADIUS  = 22.0f;
+constexpr float KITE_SIDE_RADIUS  = 13.0f;
+
+constexpr float LAPSE_TOLERANCE  = 3.0f;
+
+constexpr float LAPSE_BURN_COST = 6.0f;
+
+constexpr float LAPSE_LEG          = 10.0f;
+constexpr float LAPSE_PROGRESS_MIN = 1.0f;
+constexpr float LAPSE_DETOUR_TURNS[] = { 0.0f, 20.0f, 40.0f, 60.0f, 80.0f, 100.0f };
+
+struct Hazard
+{
+    float x;
+    float y;
+    float stand;
+    float clear;
+};
+
+struct ScoredSpot
+{
+    float score;
+    float x;
+    float y;
+};
+
+void CollectCreaturesByEntry(Player* bot, std::vector<uint32> const& entries, float radius,
+                             std::vector<Unit*>& out)
+{
+    std::list<Creature*> found;
+    bot->GetCreatureListWithEntryInGrid(found, entries, radius);
+
+    out.reserve(out.size() + found.size());
+    for (Creature* creature : found)
+    {
+        if (creature->IsAlive())
+            out.push_back(creature);
+    }
+}
+
+void CollectAttackersByEntry(Player* bot, std::vector<uint32> const& entries, float radius,
+                             std::vector<Unit*>& out)
+{
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+
+    auto const& attackers = botAI->GetAiObjectContext()->GetValue<GuidVector>("attackers")->Get();
+    for (ObjectGuid const guid : attackers)
+    {
+        Unit* attacker = botAI->GetUnit(guid);
+        if (!attacker)
+            continue;
+
+        if (std::find(entries.begin(), entries.end(), attacker->GetEntry()) == entries.end())
+            continue;
+
+        if (bot->GetExactDist2d(attacker) > radius)
+            continue;
+
+        out.push_back(attacker);
+    }
+}
+
+bool PartyCentroid(Player* bot, float& cx, float& cy)
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+        return false;
+
+    float sx = 0.0f, sy = 0.0f;
+    int n = 0;
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member || member == bot || !member->IsAlive() || member->GetMapId() != bot->GetMapId())
+            continue;
+        if (bot->GetExactDist2d(member) > PARTY_CENTROID_RANGE)
+            continue;
+
+        sx += member->GetPositionX();
+        sy += member->GetPositionY();
+        ++n;
+    }
+
+    if (n == 0)
+        return false;
+
+    cx = sx / n;
+    cy = sy / n;
+    return true;
+}
+
+bool SpotClearsHazards(std::vector<Hazard> const& hazards, float x, float y)
+{
+    for (Hazard const& hazard : hazards)
+    {
+        float const dx = x - hazard.x;
+        float const dy = y - hazard.y;
+        if (dx * dx + dy * dy < hazard.clear * hazard.clear)
+            return false;
+    }
+
+    return true;
+}
+
+bool InsideAnyHazard(std::vector<Hazard> const& hazards, float x, float y)
+{
+    for (Hazard const& hazard : hazards)
+    {
+        float const dx = x - hazard.x;
+        float const dy = y - hazard.y;
+        if (dx * dx + dy * dy < hazard.stand * hazard.stand)
+            return true;
+    }
+
+    return false;
+}
+
+void KeepBestReachable(Player* bot, std::vector<ScoredSpot>& scored, EscapeSpots& out)
+{
+    std::stable_sort(scored.begin(), scored.end(),
+                     [](ScoredSpot const& a, ScoredSpot const& b) { return a.score < b.score; });
+
+    float const bz = bot->GetPositionZ();
+
+    uint8 kept = 0;
+    for (ScoredSpot const& spot : scored)
+    {
+        float const z = bot->GetMapHeight(spot.x, spot.y, bz + GROUND_SEARCH_UP, true, GROUND_SEARCH_DOWN);
+        if (!(std::fabs(z - bz) <= GROUND_TIER_STEP))
+            continue;
+
+        if (!bot->IsWithinLOS(spot.x, spot.y, z + ESCAPE_LOS_HEIGHT))
+            continue;
+
+        out.push_back({ spot.x, spot.y, z });
+
+        if (++kept >= ESCAPE_KEEP)
+            break;
+    }
+}
+
+void CollectHazardEscapes(Player* bot, std::vector<Hazard> const& hazards, float anchorGap,
+                          EscapeSpots& out)
+{
+    if (hazards.empty())
+        return;
+
+    float const bx = bot->GetPositionX();
+    float const by = bot->GetPositionY();
+
+    if (!InsideAnyHazard(hazards, bx, by))
+        return;
+
+    float cx = 0.0f, cy = 0.0f;
+    bool const haveParty = PartyCentroid(bot, cx, cy);
+
+    std::vector<ScoredSpot> scored;
+    for (float radius : ESCAPE_RADII)
+    {
+        for (int i = 0; i < ESCAPE_BEARINGS; ++i)
+        {
+            float const angle = (2.0f * static_cast<float>(M_PI) * i) / ESCAPE_BEARINGS;
+            float const x = bx + std::cos(angle) * radius;
+            float const y = by + std::sin(angle) * radius;
+            if (!SpotClearsHazards(hazards, x, y))
+                continue;
+
+            float score = radius * ESCAPE_TRAVEL_WEIGHT;
+            if (haveParty)
+                score += std::fabs(std::hypot(x - cx, y - cy) - anchorGap);
+
+            scored.push_back({ score, x, y });
+        }
+    }
+
+    KeepBestReachable(bot, scored, out);
+}
+
+void CollectRingEscapes(Player* bot, Unit* anchor, std::vector<Hazard> const& hazards, EscapeSpots& out)
+{
+    if (hazards.empty())
+        return;
+
+    float const bx = bot->GetPositionX();
+    float const by = bot->GetPositionY();
+
+    if (!InsideAnyHazard(hazards, bx, by))
+        return;
+
+    float const ax = anchor->GetPositionX();
+    float const ay = anchor->GetPositionY();
+
+    std::vector<ScoredSpot> scored;
+    for (float radius : BURN_MELEE_RADII)
+    {
+        for (int i = 0; i < BURN_MELEE_BEARINGS; ++i)
+        {
+            float const angle = (2.0f * static_cast<float>(M_PI) * i) / BURN_MELEE_BEARINGS;
+            float const x = bx + std::cos(angle) * radius;
+            float const y = by + std::sin(angle) * radius;
+            if (!SpotClearsHazards(hazards, x, y))
+                continue;
+
+            float const score = std::hypot(x - ax, y - ay) + radius * ESCAPE_TRAVEL_WEIGHT;
+            scored.push_back({ score, x, y });
+        }
+    }
+
+    KeepBestReachable(bot, scored, out);
+}
+
+uint8 InterruptPriority(uint32 spellId)
+{
+    switch (spellId)
+    {
+        case SPELL_DEADLY_EMBRACE:
+            return 1;
+        case SPELL_HOLY_LIGHT:
+        case SPELL_HOLY_LIGHT_H:
+            return 2;
+        case SPELL_ARCANE_NOVA:
+        case SPELL_ARCANE_NOVA_H:
+            return 3;
+        case SPELL_FORKED_LIGHTNING:
+        case SPELL_FORKED_LIGHTNING_H:
+            return 4;
+        case SPELL_INCINERATE:
+        case SPELL_INCINERATE_H:
+            return 5;
+        case SPELL_FROSTBOLT:
+        case SPELL_FROSTBOLT_H:
+            return 6;
+        case SPELL_WRETCHED_FIREBALL:
+        case SPELL_WRETCHED_FROSTBOLT:
+            return 7;
+        default:
+            return 0;
+    }
+}
+
+uint8 CurrentCastPriority(Unit* caster)
+{
+    uint8 best = 0;
+    for (CurrentSpellTypes slot : { CURRENT_GENERIC_SPELL, CURRENT_CHANNELED_SPELL })
+    {
+        Spell* spell = caster->GetCurrentSpell(slot);
+        if (!spell || !spell->m_spellInfo)
+            continue;
+
+        uint8 const prio = InterruptPriority(spell->m_spellInfo->Id);
+        if (prio && (!best || prio < best))
+            best = prio;
+    }
+
+    return best;
+}
+
+bool StopsACast(uint32 spellId)
+{
+    SpellInfo const* info = sSpellMgr->GetSpellInfo(spellId);
+    if (!info)
+        return false;
+
+    if ((info->InterruptFlags & SPELL_INTERRUPT_FLAG_INTERRUPT) &&
+        info->PreventionType == SPELL_PREVENTION_TYPE_SILENCE)
+        return true;
+
+    for (uint8 i = EFFECT_0; i <= EFFECT_2; ++i)
+    {
+        if (info->Effects[i].Effect == SPELL_EFFECT_INTERRUPT_CAST)
+            return true;
+
+        if (info->Effects[i].Effect != SPELL_EFFECT_APPLY_AURA)
+            continue;
+
+        if (info->Effects[i].ApplyAuraName == SPELL_AURA_MOD_SILENCE ||
+            info->Effects[i].ApplyAuraName == SPELL_AURA_MOD_STUN)
+            return true;
+    }
+
+    return false;
+}
+
+enum class InterruptKind
+{
+    Dedicated,
+    Control,
+};
+
+struct InterruptSpell
+{
+    char const* name;
+    InterruptKind kind;
+};
+
+std::vector<InterruptSpell> const& InterruptSpells()
+{
+    static std::vector<InterruptSpell> const spells = {
+        { "kick", InterruptKind::Dedicated },
+        { "pummel", InterruptKind::Dedicated },
+        { "shield bash", InterruptKind::Dedicated },
+        { "wind shear", InterruptKind::Dedicated },
+        { "mind freeze", InterruptKind::Dedicated },
+        { "counterspell", InterruptKind::Dedicated },
+        { "spell lock", InterruptKind::Dedicated },
+        { "silencing shot", InterruptKind::Dedicated },
+        { "shockwave", InterruptKind::Control },
+        { "shadowfury", InterruptKind::Control },
+        { "concussion blow", InterruptKind::Control },
+        { "hammer of justice", InterruptKind::Control },
+        { "maim", InterruptKind::Control },
+        { "kidney shot", InterruptKind::Control },
+        { "silence", InterruptKind::Control },
+        { "bash", InterruptKind::Control },
+        { "strangulate", InterruptKind::Control },
+        { "arcane torrent", InterruptKind::Control },
+    };
+
+    return spells;
+}
+
+uint8 TrashFocusRank(uint32 entry)
+{
+    switch (entry)
+    {
+        case NPC_SUNBLADE_PHYSICIAN:
+            return 1;
+        case NPC_SUNBLADE_BLOOD_KNIGHT:
+            return 2;
+        case NPC_SISTER_OF_TORMENT:
+            return 3;
+        case NPC_SUNBLADE_WARLOCK:
+            return 4;
+        case NPC_SUNBLADE_MAGISTER:
+            return 5;
+        case NPC_ETHEREUM_SMUGGLER:
+            return 6;
+        case NPC_COILSKAR_WITCH:
+            return 7;
+        case NPC_SUNBLADE_IMP:
+            return 8;
+        case NPC_SUNBLADE_MAGE_GUARD:
+            return 9;
+        default:
+            return 0;
+    }
+}
+
+uint8 RetinueFocusRank(uint32 entry)
+{
+    switch (entry)
+    {
+        case NPC_HIGH_EXPLOSIVE_SHEEP:
+            return 1;
+        case NPC_APOKO:
+            return 2;
+        case NPC_ELLRYS_DUSKHALLOW:
+            return 3;
+        case NPC_YAZZAI:
+            return 4;
+        case NPC_ZELFAN:
+            return 5;
+        case NPC_WARLORD_SALARIS:
+            return 6;
+        case NPC_GARAXXAS:
+            return 7;
+        case NPC_KAGANI_NIGHTSTRIKE:
+            return 8;
+        case NPC_ERAMAS_BRIGHTBLAZE:
+            return 9;
+        case NPC_DELRISSA:
+            return 10;
+        default:
+            return 0;
+    }
+}
+
+Unit* PickRankedFocus(Player* bot, uint8 (*rank)(uint32), std::vector<Unit*> const& extra,
+                      ObjectGuid& latched)
+{
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+
+    Unit* held = nullptr;
+    uint8 heldRank = 0;
+    Unit* best = nullptr;
+    uint8 bestRank = 0;
+    float bestDist = 0.0f;
+
+    auto consider = [&](Unit* candidate)
+    {
+        uint8 const candidateRank = rank(candidate->GetEntry());
+        if (!candidateRank)
+            return;
+
+        float const dist = bot->GetExactDist2d(candidate);
+        if (dist > FOCUS_SCAN)
+            return;
+
+        if (!latched.IsEmpty() && candidate->GetGUID() == latched)
+        {
+            held = candidate;
+            heldRank = candidateRank;
+        }
+
+        if (!best || candidateRank < bestRank || (candidateRank == bestRank && dist < bestDist))
+        {
+            best = candidate;
+            bestRank = candidateRank;
+            bestDist = dist;
+        }
+    };
+
+    auto const& attackers = botAI->GetAiObjectContext()->GetValue<GuidVector>("attackers")->Get();
+    for (ObjectGuid const guid : attackers)
+    {
+        if (Unit* attacker = botAI->GetUnit(guid))
+            consider(attacker);
+    }
+
+    for (Unit* candidate : extra)
+        consider(candidate);
+
+    if (held && heldRank <= bestRank)
+        return held;
+
+    latched = best ? best->GetGUID() : ObjectGuid::Empty;
+    return best;
+}
+
+bool RetinueEngaged(Player* bot)
+{
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+
+    auto const& attackers = botAI->GetAiObjectContext()->GetValue<GuidVector>("attackers")->Get();
+    for (ObjectGuid const guid : attackers)
+    {
+        Unit* attacker = botAI->GetUnit(guid);
+        if (attacker && RetinueFocusRank(attacker->GetEntry()))
+            return true;
+    }
+
+    return false;
+}
+
+uint8 RetinueInterruptPriority(uint32 spellId)
+{
+    switch (spellId)
+    {
+        case SPELL_DELRISSA_FEAR:
+        case SPELL_POLYMORPH:
+            return 1;
+        case SPELL_FLASH_HEAL:
+        case SPELL_LESSER_HEALING_WAVE:
+            return 2;
+        case SPELL_SUMMON_IMP:
+            return 3;
+        default:
+            return 0;
+    }
+}
+
+uint8 CurrentRetinueCastPriority(Unit* caster)
+{
+    uint8 best = 0;
+    for (CurrentSpellTypes slot : { CURRENT_GENERIC_SPELL, CURRENT_CHANNELED_SPELL })
+    {
+        Spell* spell = caster->GetCurrentSpell(slot);
+        if (!spell || !spell->m_spellInfo)
+            continue;
+
+        uint8 const prio = RetinueInterruptPriority(spell->m_spellInfo->Id);
+        if (prio && (!best || prio < best))
+            best = prio;
+    }
+
+    return best;
+}
+
+int InterruptSlot(Player* bot)
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+        return 0;
+
+    int slot = 0;
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member || member == bot || !member->IsAlive() || member->GetMapId() != bot->GetMapId())
+            continue;
+
+        if (!GET_PLAYERBOT_AI(member))
+            continue;
+
+        if (member->GetGUID() < bot->GetGUID())
+            ++slot;
+    }
+
+    return slot;
+}
+
+constexpr FocusOrder FOCUS_ORDER_OWNERS[] = { FocusOrder::Kael, FocusOrder::Delrissa, FocusOrder::Trash };
+constexpr char const* FOCUS_ORDER_KEYS[] = { "mgt kael focus target", "mgt delrissa focus target",
+                                             "mgt focus target" };
+
+bool LapseActive(Player* bot, Unit* kael)
+{
+    if (!kael || kael->HasAura(SPELL_POWER_FEEDBACK))
+        return false;
+
+    if (bot->HasAura(SPELL_GRAVITY_LAPSE_DOT) || bot->HasAura(SPELL_GRAVITY_LAPSE_FLY))
+        return true;
+
+    for (CurrentSpellTypes slot : { CURRENT_GENERIC_SPELL, CURRENT_CHANNELED_SPELL })
+    {
+        Spell* spell = kael->GetCurrentSpell(slot);
+        if (spell && spell->m_spellInfo && spell->m_spellInfo->Id == SPELL_GRAVITY_LAPSE_INITIAL)
+            return true;
+    }
+
+    return false;
+}
+
+uint8 KaelInterruptPriority(uint32 spellId)
+{
+    switch (spellId)
+    {
+        case SPELL_PYROBLAST:
+            return 1;
+        case SPELL_KAEL_FIREBALL:
+            return 2;
+        default:
+            return 0;
+    }
+}
+
+uint8 CurrentKaelCastPriority(Unit* kael)
+{
+    uint8 best = 0;
+    for (CurrentSpellTypes slot : { CURRENT_GENERIC_SPELL, CURRENT_CHANNELED_SPELL })
+    {
+        Spell* spell = kael->GetCurrentSpell(slot);
+        if (!spell || !spell->m_spellInfo)
+            continue;
+
+        uint8 const prio = KaelInterruptPriority(spell->m_spellInfo->Id);
+        if (prio && (!best || prio < best))
+            best = prio;
+    }
+
+    return best;
+}
+
+enum class LapseRole
+{
+    Tank,
+    Healer,
+    Melee,
+    Ranged
+};
+
+LapseRole ClassifyLapseRole(Player* member)
+{
+    if (PlayerbotAI::IsTank(member))
+        return LapseRole::Tank;
+
+    if (PlayerbotAI::IsHeal(member))
+        return LapseRole::Healer;
+
+    if (PlayerbotAI::IsMelee(member))
+        return LapseRole::Melee;
+
+    return LapseRole::Ranged;
+}
+
+int LapseSlot(Player* bot, LapseRole role)
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+        return 0;
+
+    int slot = 0;
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member || member == bot || !member->IsAlive() || member->GetMapId() != bot->GetMapId())
+            continue;
+
+        if (!GET_PLAYERBOT_AI(member) || ClassifyLapseRole(member) != role)
+            continue;
+
+        if (member->GetGUID() < bot->GetGUID())
+            ++slot;
+    }
+
+    return slot;
+}
+
+bool LapseAnchor(Player* bot, LapseSpot& out)
+{
+    LapseRole const role = ClassifyLapseRole(bot);
+    size_t const slot = static_cast<size_t>(LapseSlot(bot, role));
+
+    switch (role)
+    {
+        case LapseRole::Tank:
+            out = LAPSE_TANK;
+            break;
+        case LapseRole::Healer:
+            out = LAPSE_HEALER;
+            break;
+        case LapseRole::Melee:
+            out = LAPSE_MELEE[slot % std::size(LAPSE_MELEE)];
+            break;
+        default:
+            out = LAPSE_RANGED[slot % std::size(LAPSE_RANGED)];
+            break;
+    }
+
+    return true;
+}
+
+float BearingFromKael(float x, float y)
+{
+    float degrees = std::atan2(x - KAEL_P2.x, y - KAEL_P2.y) * 180.0f / static_cast<float>(M_PI);
+    if (degrees < 0.0f)
+        degrees += 360.0f;
+
+    return degrees;
+}
+
+bool SphereHeading(Unit* sphere, float& hx, float& hy)
+{
+    if (Unit* victim = sphere->GetVictim())
+    {
+        float const dx = victim->GetPositionX() - sphere->GetPositionX();
+        float const dy = victim->GetPositionY() - sphere->GetPositionY();
+        float const len = std::hypot(dx, dy);
+        if (len < 0.1f)
+            return false;
+
+        hx = dx / len;
+        hy = dy / len;
+        return true;
+    }
+
+    hx = std::cos(sphere->GetOrientation());
+    hy = std::sin(sphere->GetOrientation());
+    return true;
+}
+
+float DistanceToSphereSweep(Unit* sphere, float x, float y)
+{
+    float const sx = sphere->GetPositionX();
+    float const sy = sphere->GetPositionY();
+
+    float hx = 0.0f, hy = 0.0f;
+    if (!SphereHeading(sphere, hx, hy))
+        return std::hypot(x - sx, y - sy);
+
+    float const reach = SPHERE_SPEED * SPHERE_LEAD;
+    float t = (x - sx) * hx + (y - sy) * hy;
+    t = std::clamp(t, 0.0f, reach);
+
+    return std::hypot(x - (sx + hx * t), y - (sy + hy * t));
+}
+
+float PointToSegment(float px, float py, float ax, float ay, float bx, float by)
+{
+    float const dx = bx - ax;
+    float const dy = by - ay;
+    float const len2 = dx * dx + dy * dy;
+    if (len2 < 0.0001f)
+        return std::hypot(px - ax, py - ay);
+
+    float t = ((px - ax) * dx + (py - ay) * dy) / len2;
+    t = std::clamp(t, 0.0f, 1.0f);
+
+    return std::hypot(px - (ax + dx * t), py - (ay + dy * t));
+}
+
+float SegmentToSegment(float ax, float ay, float bx, float by, float cx, float cy, float dx, float dy)
+{
+    auto side = [](float ox, float oy, float px, float py, float qx, float qy)
+    { return (px - ox) * (qy - oy) - (py - oy) * (qx - ox); };
+
+    float const d1 = side(cx, cy, dx, dy, ax, ay);
+    float const d2 = side(cx, cy, dx, dy, bx, by);
+    float const d3 = side(ax, ay, bx, by, cx, cy);
+    float const d4 = side(ax, ay, bx, by, dx, dy);
+
+    if (((d1 > 0.0f) != (d2 > 0.0f)) && ((d3 > 0.0f) != (d4 > 0.0f)))
+        return 0.0f;
+
+    return std::min({ PointToSegment(ax, ay, cx, cy, dx, dy), PointToSegment(bx, by, cx, cy, dx, dy),
+                      PointToSegment(cx, cy, ax, ay, bx, by), PointToSegment(dx, dy, ax, ay, bx, by) });
+}
+
+float WalkClearanceOfSphere(Unit* sphere, float fx, float fy, float tx, float ty)
+{
+    float const sx = sphere->GetPositionX();
+    float const sy = sphere->GetPositionY();
+
+    float hx = 0.0f, hy = 0.0f;
+    if (!SphereHeading(sphere, hx, hy))
+        return PointToSegment(sx, sy, fx, fy, tx, ty);
+
+    float const reach = SPHERE_SPEED * SPHERE_LEAD;
+
+    return SegmentToSegment(fx, fy, tx, ty, sx, sy, sx + hx * reach, sy + hy * reach);
+}
+
+bool InsideKiteArena(float x, float y, bool healer)
+{
+    float const bearing = BearingFromKael(x, y);
+
+    if (bearing >= KITE_NORTH_MIN || bearing <= KITE_NORTH_MAX)
+        return false;
+
+    bool const bowl = bearing >= KITE_BOWL_MIN && bearing <= KITE_BOWL_MAX;
+    if (healer && !bowl)
+        return false;
+
+    float const limit = bowl ? KITE_BOWL_RADIUS : KITE_SIDE_RADIUS;
+
+    return std::hypot(x - KAEL_P2.x, y - KAEL_P2.y) <= limit;
+}
+
+float KiteRunway(float fx, float fy, float hx, float hy, bool healer, bool outside)
+{
+    int const steps = static_cast<int>(KITE_PROBE_MAX / KITE_PROBE_STEP);
+
+    bool started = !outside;
+    float runway = 0.0f;
+    for (int i = 1; i <= steps; ++i)
+    {
+        float const step = KITE_PROBE_STEP * i;
+        bool const clear = InsideKiteArena(fx + hx * step, fy + hy * step, healer);
+
+        if (!started)
+        {
+            if (clear)
+            {
+                started = true;
+                runway = step;
+            }
+
+            continue;
+        }
+
+        if (!clear)
+            break;
+
+        runway = step;
+    }
+
+    return started ? runway : 0.0f;
+}
+
+bool IsLapseHealer(Player* bot)
+{
+    return PlayerbotAI::IsHeal(bot) && !PlayerbotAI::IsTank(bot);
+}
+
+bool InsideAnyBurn(std::vector<LapseSpot> const& burns, float x, float y)
+{
+    for (LapseSpot const& burn : burns)
+    {
+        if (std::hypot(x - burn.x, y - burn.y) < BURN_DAMAGE)
+            return true;
+    }
+
+    return false;
+}
+
+Unit* GetChasingSphere(Player* bot, LapseWorld const& world)
+{
+    for (Unit* sphere : world.spheres)
+    {
+        if (sphere->GetVictim() == bot)
+            return sphere;
+    }
+
+    return nullptr;
+}
+
+float BurningPhoenixKaelGap(Player* bot, Unit* kael)
+{
+    std::vector<Unit*> phoenixes;
+    CollectCreaturesByEntry(bot, { NPC_PHOENIX }, PHOENIX_SCAN, phoenixes);
+
+    float gap = std::numeric_limits<float>::max();
+    for (Unit* phoenix : phoenixes)
+    {
+        if (phoenix->HasAura(SPELL_PHOENIX_BURN))
+            gap = std::min(gap, phoenix->GetExactDist2d(kael));
+    }
+
+    return gap;
+}
+}
+
+Unit* GetSelin(Player* bot)
+{
+    return GET_PLAYERBOT_AI(bot)->GetAiObjectContext()->GetValue<Unit*>("find target", SELIN_NAME)->Get();
+}
+
+Unit* GetKaelthas(Player* bot)
+{
+    return GET_PLAYERBOT_AI(bot)->GetAiObjectContext()->GetValue<Unit*>("find target", KAEL_NAME)->Get();
+}
+
+Unit* GetActiveFelCrystal(Player* bot)
+{
+    if (!GetSelin(bot))
+        return nullptr;
+
+    std::vector<Unit*> crystals;
+    CollectCreaturesByEntry(bot, { NPC_FEL_CRYSTAL }, CRYSTAL_SCAN_RANGE, crystals);
+
+    Unit* best = nullptr;
+    float bestDist = CRYSTAL_SCAN_RANGE;
+    for (Unit* crystal : crystals)
+    {
+        if (!AttackersValue::IsValidTarget(crystal, bot))
+            continue;
+
+        float const dist = bot->GetExactDist2d(crystal);
+        if (dist < bestDist)
+        {
+            bestDist = dist;
+            best = crystal;
+        }
+    }
+
+    return best;
+}
+
+void CollectDampeningEscapes(Player* bot, EscapeSpots& out)
+{
+    if (!bot->IsInCombat())
+        return;
+
+    std::vector<Hazard> fields;
+    for (Position const& pos : GetDynamicObjectPositions(bot, DAMPENING_SCAN, SPELL_MAGIC_DAMPENING_FIELD))
+        fields.push_back({ pos.GetPositionX(), pos.GetPositionY(), DAMPENING_STAND, DAMPENING_CLEAR });
+
+    CollectHazardEscapes(bot, fields, PlayerbotAI::IsTank(bot) ? TANK_REJOIN_GAP : 0.0f, out);
+}
+
+Unit* GetGlaiveThrowingMageGuard(Player* bot)
+{
+    std::vector<Unit*> guards;
+    CollectAttackersByEntry(bot, { NPC_SUNBLADE_MAGE_GUARD }, GLAIVE_MAX_RANGE, guards);
+
+    for (Unit* guard : guards)
+    {
+        if (guard->GetVictim() != bot)
+            continue;
+
+        if (bot->GetExactDist2d(guard) > GLAIVE_MIN_RANGE)
+            return guard;
+    }
+
+    return nullptr;
+}
+
+void CollectNovaEscapes(Player* bot, EscapeSpots& out)
+{
+    if (PlayerbotAI::IsMelee(bot))
+        return;
+
+    std::vector<Unit*> magisters;
+    CollectAttackersByEntry(bot, { NPC_SUNBLADE_MAGISTER }, NOVA_CLEAR, magisters);
+
+    std::vector<Hazard> hazards;
+    hazards.reserve(magisters.size());
+    for (Unit* magister : magisters)
+    {
+        hazards.push_back({ magister->GetPositionX(), magister->GetPositionY(), NOVA_CLEAR,
+                            NOVA_CLEAR + 2.0f });
+    }
+
+    CollectHazardEscapes(bot, hazards, 0.0f, out);
+}
+
+uint8 GetInterruptUrgency(Unit* caster)
+{
+    return caster ? CurrentCastPriority(caster) : 0;
+}
+
+Unit* GetInterruptTarget(Player* bot)
+{
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+
+    Unit* best = nullptr;
+    uint8 bestPrio = 0;
+    float bestDist = 0.0f;
+    auto const& attackers = botAI->GetAiObjectContext()->GetValue<GuidVector>("attackers")->Get();
+    for (ObjectGuid const guid : attackers)
+    {
+        Unit* caster = botAI->GetUnit(guid);
+        if (!caster)
+            continue;
+
+        float const dist = bot->GetExactDist2d(caster);
+        if (dist > INTERRUPT_SCAN)
+            continue;
+
+        uint8 const prio = CurrentCastPriority(caster);
+        if (!prio)
+            continue;
+
+        if (!best || prio < bestPrio || (prio == bestPrio && dist < bestDist))
+        {
+            best = caster;
+            bestPrio = prio;
+            bestDist = dist;
+        }
+    }
+
+    return best;
+}
+
+std::string CastInterrupt(PlayerbotAI* botAI, Unit* target, uint8 urgency)
+{
+    if (!target->IsNonMeleeSpellCast(true))
+        return {};
+
+    bool const allowControl = urgency && urgency <= CONTROL_INTERRUPT_URGENCY;
+
+    for (InterruptSpell const& entry : InterruptSpells())
+    {
+        if (entry.kind == InterruptKind::Control && !allowControl)
+            continue;
+
+        std::string const name = entry.name;
+
+        uint32 const spellId = botAI->GetAiObjectContext()->GetValue<uint32>("spell id", name)->Get();
+        if (!spellId || !StopsACast(spellId))
+            continue;
+
+        if (!botAI->CanCastSpell(name, target))
+            continue;
+
+        if (botAI->CastSpell(name, target))
+            return name;
+    }
+
+    return {};
+}
+
+uint8 GetRetinueInterruptUrgency(Unit* caster)
+{
+    return caster ? CurrentRetinueCastPriority(caster) : 0;
+}
+
+Unit* GetFocusTarget(Player* bot, ObjectGuid& latched)
+{
+    return PickRankedFocus(bot, &TrashFocusRank, {}, latched);
+}
+
+ObjectGuid ResolveFocusOrder(PlayerbotAI* botAI)
+{
+    AiObjectContext* context = botAI->GetAiObjectContext();
+
+    for (char const* key : FOCUS_ORDER_KEYS)
+    {
+        ObjectGuid const order = context->GetValue<ObjectGuid>(key)->Get();
+        if (!order.IsEmpty())
+            return order;
+    }
+
+    return ObjectGuid::Empty;
+}
+
+FocusOrder ResolveFocusOrderOwner(PlayerbotAI* botAI)
+{
+    AiObjectContext* context = botAI->GetAiObjectContext();
+
+    for (size_t i = 0; i < std::size(FOCUS_ORDER_KEYS); ++i)
+    {
+        if (!context->GetValue<ObjectGuid>(FOCUS_ORDER_KEYS[i])->Get().IsEmpty())
+            return FOCUS_ORDER_OWNERS[i];
+    }
+
+    return FocusOrder::None;
+}
+
+void CollectFocusExclusions(Player* bot, std::vector<ObjectGuid>& out)
+{
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+
+    ObjectGuid const order = ResolveFocusOrder(botAI);
+    if (order.IsEmpty())
+        return;
+
+    Unit* focus = botAI->GetUnit(order);
+    bool const transient = !focus || focus->GetEntry() == NPC_HIGH_EXPLOSIVE_SHEEP ||
+                           focus->GetEntry() == NPC_PHOENIX_EGG;
+
+    auto const& attackers = botAI->GetAiObjectContext()->GetValue<GuidVector>("attackers")->Get();
+    out.reserve(out.size() + attackers.size() + 1);
+    for (ObjectGuid const guid : attackers)
+    {
+        if (guid != order)
+            out.push_back(guid);
+    }
+
+    if (transient)
+        out.push_back(order);
+}
+
+Unit* GetEnragedWretched(Player* bot)
+{
+    std::vector<Unit*> wretched;
+    CollectAttackersByEntry(bot, { NPC_WRETCHED_SKULKER, NPC_WRETCHED_BRUISER, NPC_WRETCHED_HUSK },
+                            WRETCHED_SCAN, wretched);
+
+    Unit* best = nullptr;
+    float bestDist = WRETCHED_SCAN;
+    for (Unit* mob : wretched)
+    {
+        if (!mob->HasAura(SPELL_DRINK_FEL_INFUSION))
+            continue;
+
+        Unit* victim = mob->GetVictim();
+        if (!victim || victim == bot)
+            continue;
+
+        float const dist = bot->GetExactDist2d(mob);
+        if (dist < bestDist)
+        {
+            bestDist = dist;
+            best = mob;
+        }
+    }
+
+    return best;
+}
+
+std::vector<std::string> const& TauntSpellNames()
+{
+    static std::vector<std::string> const names = { "taunt", "growl", "dark command", "hand of reckoning" };
+
+    return names;
+}
+
+void ClampIntoRoom(float& x, float& y)
+{
+    x = std::clamp(x, ROOM_X_MIN, ROOM_X_MAX);
+    y = std::clamp(y, ROOM_Y_MIN, ROOM_Y_MAX);
+}
+
+bool ShouldHoldTremorTotem(Player* bot)
+{
+    if (bot->getClass() != CLASS_SHAMAN || !bot->HasSpell(SPELL_TREMOR_TOTEM))
+        return false;
+
+    return RetinueEngaged(bot);
+}
+
+Unit* GetDelrissaFocusTarget(Player* bot, ObjectGuid& latched)
+{
+    std::vector<Unit*> sheep;
+    if (RetinueEngaged(bot))
+    {
+        std::vector<Unit*> found;
+        CollectCreaturesByEntry(bot, { NPC_HIGH_EXPLOSIVE_SHEEP }, FOCUS_SCAN, found);
+
+        for (Unit* mob : found)
+        {
+            if (AttackersValue::IsValidTarget(mob, bot))
+                sheep.push_back(mob);
+        }
+    }
+
+    return PickRankedFocus(bot, &RetinueFocusRank, sheep, latched);
+}
+
+void CollectDelrissaInterruptPreference(Player* bot, std::vector<Unit*>& out)
+{
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+
+    std::vector<std::pair<uint8, Unit*>> ranked;
+    auto const& attackers = botAI->GetAiObjectContext()->GetValue<GuidVector>("attackers")->Get();
+    for (ObjectGuid const guid : attackers)
+    {
+        Unit* caster = botAI->GetUnit(guid);
+        if (!caster || bot->GetExactDist2d(caster) > INTERRUPT_SCAN)
+            continue;
+
+        if (!RetinueFocusRank(caster->GetEntry()))
+            continue;
+
+        if (uint8 const prio = CurrentRetinueCastPriority(caster))
+            ranked.push_back({ prio, caster });
+    }
+
+    if (ranked.empty())
+        return;
+
+    std::sort(ranked.begin(), ranked.end(), [](auto const& a, auto const& b) {
+        if (a.first != b.first)
+            return a.first < b.first;
+
+        return a.second->GetGUID() < b.second->GetGUID();
+    });
+
+    size_t const slot = static_cast<size_t>(InterruptSlot(bot));
+    size_t const index = slot < ranked.size() ? slot : 0;
+
+    out.reserve(out.size() + ranked.size());
+    out.push_back(ranked[index].second);
+
+    for (size_t i = 0; i < ranked.size(); ++i)
+    {
+        if (i != index)
+            out.push_back(ranked[i].second);
+    }
+}
+
+void CollectDelrissaPets(Player* bot, std::vector<ObjectGuid>& out)
+{
+    std::vector<Unit*> pets;
+    CollectAttackersByEntry(bot, { NPC_FIZZLE, NPC_SLIVER }, FOCUS_SCAN, pets);
+
+    out.reserve(out.size() + pets.size());
+    for (Unit* pet : pets)
+        out.push_back(pet->GetGUID());
+}
+
+Unit* GetKaelInterruptTarget(Player* bot)
+{
+    Unit* kael = GetKaelthas(bot);
+    if (!kael || kael->HasAura(SPELL_SHOCK_BARRIER))
+        return nullptr;
+
+    return CurrentKaelCastPriority(kael) ? kael : nullptr;
+}
+
+bool IsKaelUnattackable(Player* bot)
+{
+    Unit* kael = GetKaelthas(bot);
+
+    return kael && kael->HasUnitFlag(UNIT_FLAG_IMMUNE_TO_PC);
+}
+
+void CollectFlameStrikeEscapes(Player* bot, EscapeSpots& out)
+{
+    if (!GetKaelthas(bot))
+        return;
+
+    std::vector<Hazard> hazards;
+
+    std::vector<Unit*> triggers;
+    CollectCreaturesByEntry(bot, { NPC_FLAMESTRIKE_TRIGGER }, FLAMESTRIKE_SCAN, triggers);
+    for (Unit* trigger : triggers)
+    {
+        hazards.push_back({ trigger->GetPositionX(), trigger->GetPositionY(), FLAMESTRIKE_STAND,
+                            FLAMESTRIKE_CLEAR });
+    }
+
+    for (uint32 spellId : { SPELL_FLAME_STRIKE, SPELL_FLAME_STRIKE_H })
+    {
+        for (Position const& pos : GetDynamicObjectPositions(bot, FLAMESTRIKE_SCAN, spellId))
+        {
+            hazards.push_back({ pos.GetPositionX(), pos.GetPositionY(), FLAMESTRIKE_STAND,
+                                FLAMESTRIKE_CLEAR });
+        }
+    }
+
+    CollectHazardEscapes(bot, hazards, 0.0f, out);
+}
+
+void CollectPhoenixEscapes(Player* bot, EscapeSpots& out)
+{
+    Unit* kael = GetKaelthas(bot);
+    if (!kael || LapseActive(bot, kael))
+        return;
+
+    bool const melee = PlayerbotAI::IsMelee(bot);
+    float const stand = melee ? BURN_MELEE_STAND : BURN_STAND;
+    float const clear = melee ? BURN_MELEE_CLEAR : BURN_CLEAR;
+
+    std::vector<Unit*> phoenixes;
+    CollectCreaturesByEntry(bot, { NPC_PHOENIX }, PHOENIX_SCAN, phoenixes);
+
+    std::vector<Hazard> hazards;
+    for (Unit* phoenix : phoenixes)
+    {
+        if (!phoenix->HasAura(SPELL_PHOENIX_BURN))
+            continue;
+
+        hazards.push_back({ phoenix->GetPositionX(), phoenix->GetPositionY(), stand, clear });
+    }
+
+    if (melee)
+        CollectRingEscapes(bot, kael, hazards, out);
+    else
+        CollectHazardEscapes(bot, hazards, 0.0f, out);
+}
+
+PhoenixRing GetPhoenixRing(Player* bot)
+{
+    if (!PlayerbotAI::IsMelee(bot))
+        return PhoenixRing::None;
+
+    Unit* kael = GetKaelthas(bot);
+    if (!kael || LapseActive(bot, kael))
+        return PhoenixRing::None;
+
+    float const gap = BurningPhoenixKaelGap(bot, kael);
+    if (gap >= KAEL_MELEE_RING + BURN_MELEE_CLEAR)
+        return PhoenixRing::None;
+
+    if (gap < BURN_MELEE_CLEAR - KAEL_MELEE_RING &&
+        bot->GetExactDist2d(kael) <= KAEL_MELEE_RING + BURN_MELEE_CLEAR)
+        return PhoenixRing::Covers;
+
+    return PhoenixRing::Threatens;
+}
+
+Unit* GetKaelFocusTarget(Player* bot)
+{
+    Unit* kael = GetKaelthas(bot);
+    if (!kael)
+        return nullptr;
+
+    if (kael->HasAura(SPELL_SHOCK_BARRIER) && AttackersValue::IsValidTarget(kael, bot))
+        return kael;
+
+    std::vector<Unit*> kin;
+    CollectCreaturesByEntry(bot, { NPC_PHOENIX_EGG, NPC_PHOENIX }, PHOENIX_SCAN, kin);
+
+    Unit* best = nullptr;
+    float bestDist = PHOENIX_SCAN;
+    for (Unit* egg : kin)
+    {
+        if (egg->GetEntry() != NPC_PHOENIX_EGG || !AttackersValue::IsValidTarget(egg, bot))
+            continue;
+
+        float const dist = bot->GetExactDist2d(egg);
+        if (dist < bestDist)
+        {
+            bestDist = dist;
+            best = egg;
+        }
+    }
+
+    if (best)
+        return best;
+
+    if (PlayerbotAI::IsMelee(bot))
+        return nullptr;
+
+    bestDist = PHOENIX_SCAN;
+    for (Unit* phoenix : kin)
+    {
+        if (phoenix->GetEntry() != NPC_PHOENIX || !phoenix->IsInCombat() ||
+            !AttackersValue::IsValidTarget(phoenix, bot))
+            continue;
+
+        float const dist = bot->GetExactDist2d(phoenix);
+        if (dist < bestDist)
+        {
+            bestDist = dist;
+            best = phoenix;
+        }
+    }
+
+    return best;
+}
+
+bool IsGravityLapseActive(Player* bot)
+{
+    return LapseActive(bot, GetKaelthas(bot));
+}
+
+void CollectLapseWorld(Player* bot, LapseWorld& out)
+{
+    std::vector<Unit*> units;
+    CollectCreaturesByEntry(bot, { NPC_ARCANE_SPHERE, NPC_PHOENIX }, std::max(SPHERE_SCAN, PHOENIX_SCAN), units);
+
+    for (Unit* unit : units)
+    {
+        if (unit->GetEntry() == NPC_ARCANE_SPHERE && bot->GetExactDist2d(unit) <= SPHERE_SCAN)
+            out.spheres.push_back(unit);
+        else if (unit->GetEntry() == NPC_PHOENIX && unit->HasAura(SPELL_PHOENIX_BURN) &&
+                 bot->GetExactDist2d(unit) <= PHOENIX_SCAN)
+            out.burns.push_back({ unit->GetPositionX(), unit->GetPositionY() });
+    }
+}
+
+bool GetGravityLapseKite(Player* bot, LapseWorld const& world, LapseSpot& out, KiteState& state)
+{
+    Unit* chaser = GetChasingSphere(bot, world);
+    if (!chaser)
+    {
+        state = KiteState{};
+        return false;
+    }
+
+    if (state.lastMs && GetMSTimeDiffToNow(state.lastMs) > KITE_COMMIT_BREAK_MS)
+        state = KiteState{};
+
+    float const bx = bot->GetPositionX();
+    float const by = bot->GetPositionY();
+
+    float ax = bx - chaser->GetPositionX();
+    float ay = by - chaser->GetPositionY();
+    float away = std::hypot(ax, ay);
+
+    if (away < 0.1f)
+    {
+        ax = bx - KAEL_P2.x;
+        ay = by - KAEL_P2.y;
+        away = std::hypot(ax, ay);
+        if (away < 0.1f)
+            return false;
+    }
+
+    ax /= away;
+    ay /= away;
+
+    bool const healer = IsLapseHealer(bot);
+    bool const outside = !InsideKiteArena(bx, by, healer);
+
+    float here = std::numeric_limits<float>::max();
+    for (Unit* other : world.spheres)
+        here = std::min(here, DistanceToSphereSweep(other, bx, by));
+
+    float const passBar = std::min(KITE_PASS_CLEAR, here - SPHERE_ROUTE_SLACK);
+
+    bool haveFallback = false;
+    float fallbackClear = -1.0f;
+    float fallbackTurn = 0.0f;
+    LapseSpot fallback = { bx, by };
+
+    for (int pass = 0; pass < 2; ++pass)
+    {
+        bool const requireFullLeg = pass == 0;
+
+        for (float magnitude : KITE_TURN_MAGNITUDES)
+        {
+            bool found = false;
+            float bestPreference = 0.0f;
+            float bestTurn = 0.0f;
+            LapseSpot best = { bx, by };
+
+            for (int side = 0; side < 2; ++side)
+            {
+                float const turn = side ? -magnitude : magnitude;
+                if (side && magnitude <= 0.0f)
+                    continue;
+
+                float const angle = turn * static_cast<float>(M_PI) / 180.0f;
+                float const cosT = std::cos(angle);
+                float const sinT = std::sin(angle);
+
+                float const hx = ax * cosT - ay * sinT;
+                float const hy = ax * sinT + ay * cosT;
+
+                float const x = bx + hx * KITE_LEG;
+                float const y = by + hy * KITE_LEG;
+
+                float const runway = KiteRunway(bx, by, hx, hy, healer, outside);
+
+                if (requireFullLeg ? runway < KITE_LEG : !InsideKiteArena(x, y, healer))
+                    continue;
+
+                float clearance = std::numeric_limits<float>::max();
+                for (Unit* other : world.spheres)
+                    clearance = std::min(clearance, WalkClearanceOfSphere(other, bx, by, x, y));
+
+                if (clearance < passBar)
+                {
+                    if (clearance > fallbackClear)
+                    {
+                        haveFallback = true;
+                        fallbackClear = clearance;
+                        fallbackTurn = turn;
+                        fallback = { x, y };
+                    }
+
+                    continue;
+                }
+
+                float preference = clearance + runway * KITE_RUNWAY_TIEBREAK;
+
+                if (std::fabs(turn) > KITE_COMMIT_STRAIGHT && std::fabs(state.turn) > KITE_COMMIT_STRAIGHT &&
+                    (turn > 0.0f) == (state.turn > 0.0f))
+                    preference += KITE_COMMIT_BONUS;
+
+                if (InsideAnyBurn(world.burns, x, y))
+                    preference -= LAPSE_BURN_COST;
+
+                if (!found || preference > bestPreference)
+                {
+                    found = true;
+                    bestPreference = preference;
+                    bestTurn = turn;
+                    best = { x, y };
+                }
+            }
+
+            if (found)
+            {
+                out = best;
+                state.turn = bestTurn;
+                state.lastMs = getMSTime();
+
+                return true;
+            }
+        }
+    }
+
+    if (!haveFallback)
+        return false;
+
+    out = fallback;
+    state.turn = fallbackTurn;
+    state.lastMs = getMSTime();
+
+    return true;
+}
+
+bool IsLapseMeleeSlot(Player* bot)
+{
+    LapseRole const role = ClassifyLapseRole(bot);
+
+    return role == LapseRole::Tank || role == LapseRole::Melee;
+}
+
+bool GetGravityLapseDodge(Player* bot, LapseWorld const& world, LapseSpot& out)
+{
+    if (world.spheres.empty())
+        return false;
+
+    float const bx = bot->GetPositionX();
+    float const by = bot->GetPositionY();
+
+    float here = std::numeric_limits<float>::max();
+    for (Unit* sphere : world.spheres)
+        here = std::min(here, DistanceToSphereSweep(sphere, bx, by));
+
+    if (here >= SPHERE_ALERT)
+        return false;
+
+    LapseSpot anchor = { bx, by };
+    LapseAnchor(bot, anchor);
+
+    bool const healer = IsLapseHealer(bot);
+
+    float const routeBar = std::min(SPHERE_TRANSIT, here - SPHERE_ROUTE_SLACK);
+
+    bool found = false;
+    float best = 0.0f;
+
+    bool haveFallback = false;
+    float fallbackClearance = 0.0f;
+    LapseSpot fallback = { bx, by };
+
+    for (float radius : SPHERE_DODGE_RADII)
+    {
+        for (int i = 0; i < SPHERE_DODGE_BEARINGS; ++i)
+        {
+            float const angle = (2.0f * static_cast<float>(M_PI) * i) / SPHERE_DODGE_BEARINGS;
+            float const x = bx + std::cos(angle) * radius;
+            float const y = by + std::sin(angle) * radius;
+
+            if (!InsideKiteArena(x, y, healer))
+                continue;
+
+            float clearance = std::numeric_limits<float>::max();
+            float route = std::numeric_limits<float>::max();
+            for (Unit* sphere : world.spheres)
+            {
+                clearance = std::min(clearance, DistanceToSphereSweep(sphere, x, y));
+                route = std::min(route, WalkClearanceOfSphere(sphere, bx, by, x, y));
+            }
+
+            if (route < routeBar)
+                continue;
+
+            if (clearance < SPHERE_CLEAR)
+            {
+                if (clearance > here + SPHERE_DODGE_MIN_GAIN && clearance > fallbackClearance)
+                {
+                    haveFallback = true;
+                    fallbackClearance = clearance;
+                    fallback = { x, y };
+                }
+
+                continue;
+            }
+
+            float const margin = std::min(clearance - SPHERE_CLEAR, SPHERE_DODGE_MARGIN_CAP);
+            float const score = std::hypot(x - anchor.x, y - anchor.y) +
+                                radius * SPHERE_DODGE_TRAVEL_COST - margin * SPHERE_DODGE_MARGIN_WEIGHT +
+                                (InsideAnyBurn(world.burns, x, y) ? LAPSE_BURN_COST : 0.0f);
+
+            if (!found || score < best)
+            {
+                best = score;
+                out = { x, y };
+                found = true;
+            }
+        }
+    }
+
+    if (found)
+        return true;
+
+    if (haveFallback)
+    {
+        out = fallback;
+        return true;
+    }
+
+    return false;
+}
+
+bool GetGravityLapseSpot(Player* bot, LapseWorld const& world, LapseSpot& out)
+{
+    if (!LapseAnchor(bot, out))
+        return false;
+
+    LapseSpot const anchor = out;
+
+    for (Unit* sphere : world.spheres)
+    {
+        float dx = out.x - sphere->GetPositionX();
+        float dy = out.y - sphere->GetPositionY();
+        float dist = std::hypot(dx, dy);
+        if (dist >= SPHERE_CLEAR)
+            continue;
+
+        if (dist < 0.1f)
+        {
+            dx = out.x - KAEL_P2.x;
+            dy = out.y - KAEL_P2.y;
+            dist = std::hypot(dx, dy);
+            if (dist < 0.1f)
+                break;
+        }
+
+        out.x = sphere->GetPositionX() + (dx / dist) * SPHERE_CLEAR;
+        out.y = sphere->GetPositionY() + (dy / dist) * SPHERE_CLEAR;
+    }
+
+    float const pushX = out.x - anchor.x;
+    float const pushY = out.y - anchor.y;
+    float const push = std::hypot(pushX, pushY);
+    if (push > LAPSE_PUSH_MAX)
+    {
+        out.x = anchor.x + (pushX / push) * LAPSE_PUSH_MAX;
+        out.y = anchor.y + (pushY / push) * LAPSE_PUSH_MAX;
+    }
+
+    bool const healer = IsLapseHealer(bot);
+    if (InsideKiteArena(anchor.x, anchor.y, healer) && !InsideKiteArena(out.x, out.y, healer))
+        out = anchor;
+
+    return true;
+}
+
+bool OnLapseStation(Player* bot, Unit* kael, LapseSpot const& spot)
+{
+    if (!IsLapseMeleeSlot(bot) || !kael)
+        return bot->GetExactDist2d(spot.x, spot.y) <= LAPSE_TOLERANCE;
+
+    return bot->IsWithinCombatRange(kael, sPlayerbotAIConfig.meleeDistance + CONTACT_DISTANCE);
+}
+
+bool LapseThreatened(Player* bot, LapseWorld const& world)
+{
+    float const bx = bot->GetPositionX();
+    float const by = bot->GetPositionY();
+
+    for (Unit* sphere : world.spheres)
+    {
+        if (DistanceToSphereSweep(sphere, bx, by) < SPHERE_ALERT)
+            return true;
+    }
+
+    return false;
+}
+
+bool GetLapseApproach(Player* bot, LapseWorld const& world, LapseSpot const& station, bool allowBlocked,
+                      LapseSpot& out)
+{
+    float const bx = bot->GetPositionX();
+    float const by = bot->GetPositionY();
+
+    float const gap = std::hypot(station.x - bx, station.y - by);
+    if (gap < 0.1f)
+        return false;
+
+    float const leg = std::min(LAPSE_LEG, gap);
+    float const progressBar = std::min(LAPSE_PROGRESS_MIN, leg * 0.5f);
+    float const dx = (station.x - bx) / gap;
+    float const dy = (station.y - by) / gap;
+
+    float here = std::numeric_limits<float>::max();
+    for (Unit* sphere : world.spheres)
+        here = std::min(here, DistanceToSphereSweep(sphere, bx, by));
+
+    float const routeBar = std::min(SPHERE_TRANSIT, here - SPHERE_ROUTE_SLACK);
+
+    bool haveFallback = false;
+    float fallbackRoute = -1.0f;
+    LapseSpot fallback = { bx, by };
+
+    for (float magnitude : LAPSE_DETOUR_TURNS)
+    {
+        bool found = false;
+        float bestRoute = 0.0f;
+        LapseSpot best = { bx, by };
+
+        for (int side = 0; side < 2; ++side)
+        {
+            if (side && magnitude <= 0.0f)
+                continue;
+
+            float const angle = (side ? -magnitude : magnitude) * static_cast<float>(M_PI) / 180.0f;
+            float const cosT = std::cos(angle);
+            float const sinT = std::sin(angle);
+
+            float const x = bx + (dx * cosT - dy * sinT) * leg;
+            float const y = by + (dx * sinT + dy * cosT) * leg;
+
+            if (gap - std::hypot(station.x - x, station.y - y) < progressBar)
+                continue;
+
+            float route = std::numeric_limits<float>::max();
+            for (Unit* sphere : world.spheres)
+                route = std::min(route, WalkClearanceOfSphere(sphere, bx, by, x, y));
+
+            if (route < routeBar)
+            {
+                if (route > fallbackRoute)
+                {
+                    haveFallback = true;
+                    fallbackRoute = route;
+                    fallback = { x, y };
+                }
+
+                continue;
+            }
+
+            if (!found || route > bestRoute)
+            {
+                found = true;
+                bestRoute = route;
+                best = { x, y };
+            }
+        }
+
+        if (found)
+        {
+            out = best;
+            return true;
+        }
+    }
+
+    if (!allowBlocked || !haveFallback)
+        return false;
+
+    out = fallback;
+
+    return true;
+}
+
+void CollectMeleePhoenixExclusions(Player* bot, std::vector<ObjectGuid>& out)
+{
+    if (!PlayerbotAI::IsMelee(bot) || !GetKaelthas(bot))
+        return;
+
+    std::vector<Unit*> phoenixes;
+    CollectCreaturesByEntry(bot, { NPC_PHOENIX }, PHOENIX_SCAN, phoenixes);
+
+    for (Unit* phoenix : phoenixes)
+        out.push_back(phoenix->GetGUID());
+}
+}

--- a/src/Ai/Dungeon/MgT/MgTShared.h
+++ b/src/Ai/Dungeon/MgT/MgTShared.h
@@ -1,0 +1,150 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_MGTSHARED_H
+#define PLAYERBOTS_MGTSHARED_H
+
+#include "Define.h"
+#include "ObjectGuid.h"
+#include <string>
+#include <vector>
+
+class Player;
+class PlayerbotAI;
+class Unit;
+
+namespace MagistersTerrace
+{
+constexpr uint32 MAP_MAGISTERS_TERRACE = 585;
+
+constexpr float SELIN_LEASH_X   = 216.0f;
+constexpr float SELIN_SAFE_X    = SELIN_LEASH_X + 4.0f;
+constexpr float SELIN_REGROUP_X = 232.0f;
+constexpr float SELIN_FLEE_SLACK = 6.0f;
+
+constexpr float GROUND_TIER_STEP   = 3.0f;
+constexpr float GROUND_SEARCH_UP   = 5.0f;
+constexpr float GROUND_SEARCH_DOWN = 12.0f;
+
+constexpr uint8 CONTROL_INTERRUPT_URGENCY = 2;
+
+struct EscapeSpot
+{
+    float x;
+    float y;
+    float z;
+};
+
+using EscapeSpots = std::vector<EscapeSpot>;
+
+struct LapseSpot
+{
+    float x;
+    float y;
+};
+
+struct LapseWorld
+{
+    std::vector<Unit*> spheres;
+    std::vector<LapseSpot> burns;
+};
+
+struct KiteState
+{
+    float turn = 0.0f;
+    uint32 lastMs = 0;
+};
+
+enum class PhoenixRing : uint8
+{
+    None,
+    Threatens,
+    Covers
+};
+
+enum class FocusOrder
+{
+    None,
+    Kael,
+    Delrissa,
+    Trash
+};
+
+Unit* GetSelin(Player* bot);
+Unit* GetKaelthas(Player* bot);
+
+Unit* GetActiveFelCrystal(Player* bot);
+
+void CollectDampeningEscapes(Player* bot, EscapeSpots& out);
+
+Unit* GetGlaiveThrowingMageGuard(Player* bot);
+
+void CollectNovaEscapes(Player* bot, EscapeSpots& out);
+
+std::string CastInterrupt(PlayerbotAI* botAI, Unit* target, uint8 urgency);
+
+Unit* GetInterruptTarget(Player* bot);
+
+uint8 GetInterruptUrgency(Unit* caster);
+uint8 GetRetinueInterruptUrgency(Unit* caster);
+
+Unit* GetFocusTarget(Player* bot, ObjectGuid& latched);
+
+ObjectGuid ResolveFocusOrder(PlayerbotAI* botAI);
+
+FocusOrder ResolveFocusOrderOwner(PlayerbotAI* botAI);
+
+void CollectFocusExclusions(Player* bot, std::vector<ObjectGuid>& out);
+
+Unit* GetEnragedWretched(Player* bot);
+
+std::vector<std::string> const& TauntSpellNames();
+
+void ClampIntoRoom(float& x, float& y);
+
+bool ShouldHoldTremorTotem(Player* bot);
+
+Unit* GetDelrissaFocusTarget(Player* bot, ObjectGuid& latched);
+
+void CollectDelrissaInterruptPreference(Player* bot, std::vector<Unit*>& out);
+
+void CollectDelrissaPets(Player* bot, std::vector<ObjectGuid>& out);
+
+void CollectFlameStrikeEscapes(Player* bot, EscapeSpots& out);
+
+void CollectPhoenixEscapes(Player* bot, EscapeSpots& out);
+
+PhoenixRing GetPhoenixRing(Player* bot);
+
+Unit* GetKaelInterruptTarget(Player* bot);
+
+bool IsKaelUnattackable(Player* bot);
+
+Unit* GetKaelFocusTarget(Player* bot);
+
+bool IsGravityLapseActive(Player* bot);
+
+void CollectLapseWorld(Player* bot, LapseWorld& out);
+
+bool GetGravityLapseKite(Player* bot, LapseWorld const& world, LapseSpot& out, KiteState& state);
+
+bool GetGravityLapseSpot(Player* bot, LapseWorld const& world, LapseSpot& out);
+
+bool GetGravityLapseDodge(Player* bot, LapseWorld const& world, LapseSpot& out);
+
+bool IsLapseMeleeSlot(Player* bot);
+
+bool OnLapseStation(Player* bot, Unit* kael, LapseSpot const& spot);
+
+bool LapseThreatened(Player* bot, LapseWorld const& world);
+
+bool GetLapseApproach(Player* bot, LapseWorld const& world, LapseSpot const& station, bool allowBlocked,
+                      LapseSpot& out);
+
+void CollectMeleePhoenixExclusions(Player* bot, std::vector<ObjectGuid>& out);
+}
+
+#endif

--- a/src/Ai/Dungeon/MgT/MgTStrategy.cpp
+++ b/src/Ai/Dungeon/MgT/MgTStrategy.cpp
@@ -1,0 +1,93 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "MgTStrategy.h"
+#include "MgTMultipliers.h"
+#include "MgTTriggers.h"
+#include "Playerbots.h"
+
+void TbcDungeonMagistersTerraceStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+{
+    triggers.push_back(new TriggerNode("mgt out of room", {
+        NextAction("mgt return to room", ACTION_EMERGENCY + 10) }));
+
+    triggers.push_back(new TriggerNode("mgt crystal active", {
+        NextAction("mgt kill crystal", ACTION_EMERGENCY + 8) }));
+
+    triggers.push_back(new TriggerNode("mgt in dampening field", {
+        NextAction("mgt leave dampening field", ACTION_EMERGENCY + 6) }));
+
+    triggers.push_back(new TriggerNode("mgt priority interrupt", {
+        NextAction("mgt priority interrupt", ACTION_INTERRUPT + 5) }));
+
+    triggers.push_back(new TriggerNode("mgt arcane nova range", {
+        NextAction("mgt clear arcane nova", ACTION_EMERGENCY + 4) }));
+
+    triggers.push_back(new TriggerNode("mgt mage guard at range", {
+        NextAction("mgt close on mage guard", ACTION_MOVE + 5) }));
+
+    triggers.push_back(new TriggerNode("mgt enraged wretched", {
+        NextAction("mgt taunt enraged wretched", ACTION_HIGH + 2) }));
+
+    triggers.push_back(new TriggerNode("mgt focus target", {
+        NextAction("mgt focus target", ACTION_RAID + 2) }));
+
+    triggers.push_back(new TriggerNode("mgt delrissa interrupt", {
+        NextAction("mgt delrissa interrupt", ACTION_INTERRUPT + 5) }));
+
+    triggers.push_back(new TriggerNode("mgt delrissa focus target", {
+        NextAction("mgt delrissa focus target", ACTION_RAID + 2) }));
+
+    triggers.push_back(new TriggerNode("mgt delrissa tremor totem", {
+        NextAction("mgt delrissa tremor totem", ACTION_HIGH + 5) }));
+
+    triggers.push_back(new TriggerNode("mgt flame strike", {
+        NextAction("mgt leave flame strike", ACTION_EMERGENCY + 7) }));
+
+    triggers.push_back(new TriggerNode("mgt phoenix burn", {
+        NextAction("mgt leave phoenix burn", ACTION_EMERGENCY + 6) }));
+
+    triggers.push_back(new TriggerNode("mgt kael focus target", {
+        NextAction("mgt kael focus target", ACTION_RAID + 2) }));
+
+    triggers.push_back(new TriggerNode("mgt kael interrupt", {
+        NextAction("mgt kael interrupt", ACTION_INTERRUPT + 6) }));
+
+    triggers.push_back(new TriggerNode("mgt gravity lapse", {
+        NextAction("mgt take lapse spot", ACTION_MOVE + 8) }));
+}
+
+void TbcDungeonMagistersTerraceStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
+{
+    multipliers.push_back(new MgTCrystalFocusMultiplier(botAI));
+    multipliers.push_back(new MgTFocusOrderMultiplier(botAI));
+    multipliers.push_back(new MgTFocusBurstMultiplier(botAI));
+    multipliers.push_back(new MgTRoomLeashMultiplier(botAI));
+    multipliers.push_back(new MgTDampeningFieldMultiplier(botAI));
+    multipliers.push_back(new MgTDelrissaTremorTotemMultiplier(botAI));
+    multipliers.push_back(new MgTFlameStrikeMultiplier(botAI));
+    multipliers.push_back(new MgTPhoenixBurnMultiplier(botAI));
+    multipliers.push_back(new MgTKaelUnattackableMultiplier(botAI));
+    multipliers.push_back(new MgTGravityLapseMultiplier(botAI));
+}
+
+void TbcDungeonMagistersTerraceStrategy::AppendTargetExclusions(GuidSet& exclusions,
+                                                               TargetValueExclusionType type)
+{
+    AiObjectContext* context = botAI->GetAiObjectContext();
+
+    for (ObjectGuid const guid : context->GetValue<GuidVector>("mgt delrissa pets")->Get())
+        exclusions.insert(guid);
+
+    for (ObjectGuid const guid : context->GetValue<GuidVector>("mgt melee phoenix exclusions")->Get())
+        exclusions.insert(guid);
+
+    if (type != TargetValueExclusionType::Attacker)
+        return;
+
+    for (ObjectGuid const guid : context->GetValue<GuidVector>("mgt focus exclusions")->Get())
+        exclusions.insert(guid);
+}

--- a/src/Ai/Dungeon/MgT/MgTStrategy.h
+++ b/src/Ai/Dungeon/MgT/MgTStrategy.h
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_MGTSTRATEGY_H
+#define PLAYERBOTS_MGTSTRATEGY_H
+
+#include "AiObjectContext.h"
+#include "Multiplier.h"
+#include "Strategy.h"
+
+class TbcDungeonMagistersTerraceStrategy : public Strategy
+{
+public:
+    TbcDungeonMagistersTerraceStrategy(PlayerbotAI* botAI) : Strategy(botAI) {}
+
+    std::string const getName() override { return "tbc-mgt"; }
+
+    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
+    void InitMultipliers(std::vector<Multiplier*>& multipliers) override;
+
+    bool HasTargetExclusions() const override { return true; }
+    void AppendTargetExclusions(GuidSet& exclusions, TargetValueExclusionType type) override;
+};
+
+#endif

--- a/src/Ai/Dungeon/MgT/MgTTriggerContext.h
+++ b/src/Ai/Dungeon/MgT/MgTTriggerContext.h
@@ -1,0 +1,64 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_MGTTRIGGERCONTEXT_H
+#define PLAYERBOTS_MGTTRIGGERCONTEXT_H
+
+#include "AiObjectContext.h"
+#include "MgTTriggers.h"
+#include "TriggerContext.h"
+
+class TbcDungeonMagistersTerraceTriggerContext : public NamedObjectContext<Trigger>
+{
+public:
+    TbcDungeonMagistersTerraceTriggerContext()
+    {
+        creators["mgt crystal active"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_crystal_active;
+        creators["mgt out of room"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_out_of_room;
+        creators["mgt in dampening field"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_in_dampening_field;
+        creators["mgt mage guard at range"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_mage_guard_at_range;
+        creators["mgt arcane nova range"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_arcane_nova_range;
+        creators["mgt priority interrupt"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_priority_interrupt;
+        creators["mgt focus target"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_focus_target;
+        creators["mgt enraged wretched"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_enraged_wretched;
+        creators["mgt delrissa interrupt"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_delrissa_interrupt;
+        creators["mgt delrissa focus target"] =
+            &TbcDungeonMagistersTerraceTriggerContext::mgt_delrissa_focus_target;
+        creators["mgt delrissa tremor totem"] =
+            &TbcDungeonMagistersTerraceTriggerContext::mgt_delrissa_tremor_totem;
+        creators["mgt flame strike"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_flame_strike;
+        creators["mgt phoenix burn"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_phoenix_burn;
+        creators["mgt kael focus target"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_kael_focus_target;
+        creators["mgt kael interrupt"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_kael_interrupt;
+        creators["mgt gravity lapse"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_gravity_lapse;
+    }
+
+private:
+    static Trigger* mgt_crystal_active(PlayerbotAI* botAI) { return new MgTCrystalActiveTrigger(botAI); }
+    static Trigger* mgt_out_of_room(PlayerbotAI* botAI) { return new MgTOutOfRoomTrigger(botAI); }
+    static Trigger* mgt_in_dampening_field(PlayerbotAI* botAI) { return new MgTInDampeningFieldTrigger(botAI); }
+    static Trigger* mgt_mage_guard_at_range(PlayerbotAI* botAI) { return new MgTMageGuardAtRangeTrigger(botAI); }
+    static Trigger* mgt_arcane_nova_range(PlayerbotAI* botAI) { return new MgTArcaneNovaRangeTrigger(botAI); }
+    static Trigger* mgt_priority_interrupt(PlayerbotAI* botAI) { return new MgTPriorityInterruptTrigger(botAI); }
+    static Trigger* mgt_focus_target(PlayerbotAI* botAI) { return new MgTFocusTargetTrigger(botAI); }
+    static Trigger* mgt_enraged_wretched(PlayerbotAI* botAI) { return new MgTEnragedWretchedTrigger(botAI); }
+    static Trigger* mgt_delrissa_interrupt(PlayerbotAI* botAI) { return new MgTDelrissaInterruptTrigger(botAI); }
+    static Trigger* mgt_delrissa_focus_target(PlayerbotAI* botAI)
+    {
+        return new MgTDelrissaFocusTargetTrigger(botAI);
+    }
+    static Trigger* mgt_delrissa_tremor_totem(PlayerbotAI* botAI)
+    {
+        return new MgTDelrissaTremorTotemTrigger(botAI);
+    }
+    static Trigger* mgt_flame_strike(PlayerbotAI* botAI) { return new MgTFlameStrikeTrigger(botAI); }
+    static Trigger* mgt_phoenix_burn(PlayerbotAI* botAI) { return new MgTPhoenixBurnTrigger(botAI); }
+    static Trigger* mgt_kael_focus_target(PlayerbotAI* botAI) { return new MgTKaelFocusTargetTrigger(botAI); }
+    static Trigger* mgt_kael_interrupt(PlayerbotAI* botAI) { return new MgTKaelInterruptTrigger(botAI); }
+    static Trigger* mgt_gravity_lapse(PlayerbotAI* botAI) { return new MgTGravityLapseTrigger(botAI); }
+};
+
+#endif

--- a/src/Ai/Dungeon/MgT/MgTTriggers.cpp
+++ b/src/Ai/Dungeon/MgT/MgTTriggers.cpp
@@ -1,0 +1,124 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "MgTTriggers.h"
+#include "AiObjectContext.h"
+#include "MgTShared.h"
+#include "Playerbots.h"
+
+bool MgTCrystalActiveTrigger::IsActive()
+{
+    return !AI_VALUE(ObjectGuid, "mgt crystal target").IsEmpty();
+}
+
+bool MgTOutOfRoomTrigger::IsActive()
+{
+    if (bot->GetPositionX() >= MagistersTerrace::SELIN_SAFE_X)
+        return false;
+
+    return MagistersTerrace::GetSelin(bot) != nullptr;
+}
+
+bool MgTInDampeningFieldTrigger::IsActive()
+{
+    auto const& spots = AI_VALUE_REF(MagistersTerrace::EscapeSpots, "mgt dampening escape");
+    return !spots.empty();
+}
+
+bool MgTMageGuardAtRangeTrigger::IsActive()
+{
+    return !AI_VALUE(ObjectGuid, "mgt mage guard target").IsEmpty();
+}
+
+bool MgTArcaneNovaRangeTrigger::IsActive()
+{
+    auto const& spots = AI_VALUE_REF(MagistersTerrace::EscapeSpots, "mgt nova escape");
+    return !spots.empty();
+}
+
+bool MgTPriorityInterruptTrigger::IsActive()
+{
+    return !AI_VALUE(ObjectGuid, "mgt interrupt target").IsEmpty();
+}
+
+bool MgTFocusTargetTrigger::IsActive()
+{
+    if (!bot->IsInCombat())
+        return false;
+
+    if (!PlayerbotAI::IsDps(bot) || PlayerbotAI::IsTank(bot))
+        return false;
+
+    if (!AI_VALUE(ObjectGuid, "mgt crystal target").IsEmpty())
+        return false;
+
+    ObjectGuid const order = AI_VALUE(ObjectGuid, "mgt focus target");
+    return !order.IsEmpty() && MagistersTerrace::ResolveFocusOrder(botAI) == order;
+}
+
+bool MgTEnragedWretchedTrigger::IsActive()
+{
+    return !AI_VALUE(ObjectGuid, "mgt enraged wretched").IsEmpty();
+}
+
+bool MgTDelrissaInterruptTrigger::IsActive()
+{
+    auto const& order = AI_VALUE_REF(GuidVector, "mgt delrissa interrupt order");
+    return !order.empty();
+}
+
+bool MgTDelrissaFocusTargetTrigger::IsActive()
+{
+    if (!bot->IsInCombat())
+        return false;
+
+    if (!PlayerbotAI::IsDps(bot) || PlayerbotAI::IsTank(bot))
+        return false;
+
+    ObjectGuid const order = AI_VALUE(ObjectGuid, "mgt delrissa focus target");
+    return !order.IsEmpty() && MagistersTerrace::ResolveFocusOrder(botAI) == order;
+}
+
+bool MgTDelrissaTremorTotemTrigger::IsActive()
+{
+    if (!AI_VALUE(bool, "mgt delrissa tremor totem"))
+        return false;
+
+    return !AI_VALUE2(bool, "has totem", "tremor totem");
+}
+
+bool MgTFlameStrikeTrigger::IsActive()
+{
+    auto const& spots = AI_VALUE_REF(MagistersTerrace::EscapeSpots, "mgt flame strike escape");
+    return !spots.empty();
+}
+
+bool MgTPhoenixBurnTrigger::IsActive()
+{
+    auto const& spots = AI_VALUE_REF(MagistersTerrace::EscapeSpots, "mgt phoenix escape");
+    return !spots.empty();
+}
+
+bool MgTKaelFocusTargetTrigger::IsActive()
+{
+    if (!bot->IsInCombat())
+        return false;
+
+    if (!PlayerbotAI::IsDps(bot) || PlayerbotAI::IsTank(bot))
+        return false;
+
+    return !AI_VALUE(ObjectGuid, "mgt kael focus target").IsEmpty();
+}
+
+bool MgTKaelInterruptTrigger::IsActive()
+{
+    return !AI_VALUE(ObjectGuid, "mgt kael interrupt target").IsEmpty();
+}
+
+bool MgTGravityLapseTrigger::IsActive()
+{
+    return AI_VALUE(bool, "mgt gravity lapse");
+}

--- a/src/Ai/Dungeon/MgT/MgTTriggers.h
+++ b/src/Ai/Dungeon/MgT/MgTTriggers.h
@@ -1,0 +1,125 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_MGTTRIGGERS_H
+#define PLAYERBOTS_MGTTRIGGERS_H
+
+#include "MgTShared.h"
+#include "Trigger.h"
+
+class MgTCrystalActiveTrigger : public Trigger
+{
+public:
+    MgTCrystalActiveTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt crystal active") {}
+    bool IsActive() override;
+};
+
+class MgTOutOfRoomTrigger : public Trigger
+{
+public:
+    MgTOutOfRoomTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt out of room") {}
+    bool IsActive() override;
+};
+
+class MgTInDampeningFieldTrigger : public Trigger
+{
+public:
+    MgTInDampeningFieldTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt in dampening field") {}
+    bool IsActive() override;
+};
+
+class MgTMageGuardAtRangeTrigger : public Trigger
+{
+public:
+    MgTMageGuardAtRangeTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt mage guard at range") {}
+    bool IsActive() override;
+};
+
+class MgTArcaneNovaRangeTrigger : public Trigger
+{
+public:
+    MgTArcaneNovaRangeTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt arcane nova range") {}
+    bool IsActive() override;
+};
+
+class MgTPriorityInterruptTrigger : public Trigger
+{
+public:
+    MgTPriorityInterruptTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt priority interrupt") {}
+    bool IsActive() override;
+};
+
+class MgTFocusTargetTrigger : public Trigger
+{
+public:
+    MgTFocusTargetTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt focus target") {}
+    bool IsActive() override;
+};
+
+class MgTEnragedWretchedTrigger : public Trigger
+{
+public:
+    MgTEnragedWretchedTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt enraged wretched") {}
+    bool IsActive() override;
+};
+
+class MgTDelrissaInterruptTrigger : public Trigger
+{
+public:
+    MgTDelrissaInterruptTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt delrissa interrupt") {}
+    bool IsActive() override;
+};
+
+class MgTDelrissaFocusTargetTrigger : public Trigger
+{
+public:
+    MgTDelrissaFocusTargetTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt delrissa focus target") {}
+    bool IsActive() override;
+};
+
+class MgTDelrissaTremorTotemTrigger : public Trigger
+{
+public:
+    MgTDelrissaTremorTotemTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt delrissa tremor totem") {}
+    bool IsActive() override;
+};
+
+class MgTFlameStrikeTrigger : public Trigger
+{
+public:
+    MgTFlameStrikeTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt flame strike") {}
+    bool IsActive() override;
+};
+
+class MgTPhoenixBurnTrigger : public Trigger
+{
+public:
+    MgTPhoenixBurnTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt phoenix burn") {}
+    bool IsActive() override;
+};
+
+class MgTKaelFocusTargetTrigger : public Trigger
+{
+public:
+    MgTKaelFocusTargetTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt kael focus target") {}
+    bool IsActive() override;
+};
+
+class MgTKaelInterruptTrigger : public Trigger
+{
+public:
+    MgTKaelInterruptTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt kael interrupt") {}
+    bool IsActive() override;
+};
+
+class MgTGravityLapseTrigger : public Trigger
+{
+public:
+    MgTGravityLapseTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt gravity lapse") {}
+    bool IsActive() override;
+};
+
+#endif

--- a/src/Ai/Dungeon/MgT/MgTValueContext.h
+++ b/src/Ai/Dungeon/MgT/MgTValueContext.h
@@ -1,0 +1,376 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_MGTVALUECONTEXT_H
+#define PLAYERBOTS_MGTVALUECONTEXT_H
+
+#include "MgTShared.h"
+#include "NamedObjectContext.h"
+#include "ObjectGuid.h"
+#include "PlayerbotAI.h"
+#include "Unit.h"
+#include "Value.h"
+
+class MgTEscapeSpotsValue : public CalculatedValue<MagistersTerrace::EscapeSpots>
+{
+public:
+    MgTEscapeSpotsValue(PlayerbotAI* botAI, std::string const name)
+        : CalculatedValue<MagistersTerrace::EscapeSpots>(botAI, name, 200)
+    {
+    }
+};
+
+class MgTDampeningEscapeValue : public MgTEscapeSpotsValue
+{
+public:
+    MgTDampeningEscapeValue(PlayerbotAI* botAI) : MgTEscapeSpotsValue(botAI, "mgt dampening escape") {}
+
+protected:
+    MagistersTerrace::EscapeSpots Calculate() override
+    {
+        MagistersTerrace::EscapeSpots spots;
+        MagistersTerrace::CollectDampeningEscapes(bot, spots);
+        return spots;
+    }
+};
+
+class MgTNovaEscapeValue : public MgTEscapeSpotsValue
+{
+public:
+    MgTNovaEscapeValue(PlayerbotAI* botAI) : MgTEscapeSpotsValue(botAI, "mgt nova escape") {}
+
+protected:
+    MagistersTerrace::EscapeSpots Calculate() override
+    {
+        MagistersTerrace::EscapeSpots spots;
+        MagistersTerrace::CollectNovaEscapes(bot, spots);
+        return spots;
+    }
+};
+
+class MgTFlameStrikeEscapeValue : public MgTEscapeSpotsValue
+{
+public:
+    MgTFlameStrikeEscapeValue(PlayerbotAI* botAI) : MgTEscapeSpotsValue(botAI, "mgt flame strike escape") {}
+
+protected:
+    MagistersTerrace::EscapeSpots Calculate() override
+    {
+        MagistersTerrace::EscapeSpots spots;
+        MagistersTerrace::CollectFlameStrikeEscapes(bot, spots);
+        return spots;
+    }
+};
+
+class MgTPhoenixEscapeValue : public MgTEscapeSpotsValue
+{
+public:
+    MgTPhoenixEscapeValue(PlayerbotAI* botAI) : MgTEscapeSpotsValue(botAI, "mgt phoenix escape") {}
+
+protected:
+    MagistersTerrace::EscapeSpots Calculate() override
+    {
+        MagistersTerrace::EscapeSpots spots;
+        MagistersTerrace::CollectPhoenixEscapes(bot, spots);
+        return spots;
+    }
+};
+
+class MgTPhoenixRingValue : public CalculatedValue<MagistersTerrace::PhoenixRing>
+{
+public:
+    MgTPhoenixRingValue(PlayerbotAI* botAI)
+        : CalculatedValue<MagistersTerrace::PhoenixRing>(botAI, "mgt phoenix ring", 200)
+    {
+    }
+
+protected:
+    MagistersTerrace::PhoenixRing Calculate() override { return MagistersTerrace::GetPhoenixRing(bot); }
+};
+
+class MgTCrystalTargetValue : public ObjectGuidCalculatedValue
+{
+public:
+    MgTCrystalTargetValue(PlayerbotAI* botAI) : ObjectGuidCalculatedValue(botAI, "mgt crystal target", 200) {}
+
+protected:
+    ObjectGuid Calculate() override
+    {
+        Unit* crystal = MagistersTerrace::GetActiveFelCrystal(bot);
+        return crystal ? crystal->GetGUID() : ObjectGuid::Empty;
+    }
+};
+
+class MgTMageGuardTargetValue : public ObjectGuidCalculatedValue
+{
+public:
+    MgTMageGuardTargetValue(PlayerbotAI* botAI) : ObjectGuidCalculatedValue(botAI, "mgt mage guard target", 200) {}
+
+protected:
+    ObjectGuid Calculate() override
+    {
+        if (!PlayerbotAI::IsTank(bot))
+            return ObjectGuid::Empty;
+
+        Unit* guard = MagistersTerrace::GetGlaiveThrowingMageGuard(bot);
+        return guard ? guard->GetGUID() : ObjectGuid::Empty;
+    }
+};
+
+class MgTEnragedWretchedValue : public ObjectGuidCalculatedValue
+{
+public:
+    MgTEnragedWretchedValue(PlayerbotAI* botAI) : ObjectGuidCalculatedValue(botAI, "mgt enraged wretched", 200) {}
+
+protected:
+    ObjectGuid Calculate() override
+    {
+        if (!PlayerbotAI::IsTank(bot))
+            return ObjectGuid::Empty;
+
+        Unit* wretched = MagistersTerrace::GetEnragedWretched(bot);
+        return wretched ? wretched->GetGUID() : ObjectGuid::Empty;
+    }
+};
+
+class MgTInterruptTargetValue : public ObjectGuidCalculatedValue
+{
+public:
+    MgTInterruptTargetValue(PlayerbotAI* botAI) : ObjectGuidCalculatedValue(botAI, "mgt interrupt target", 200) {}
+
+protected:
+    ObjectGuid Calculate() override
+    {
+        Unit* target = MagistersTerrace::GetInterruptTarget(bot);
+        return target ? target->GetGUID() : ObjectGuid::Empty;
+    }
+};
+
+class MgTSunbladeFocusTargetValue : public ObjectGuidCalculatedValue
+{
+public:
+    MgTSunbladeFocusTargetValue(PlayerbotAI* botAI) : ObjectGuidCalculatedValue(botAI, "mgt focus target", 200) {}
+
+protected:
+    ObjectGuid Calculate() override
+    {
+        Unit* target = MagistersTerrace::GetFocusTarget(bot, _latched);
+        return target ? target->GetGUID() : ObjectGuid::Empty;
+    }
+
+private:
+    ObjectGuid _latched;
+};
+
+class MgTDelrissaInterruptOrderValue : public ObjectGuidListCalculatedValue
+{
+public:
+    MgTDelrissaInterruptOrderValue(PlayerbotAI* botAI)
+        : ObjectGuidListCalculatedValue(botAI, "mgt delrissa interrupt order", 200)
+    {
+    }
+
+protected:
+    GuidVector Calculate() override
+    {
+        std::vector<Unit*> preference;
+        MagistersTerrace::CollectDelrissaInterruptPreference(bot, preference);
+
+        GuidVector order;
+        order.reserve(preference.size());
+        for (Unit* caster : preference)
+            order.push_back(caster->GetGUID());
+
+        return order;
+    }
+};
+
+class MgTDelrissaFocusTargetValue : public ObjectGuidCalculatedValue
+{
+public:
+    MgTDelrissaFocusTargetValue(PlayerbotAI* botAI)
+        : ObjectGuidCalculatedValue(botAI, "mgt delrissa focus target", 200)
+    {
+    }
+
+protected:
+    ObjectGuid Calculate() override
+    {
+        Unit* target = MagistersTerrace::GetDelrissaFocusTarget(bot, _latched);
+        return target ? target->GetGUID() : ObjectGuid::Empty;
+    }
+
+private:
+    ObjectGuid _latched;
+};
+
+class MgTDelrissaTremorTotemValue : public BoolCalculatedValue
+{
+public:
+    MgTDelrissaTremorTotemValue(PlayerbotAI* botAI) : BoolCalculatedValue(botAI, "mgt delrissa tremor totem", 500) {}
+
+protected:
+    bool Calculate() override { return MagistersTerrace::ShouldHoldTremorTotem(bot); }
+};
+
+class MgTDelrissaPetsValue : public ObjectGuidListCalculatedValue
+{
+public:
+    MgTDelrissaPetsValue(PlayerbotAI* botAI) : ObjectGuidListCalculatedValue(botAI, "mgt delrissa pets", 500) {}
+
+protected:
+    GuidVector Calculate() override
+    {
+        GuidVector pets;
+        MagistersTerrace::CollectDelrissaPets(bot, pets);
+        return pets;
+    }
+};
+
+class MgTKaelFocusTargetValue : public ObjectGuidCalculatedValue
+{
+public:
+    MgTKaelFocusTargetValue(PlayerbotAI* botAI) : ObjectGuidCalculatedValue(botAI, "mgt kael focus target", 200) {}
+
+protected:
+    ObjectGuid Calculate() override
+    {
+        Unit* target = MagistersTerrace::GetKaelFocusTarget(bot);
+        return target ? target->GetGUID() : ObjectGuid::Empty;
+    }
+};
+
+class MgTGravityLapseValue : public BoolCalculatedValue
+{
+public:
+    MgTGravityLapseValue(PlayerbotAI* botAI) : BoolCalculatedValue(botAI, "mgt gravity lapse", 200) {}
+
+protected:
+    bool Calculate() override { return MagistersTerrace::IsGravityLapseActive(bot); }
+};
+
+class MgTKaelUnattackableValue : public BoolCalculatedValue
+{
+public:
+    MgTKaelUnattackableValue(PlayerbotAI* botAI) : BoolCalculatedValue(botAI, "mgt kael unattackable", 500) {}
+
+protected:
+    bool Calculate() override { return MagistersTerrace::IsKaelUnattackable(bot); }
+};
+
+class MgTKaelInterruptTargetValue : public ObjectGuidCalculatedValue
+{
+public:
+    MgTKaelInterruptTargetValue(PlayerbotAI* botAI)
+        : ObjectGuidCalculatedValue(botAI, "mgt kael interrupt target", 200)
+    {
+    }
+
+protected:
+    ObjectGuid Calculate() override
+    {
+        Unit* target = MagistersTerrace::GetKaelInterruptTarget(bot);
+        return target ? target->GetGUID() : ObjectGuid::Empty;
+    }
+};
+
+class MgTMeleePhoenixExclusionsValue : public ObjectGuidListCalculatedValue
+{
+public:
+    MgTMeleePhoenixExclusionsValue(PlayerbotAI* botAI)
+        : ObjectGuidListCalculatedValue(botAI, "mgt melee phoenix exclusions", 500)
+    {
+    }
+
+protected:
+    GuidVector Calculate() override
+    {
+        GuidVector phoenixes;
+        MagistersTerrace::CollectMeleePhoenixExclusions(bot, phoenixes);
+        return phoenixes;
+    }
+};
+
+class MgTFocusExclusionsValue : public ObjectGuidListCalculatedValue
+{
+public:
+    MgTFocusExclusionsValue(PlayerbotAI* botAI) : ObjectGuidListCalculatedValue(botAI, "mgt focus exclusions", 200) {}
+
+protected:
+    GuidVector Calculate() override
+    {
+        GuidVector exclusions;
+        MagistersTerrace::CollectFocusExclusions(bot, exclusions);
+        return exclusions;
+    }
+};
+
+class TbcDungeonMgTValueContext : public NamedObjectContext<UntypedValue>
+{
+public:
+    TbcDungeonMgTValueContext()
+    {
+        creators["mgt crystal target"] = &TbcDungeonMgTValueContext::mgt_crystal_target;
+        creators["mgt dampening escape"] = &TbcDungeonMgTValueContext::mgt_dampening_escape;
+        creators["mgt nova escape"] = &TbcDungeonMgTValueContext::mgt_nova_escape;
+        creators["mgt mage guard target"] = &TbcDungeonMgTValueContext::mgt_mage_guard_target;
+        creators["mgt enraged wretched"] = &TbcDungeonMgTValueContext::mgt_enraged_wretched;
+        creators["mgt interrupt target"] = &TbcDungeonMgTValueContext::mgt_interrupt_target;
+        creators["mgt focus target"] = &TbcDungeonMgTValueContext::mgt_focus_target;
+        creators["mgt delrissa interrupt order"] = &TbcDungeonMgTValueContext::mgt_delrissa_interrupt_order;
+        creators["mgt delrissa focus target"] = &TbcDungeonMgTValueContext::mgt_delrissa_focus_target;
+        creators["mgt delrissa tremor totem"] = &TbcDungeonMgTValueContext::mgt_delrissa_tremor_totem;
+        creators["mgt delrissa pets"] = &TbcDungeonMgTValueContext::mgt_delrissa_pets;
+        creators["mgt flame strike escape"] = &TbcDungeonMgTValueContext::mgt_flame_strike_escape;
+        creators["mgt phoenix escape"] = &TbcDungeonMgTValueContext::mgt_phoenix_escape;
+        creators["mgt phoenix ring"] = &TbcDungeonMgTValueContext::mgt_phoenix_ring;
+        creators["mgt kael focus target"] = &TbcDungeonMgTValueContext::mgt_kael_focus_target;
+        creators["mgt kael interrupt target"] = &TbcDungeonMgTValueContext::mgt_kael_interrupt_target;
+        creators["mgt kael unattackable"] = &TbcDungeonMgTValueContext::mgt_kael_unattackable;
+        creators["mgt gravity lapse"] = &TbcDungeonMgTValueContext::mgt_gravity_lapse;
+        creators["mgt melee phoenix exclusions"] = &TbcDungeonMgTValueContext::mgt_melee_phoenix_exclusions;
+        creators["mgt focus exclusions"] = &TbcDungeonMgTValueContext::mgt_focus_exclusions;
+    }
+
+private:
+    static UntypedValue* mgt_crystal_target(PlayerbotAI* botAI) { return new MgTCrystalTargetValue(botAI); }
+    static UntypedValue* mgt_dampening_escape(PlayerbotAI* botAI) { return new MgTDampeningEscapeValue(botAI); }
+    static UntypedValue* mgt_nova_escape(PlayerbotAI* botAI) { return new MgTNovaEscapeValue(botAI); }
+    static UntypedValue* mgt_mage_guard_target(PlayerbotAI* botAI) { return new MgTMageGuardTargetValue(botAI); }
+    static UntypedValue* mgt_enraged_wretched(PlayerbotAI* botAI) { return new MgTEnragedWretchedValue(botAI); }
+    static UntypedValue* mgt_interrupt_target(PlayerbotAI* botAI) { return new MgTInterruptTargetValue(botAI); }
+    static UntypedValue* mgt_focus_target(PlayerbotAI* botAI) { return new MgTSunbladeFocusTargetValue(botAI); }
+    static UntypedValue* mgt_delrissa_interrupt_order(PlayerbotAI* botAI)
+    {
+        return new MgTDelrissaInterruptOrderValue(botAI);
+    }
+    static UntypedValue* mgt_delrissa_focus_target(PlayerbotAI* botAI)
+    {
+        return new MgTDelrissaFocusTargetValue(botAI);
+    }
+    static UntypedValue* mgt_delrissa_tremor_totem(PlayerbotAI* botAI)
+    {
+        return new MgTDelrissaTremorTotemValue(botAI);
+    }
+    static UntypedValue* mgt_delrissa_pets(PlayerbotAI* botAI) { return new MgTDelrissaPetsValue(botAI); }
+    static UntypedValue* mgt_flame_strike_escape(PlayerbotAI* botAI) { return new MgTFlameStrikeEscapeValue(botAI); }
+    static UntypedValue* mgt_phoenix_escape(PlayerbotAI* botAI) { return new MgTPhoenixEscapeValue(botAI); }
+    static UntypedValue* mgt_phoenix_ring(PlayerbotAI* botAI) { return new MgTPhoenixRingValue(botAI); }
+    static UntypedValue* mgt_kael_focus_target(PlayerbotAI* botAI) { return new MgTKaelFocusTargetValue(botAI); }
+    static UntypedValue* mgt_kael_interrupt_target(PlayerbotAI* botAI)
+    {
+        return new MgTKaelInterruptTargetValue(botAI);
+    }
+    static UntypedValue* mgt_kael_unattackable(PlayerbotAI* botAI) { return new MgTKaelUnattackableValue(botAI); }
+    static UntypedValue* mgt_gravity_lapse(PlayerbotAI* botAI) { return new MgTGravityLapseValue(botAI); }
+    static UntypedValue* mgt_melee_phoenix_exclusions(PlayerbotAI* botAI)
+    {
+        return new MgTMeleePhoenixExclusionsValue(botAI);
+    }
+    static UntypedValue* mgt_focus_exclusions(PlayerbotAI* botAI) { return new MgTFocusExclusionsValue(botAI); }
+};
+
+#endif

--- a/src/Ai/Dungeon/TbcDungeonActionContext.h
+++ b/src/Ai/Dungeon/TbcDungeonActionContext.h
@@ -9,6 +9,7 @@
 
 #include "ACActionContext.h"
 #include "MechActionContext.h"
+#include "MgTActionContext.h"
 #include "SethActionContext.h"
 #include "UBActionContext.h"
 

--- a/src/Ai/Dungeon/TbcDungeonTriggerContext.h
+++ b/src/Ai/Dungeon/TbcDungeonTriggerContext.h
@@ -9,6 +9,7 @@
 
 #include "ACTriggerContext.h"
 #include "MechTriggerContext.h"
+#include "MgTTriggerContext.h"
 #include "SethTriggerContext.h"
 #include "UBTriggerContext.h"
 

--- a/src/Bot/Engine/BuildSharedActionContexts.cpp
+++ b/src/Bot/Engine/BuildSharedActionContexts.cpp
@@ -58,6 +58,7 @@ void AiObjectContext::BuildSharedActionContexts(SharedNamedObjectContextList<Act
     actionContexts.Add(new TbcDungeonSethekkHallsActionContext());
     actionContexts.Add(new TbcDungeonMechanarActionContext());
     actionContexts.Add(new TbcDungeonUnderbogActionContext());
+    actionContexts.Add(new TbcDungeonMagistersTerraceActionContext());
     actionContexts.Add(new WotlkDungeonUKActionContext());
     actionContexts.Add(new WotlkDungeonNexActionContext());
     actionContexts.Add(new WotlkDungeonANActionContext());

--- a/src/Bot/Engine/BuildSharedTriggerContexts.cpp
+++ b/src/Bot/Engine/BuildSharedTriggerContexts.cpp
@@ -58,6 +58,7 @@ void AiObjectContext::BuildSharedTriggerContexts(SharedNamedObjectContextList<Tr
     triggerContexts.Add(new TbcDungeonSethekkHallsTriggerContext());
     triggerContexts.Add(new TbcDungeonMechanarTriggerContext());
     triggerContexts.Add(new TbcDungeonUnderbogTriggerContext());
+    triggerContexts.Add(new TbcDungeonMagistersTerraceTriggerContext());
     triggerContexts.Add(new WotlkDungeonUKTriggerContext());
     triggerContexts.Add(new WotlkDungeonNexTriggerContext());
     triggerContexts.Add(new WotlkDungeonANTriggerContext());

--- a/src/Bot/Engine/BuildSharedValueContexts.cpp
+++ b/src/Bot/Engine/BuildSharedValueContexts.cpp
@@ -6,6 +6,7 @@
 
 #include "AiObjectContext.h"
 #include "MechValueContext.h"
+#include "MgTValueContext.h"
 #include "UBValueContext.h"
 #include "ValueContext.h"
 
@@ -14,4 +15,5 @@ void AiObjectContext::BuildSharedValueContexts(SharedNamedObjectContextList<Unty
     valueContexts.Add(new ValueContext());
     valueContexts.Add(new TbcDungeonMechValueContext());
     valueContexts.Add(new TbcDungeonUnderbogValueContext());
+    valueContexts.Add(new TbcDungeonMgTValueContext());
 }

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -1633,7 +1633,7 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
     static const std::vector<std::string> allInstanceStrategies =
     {
         "aq20", "blacktemple", "bwl", "gruulslair", "hyjal", "icc", "karazhan", "magtheridon",
-        "moltencore", "naxx", "onyxia", "rs", "ssc", "tbc-ac", "tbc-mech", "tbc-seth", "tbc-ub",
+        "moltencore", "naxx", "onyxia", "rs", "ssc", "tbc-ac", "tbc-mech", "tbc-mgt", "tbc-seth", "tbc-ub",
         "tempestkeep", "ulduar", "voa", "wotlk-an", "wotlk-cos", "wotlk-dtk", "wotlk-eoe",
         "wotlk-fos", "wotlk-gd", "wotlk-hol", "wotlk-hos", "wotlk-nex", "wotlk-occ", "wotlk-ok",
         "wotlk-os", "wotlk-pos", "wotlk-toc", "wotlk-uk", "wotlk-up", "wotlk-vh", "zulaman"
@@ -1710,6 +1710,9 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
             break;
         case 578:
             strategyName = "wotlk-occ";  // The Oculus
+            break;
+        case 585:
+            strategyName = "tbc-mgt";  // Magisters' Terrace
             break;
         case 595:
             strategyName = "wotlk-cos";  // The Culling of Stratholme


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles. -->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

Adds a dungeon strategy for Magisters' Terrace, covering the Sunblade and Wretched trash and all three fights that have a mechanic: Selin Fireheart, Priestess Delrissa, and Kael'thas Sunstrider. Vexallus needs nothing beyond the default rotations.

By default a bot group loses the instance in the same three places. It lets Selin drain his Fel Crystals and heal mana to full. It lets Delrissa's retinue heal, fear and polymorph its way through the party while the bots spread damage across every add. And it stands in everything Kael'thas puts on the floor, chases the Phoenix out of the fight, and has no answer to Gravity Lapse.

**Selin Fireheart and the Sunblade trash**

- Selin drains a Fel Crystal to refill his mana and follow with Fel Explosion, so the active crystal is killed at emergency priority. While one stands, assist, attacker debuffs and DPS AoE are zeroed for everyone but the healer, so the party burns it instead of trickling onto it.
- Selin evades if the fight leaves his chamber. Flee and run-away are zeroed inside the room, and a bot that ends up past the door walks itself back in a step at a time.
- Sunblade Physicians drop a Magic Dampening Field that silences casting inside 5yd. Bots step clear of it; a tank only moves far enough to keep hold of the pull.
- Sunblade Magisters cast Arcane Nova centred on themselves, so ranged bots clear 16yd. Melee stay in, as players do.
- A Sunblade Mage Guard more than 12yd from its victim throws glaives instead of meleeing, so the bot it fixed on closes the gap.
- Wretched that reach a crystal and drink Fel Infusion enrage; the tank taunts the enraged one off whoever it grabbed.
- DPS focus fire is ranked by what a mob costs to leave alive (Physician, Blood Knight, Sister of Torment, Warlock, Magister, ...) and the pick is latched until it dies, so bots stop rotating targets every time threat shuffles.
- Interrupts are ranked the same way (Deadly Embrace, Holy Light, Arcane Nova, Forked Lightning, Incinerate, ...). A dedicated interrupt is always allowed; a stun or silence is only spent on the top two casts, so those cooldowns are still up when a Deadly Embrace or a heal lands.

**Priestess Delrissa**

- The retinue gets its own focus order, High Explosive Sheep first, then the healers, then the casters, Delrissa herself last, because the fight is decided by killing the support and not the boss.
- And its own interrupt order (fear and polymorph, then Flash Heal and Lesser Healing Wave, then Summon Imp). Each bot takes a stable slot into that list by group order, so four bots kick four different casters instead of racing for the same one.
- A shaman drops Tremor Totem for the fight and the other earth totems are suppressed, since they share the slot and would otherwise overwrite the only counter to Delrissa's fear.
- The retinue's pets are added to the strategy's target exclusions, so target selection never spends the fight on a respawning pet.

**Kael'thas Sunstrider**

- Flame Strike and the burning Phoenix are read off the trigger creature and the dynamic objects, and bots step out to a scored, reachable spot rather than the generic flee position.
- Melee never target the Phoenix and never chase it: it is excluded from target selection outright, and while it burns across Kael's melee ring the step-out is scored on the ring itself so they keep hitting the boss. Getting behind the target is zeroed while a Phoenix burns there, since it walks a bot straight back through the fire it just left.
- Phoenix Eggs are killed on sight before they rehatch; ranged also finish an engaged Phoenix, and everyone switches to Kael while Shock Barrier is up so the barrier breaks before the Pyroblast lands.
- Kael's interrupts are Pyroblast first, then Fireball, and are skipped entirely under Shock Barrier where they cannot land.
- Kael turns immune between phases; assist, debuffs and DPS AoE are suppressed while he does, so the party does not spin on an untargetable boss.
- Gravity Lapse gets a full station layout: tank and melee hold the two spots by Kael, healer and ranged spread behind, and each bot walks its route in legs, re-deciding per leg. Arcane Spheres are dodged on their predicted sweep with a lead, a sphere that chases is kited by scored turn with commit hysteresis so bots do not jitter between headings, and Power Feedback burn patches are costed into every candidate spot. Formation, follow and reach-target are zeroed for the duration so nothing drags a lapsed bot off its station.

It follows the existing per-dungeon pattern, so it is inert everywhere except inside Magisters' Terrace.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.

Sixteen triggers with their actions and ten multipliers, installed only on map 585. Each one exits on the cheapest check first: in combat, then a threat-list or `find target` lookup for the encounter it belongs to, so nothing past the first branch runs during the rest of the instance. Every grid search behind them is shared through a per-bot calculated value on a 200-500ms interval, so the cost on the tick is one lookup and not one search per action evaluated. Hazard sets are gathered once per action and reused across scoring instead of being re-queried per candidate.

- Describe the **processing cost** when this logic executes across many bots.

Nothing runs outside Magisters' Terrace, so the open-world population is unaffected. Inside, the per-bot per-tick cost is a handful of cached, range-bounded grid searches behind early-outs. The scoring loops (escape spots, lapse routes, sphere dodges) run only for a bot that is actually standing in a hazard or lapsed, for the few bots in the dungeon.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it. -->

With a group covering tank, healer, and DPS, clear Magisters' Terrace on Normal and Heroic.

Expected:
- Selin: the party swaps to the active Fel Crystal as soon as it lights up, and no bot flees out of the chamber and resets him.
- Trash: ranged step out of Arcane Nova, everyone steps out of the Dampening Field, a Mage Guard at range gets closed on, an enraged Wretched gets taunted, and the pull dies in priority order rather than whatever each bot happened to tag.
- Delrissa: the sheep dies first, the healers next, Delrissa last; fears, polymorphs and heals get kicked, and different bots kick different casters.
- Kael'thas: no bot stands in a Flame Strike; melee never run off after a Phoenix; eggs die before they hatch; the party switches to Kael under Shock Barrier.
- Gravity Lapse: bots take their stations rather than clumping, keep clear of the Arcane Spheres, and resume the fight when it ends.

## Impact Assessment
<!-- As a generic test, before and after measure of pmon (playerbot pmon tick) can help you here. -->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

The added work exists only for bots inside Magisters' Terrace, so it does not scale with global bot count. Within the instance it is a small number of cached, bounded grid searches behind early-outs, with the heavier scoring gated on a bot actually being in a hazard.

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

Inside this instance it overrides targeting and movement: focus order and target exclusions during the trash and the Delrissa fight, hazard step-outs and Gravity Lapse stations during Kael'thas, and suppression of the competing movement and AoE actions while those are active. The default behavior loses these fights. The override is confined to map 585 and mirrors the existing per-dungeon strategies.

- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [x] Yes (**explain below**)

It adds a self-contained `src/Ai/Dungeon/MgT/` unit plus one registration line each in the existing dungeon strategy, context and `ApplyInstanceStrategies` files. The complexity is isolated to the new directory and follows the established layout.

## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor. We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**) <!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

Used for code generation, iteration on the escape-spot, lapse-route and sphere-dodge geometry, and documentation. The behavior was refined against the live fights across repeated runs on both difficulties, and all logic has been reviewed and is owned by the contributor.

## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header. -->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**) <!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets. -->

## Final Checklist

- - [x] Stability is not compromised.
- - [x] Performance impact is understood, tested, and acceptable.
- - [x] Added logic complexity is justified and explained.
- - [x] Any new bot dialogue lines are translated. (N/A: no dialogue added.)
- - [x] Any code ported/adapted from another project is attributed. (N/A: all original.)
- - [x] New source files use the GPLv2 header.
- - [x] New and modified files do not introduce new compiler warnings.
- - [x] Documentation updated if needed (Conf comments, WiKi commands). (N/A: no config or commands added.)

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->

- Prior art, so the patterns here are not new to review: the healing-exempt AoE suppression is the Erekem/Violet Hold shape from #2570; the kite and hazard-scoring geometry is the same approach as the Sepethrea kite in #2570; and the focus exclusions are built on the `AppendTargetExclusions` hook added in #2604.
- `TargetValueExclusionType::Attacker` feeds only `AttackerWithoutAuraTargetValue`. The DPS and tank pickers use their own types and `FindTargetStrategy` uses `None`, so the focus exclusions cannot starve tank targeting or the boss `find target` lookups.
- Bots do not float during Gravity Lapse. The encounter grants flight through the client, and a bot never acks it, so it takes the auras and the damage but stays on the floor. The lapse stations are therefore ground positions, and `LapseActive()` keys on the auras and Kael's channel rather than on any movement flag.
- New files under `src/Ai/Dungeon/MgT/` follow the same convention as the existing dungeon strategy files: GPLv2 header, header guard, no inline comments, and a single anonymous namespace in `MgTShared.cpp` for the entries, spell IDs and tuning constants.
- Melee can run up to four Phoenix grid searches per 200-500ms window during the Kael'thas fight. Folding them behind one shared list value was considered and left out to match the neighbouring strategies, which scan per value; it is an easy follow-up if a maintainer prefers it.
- Expect the usual additive collision with sibling dungeon strategy PRs: one line each in `DungeonStrategyContext.h`,
`TbcDungeonActionContext.h`, `TbcDungeonTriggerContext.h`, `BuildSharedActionContexts.cpp`, `BuildSharedTriggerContexts.cpp`, `BuildSharedValueContexts.cpp`, and the strategy list plus map case in `PlayerbotAI.cpp`.
