### PR TITLE
Naxx: re-enable Heigan safety dance with a time-based fight clock

### DIFF
--- a/src/Ai/Raid/Naxx/Action/NaxxActions.h
+++ b/src/Ai/Raid/Naxx/Action/NaxxActions.h
@@ -62,33 +62,25 @@ private:
     float distance;
 };
 
+// One action for both roles: melee (and tanks) dance every phase, ranged/healers wait on the platform during the
+// slow dance and only dance the fast one.
 class HeiganDanceAction : public MovementAction
 {
 public:
-    HeiganDanceAction(PlayerbotAI* ai, std::string const name = "heigan dance")
-        : MovementAction(ai, name), helper(ai) {}
+    HeiganDanceAction(PlayerbotAI* ai, bool ranged)
+        : MovementAction(ai, ranged ? "heigan dance ranged" : "heigan dance melee"), helper(ai), ranged(ranged)
+    {
+    }
+    bool Execute(Event event) override;
 
-protected:
+private:
     // Move to (near) the given dance waypoint. Returns true while a move had to be issued.
     bool MoveToWaypoint(uint32 index, float distance);
     bool MoveToPlatform(float distance);
 
     HeiganBossHelper helper;
+    bool ranged;
     int32 lastWaypoint = -1;
-};
-
-class HeiganDanceMeleeAction : public HeiganDanceAction
-{
-public:
-    HeiganDanceMeleeAction(PlayerbotAI* ai) : HeiganDanceAction(ai, "heigan dance melee") {}
-    bool Execute(Event event) override;
-};
-
-class HeiganDanceRangedAction : public HeiganDanceAction
-{
-public:
-    HeiganDanceRangedAction(PlayerbotAI* ai) : HeiganDanceAction(ai, "heigan dance ranged") {}
-    bool Execute(Event event) override;
 };
 
 class ThaddiusAttackNearestPetAction : public AttackAction

--- a/src/Ai/Raid/Naxx/Action/NaxxActions.h
+++ b/src/Ai/Raid/Naxx/Action/NaxxActions.h
@@ -62,56 +62,34 @@ private:
     float distance;
 };
 
-//class HeiganDanceAction : public MovementAction
-//{
-//public:
-//    HeiganDanceAction(PlayerbotAI* ai) : MovementAction(ai, "heigan dance")
-//    {
-//        this->last_eruption_ms = 0;
-//        this->platform_phase = false;
-//        ResetSafe();
-//        waypoints.push_back(std::make_pair(2794.88f, -3668.12f));
-//        waypoints.push_back(std::make_pair(2775.49f, -3674.43f));
-//        waypoints.push_back(std::make_pair(2762.30f, -3684.59f));
-//        waypoints.push_back(std::make_pair(2755.99f, -3703.96f));
-//        platform = std::make_pair(2794.26f, -3706.67f);
-//    }
-//
-//protected:
-//    bool CalculateSafe();
-//    void ResetSafe()
-//    {
-//        curr_safe = 0;
-//        curr_dir = 1;
-//    }
-//    void NextSafe()
-//    {
-//        curr_safe += curr_dir;
-//        if (curr_safe == 3 || curr_safe == 0)
-//        {
-//            curr_dir = -curr_dir;
-//        }
-//    }
-//    uint32 last_eruption_ms;
-//    bool platform_phase;
-//    uint32 curr_safe, curr_dir;
-//    std::vector<std::pair<float, float>> waypoints;
-//    std::pair<float, float> platform;
-//};
-//
-//class HeiganDanceMeleeAction : public HeiganDanceAction
-//{
-//public:
-//    HeiganDanceMeleeAction(PlayerbotAI* ai) : HeiganDanceAction(ai) {}
-//    virtual bool Execute(Event event);
-//};
-//
-//class HeiganDanceRangedAction : public HeiganDanceAction
-//{
-//public:
-//    HeiganDanceRangedAction(PlayerbotAI* ai) : HeiganDanceAction(ai) {}
-//    virtual bool Execute(Event event);
-//};
+class HeiganDanceAction : public MovementAction
+{
+public:
+    HeiganDanceAction(PlayerbotAI* ai, std::string const name = "heigan dance")
+        : MovementAction(ai, name), helper(ai) {}
+
+protected:
+    // Move to (near) the given dance waypoint. Returns true while a move had to be issued.
+    bool MoveToWaypoint(uint32 index, float distance);
+    bool MoveToPlatform(float distance);
+
+    HeiganBossHelper helper;
+    int32 lastWaypoint = -1;
+};
+
+class HeiganDanceMeleeAction : public HeiganDanceAction
+{
+public:
+    HeiganDanceMeleeAction(PlayerbotAI* ai) : HeiganDanceAction(ai, "heigan dance melee") {}
+    bool Execute(Event event) override;
+};
+
+class HeiganDanceRangedAction : public HeiganDanceAction
+{
+public:
+    HeiganDanceRangedAction(PlayerbotAI* ai) : HeiganDanceAction(ai, "heigan dance ranged") {}
+    bool Execute(Event event) override;
+};
 
 class ThaddiusAttackNearestPetAction : public AttackAction
 {

--- a/src/Ai/Raid/Naxx/Action/NaxxActions_Heigan.cpp
+++ b/src/Ai/Raid/Naxx/Action/NaxxActions_Heigan.cpp
@@ -39,27 +39,20 @@ bool HeiganDanceAction::MoveToPlatform(float distance)
                       HeiganBossHelper::PlatformZ, distance, MovementPriority::MOVEMENT_COMBAT);
 }
 
-bool HeiganDanceMeleeAction::Execute(Event /*event*/)
+bool HeiganDanceAction::Execute(Event /*event*/)
 {
     if (!helper.UpdateBossAI())
         return false;
+
+    // Slow dance: the platform is safe from eruptions. Ranged leave it right after the last slow eruption
+    // so they are out of Plague Cloud range (and at the first fast spot) before the fast dance starts.
+    if (ranged)
+        return helper.ShouldRangedHoldPlatform() ? MoveToPlatform(2.0f)
+                                                 : MoveToWaypoint(helper.GetSafeWaypoint(), 1.5f);
 
     // The boss follows the main tank, so the tank first has to hold him before it can lead the dance.
     if (!helper.ShouldDance())
         return false;
 
-    return MoveToWaypoint(helper.GetSafeWaypoint(), botAI->IsMainTank(bot) ? 0.5f : 1.5f);
-}
-
-bool HeiganDanceRangedAction::Execute(Event /*event*/)
-{
-    if (!helper.UpdateBossAI())
-        return false;
-
-    // Slow dance: the platform is safe from eruptions. Leave it right after the last slow eruption
-    // so we are out of Plague Cloud range (and at the first fast spot) before the fast dance starts.
-    if (helper.ShouldRangedHoldPlatform())
-        return MoveToPlatform(2.0f);
-
-    return MoveToWaypoint(helper.GetSafeWaypoint(), 1.5f);
+    return MoveToWaypoint(helper.GetSafeWaypoint(), PlayerbotAI::IsMainTank(bot) ? 0.5f : 1.5f);
 }

--- a/src/Ai/Raid/Naxx/Action/NaxxActions_Heigan.cpp
+++ b/src/Ai/Raid/Naxx/Action/NaxxActions_Heigan.cpp
@@ -5,79 +5,61 @@
  */
 
 #include "NaxxActions.h"
-#include "NaxxSpellIds.h"
+#include "LastMovementValue.h"
 #include "Playerbots.h"
-#include "Spell.h"
-#include "Timer.h"
 
