### PR TITLE
fix(Naxx/Thaddius): treat feign-dead Stalagg and Feugen as down

### DIFF
--- a/src/Ai/Raid/Naxx/NaxxBossHelper.h
+++ b/src/Ai/Raid/Naxx/NaxxBossHelper.h
@@ -488,7 +488,11 @@ public:
         stalagg = AI_VALUE2(Unit*, "find target", "stalagg");
         return true;
     }
-    bool IsPhasePet() { return (feugen && feugen->IsAlive()) || (stalagg && stalagg->IsAlive()); }
+    // Stalagg and Feugen only feign death: they stay alive at 1 HP, flagged NOT_SELECTABLE, until
+    // Thaddius' tesla overload finishes them off or ACTION_RESTORE revives them. Testing IsAlive()
+    // alone would latch the pet phase on forever.
+    static bool IsPetActive(Unit* pet) { return pet && pet->IsAlive() && !pet->HasUnitFlag(UNIT_FLAG_NOT_SELECTABLE); }
+    bool IsPhasePet() { return IsPetActive(feugen) || IsPetActive(stalagg); }
     bool IsPhaseTransition()
     {
         if (IsPhasePet())
@@ -500,11 +504,11 @@ public:
     Unit* GetNearestPet()
     {
         Unit* unit = nullptr;
-        if (feugen && feugen->IsAlive())
+        if (IsPetActive(feugen))
             unit = feugen;
 
-        if (stalagg && stalagg->IsAlive() &&
-            (!feugen || !feugen->IsAlive() || bot->GetDistance(stalagg) < bot->GetDistance(feugen)))
+        if (IsPetActive(stalagg) &&
+            (!IsPetActive(feugen) || bot->GetDistance(stalagg) < bot->GetDistance(feugen)))
             unit = stalagg;
 
         return unit;


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

Core PR #26771 changed Stalagg and Feugen to feign death instead of dying. They now stay alive at 1 HP with UNIT_FLAG_NOT_SELECTABLE until Thaddius' tesla overload finishes them off or ACTION_RESTORE revives them.

ThaddiusBossHelper::IsPhasePet() tested IsAlive() only.  IsPhaseTransition() and IsPhaseThaddius() then never fired, leaving bots stuck attacking an unselectable pet instead of moving to the platform and handling polarity.

This is an AI resolution consistent with the core. I have not tested. 


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->
Someone go try to kill Thadd

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.



## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
Killem 


## Impact Assessment
<!--
As a generic test, pmon checks before and after your edits are helpful. To standardize the measurement, set the configs
BotActiveAlone = 100 & botActiveAloneSmartScale = 0. After server boot, enable the monitor `playerbot pmon toggle`
right after the bots finished logging-in, and run the stack command `playerbot pmon stack` 5 minutes after that.
The last "Total" line is the main result to look for.
-->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [x] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->
The Issue was caught by claude and resolution proposed. It makes sense from my read of it, I just dont have time to test. 


## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/Ai/Base/Actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated.
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


