### PR TITLE
Fix one way nodes, and cross map taxis. 

### DIFF
--- a/src/Ai/World/Rpg/Action/NewRpgAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.cpp
@@ -8,8 +8,11 @@
 #include "AreaDefines.h"
 #include "BroadcastHelper.h"
 #include "ChatHelper.h"
+#include "DBCStores.h"
 #include "GossipDef.h"
 #include "IVMapMgr.h"
+#include "MotionMaster.h"
+#include "MoveSpline.h"
 #include "NewRpgInfo.h"
 #include "NewRpgStrategy.h"
 #include "Object.h"
@@ -26,6 +29,7 @@
 #include "SharedDefines.h"
 #include "Timer.h"
 #include "TravelMgr.h"
+#include "WaypointMovementGenerator.h"
 #include "G3D/Vector2.h"
 #include <cmath>
 #include <cstdlib>
@@ -639,6 +643,7 @@ bool NewRpgTravelFlightAction::Execute(Event /*event*/)
     if (bot->IsInFlight())
     {
         data.inFlight = true;
+        ContinueCrossMapTaxi();
         return false;
     }
 
@@ -665,9 +670,49 @@ bool NewRpgTravelFlightAction::Execute(Event /*event*/)
     if (!bot->ActivateTaxiPathTo(nodes, flightMaster, 0))
     {
         LOG_DEBUG("playerbots", "[New RPG] {} active taxi path {} (from {} to {}) failed", bot->GetName(),
-                  flightMaster->GetEntry(), nodes[0], nodes[nodes.size() - 1]);
+                  flightMaster->GetEntry(), nodes.empty() ? 0 : nodes.front(), nodes.empty() ? 0 : nodes.back());
         info.ChangeToIdle();
         return true;
     }
     return true;
+}
+
+void NewRpgTravelFlightAction::ContinueCrossMapTaxi()
+{
+    if (bot->IsBeingTeleported())
+        return;
+
+    if (!bot->movespline->Finalized())
+        return;
+
+    MotionMaster* mm = bot->GetMotionMaster();
+    if (!mm || mm->GetCurrentMovementGeneratorType() != FLIGHT_MOTION_TYPE)
+        return;
+
+    // Check if we are at our destination.
+    uint32 nextDest = bot->m_taxi.GetTaxiDestination();
+    if (!nextDest)
+        return;
+
+    // Confirm next node needs different map.
+    TaxiNodesEntry const* nextNode = sTaxiNodesStore.LookupEntry(nextDest);
+    if (!nextNode || nextNode->map_id == bot->GetMapId())
+        return;
+
+    FlightPathMovementGenerator* flight = dynamic_cast<FlightPathMovementGenerator*>(mm->top());
+    if (!flight)
+        return;
+
+    LOG_DEBUG("playerbots", "[New RPG] {} continuing taxi across map boundary (next node {} on map {})",
+              bot->GetName(), nextDest, nextNode->map_id);
+
+    flight->SetCurrentNodeAfterTeleport();
+
+    if (flight->HasArrived())
+        return;
+
+    TaxiPathNodeEntry const* node = flight->GetPath()[flight->GetCurrentNode()];
+    flight->SkipCurrentNode();
+
+    bot->TeleportTo(nextNode->map_id, node->x, node->y, node->z, bot->GetOrientation(), TELE_TO_NOT_LEAVE_TAXI);
 }

--- a/src/Ai/World/Rpg/Action/NewRpgAction.h
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.h
@@ -117,6 +117,9 @@ class NewRpgTravelFlightAction : public NewRpgBaseAction
 public:
     NewRpgTravelFlightAction(PlayerbotAI* botAI) : NewRpgBaseAction(botAI, "new rpg travel flight") {}
     bool Execute(Event event) override;
+
+protected:
+    void ContinueCrossMapTaxi();
 };
 
 #endif

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -807,8 +807,8 @@ void PlayerbotAI::HandleTeleportAck()
         // reset AI state after teleport
         Reset(true);
 
-        // clear movement only AFTER teleport is finalized and bot is in world
-        if (bot->IsInWorld() && bot->GetMotionMaster())
+        // clear movement only AFTER teleport is finalized and bot is in world. Skip during a taxi map-transfer
+        if (bot->IsInWorld() && bot->GetMotionMaster() && !bot->IsInFlight())
         {
             bot->GetMotionMaster()->Clear(true);
             bot->StopMoving();

--- a/src/Mgr/Travel/TravelNode.cpp
+++ b/src/Mgr/Travel/TravelNode.cpp
@@ -2494,7 +2494,6 @@ void TravelNodeMap::BuildTaxiGraph()
             continue;
 
         tempGraph[path->from].insert(path->to);
-        tempGraph[path->to].insert(path->from);
     }
     for (auto const& [node, neighbors] : tempGraph)
         taxiGraph[node] = std::vector<uint32>(neighbors.begin(), neighbors.end());
@@ -2504,7 +2503,10 @@ void TravelNodeMap::ComputeAllPaths()
 {
     std::set<uint32> allNodes;
     for (auto const& [source, neighbors] : taxiGraph)
+    {
         allNodes.insert(source);
+        allNodes.insert(neighbors.begin(), neighbors.end());
+    }
 
     for (uint32 source : allNodes)
     {
@@ -2537,7 +2539,11 @@ std::unordered_map<uint32, uint32> TravelNodeMap::BFS(uint32 fromNode)
         uint32 current = workQueue.front();
         workQueue.pop();
 
-        for (uint32 next : taxiGraph.at(current))
+        auto graphItr = taxiGraph.find(current);
+        if (graphItr == taxiGraph.end())
+            continue;
+
+        for (uint32 next : graphItr->second)
         {
             if (visited.count(next))
                 continue;


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
The BFS graph assumed every node was bidirectional, they are not. Then there was a second issue where the server relies on a client packet to trigger the map change while flying. This was not sent leading to buildup of bots outside IF> 


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.
This is mostly gated behind the flying RPG state. 


## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
Sit outside IF for a while. 


## Impact Assessment
<!--
As a generic test, pmon checks before and after your edits are helpful. To standardize the measurement, set the configs
BotActiveAlone = 100 & botActiveAloneSmartScale = 0. After server boot, enable the monitor `playerbot pmon toggle`
right after the bots finished logging-in, and run the stack command `playerbot pmon stack` 5 minutes after that.
The last "Total" line is the main result to look for.
-->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->
Investigation, and implementation. 


## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/Ai/Base/Actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated.
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