-//bool HeiganDanceAction::CalculateSafe()
-//{
-//    Unit* boss = AI_VALUE2(Unit*, "find target", "heigan the unclean");
-//    if (!boss)
-//    {
-//        return false;
-//    }
-//    uint32 now = getMSTime();
-//    platform_phase = boss->IsWithinDist2d(platform.first, platform.second, 10.0f);
-//    if (last_eruption_ms != 0 && now - last_eruption_ms > 15000)
-//    {
-//        ResetSafe();
-//    }
-//    if (boss->HasUnitState(UNIT_STATE_CASTING))
-//    {
-//        Spell* spell = boss->GetCurrentSpell(CURRENT_GENERIC_SPELL);
-//        if (!spell)
-//        {
-//            spell = boss->GetCurrentSpell(CURRENT_CHANNELED_SPELL);
-//        }
-//        if (spell)
-//        {
-//            SpellInfo const* info = spell->GetSpellInfo();
-//            bool isEruption = NaxxSpellIds::MatchesAnySpellId(info, {NaxxSpellIds::Eruption10});
-//            if (!isEruption && info && info->SpellName[LOCALE_enUS])
-//            {
-//                // Fallback to name for custom spell data.
-//                isEruption = botAI->EqualLowercaseName(info->SpellName[LOCALE_enUS], "eruption");
-//            }
-//            if (isEruption)
-//            {
-//                if (last_eruption_ms == 0 || now - last_eruption_ms > 500)
-//                {
-//                    NextSafe();
-//                }
-//                last_eruption_ms = now;
-//            }
-//        }
-//    }
-//    return true;
-//}
-//
-//bool HeiganDanceMeleeAction::Execute(Event event)
-//{
-//    CalculateSafe();
-//    if (!platform_phase && botAI->IsMainTank(bot) && !AI_VALUE2(bool, "has aggro", "boss target"))
-//    {
-//        return false;
-//    }
-//    assert(curr_safe >= 0 && curr_safe <= 3);
-//    return MoveInside(bot->GetMapId(), waypoints[curr_safe].first, waypoints[curr_safe].second, bot->GetPositionZ(),
-//                      botAI->IsMainTank(bot) ? 0 : 0, MovementPriority::MOVEMENT_COMBAT);
-//}
-//
-//bool HeiganDanceRangedAction::Execute(Event event)
-//{
-//    CalculateSafe();
-//    if (!platform_phase)
-//    {
-//        if (MoveTo(bot->GetMapId(), platform.first, platform.second, 276.54f, false, false, false, false,
-//                   MovementPriority::MOVEMENT_COMBAT))
-//        {
-//            return true;
-//        }
-//        return MoveInside(bot->GetMapId(), platform.first, platform.second, 276.54f, 2.0f,
-//                          MovementPriority::MOVEMENT_COMBAT);
-//    }
-//    botAI->InterruptSpell();
-//    return MoveInside(bot->GetMapId(), waypoints[curr_safe].first, waypoints[curr_safe].second, bot->GetPositionZ(), 0,
-//                      MovementPriority::MOVEMENT_COMBAT);
-//}
+bool HeiganDanceAction::MoveToWaypoint(uint32 index, float distance)
+{
+    if (index >= HeiganBossHelper::WaypointCount)
+        return false;
+
+    if (int32(index) != lastWaypoint)
+    {
+        // New safe spot: forget the previous (same priority) move so we are not stuck waiting for it,
+        // and stop whatever we were casting.
+        lastWaypoint = int32(index);
+        AI_VALUE(LastMovement&, "last movement").Set(nullptr);
+        if (bot->IsNonMeleeSpellCast(true))
+            botAI->InterruptSpell();
+    }
+
+    return MoveInside(bot->GetMapId(), HeiganBossHelper::WaypointX[index], HeiganBossHelper::WaypointY[index],
+                      bot->GetPositionZ(), distance, MovementPriority::MOVEMENT_COMBAT);
+}
+
+bool HeiganDanceAction::MoveToPlatform(float distance)
+{
+    if (lastWaypoint != -1)
+    {
+        lastWaypoint = -1;
+        AI_VALUE(LastMovement&, "last movement").Set(nullptr);
+    }
+
+    return MoveInside(bot->GetMapId(), HeiganBossHelper::PlatformX, HeiganBossHelper::PlatformY,
+                      HeiganBossHelper::PlatformZ, distance, MovementPriority::MOVEMENT_COMBAT);
+}
+
+bool HeiganDanceMeleeAction::Execute(Event /*event*/)
+{
+    if (!helper.UpdateBossAI())
+        return false;
+
+    // The boss follows the main tank, so the tank first has to hold him before it can lead the dance.
+    if (!helper.ShouldDance())
+        return false;
+
+    return MoveToWaypoint(helper.GetSafeWaypoint(), botAI->IsMainTank(bot) ? 0.5f : 1.5f);
+}
+
+bool HeiganDanceRangedAction::Execute(Event /*event*/)
+{
+    if (!helper.UpdateBossAI())
+        return false;
+
+    // Slow dance: the platform is safe from eruptions. Leave it right after the last slow eruption
+    // so we are out of Plague Cloud range (and at the first fast spot) before the fast dance starts.
+    if (helper.ShouldRangedHoldPlatform())
+        return MoveToPlatform(2.0f);
+
+    return MoveToWaypoint(helper.GetSafeWaypoint(), 1.5f);
+}

--- a/src/Ai/Raid/Naxx/NaxxActionContext.h
+++ b/src/Ai/Raid/Naxx/NaxxActionContext.h
@@ -21,8 +21,8 @@ public:
         creators["grobbulus move center"] = &RaidNaxxActionContext::grobbulus_move_center;
         creators["grobbulus move away"] = &RaidNaxxActionContext::grobbulus_move_away;
 
-        //creators["heigan dance melee"] = &RaidNaxxActionContext::heigan_dance_melee;
-        //creators["heigan dance ranged"] = &RaidNaxxActionContext::heigan_dance_ranged;
+        creators["heigan dance melee"] = &RaidNaxxActionContext::heigan_dance_melee;
+        creators["heigan dance ranged"] = &RaidNaxxActionContext::heigan_dance_ranged;
         creators["thaddius attack nearest pet"] = &RaidNaxxActionContext::thaddius_attack_nearest_pet;
         // creators["thaddius melee to place"] = &RaidNaxxActionContext::thaddius_tank_to_place;
         // creators["thaddius ranged to place"] = &RaidNaxxActionContext::thaddius_ranged_to_place;
@@ -59,8 +59,8 @@ private:
     static Action* rotate_grobbulus(PlayerbotAI* ai) { return new GrobbulusRotateAction(ai); }
     static Action* grobbulus_move_center(PlayerbotAI* ai) { return new GrobbulusMoveCenterAction(ai); }
     static Action* grobbulus_move_away(PlayerbotAI* ai) { return new GrobbulusMoveAwayAction(ai); }
-    //static Action* heigan_dance_melee(PlayerbotAI* ai) { return new HeiganDanceMeleeAction(ai); }
-    //static Action* heigan_dance_ranged(PlayerbotAI* ai) { return new HeiganDanceRangedAction(ai); }
+    static Action* heigan_dance_melee(PlayerbotAI* ai) { return new HeiganDanceMeleeAction(ai); }
+    static Action* heigan_dance_ranged(PlayerbotAI* ai) { return new HeiganDanceRangedAction(ai); }
     static Action* thaddius_attack_nearest_pet(PlayerbotAI* ai) { return new ThaddiusAttackNearestPetAction(ai); }
     // static Action* thaddius_tank_to_place(PlayerbotAI* ai) { return new ThaddiusMeleeToPlaceAction(ai); }
     // static Action* thaddius_ranged_to_place(PlayerbotAI* ai) { return new ThaddiusRangedToPlaceAction(ai); }

