### PR TITLE
Fix Blade Flurry trigger and strategy

### DIFF
--- a/src/Ai/Class/Rogue/RogueAiObjectContext.cpp
+++ b/src/Ai/Class/Rogue/RogueAiObjectContext.cpp
@@ -77,12 +77,10 @@ public:
         creators["off hand weapon no enchant"] = &RogueTriggerFactoryInternal::off_hand_weapon_no_enchant;
         creators["tricks of the trade on main tank"] = &RogueTriggerFactoryInternal::tricks_of_the_trade_on_main_tank;
         creators["adrenaline rush"] = &RogueTriggerFactoryInternal::adrenaline_rush;
-        creators["blade fury"] = &RogueTriggerFactoryInternal::blade_fury;
+        creators["blade flurry"] = &RogueTriggerFactoryInternal::blade_flurry;
     }
 
 private:
-    static Trigger* adrenaline_rush(PlayerbotAI* botAI) { return new AdrenalineRushTrigger(botAI); }
-    static Trigger* blade_fury(PlayerbotAI* botAI) { return new BladeFuryTrigger(botAI); }
     static Trigger* kick(PlayerbotAI* botAI) { return new KickInterruptSpellTrigger(botAI); }
     static Trigger* rupture(PlayerbotAI* botAI) { return new RuptureTrigger(botAI); }
     static Trigger* slice_and_dice(PlayerbotAI* botAI) { return new SliceAndDiceTrigger(botAI); }
@@ -101,6 +99,8 @@ private:
     {
         return new TricksOfTheTradeOnMainTankTrigger(ai);
     }
+    static Trigger* adrenaline_rush(PlayerbotAI* botAI) { return new AdrenalineRushTrigger(botAI); }
+    static Trigger* blade_flurry(PlayerbotAI* botAI) { return new BladeFlurryTrigger(botAI); }
 };
 
 class RogueAiObjectContextInternal : public NamedObjectContext<Action>

--- a/src/Ai/Class/Rogue/RogueTriggers.h
+++ b/src/Ai/Class/Rogue/RogueTriggers.h
@@ -37,10 +37,10 @@ public:
     // bool isPossible();
 };
 
-class BladeFuryTrigger : public BoostTrigger
+class BladeFlurryTrigger : public BoostTrigger
 {
 public:
-    BladeFuryTrigger(PlayerbotAI* botAI) : BoostTrigger(botAI, "blade fury") {}
+    BladeFlurryTrigger(PlayerbotAI* botAI) : BoostTrigger(botAI, "blade flurry") {}
 };
 
 class RuptureTrigger : public DebuffTrigger

--- a/src/Ai/Class/Rogue/Strategy/DpsRogueStrategy.cpp
+++ b/src/Ai/Class/Rogue/Strategy/DpsRogueStrategy.cpp
@@ -101,7 +101,7 @@ void DpsRogueStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
         new TriggerNode(
             "slice and dice",
             {
-                NextAction("slice and dice", ACTION_HIGH + 2)
+                NextAction("slice and dice", ACTION_HIGH + 5)
             }
         )
     );
@@ -167,24 +167,6 @@ void DpsRogueStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
             "kick on enemy healer",
             {
                 NextAction("kick on enemy healer", ACTION_INTERRUPT + 1)
-            }
-        )
-    );
-
-    triggers.push_back(
-        new TriggerNode(
-            "light aoe",
-            {
-                NextAction("blade flurry", ACTION_HIGH + 3)
-            }
-        )
-    );
-
-    triggers.push_back(
-        new TriggerNode(
-            "blade flurry",
-                {
-                NextAction("blade flurry", ACTION_HIGH + 2)
             }
         )
     );
@@ -361,7 +343,7 @@ void RogueAoeStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
         new TriggerNode(
             "light aoe",
             {
-                NextAction("blade flurry", ACTION_HIGH)
+                NextAction("blade flurry", ACTION_HIGH + 4)
             }
         )
     );
@@ -382,6 +364,15 @@ void RogueBoostStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
             "adrenaline rush",
             {
                 NextAction("adrenaline rush", ACTION_HIGH + 2)
+            }
+        )
+    );
+
+    triggers.push_back(
+        new TriggerNode(
+            "blade flurry",
+            {
+                NextAction("blade flurry", ACTION_HIGH + 4)
             }
         )
     );


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

God the Rogue files are so bad. To recap, the "dps" strategy applies to all Rogues, and Assassination additionally gets "melee" for stuff like Mutilate and HFB.

Right now, Blade Flurry is present in the "dps" and the "aoe" strategies. It is triggered by "light aoe" in both, and then it separately is also triggered by "blade flurry" in the dps strategy.

Problem? There is no "blade flurry" trigger registered. It is BladeFuryTrigger (???) and has the "blade fury" string key. Thus, the ability is currently not used outside of aoe situations.

I've renamed the class to BladeFlurryTrigger and fixed the associated registrations/keys. I deleted the TriggerNode that fires based on light aoe in DpsRogueStrategy so that it sits only in RogueAoeStrategy. I moved the TriggerNode that fires based on blade flurry in DpsRogueStrategy and moved it to RogueBoostStrategy (it already inherits from BoostTrigger). 

I also tweaked the priorities. BF should be very high priority in AoE situations so I bumped it to ACTION_HIGH + 4 in the aoe strategy, which basically displaces everything that isn't a stealth move or defensive cooldown. However, it shouldn't be above SnD, so I moved SnD up to ACTION_HIGH + 5. In the boost strategy, I also made it ACTION_HIGH + 4, which puts it above AR at ACTION_HIGH + 2 (BF should be used first since it spends energy while AR restores it). I did 4 because it's unoccupied otherwise. That does put it over EA at ACTION_HIGH + 3, but it's getting too crammed, and to fix that I would need to start moving a ton of shit so we'll just live with this tiny inefficiency. The Rogue files badly need redoing anyway.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

Minimum logic described above. Processing cost is just the additional evaluation of one more BoostTrigger, which always existed but was not properly implemented.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->



## Impact Assessment
<!--
As a generic test, pmon checks before and after your edits are helpful. To standardize the measurement, set the configs
BotActiveAlone = 100 & botActiveAloneSmartScale = 0. After server boot, enable the monitor `playerbot pmon toggle`
right after the bots finished logging-in, and run the stack command `playerbot pmon stack` 5 minutes after that.
The last "Total" line is the main result to look for.
-->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

One more BoostTrigger.

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

Rogues will properly use BF as a dps cooldown in single-target situations when boost is active (most importantly, boss fights).

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [x] No
- - [ ] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->



## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/Ai/Base/Actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated.
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


