### PR TITLE
Fix disabled brackets, arenas, and other guards for Level Brackets

### DIFF
--- a/src/Bot/RandomBotLevelMgr.cpp
+++ b/src/Bot/RandomBotLevelMgr.cpp
@@ -1036,6 +1036,13 @@ void RandomBotLevelMgr::OnBotLevelChanged(Player* player, uint8 oldLevel)
 
     uint8 newLevel = player->GetLevel();
 
+    if (newLevel == 1)
+        return;
+
+    if (player->getClass() == CLASS_DEATH_KNIGHT &&
+        newLevel == static_cast<uint8>(sWorld->getIntConfig(CONFIG_START_HEROIC_PLAYER_LEVEL)))
+        return;
+
     // SkipFromLevel takes priority and is not affected by ScaledChance or RestrictTimePlayed.
     if (sPlayerbotAIConfig.resetBotLevelSkipFrom > 0 && newLevel == sPlayerbotAIConfig.resetBotLevelSkipFrom)
     {

--- a/src/Bot/RandomBotLevelMgr.cpp
+++ b/src/Bot/RandomBotLevelMgr.cpp
@@ -606,19 +606,12 @@ void RandomBotLevelMgr::RunLevelBracketsDistribution()
             uint32 totalCombinedReal = totalAllianceReal + totalHordeReal;
             for (uint8 i = 0; i < _numRanges; ++i)
             {
-                if (IsDisabledBracket(sPlayerbotAIConfig.levelBracketsAlliance, i) &&
-                    IsDisabledBracket(sPlayerbotAIConfig.levelBracketsHorde, i))
-                {
-                    allianceWeights[i] = 0.0f;
-                    hordeWeights[i] = 0.0f;
-                    continue;
-                }
-
                 int combinedReal = allianceRealCounts[i] + hordeRealCounts[i];
                 float weight = baseline + sPlayerbotAIConfig.levelBracketsRealPlayerWeight *
                     (totalCombinedReal > 0 ? (1.0f / float(totalCombinedReal)) : 1.0f) * std::log(1 + combinedReal);
-                allianceWeights[i] = weight;
-                hordeWeights[i] = weight;
+
+                allianceWeights[i] = IsDisabledBracket(sPlayerbotAIConfig.levelBracketsAlliance, i) ? 0.0f : weight;
+                hordeWeights[i] = IsDisabledBracket(sPlayerbotAIConfig.levelBracketsHorde, i) ? 0.0f : weight;
             }
         }
         else

--- a/src/Bot/RandomBotLevelMgr.cpp
+++ b/src/Bot/RandomBotLevelMgr.cpp
@@ -57,9 +57,9 @@ static bool BotInArenaTeam(Player* bot)
 {
     if (!bot)
         return false;
-    for (uint32 slot = 0; slot < MAX_ARENA_SLOT; ++slot)
+    for (uint8 slot = ARENA_SLOT_2v2; slot <= ARENA_SLOT_5v5; ++slot)
     {
-        if (bot->GetArenaTeamId(slot))
+        if (sArenaTeamMgr->GetArenaTeamById(bot->GetArenaTeamId(slot)))
             return true;
     }
     return false;

--- a/src/Bot/RandomBotLevelMgr.cpp
+++ b/src/Bot/RandomBotLevelMgr.cpp
@@ -47,6 +47,11 @@ static bool BotInFriendList(Player* bot, std::vector<uint32> const& socialFriend
         socialFriendsList.end();
 }
 
+static bool IsDisabledBracket(std::vector<LevelBracketConfig> const& configured, uint8 index)
+{
+    return index < configured.size() && configured[index].pct == 0;
+}
+
 // Checks if the given bot is a member of any arena team.
 static bool BotInArenaTeam(Player* bot)
 {
@@ -431,6 +436,9 @@ int RandomBotLevelMgr::GetOrFlagPlayerBracket(Player* player)
         if (factionRanges[i].lower > factionRanges[i].upper)
             continue;
 
+        if (factionRanges[i].pct == 0)
+            continue;
+
         // Skip brackets that Death Knights cannot be assigned to.
         if (player->getClass() == CLASS_DEATH_KNIGHT && factionRanges[i].upper < dkMinLevel)
             continue;
@@ -597,6 +605,14 @@ void RandomBotLevelMgr::RunLevelBracketsDistribution()
             uint32 totalCombinedReal = totalAllianceReal + totalHordeReal;
             for (uint8 i = 0; i < _numRanges; ++i)
             {
+                if (IsDisabledBracket(sPlayerbotAIConfig.levelBracketsAlliance, i) &&
+                    IsDisabledBracket(sPlayerbotAIConfig.levelBracketsHorde, i))
+                {
+                    allianceWeights[i] = 0.0f;
+                    hordeWeights[i] = 0.0f;
+                    continue;
+                }
+
                 int combinedReal = allianceRealCounts[i] + hordeRealCounts[i];
                 float weight = baseline + sPlayerbotAIConfig.levelBracketsRealPlayerWeight *
                     (totalCombinedReal > 0 ? (1.0f / float(totalCombinedReal)) : 1.0f) * std::log(1 + combinedReal);
@@ -609,14 +625,16 @@ void RandomBotLevelMgr::RunLevelBracketsDistribution()
             // Separate dynamic weighting for each faction.
             for (uint8 i = 0; i < _numRanges; ++i)
             {
-                if (_allianceRanges[i].lower > _allianceRanges[i].upper)
+                if (_allianceRanges[i].lower > _allianceRanges[i].upper ||
+                    IsDisabledBracket(sPlayerbotAIConfig.levelBracketsAlliance, i))
                     allianceWeights[i] = 0.0f;
                 else
                     allianceWeights[i] = baseline + sPlayerbotAIConfig.levelBracketsRealPlayerWeight *
                         (totalAllianceReal > 0 ? (1.0f / totalAllianceReal) : 1.0f) *
                         std::log(1 + allianceRealCounts[i]);
 
-                if (_hordeRanges[i].lower > _hordeRanges[i].upper)
+                if (_hordeRanges[i].lower > _hordeRanges[i].upper ||
+                    IsDisabledBracket(sPlayerbotAIConfig.levelBracketsHorde, i))
                     hordeWeights[i] = 0.0f;
                 else
                     hordeWeights[i] = baseline + sPlayerbotAIConfig.levelBracketsRealPlayerWeight *

--- a/src/Bot/RandomBotLevelMgr.cpp
+++ b/src/Bot/RandomBotLevelMgr.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "RandomBotLevelMgr.h"
+#include "ArenaTeamMgr.h"
 #include "DatabaseEnv.h"
 #include "LFGMgr.h"
 #include "Log.h"


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
The original Port missed a few things this should resolve. 


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.
Minimal solution was applied. 


## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
Disable level bracket and verify bots are moved out of it. 


## Impact Assessment
<!--
As a generic test, pmon checks before and after your edits are helpful. To standardize the measurement, set the configs
BotActiveAlone = 100 & botActiveAloneSmartScale = 0. After server boot, enable the monitor `playerbot pmon toggle`
right after the bots finished logging-in, and run the stack command `playerbot pmon stack` 5 minutes after that.
The last "Total" line is the main result to look for.
-->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->
Comparison of missing code from port. 


## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [ ] No, all code in this PR is original
- - [x] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->
Already attributed. 


<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/Ai/Base/Actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated.
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