--- a/src/Ai/Raid/Naxx/NaxxActionContext.h
+++ b/src/Ai/Raid/Naxx/NaxxActionContext.h
@@ -59,8 +59,8 @@ private:
     static Action* rotate_grobbulus(PlayerbotAI* ai) { return new GrobbulusRotateAction(ai); }
     static Action* grobbulus_move_center(PlayerbotAI* ai) { return new GrobbulusMoveCenterAction(ai); }
     static Action* grobbulus_move_away(PlayerbotAI* ai) { return new GrobbulusMoveAwayAction(ai); }
-    static Action* heigan_dance_melee(PlayerbotAI* ai) { return new HeiganDanceMeleeAction(ai); }
-    static Action* heigan_dance_ranged(PlayerbotAI* ai) { return new HeiganDanceRangedAction(ai); }
+    static Action* heigan_dance_melee(PlayerbotAI* ai) { return new HeiganDanceAction(ai, false); }
+    static Action* heigan_dance_ranged(PlayerbotAI* ai) { return new HeiganDanceAction(ai, true); }
     static Action* thaddius_attack_nearest_pet(PlayerbotAI* ai) { return new ThaddiusAttackNearestPetAction(ai); }
     // static Action* thaddius_tank_to_place(PlayerbotAI* ai) { return new ThaddiusMeleeToPlaceAction(ai); }
     // static Action* thaddius_ranged_to_place(PlayerbotAI* ai) { return new ThaddiusRangedToPlaceAction(ai); }

--- a/src/Ai/Raid/Naxx/NaxxBossHelper.cpp
+++ b/src/Ai/Raid/Naxx/NaxxBossHelper.cpp
@@ -1,0 +1,178 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "NaxxBossHelper.h"
+#include "Playerbots.h"
+#include "SpellAuras.h"
+#include "Timer.h"
+#include <mutex>
+#include <unordered_map>
+
+namespace
+{
+    // Fight clock shared by every bot fighting the same Heigan (keyed by the boss guid).
+    std::mutex heiganStateLock;
+    std::unordered_map<ObjectGuid, HeiganBossHelper::FightState> heiganStates;
+
+    // A fight not observed for this long is over (wipe / evade); the next pull starts from scratch.
+    constexpr uint32 HeiganStateStaleMs = 30000;
+}
+
+bool HeiganBossHelper::UpdateBossAI()
+{
+    if (_unit && (!_unit->IsInWorld() || !_unit->IsAlive() || !_unit->IsInCombat()))
+        Reset();
+
+    if (!_unit)
+    {
+        if (!bot->IsInCombat())
+        {
+            Reset();
+            return false;
+        }
+
+        _unit = AI_VALUE2(Unit*, "find target", "heigan the unclean");
+        if (!_unit)
+            return false;
+    }
+
+    uint32 now = getMSTime();
+
+    // Fast dance: Heigan teleports onto his platform, stops attacking (REACT_PASSIVE) and, one second later,
+    // channels Plague Cloud for the rest of the phase. The aura is authoritative; "on the platform without a
+    // victim" only bridges that first second (and a possibly interrupted channel).
+    Aura* plagueCloud = _unit->GetAura(NaxxSpellIds::PlagueCloud);
+    bool idleOnPlatform = !_unit->GetVictim() && _unit->IsWithinDist2d(PlatformX, PlatformY, PlatformRadius);
+
+    std::lock_guard<std::mutex> lock(heiganStateLock);
+
+    // Drop stale entries (previous attempts / other instances that are long over).
+    for (auto itr = heiganStates.begin(); itr != heiganStates.end();)
+    {
+        if (now - itr->second.lastSeenMs > HeiganStateStaleMs)
+            itr = heiganStates.erase(itr);
+        else
+            ++itr;
+    }
+
+    FightState& state = heiganStates[_unit->GetGUID()];
+    bool firstObservation = state.lastSeenMs == 0;
+    uint32 elapsed = firstObservation ? 0 : now - state.phaseStartMs;
+
+    bool fast;
+    if (plagueCloud)
+        fast = true;
+    else if (state.fastPhase)
+        fast = idleOnPlatform;   // still on the platform without a victim: the fast dance goes on
+    else
+        // A slow dance always lasts SlowPhaseDurationMs, so ignore an idle boss on the platform before that
+        // (e.g. victim just died while he was still standing there at the pull).
+        fast = idleOnPlatform && !firstObservation && elapsed + 5000 >= SlowPhaseDurationMs;
+
+    if (fast)
+    {
+        if (plagueCloud)
+        {
+            // Exact: the aura is applied PlagueCloudDelayMs into the phase and lasts FastPhaseDurationMs.
+            int32 auraElapsed = plagueCloud->GetMaxDuration() - plagueCloud->GetDuration();
+            if (auraElapsed < 0)
+                auraElapsed = 0;
+            state.phaseStartMs = now - PlagueCloudDelayMs - uint32(auraElapsed);
+            state.exact = true;
+        }
+        else if (!state.fastPhase)
+        {
+            // Just teleported, Plague Cloud not up yet.
+            state.phaseStartMs = now;
+            state.exact = false;
+        }
+        state.fastPhase = true;
+    }
+    else
+    {
+        if (state.fastPhase)
+        {
+            // Fast -> slow: the fast dance lasts exactly FastPhaseDurationMs.
+            state.phaseStartMs = state.exact ? state.phaseStartMs + FastPhaseDurationMs : now;
+        }
+        else if (firstObservation)
+        {
+            // Pull (or nobody has been watching this fight for a while).
+            state.phaseStartMs = now;
+            state.exact = false;
+        }
+        state.fastPhase = false;
+    }
+    state.lastSeenMs = now;
+
+    _fastPhase = state.fastPhase;
+    _phaseElapsedMs = now - state.phaseStartMs;
+    return true;
+}
+
+uint32 HeiganBossHelper::GetEruptionIndex() const
+{
+    uint32 first = _fastPhase ? FastFirstEruptionMs : SlowFirstEruptionMs;
+    uint32 interval = _fastPhase ? FastEruptionIntervalMs : SlowEruptionIntervalMs;
+    if (_phaseElapsedMs < first + EruptionSafetyMarginMs)
+        return 0;
+    return (_phaseElapsedMs - EruptionSafetyMarginMs - first) / interval + 1;
+}
+
+uint32 HeiganBossHelper::GetSafeWaypoint() const
+{
+    uint32 index = GetEruptionIndex();
+    // After the last eruption of a phase the next spot is the first one of the following phase.
+    if (index >= (_fastPhase ? FastEruptionCount : SlowEruptionCount))
+        return 0;
+    uint32 r = index % (2 * (WaypointCount - 1));
+    return r < WaypointCount ? r : 2 * (WaypointCount - 1) - r;
+}
+
+uint32 HeiganBossHelper::GetMsUntilNextEruption() const
+{
+    uint32 first = _fastPhase ? FastFirstEruptionMs : SlowFirstEruptionMs;
+    uint32 interval = _fastPhase ? FastEruptionIntervalMs : SlowEruptionIntervalMs;
+    uint32 count = _fastPhase ? FastEruptionCount : SlowEruptionCount;
+    uint32 happened = _phaseElapsedMs < first ? 0 : (_phaseElapsedMs - first) / interval + 1;
+    uint32 next;
+    if (happened >= count)
+    {
+        // No more eruptions this phase; the next one is the first of the following phase.
+        uint32 phaseLength = _fastPhase ? FastPhaseDurationMs : SlowPhaseDurationMs;
+        uint32 nextFirst = _fastPhase ? SlowFirstEruptionMs : FastFirstEruptionMs;
+        next = phaseLength + nextFirst;
+    }
+    else
+        next = first + happened * interval;
+
+    return next > _phaseElapsedMs ? next - _phaseElapsedMs : 0;
+}
+
+bool HeiganBossHelper::IsAtWaypoint(uint32 index, float tolerance) const
+{
+    if (index >= WaypointCount)
+        return false;
+    return bot->GetDistance2d(WaypointX[index], WaypointY[index]) <= tolerance;
+}
+
+bool HeiganBossHelper::ShouldDance()
+{
+    if (_fastPhase)
+        return true;
+    if (botAI->IsRanged(bot))
+        return false;
+    if (botAI->IsMainTank(bot) && !AI_VALUE2(bool, "has aggro", "boss target"))
+        return false;
+    return true;
+}
+
+bool HeiganBossHelper::CanStandStillFor(uint32 ms)
+{
+    if (!ShouldDance())
+        return true;
+    return IsAtWaypoint(GetSafeWaypoint()) && GetMsUntilNextEruption() > ms;
+}

