### PR TITLE
feat: expose non-mutating chat command classifier

### DIFF
--- a/src/Bot/Engine/ExternalEventHelper.cpp
+++ b/src/Bot/Engine/ExternalEventHelper.cpp
@@ -43,6 +43,26 @@ bool ExternalEventHelper::ParseChatCommand(std::string const command, Player* ow
     return true;
 }
 
+bool ExternalEventHelper::IsChatCommand(std::string const command) const
+{
+    if (aiObjectContext->GetTrigger(command))
+        return true;
+
+    size_t i = std::string::npos;
+    while (true)
+    {
+        size_t found = command.rfind(" ", i);
+        if (found == std::string::npos || !found)
+            break;
+
+        if (aiObjectContext->GetTrigger(command.substr(0, found)))
+            return true;
+        i = found - 1;
+    }
+
+    return ChatHelper::parseableItem(command);
+}
+
 void ExternalEventHelper::HandlePacket(std::map<uint16, std::string>& handlers, WorldPacket const& packet,
                                        Player* owner)
 {

--- a/src/Bot/Engine/ExternalEventHelper.h
+++ b/src/Bot/Engine/ExternalEventHelper.h
@@ -21,6 +21,9 @@ public:
     ExternalEventHelper(AiObjectContext* aiObjectContext) : aiObjectContext(aiObjectContext) {}
 
     bool ParseChatCommand(std::string const command, Player* owner = nullptr);
+    // Classify with the same progressive trigger and item-link rules as
+    // ParseChatCommand, but never dispatch an action.
+    bool IsChatCommand(std::string const command) const;
     void HandlePacket(std::map<uint16, std::string>& handlers, WorldPacket const& packet, Player* owner = nullptr);
     bool HandleCommand(std::string const name, std::string const param, Player* owner = nullptr);
 

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -590,6 +590,44 @@ void PlayerbotAI::HandleCommands()
     }
 }
 
+bool PlayerbotAI::IsChatCommand(std::string const text) const
+{
+    std::string filtered = text;
+    if (filtered.find("BOT\t") == 0)
+        filtered = filtered.substr(4);
+
+    if (!sPlayerbotAIConfig.commandSeparator.empty() &&
+        filtered.find(sPlayerbotAIConfig.commandSeparator) != std::string::npos)
+    {
+        std::vector<std::string> commands;
+        split(commands, filtered, sPlayerbotAIConfig.commandSeparator.c_str());
+        for (std::string const& command : commands)
+            if (IsChatCommand(command))
+                return true;
+        return false;
+    }
+
+    if (!sPlayerbotAIConfig.commandPrefix.empty())
+    {
+        if (filtered.find(sPlayerbotAIConfig.commandPrefix) != 0)
+            return false;
+        filtered = filtered.substr(sPlayerbotAIConfig.commandPrefix.size());
+    }
+
+    filtered = trim((std::string&)filtered);
+    if (filtered.empty())
+        return false;
+
+    if (filtered.find("debug ") == 0 || filtered == "reset" ||
+        (filtered.size() > 2 && filtered.substr(0, 2) == "d ") ||
+        (filtered.size() > 3 && filtered.substr(0, 3) == "do ") ||
+        ChatHelper::parseValue("command", filtered).substr(0, 3) == "do ")
+        return true;
+
+    ExternalEventHelper helper(aiObjectContext);
+    return helper.IsChatCommand(filtered);
+}
+
 std::map<std::string, ChatMsg> chatMap;
 void PlayerbotAI::HandleCommand(uint32 type, const std::string& text, Player& fromPlayer, const uint32 lang)
 {

--- a/src/Bot/PlayerbotAI.h
+++ b/src/Bot/PlayerbotAI.h
@@ -392,6 +392,9 @@ public:
 
     std::string const HandleRemoteCommand(std::string const command);
     void HandleCommand(uint32 type, std::string const text, Player* fromPlayer);
+    // Non-mutating classifier for integrations which must not execute a
+    // Playerbot command while deciding how to handle a chat line.
+    bool IsChatCommand(std::string const text) const;
     void QueueChatResponse(const ChatQueuedReply reply);
     void HandleBotOutgoingPacket(WorldPacket const& packet);
     void HandleMasterIncomingPacket(WorldPacket const& packet);


### PR DESCRIPTION
Adds a non-mutating PlayerbotAI::IsChatCommand API, using the existing trigger and item-link recognition rules. This lets integrations classify playerbot commands without executing them.