### PR TITLE
Allow playerbots to sell normal quality equipment

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -208,6 +208,12 @@ AiPlayerbot.AutoInitEquipLevelLimitRatio = 1.0
 # Default: 1 - (enabled)
 AiPlayerbot.AllowLearnTrainerSpells = 1
 
+# SellNormalQualityEquipment
+# Description: Allow the bot to sell white armor when using the `s *` command.
+# Useful while low-level questing so bots sell their unequipped white (normal quality) equipment.
+# Default: 0 - (disabled)
+AiPlayerbot.SellNormalQualityEquipment = 0
+
 #
 #
 ####################################################################################################

--- a/src/Ai/Base/Actions/SellAction.cpp
+++ b/src/Ai/Base/Actions/SellAction.cpp
@@ -10,6 +10,7 @@
 #include "ItemUsageValue.h"
 #include "ItemVisitors.h"
 #include "Playerbots.h"
+#include "PlayerbotAIConfig.h"
 
 class SellItemsVisitor : public IterateItemsVisitor
 {
@@ -33,8 +34,16 @@ public:
 
     bool Visit(Item* item) override
     {
-        if (item->GetTemplate()->Quality != ITEM_QUALITY_POOR)
+        ItemTemplate const* itemTemplate = item->GetTemplate();
+
+        bool isGrayItem = itemTemplate->Quality == ITEM_QUALITY_POOR;
+        bool isWhiteEquipment = itemTemplate->Quality == ITEM_QUALITY_NORMAL && (itemTemplate->Class == ITEM_CLASS_ARMOR);
+        //would like to consider Weapons too but how to check that it isn't mining pickaxe, skinning knife, fishing rods...
+
+        if (!isGrayItem && !(sPlayerbotAIConfig.sellNormalQualityEquipment && isWhiteEquipment))
+        {
             return true;
+        }
 
         return SellItemsVisitor::Visit(item);
     }

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -102,6 +102,7 @@ bool PlayerbotAIConfig::Initialize()
     sitDelay = sConfigMgr->GetOption<int32>("AiPlayerbot.SitDelay", 20000);
     returnDelay = sConfigMgr->GetOption<int32>("AiPlayerbot.ReturnDelay", 2000);
     lootDelay = sConfigMgr->GetOption<int32>("AiPlayerbot.LootDelay", 1000);
+    sellNormalQualityEquipment = sConfigMgr->GetOption<bool>("AiPlayerbot.SellNormalQualityEquipment", false);
     disabledWithoutRealPlayerLoginDelay = sConfigMgr->GetOption<int32>("AiPlayerbot.DisabledWithoutRealPlayerLoginDelay", 30);
     disabledWithoutRealPlayerLogoutDelay = sConfigMgr->GetOption<int32>("AiPlayerbot.DisabledWithoutRealPlayerLogoutDelay", 300);
 

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -109,6 +109,7 @@ public:
     bool randomBotGuildNearby, randomBotInvitePlayer, inviteChat;
     uint32 globalCoolDown, reactDelay, maxWaitForMove, disableMoveSplinePath, maxMovementSearchTime, expireActionTime,
         dispelAuraDuration, passiveDelay, repeatDelay, errorDelay, rpgDelay, sitDelay, returnDelay, lootDelay;
+    bool sellNormalQualityEquipment;
     bool dynamicReactDelay;
     float sightDistance, spellDistance, reactDistance, grindDistance, lootDistance, shootDistance, fleeDistance,
         tooCloseDistance, meleeDistance, followDistance, whisperDistance, contactDistance, aoeRadius, rpgDistance,


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
When running `s *` on a playerbot, unequipped normal-quality equipment will now also be sold when `AiPlayerbot.SellNormalQualityEquipment = 1`.

While questing in low-level areas, quests often reward white equipment. By default, these items are not sold, which can cause them to accumulate in the playerbot's inventory.


## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
1. Give a playerbot a normal-quality (white) equipment armor.
2. Run `s *` on the bot. The white item should NOT be sold (default behavior).
3. Set `AiPlayerbot.SellNormalQualityEquipment = 1` in `playerbots.conf`.
4. Run `s *` on the bot again. The white item should now be sold.



## Impact Assessment
<!--
As a generic test, pmon checks before and after your edits are helpful. To standardize the measurement, set the configs
BotActiveAlone = 100 & botActiveAloneSmartScale = 0. After server boot, enable the monitor `playerbot pmon toggle`
right after the bots finished logging-in, and run the stack command `playerbot pmon stack` 5 minutes after that.
The last "Total" line is the main result to look for.
-->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [x ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [x] No
- - [ ] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->



## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/Ai/Base/Actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated.
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->

zug zug