--- a/src/Ai/Raid/Naxx/NaxxBossHelper.cpp
+++ b/src/Ai/Raid/Naxx/NaxxBossHelper.cpp
@@ -13,12 +13,21 @@
 
 namespace
 {
-    // Fight clock shared by every bot fighting the same Heigan (keyed by the boss guid).
-    std::mutex heiganStateLock;
-    std::unordered_map<ObjectGuid, HeiganBossHelper::FightState> heiganStates;
-
     // A fight not observed for this long is over (wipe / evade); the next pull starts from scratch.
     constexpr uint32 HeiganStateStaleMs = 30000;
+
+    // Fight clock shared by every bot fighting the same Heigan (keyed by the boss guid).
+    struct HeiganFightRegistry
+    {
+        std::mutex lock;
+        std::unordered_map<ObjectGuid, HeiganBossHelper::FightState> states;
+    };
+
+    HeiganFightRegistry& GetHeiganFightRegistry()
+    {
+        static HeiganFightRegistry registry;
+        return registry;
+    }
 }
 
 bool HeiganBossHelper::UpdateBossAI()
@@ -47,31 +56,48 @@ bool HeiganBossHelper::UpdateBossAI()
     Aura* plagueCloud = _unit->GetAura(NaxxSpellIds::PlagueCloud);
     bool idleOnPlatform = !_unit->GetVictim() && _unit->IsWithinDist2d(PlatformX, PlatformY, PlatformRadius);
 
-    std::lock_guard<std::mutex> lock(heiganStateLock);
+    HeiganFightRegistry& registry = GetHeiganFightRegistry();
+    std::scoped_lock lock(registry.lock);
 
     // Drop stale entries (previous attempts / other instances that are long over).
-    for (auto itr = heiganStates.begin(); itr != heiganStates.end();)
+    for (auto itr = registry.states.begin(); itr != registry.states.end();)
     {
         if (now - itr->second.lastSeenMs > HeiganStateStaleMs)
-            itr = heiganStates.erase(itr);
+            itr = registry.states.erase(itr);
         else
             ++itr;
     }
 
-    FightState& state = heiganStates[_unit->GetGUID()];
+    FightState& state = registry.states[_unit->GetGUID()];
     bool firstObservation = state.lastSeenMs == 0;
     uint32 elapsed = firstObservation ? 0 : now - state.phaseStartMs;
 
-    bool fast;
-    if (plagueCloud)
-        fast = true;
-    else if (state.fastPhase)
-        fast = idleOnPlatform;   // still on the platform without a victim: the fast dance goes on
-    else
-        // A slow dance always lasts SlowPhaseDurationMs, so ignore an idle boss on the platform before that
-        // (e.g. victim just died while he was still standing there at the pull).
-        fast = idleOnPlatform && !firstObservation && elapsed + 5000 >= SlowPhaseDurationMs;
+    bool fast = DetectFastPhase(state, plagueCloud != nullptr, idleOnPlatform, firstObservation, elapsed);
+    UpdateFightState(state, fast, plagueCloud, firstObservation, now);
 
+    _fastPhase = state.fastPhase;
+    _phaseElapsedMs = now - state.phaseStartMs;
+    return true;
+}
+
+bool HeiganBossHelper::DetectFastPhase(FightState const& state, bool plagueCloudUp, bool idleOnPlatform,
+                                       bool firstObservation, uint32 elapsed) const
+{
+    if (plagueCloudUp)
+        return true;
+
+    // Still on the platform without a victim: the fast dance goes on (bridges the second before the aura).
+    if (state.fastPhase)
+        return idleOnPlatform;
+
+    // A slow dance always lasts SlowPhaseDurationMs, so ignore an idle boss on the platform before that
+    // (e.g. victim just died while he was still standing there at the pull).
+    return idleOnPlatform && !firstObservation && elapsed + 5000 >= SlowPhaseDurationMs;
+}
+
+void HeiganBossHelper::UpdateFightState(FightState& state, bool fast, Aura const* plagueCloud,
+                                        bool firstObservation, uint32 now)
+{
     if (fast)
     {
         if (plagueCloud)
@@ -107,10 +133,6 @@ bool HeiganBossHelper::UpdateBossAI()
         state.fastPhase = false;
     }
     state.lastSeenMs = now;
-
-    _fastPhase = state.fastPhase;
-    _phaseElapsedMs = now - state.phaseStartMs;
-    return true;
 }
 
 uint32 HeiganBossHelper::GetEruptionIndex() const
@@ -163,9 +185,9 @@ bool HeiganBossHelper::ShouldDance()
 {
     if (_fastPhase)
         return true;
-    if (botAI->IsRanged(bot))
+    if (PlayerbotAI::IsRanged(bot))
         return false;
-    if (botAI->IsMainTank(bot) && !AI_VALUE2(bool, "has aggro", "boss target"))
+    if (PlayerbotAI::IsMainTank(bot) && !AI_VALUE2(bool, "has aggro", "boss target"))
         return false;
     return true;
 }

--- a/src/Ai/Raid/Naxx/NaxxBossHelper.h
+++ b/src/Ai/Raid/Naxx/NaxxBossHelper.h
@@ -79,6 +79,88 @@ protected:
     uint32 _timer = 0;
 };
 
+// Heigan the Unclean ("safety dance").
+//
+// Everything here is derived from observable state only; the core boss script (boss_heigan.cpp) is not touched.
+// The fight is fully periodic:
+//   * slow dance (starts on pull, 90s): eruptions at 15s then every 10s (8 eruptions);
+//   * fast dance (45s): Heigan teleports onto his platform and channels Plague Cloud (29350, 45s aura, 1s after
+//     the teleport), eruptions at 7s then every 4s (10 eruptions); then back to the slow dance.
+// The eruption itself is cast by the floor gameobjects (never by the boss), so it cannot be seen as a boss cast;
+// instead the safe spot is computed from the phase clock. In each phase the safe section walks
+// waypoint 0 -> 1 -> 2 -> 3 -> 2 -> 1 -> 0 -> ... (the core's sections 3,2,1,0,1,2,3,...).
+// The phase clock is exact during the fast dance (Plague Cloud remaining duration) and derived from that for the
+// following slow dances; only the very first slow dance is anchored on the moment the raid saw the pull.
+// The clock is shared between all bots fighting the same Heigan so a bot that died and got resurrected mid-fight
+// (or joined late) picks the schedule up again.
+class HeiganBossHelper : public AiObject
+{
+public:
+    static constexpr uint32 WaypointCount = 4;
+    // Section centres, index 0 is the section that is safe at the first eruption of every phase.
+    static constexpr float WaypointX[WaypointCount] = {2794.88f, 2775.49f, 2762.30f, 2755.99f};
+    static constexpr float WaypointY[WaypointCount] = {-3668.12f, -3674.43f, -3684.59f, -3703.96f};
+    // Heigan's platform: ranged/healers stand here during the slow dance, nobody may be near it during the fast one.
+    static constexpr float PlatformX = 2794.26f;
+    static constexpr float PlatformY = -3706.67f;
+    static constexpr float PlatformZ = 276.54f;
+    static constexpr float PlatformRadius = 10.0f;
+
+    static constexpr uint32 SlowFirstEruptionMs = 15000;
+    static constexpr uint32 SlowEruptionIntervalMs = 10000;
+    static constexpr uint32 SlowEruptionCount = 8;
+    static constexpr uint32 SlowPhaseDurationMs = 90000;
+    static constexpr uint32 FastFirstEruptionMs = 7000;
+    static constexpr uint32 FastEruptionIntervalMs = 4000;
+    static constexpr uint32 FastEruptionCount = 10;
+    static constexpr uint32 FastPhaseDurationMs = 45000;
+    static constexpr uint32 PlagueCloudDelayMs = 1000;    // Plague Cloud is cast 1s after the teleport
+    // Do not leave the current safe spot until this long after the computed eruption time (scheduler jitter).
+    static constexpr uint32 EruptionSafetyMarginMs = 300;
+    static constexpr float SafeSpotTolerance = 4.0f;
+
+    struct FightState
+    {
+        bool fastPhase = false;
+        uint32 phaseStartMs = 0;
+        bool exact = false;   // phaseStartMs derived from the Plague Cloud aura (directly or via the phase length)
+        uint32 lastSeenMs = 0;
+    };
+
+    HeiganBossHelper(PlayerbotAI* botAI) : AiObject(botAI) {}
+
+    // Finds Heigan and refreshes the shared fight clock. False when the bot is not fighting Heigan.
+    bool UpdateBossAI();
+    Unit* GetBoss() const { return _unit; }
+    bool IsFastPhase() const { return _fastPhase; }
+    uint32 GetPhaseElapsedMs() const { return _phaseElapsedMs; }
+    // Number of eruptions of the current phase that already happened (safety margin applied).
+    uint32 GetEruptionIndex() const;
+    // Waypoint (0..3) the bot has to stand at right now.
+    uint32 GetSafeWaypoint() const;
+    uint32 GetMsUntilNextEruption() const;
+    bool IsAtWaypoint(uint32 index, float tolerance = SafeSpotTolerance) const;
+    // Ranged bots wait on the platform during the slow dance until its last eruption is over, then head to the
+    // first fast-dance spot.
+    bool ShouldRangedHoldPlatform() const { return !_fastPhase && GetEruptionIndex() < SlowEruptionCount; }
+    // Melee always dance, ranged only during the fast dance. A main tank without aggro is free to go get it.
+    bool ShouldDance();
+    // Safe to stand still (e.g. cast) for the given time without missing the next move.
+    bool CanStandStillFor(uint32 ms);
+
+private:
+    void Reset()
+    {
+        _unit = nullptr;
+        _fastPhase = false;
+        _phaseElapsedMs = 0;
+    }
+
+    Unit* _unit = nullptr;
+    bool _fastPhase = false;
+    uint32 _phaseElapsedMs = 0;
+};
+
 class KelthuzadBossHelper : public AiObject
 {
 public:

--- a/src/Ai/Raid/Naxx/NaxxBossHelper.h
+++ b/src/Ai/Raid/Naxx/NaxxBossHelper.h
@@ -20,7 +20,10 @@
 #include "SharedDefines.h"
 #include "Spell.h"
 #include "Timer.h"
+#include <array>
 #include <string>
+
+class Aura;
 
 const uint32 NAXX_MAP_ID = 533;
 
@@ -98,8 +101,8 @@ class HeiganBossHelper : public AiObject
 public:
     static constexpr uint32 WaypointCount = 4;
     // Section centres, index 0 is the section that is safe at the first eruption of every phase.
-    static constexpr float WaypointX[WaypointCount] = {2794.88f, 2775.49f, 2762.30f, 2755.99f};
-    static constexpr float WaypointY[WaypointCount] = {-3668.12f, -3674.43f, -3684.59f, -3703.96f};
+    static constexpr std::array<float, WaypointCount> WaypointX = {2794.88f, 2775.49f, 2762.30f, 2755.99f};
+    static constexpr std::array<float, WaypointCount> WaypointY = {-3668.12f, -3674.43f, -3684.59f, -3703.96f};
     // Heigan's platform: ranged/healers stand here during the slow dance, nobody may be near it during the fast one.
     static constexpr float PlatformX = 2794.26f;
     static constexpr float PlatformY = -3706.67f;
@@ -127,7 +130,7 @@ public:
         uint32 lastSeenMs = 0;
     };
 
-    HeiganBossHelper(PlayerbotAI* botAI) : AiObject(botAI) {}
+    explicit HeiganBossHelper(PlayerbotAI* botAI) : AiObject(botAI) {}
 
     // Finds Heigan and refreshes the shared fight clock. False when the bot is not fighting Heigan.
     bool UpdateBossAI();
@@ -155,6 +158,13 @@ private:
         _fastPhase = false;
         _phaseElapsedMs = 0;
     }
+
+    // Decide from the boss state whether the fast dance is on right now.
+    bool DetectFastPhase(FightState const& state, bool plagueCloudUp, bool idleOnPlatform, bool firstObservation,
+                         uint32 elapsed) const;
+    // Move the shared clock to the phase we just observed.
+    static void UpdateFightState(FightState& state, bool fast, Aura const* plagueCloud, bool firstObservation,
+                                 uint32 now);
 
     Unit* _unit = nullptr;
     bool _fastPhase = false;

--- a/src/Ai/Raid/Naxx/NaxxMultipliers.cpp
+++ b/src/Ai/Raid/Naxx/NaxxMultipliers.cpp
@@ -42,68 +42,50 @@ float GrobbulusMultiplier::GetValue(Action* action)
     return 1.0f;
 }
 
-//float HeiganDanceMultiplier::GetValue(Action* action)
-//{
-//    Unit* boss = AI_VALUE2(Unit*, "find target", "heigan the unclean");
-//    if (!boss)
-//    {
-//        return 1.0f;
-//    }
-//    bool platform_phase = boss->IsWithinDist2d(2794.26f, -3706.67f, 10.0f);
-//    bool eruption_casting = false;
-//    if (boss->HasUnitState(UNIT_STATE_CASTING))
-//    {
-//        Spell* spell = boss->GetCurrentSpell(CURRENT_GENERIC_SPELL);
-//        if (!spell)
-//        {
-//            spell = boss->GetCurrentSpell(CURRENT_CHANNELED_SPELL);
-//        }
-//        if (spell)
-//        {
-//            SpellInfo const* info = spell->GetSpellInfo();
-//            bool isEruption = NaxxSpellIds::MatchesAnySpellId(info, {NaxxSpellIds::Eruption10});
-//            if (!isEruption && info && info->SpellName[LOCALE_enUS])
-//            {
-//                // Fallback to name for custom spell data.
-//                isEruption = botAI->EqualLowercaseName(info->SpellName[LOCALE_enUS], "eruption");
-//            }
-//            if (isEruption)
-//            {
-//                eruption_casting = true;
-//            }
-//        }
-//    }
-//    if (dynamic_cast<CombatFormationMoveAction*>(action) ||
-//        dynamic_cast<CastDisengageAction*>(action) ||
-//        dynamic_cast<CastBlinkBackAction*>(action) )
-//    {
-//        return 0.0f;
-//    }
-//    if (!platform_phase && !eruption_casting)
-//    {
-//        return 1.0f;
-//    }
-//    if (dynamic_cast<HeiganDanceAction*>(action) || dynamic_cast<CurePartyMemberAction*>(action))
-//    {
-//        return 1.0f;
-//    }
-//    if (dynamic_cast<CastSpellAction*>(action) && !dynamic_cast<CastMeleeSpellAction*>(action))
-//    {
-//        CastSpellAction* spellAction = dynamic_cast<CastSpellAction*>(action);
-//        uint32 spellId = AI_VALUE2(uint32, "spell id", spellAction->getSpell());
-//        SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
-//        if (!spellInfo)
-//        {
-//            return 0.0f;
-//        }
-//        uint32 castTime = spellInfo->CalcCastTime();
-//        if (castTime == 0 && !spellInfo->IsChanneled())
-//        {
-//            return 1.0f;
-//        }
-//    }
-//    return 0.0f;
-//}
+float HeiganDanceMultiplier::GetValue(Action* action)
+{
+    if (!helper.UpdateBossAI())
+        return 1.0f;
+
+    if (dynamic_cast<HeiganDanceAction*>(action) || dynamic_cast<CurePartyMemberAction*>(action))
+        return 1.0f;
+
+    // Generic repositioning must never pull a bot off its safe spot or off the platform.
+    if (dynamic_cast<CombatFormationMoveAction*>(action) || dynamic_cast<FleeAction*>(action) ||
+        dynamic_cast<CastDisengageAction*>(action) || dynamic_cast<CastBlinkBackAction*>(action))
+        return 0.0f;
+
+    // Ranged bots on the platform during the slow dance are free to act as usual.
+    if (!helper.ShouldDance())
+        return 1.0f;
+
+    // Dancing: only the dance moves us (charge/intercept/feral charge included - during the fast dance the boss
+    // stands in his Plague Cloud). Everything that is not a cast is fine (target selection, facing, ...).
+    if (dynamic_cast<MovementAction*>(action) || dynamic_cast<CastReachTargetSpellAction*>(action))
+        return 0.0f;
+
+    CastSpellAction* spellAction = dynamic_cast<CastSpellAction*>(action);
+    if (!spellAction || dynamic_cast<CastMeleeSpellAction*>(action))
+        return 1.0f;
+
+    // Casts are allowed while standing on the safe spot with enough time left before the next eruption.
+    uint32 spellId = AI_VALUE2(uint32, "spell id", spellAction->getSpell());
+    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+    if (!spellInfo)
+        return 1.0f;
+
+    uint32 castTime = spellInfo->CalcCastTime(bot);
+    if (spellInfo->IsChanneled())
+    {
+        int32 duration = spellInfo->GetDuration();
+        if (duration > 0)
+            castTime += uint32(duration);
+    }
+    if (castTime == 0)
+        return 1.0f;
+
+    return helper.CanStandStillFor(castTime + 500) ? 1.0f : 0.0f;
+}
 
 float LoathebGenericMultiplier::GetValue(Action* action)
 {

--- a/src/Ai/Raid/Naxx/NaxxMultipliers.cpp
+++ b/src/Ai/Raid/Naxx/NaxxMultipliers.cpp
@@ -26,6 +26,7 @@
 #include "Spell.h"
 #include "UseMeetingStoneAction.h"
 #include "WarriorActions.h"
+#include "WipeAction.h"
 
 float GrobbulusMultiplier::GetValue(Action* action)
 {
@@ -44,15 +45,24 @@ float GrobbulusMultiplier::GetValue(Action* action)
 
 float HeiganDanceMultiplier::GetValue(Action* action)
 {
+    // Cheap action-type checks first; the encounter state is only looked up for actions we may have to block.
+    if (dynamic_cast<HeiganDanceAction*>(action) || dynamic_cast<CurePartyMemberAction*>(action) ||
+        dynamic_cast<WipeAction*>(action))
+        return 1.0f;
+
+    bool repositions = dynamic_cast<CombatFormationMoveAction*>(action) || dynamic_cast<FleeAction*>(action) ||
+                       dynamic_cast<CastDisengageAction*>(action) || dynamic_cast<CastBlinkBackAction*>(action);
+    bool moves = dynamic_cast<MovementAction*>(action) || dynamic_cast<CastReachTargetSpellAction*>(action);
+    auto* spellAction = dynamic_cast<CastSpellAction*>(action);
+    bool timedCast = spellAction && !dynamic_cast<CastMeleeSpellAction*>(action);
+    if (!repositions && !moves && !timedCast)
+        return 1.0f;
+
     if (!helper.UpdateBossAI())
         return 1.0f;
 
-    if (dynamic_cast<HeiganDanceAction*>(action) || dynamic_cast<CurePartyMemberAction*>(action))
-        return 1.0f;
-
     // Generic repositioning must never pull a bot off its safe spot or off the platform.
-    if (dynamic_cast<CombatFormationMoveAction*>(action) || dynamic_cast<FleeAction*>(action) ||
-        dynamic_cast<CastDisengageAction*>(action) || dynamic_cast<CastBlinkBackAction*>(action))
+    if (repositions)
         return 0.0f;
 
     // Ranged bots on the platform during the slow dance are free to act as usual.
@@ -61,12 +71,8 @@ float HeiganDanceMultiplier::GetValue(Action* action)
 
     // Dancing: only the dance moves us (charge/intercept/feral charge included - during the fast dance the boss
     // stands in his Plague Cloud). Everything that is not a cast is fine (target selection, facing, ...).
-    if (dynamic_cast<MovementAction*>(action) || dynamic_cast<CastReachTargetSpellAction*>(action))
+    if (moves)
         return 0.0f;
-
-    CastSpellAction* spellAction = dynamic_cast<CastSpellAction*>(action);
-    if (!spellAction || dynamic_cast<CastMeleeSpellAction*>(action))
-        return 1.0f;
 
     // Casts are allowed while standing on the safe spot with enough time left before the next eruption.
     uint32 spellId = AI_VALUE2(uint32, "spell id", spellAction->getSpell());

--- a/src/Ai/Raid/Naxx/NaxxMultipliers.h
+++ b/src/Ai/Raid/Naxx/NaxxMultipliers.h
@@ -19,14 +19,17 @@ public:
     float GetValue(Action* action) override;
 };
 
-//class HeiganDanceMultiplier : public Multiplier
-//{
-//public:
-//    HeiganDanceMultiplier(PlayerbotAI* ai) : Multiplier(ai, "helgan dance") {}
-//
-//public:
-//    float GetValue(Action* action) override;
-//};
+class HeiganDanceMultiplier : public Multiplier
+{
+public:
+    HeiganDanceMultiplier(PlayerbotAI* ai) : Multiplier(ai, "heigan dance"), helper(ai) {}
+
+public:
+    float GetValue(Action* action) override;
+
+private:
+    HeiganBossHelper helper;
+};
 
 class LoathebGenericMultiplier : public Multiplier
 {

--- a/src/Ai/Raid/Naxx/NaxxMultipliers.h
+++ b/src/Ai/Raid/Naxx/NaxxMultipliers.h
@@ -22,7 +22,7 @@ public:
 class HeiganDanceMultiplier : public Multiplier
 {
 public:
-    HeiganDanceMultiplier(PlayerbotAI* ai) : Multiplier(ai, "heigan dance"), helper(ai) {}
+    explicit HeiganDanceMultiplier(PlayerbotAI* ai) : Multiplier(ai, "heigan dance"), helper(ai) {}
 
 public:
     float GetValue(Action* action) override;

--- a/src/Ai/Raid/Naxx/NaxxSpellIds.h
+++ b/src/Ai/Raid/Naxx/NaxxSpellIds.h
@@ -14,7 +14,9 @@
 namespace NaxxSpellIds
 {
     // Heigan
-    static constexpr uint32 Eruption10 = 29371;
+    static constexpr uint32 Eruption10 = 29371;      // cast by the floor gameobjects, not by the boss
+    static constexpr uint32 PlagueCloud = 29350;     // 45s self-channel while Heigan is on his platform (fast dance)
+    static constexpr uint32 TeleportSelf = 30211;
 /*
     SPELL_SPELL_DISRUPTION          = 29310,
     SPELL_DECREPIT_FEVER            = 29998,

--- a/src/Ai/Raid/Naxx/NaxxStrategy.cpp
+++ b/src/Ai/Raid/Naxx/NaxxStrategy.cpp
@@ -27,13 +27,13 @@ void RaidNaxxStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     ));
 
     // Heigan the Unclean
-    //triggers.push_back(new TriggerNode("heigan melee",
-    //    { NextAction("heigan dance melee", ACTION_RAID + 1) }
-    //));
+    triggers.push_back(new TriggerNode("heigan melee",
+        { NextAction("heigan dance melee", ACTION_RAID + 1) }
+    ));
 
-    //triggers.push_back(new TriggerNode("heigan ranged",
-    //    { NextAction("heigan dance ranged", ACTION_RAID + 1) }
-    //));
+    triggers.push_back(new TriggerNode("heigan ranged",
+        { NextAction("heigan dance ranged", ACTION_RAID + 1) }
+    ));
 
     // Kel'Thuzad
     triggers.push_back(
@@ -148,7 +148,7 @@ void RaidNaxxStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 void RaidNaxxStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
 {
     multipliers.push_back(new GrobbulusMultiplier(botAI));
-    //multipliers.push_back(new HeiganDanceMultiplier(botAI));
+    multipliers.push_back(new HeiganDanceMultiplier(botAI));
     multipliers.push_back(new LoathebGenericMultiplier(botAI));
     multipliers.push_back(new ThaddiusGenericMultiplier(botAI));
     multipliers.push_back(new SapphironGenericMultiplier(botAI));

--- a/src/Ai/Raid/Naxx/NaxxTriggerContext.h
+++ b/src/Ai/Raid/Naxx/NaxxTriggerContext.h
@@ -19,8 +19,8 @@ public:
         creators["mutating injection ranged"] = &RaidNaxxTriggerContext::mutating_injection_ranged;
         creators["mutating injection removed"] = &RaidNaxxTriggerContext::mutating_injection_removed;
         creators["grobbulus cloud"] = &RaidNaxxTriggerContext::grobbulus_cloud;
-        //creators["heigan melee"] = &RaidNaxxTriggerContext::heigan_melee;
-        //creators["heigan ranged"] = &RaidNaxxTriggerContext::heigan_ranged;
+        creators["heigan melee"] = &RaidNaxxTriggerContext::heigan_melee;
+        creators["heigan ranged"] = &RaidNaxxTriggerContext::heigan_ranged;
 
         creators["thaddius phase pet"] = &RaidNaxxTriggerContext::thaddius_phase_pet;
         creators["thaddius phase pet lose aggro"] = &RaidNaxxTriggerContext::thaddius_phase_pet_lose_aggro;
@@ -56,8 +56,8 @@ private:
     static Trigger* mutating_injection_ranged(PlayerbotAI* ai) { return new MutatingInjectionRangedTrigger(ai); }
     static Trigger* mutating_injection_removed(PlayerbotAI* ai) { return new MutatingInjectionRemovedTrigger(ai); }
     static Trigger* grobbulus_cloud(PlayerbotAI* ai) { return new GrobbulusCloudTrigger(ai); }
-    //static Trigger* heigan_melee(PlayerbotAI* ai) { return new HeiganMeleeTrigger(ai); }
-    //static Trigger* heigan_ranged(PlayerbotAI* ai) { return new HeiganRangedTrigger(ai); }
+    static Trigger* heigan_melee(PlayerbotAI* ai) { return new HeiganMeleeTrigger(ai); }
+    static Trigger* heigan_ranged(PlayerbotAI* ai) { return new HeiganRangedTrigger(ai); }
 
     static Trigger* thaddius_phase_pet(PlayerbotAI* ai) { return new ThaddiusPhasePetTrigger(ai); }
     static Trigger* thaddius_phase_pet_lose_aggro(PlayerbotAI* ai) { return new ThaddiusPhasePetLoseAggroTrigger(ai); }

--- a/src/Ai/Raid/Naxx/NaxxTriggers.cpp
+++ b/src/Ai/Raid/Naxx/NaxxTriggers.cpp
@@ -83,12 +83,12 @@ bool GrobbulusCloudTrigger::IsActive()
 
 bool HeiganMeleeTrigger::IsActive()
 {
-    return helper.UpdateBossAI() && !botAI->IsRanged(bot);
+    return PlayerbotAI::IsMelee(bot) && helper.UpdateBossAI();
 }
 
 bool HeiganRangedTrigger::IsActive()
 {
-    return helper.UpdateBossAI() && botAI->IsRanged(bot);
+    return PlayerbotAI::IsRanged(bot) && helper.UpdateBossAI();
 }
 
 bool RazuviousTankTrigger::IsActive()

--- a/src/Ai/Raid/Naxx/NaxxTriggers.cpp
+++ b/src/Ai/Raid/Naxx/NaxxTriggers.cpp
@@ -81,25 +81,15 @@ bool GrobbulusCloudTrigger::IsActive()
     return true;
 }
 
-//bool HeiganMeleeTrigger::IsActive()
-//{
-//    Unit* heigan = AI_VALUE2(Unit*, "find target", "heigan the unclean");
-//    if (!heigan)
-//    {
-//        return false;
-//    }
-//    return !botAI->IsRanged(bot);
-//}
-//
-//bool HeiganRangedTrigger::IsActive()
-//{
-//    Unit* heigan = AI_VALUE2(Unit*, "find target", "heigan the unclean");
-//    if (!heigan)
-//    {
-//        return false;
-//    }
-//    return botAI->IsRanged(bot);
-//}
+bool HeiganMeleeTrigger::IsActive()
+{
+    return helper.UpdateBossAI() && !botAI->IsRanged(bot);
+}
+
+bool HeiganRangedTrigger::IsActive()
+{
+    return helper.UpdateBossAI() && botAI->IsRanged(bot);
+}
 
 bool RazuviousTankTrigger::IsActive()
 {

--- a/src/Ai/Raid/Naxx/NaxxTriggers.h
+++ b/src/Ai/Raid/Naxx/NaxxTriggers.h
@@ -64,19 +64,25 @@ private:
     static constexpr uint32 CloudRotationDelayMs = 15000;
 };
 
-//class HeiganMeleeTrigger : public Trigger
-//{
-//public:
-//    HeiganMeleeTrigger(PlayerbotAI* ai) : Trigger(ai, "heigan melee") {}
-//    virtual bool IsActive();
-//};
-//
-//class HeiganRangedTrigger : public Trigger
-//{
-//public:
-//    HeiganRangedTrigger(PlayerbotAI* ai) : Trigger(ai, "heigan ranged") {}
-//    bool IsActive() override;
-//};
+class HeiganMeleeTrigger : public Trigger
+{
+public:
+    HeiganMeleeTrigger(PlayerbotAI* ai) : Trigger(ai, "heigan melee"), helper(ai) {}
+    bool IsActive() override;
+
+private:
+    HeiganBossHelper helper;
+};
+
+class HeiganRangedTrigger : public Trigger
+{
+public:
+    HeiganRangedTrigger(PlayerbotAI* ai) : Trigger(ai, "heigan ranged"), helper(ai) {}
+    bool IsActive() override;
+
+private:
+    HeiganBossHelper helper;
+};
 
 class RazuviousTankTrigger : public Trigger
 {

--- a/src/Ai/Raid/Naxx/NaxxTriggers.h
+++ b/src/Ai/Raid/Naxx/NaxxTriggers.h
@@ -67,7 +67,7 @@ private:
 class HeiganMeleeTrigger : public Trigger
 {
 public:
-    HeiganMeleeTrigger(PlayerbotAI* ai) : Trigger(ai, "heigan melee"), helper(ai) {}
+    explicit HeiganMeleeTrigger(PlayerbotAI* ai) : Trigger(ai, "heigan melee"), helper(ai) {}
     bool IsActive() override;
 
 private:
@@ -77,7 +77,7 @@ private:
 class HeiganRangedTrigger : public Trigger
 {
 public:
-    HeiganRangedTrigger(PlayerbotAI* ai) : Trigger(ai, "heigan ranged"), helper(ai) {}
+    explicit HeiganRangedTrigger(PlayerbotAI* ai) : Trigger(ai, "heigan ranged"), helper(ai) {}
     bool IsActive() override;
 
 private:


### PR DESCRIPTION
## Pull Request Description

Re-enables the Heigan the Unclean "safety dance" in the Naxxramas strategy, which has shipped commented out since #2031 (and was removed before that in #1961 because it depended on core script internals).

The #2031 rewrite tried to advance the safe zone whenever it saw the **boss** cast Eruption (29371). That can never fire: in AzerothCore the eruption is cast by the floor GameObjects (`instance_naxxramas.cpp` `HeiganEruptSections` -> `go->CastSpell(nullptr, SPELL_ERUPTION)`), never by Heigan himself. So bots stood in the eruptions.

This PR keeps the "observable state only, no core changes" constraint and instead drives the dance from a fight clock:

- `boss_heigan.cpp` uses fixed constants (identical for 10/25): slow dance 90 s with eruptions at 15 s then every 10 s (8 total); fast dance 45 s with eruptions at 7 s then every 4 s (10 total); safe section bounces 3,2,1,0,1,2,3,...
- During the fast dance Heigan channels **Plague Cloud (29350)**, a 45 s self-aura applied 1 s after his teleport. Its remaining duration is an exact clock for the phase, and because phase lengths are constant, the following slow dance is exact too (`slowStart = fastStart + 45 s`). Only the very first slow dance is anchored on "first bot tick after the pull", and any latency there errs in the safe direction (bots leave a spot later, never earlier).
- The clock lives in one small `static` map keyed by boss GUID (mutex-guarded, same precedent as the RS/Ulduar helpers) so a bot that dies and is battle-rezzed, or joins late, picks the schedule back up instead of restarting it from "now".
- Safe waypoint = f(phase, elapsed) with a 300 ms margin (the boss `TaskScheduler` fires up to a tick late); after a phase's last eruption bots pre-move to the first spot of the next phase, which makes the transitions seamless.
- Roles: melee/off-tanks always dance; the bot main tank dances once it has aggro (Heigan starts on his platform, so the tank is free to go pick him up); ranged/healers stand on the platform during the slow dance (Plague Cloud radius 21 y, platform is >= 38 y from the dance spots) and leave after its 8th eruption; everyone dances the fast dance.
- `HeiganDanceMultiplier` gates casts by `CanStandStillFor(castTime + 500 ms)` (instants always allowed) and suppresses formation/flee/blink/disengage moves and reach/charge actions while dancing (Heigan stands inside his own Plague Cloud during the fast dance).

The module's original waypoints were kept; they were checked against the core's `GetEruptionSection` classifier (module waypoint 0..3 = core sections 3..0). Spell facts (45 000 ms duration, 21 y radius) were confirmed from `Spell.dbc`.

Files: `src/Ai/Raid/Naxx/` only. New `NaxxBossHelper.cpp` (the clock and waypoint math), `HeiganBossHelper` in `NaxxBossHelper.h`, `NaxxActions_Heigan.cpp` rewritten, the Heigan trigger/action/multiplier declarations and their registrations uncommented and updated.

## Feature Evaluation

- **Minimum logic:** per bot per tick while fighting Heigan: one `find target` lookup (as every other Naxx trigger), one `GetAura(29350)`, one distance check, one hash-map lookup under a mutex, integer arithmetic for the safe waypoint. The multiplier does a handful of `dynamic_cast`s per candidate action, like the existing raid multipliers.
- **Processing cost:** the trigger only exists on map 533 (instance strategy) and returns immediately when the bot is not in combat with Heigan. There is no per-tick pathing beyond the moves the bot would issue anyway; `MoveInside` returns false once at the spot, so no repeated sub-yard moves. Nothing runs for bots outside Naxxramas.

## How to Test the Changes

Setup: `AiPlayerbot.ApplyInstanceStrategies = 1` (default), a 10-man group of you plus 9 bots with melee, ranged and healers, Naxxramas 10, clear to Heigan.

1. Pull with the tank (human or bot). Expected: melee bots stand on the first spot (west of the platform) and step to the next section every 10 s starting at 15 s; ranged/healers stand on the platform and heal/DPS from there; at ~85 s ranged leave the platform for the first fast-dance spot; at 90 s Heigan teleports and every bot moves every 4 s from 7 s on; at 135 s everyone is back on the first slow-dance spot; repeat until dead. Nobody should take Eruption damage.
2. Optional: kill a bot mid-fight and battle-rez it. Expected: it rejoins the correct spot immediately instead of standing on waypoint 0.
3. Optional: wipe or evade, then re-pull. Expected: the schedule restarts cleanly (state is dropped after 30 s without observation).

### Test scenarios performed and results

Environment: AzerothCore Playerbot branch `092e9ba6ff8d`, module at `a7b885d2` plus this change, Docker (Linux), `MapUpdate.Threads = 4`, 250 random bots online, `mod-autobalance` on dist defaults.

| # | Scenario | Result |
|---|---|---|
| 1 | Compile the module (full worldserver image build) | Builds; zero compiler warnings in `src/Ai/Raid/Naxx/` |
| 2 | Boot the worldserver with the change | Clean boot ("World Initialized"), 250 random bots logged in, no new log errors |
| 3 | 10-man Naxxramas, human blood-DK tank plus 9 bots (mixed melee, ranged and healers), pull Heigan and kill him | **Kill, zero deaths.** DBM: "Heigan the Unclean down after 3 minutes and 28.00 seconds" (208 s = slow dance 0 to 90 s, fast dance 90 to 135 s, second slow dance to the kill), so both phases and both phase transitions were exercised. Observed: melee danced from 15 s on the 10 s schedule; ranged and healers stood on the platform and cast from there; ranged left the platform at ~85 s; every bot danced the 4 s fast phase; all bots back on the first slow-dance spot at 135 s. Screenshot of the kill attached below. |
| 4 | Bots outside Naxxramas during the same session | No behavior change (trigger only exists on map 533) |

10-man kill (DBM timer bottom left, all raid frames alive):

<img width="2765" height="1458" alt="WoWScrnShot_081726_141711" src="https://github.com/user-attachments/assets/045b34cd-8d3c-4599-b1b5-837a52aba1e6" />

Not yet exercised (would appreciate testers): bot main tank pulling (code path is there: the tank dances once it has aggro), battle-rez rejoin mid-fight, wipe and re-pull, 25-man.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

Only bots in Naxxramas and in combat with Heigan pay anything (see Feature Evaluation). Bots elsewhere are unaffected.

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

Bots in the Heigan encounter now dance instead of standing still; that is the previously commented-out, intended behavior of the Naxx strategy.

- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [x] Yes (**explain below**)

The schedule constants mirror `boss_heigan.cpp`; if the core script's timings ever change, the constants in `HeiganBossHelper` need to follow. They are documented in one place at the top of the class.

## AI Assistance

Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)

The investigation (git history, core script and Spell.dbc reading) and the code were produced with Claude Code, driven and reviewed by me. I have read and understand the full change and tested it live as described above.

## Code Provenance / Attribution

Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots, MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated. (none added)
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands). (behavior described in code comments; no conf changes)
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers

- The static fight state is guarded by a mutex because bot AI runs from `OnPlayerAfterUpdate` inside `Map::Update`, and with `MapUpdate.Threads > 1` two Naxxramas instances can tick concurrently.
- `HeiganDanceAction` clears `last movement` before re-issuing a `MOVEMENT_COMBAT` move when the safe waypoint changes; otherwise `IsWaitingForLastMove` would keep a bot walking toward the section that is about to erupt.
- Known limit: a healer more than 40 y from the tank could in theory step off the platform to get in range during the slow dance (platform to far waypoint is ~38 to 40 y). Not observed in testing.
