### PR TITLE
fix(TravelNode): stop reallocating teleportNodes on every getRoute

### DIFF
--- a/src/Mgr/Travel/TravelNode.cpp
+++ b/src/Mgr/Travel/TravelNode.cpp
@@ -1210,9 +1210,9 @@ TravelNodeRoute TravelNodeMap::getRoute(TravelNode* start, TravelNode* goal, Pla
             if (homeNode)
             {
                 PortalNode* portNode = (PortalNode*)TravelNodeMap::instance().teleportNodes[bot->GetGUID()][8690];
+                if (!portNode)
                 {
                     portNode = new PortalNode(start);
-
                     TravelNodeMap::instance().teleportNodes[bot->GetGUID()][8690] = portNode;
                 }
 
@@ -1377,6 +1377,7 @@ TravelNodeRoute TravelNodeMap::getRoute(WorldPosition startPos, WorldPosition en
     {
         startPath.clear();
         TravelNode* botNode = TravelNodeMap::instance().teleportNodes[bot->GetGUID()][0];
+        if (!botNode)
         {
             botNode = new TravelNode(startPos, "Bot Pos", false);
             TravelNodeMap::instance().teleportNodes[bot->GetGUID()][0] = botNode;


### PR DESCRIPTION
## Pull Request Description

`TravelNodeMap::getRoute()` can inject a hearthstone hop into A* when spell 8690 is off cooldown. For that it keeps temporary nodes in `teleportNodes[botGuid]`.

The lookup already pulled the cached `PortalNode` / `TravelNode` pointer, but the code always did `new` and wrote it back into the map. The old pointer was never deleted. The empty braces around those `new` calls look like a missing `if (!node)` that never made it in. That pattern has been there since the original TravelNode import.

In my homelab I run about 250 to 300 random bots with WalkingRPG on. Worldserver RSS keeps climbing for the whole week until I restart. I already ruled out `DontCacheRandomMovementPaths` (that one is fixed and live in my chart) and mod-ollama-chat (which i also thought might be the memory-leak-culprit). With bots doing long-range travel a lot, this path gets hit constantly, so each route search was leaking another heap node.

This change only allocates when the map entry is missing. Later calls reuse the same node and refresh it with `SetPortal` / `setPoint`, which is what those helpers already do.

## Feature Evaluation

- **Minimum logic:** Add `if (!portNode)`/`if (!botNode)` before the two `new` sites in `TravelNode.cpp`. No new helpers, no logout cleanup, no API changes.
- **Processing cost:** Fewer allocations on hearthstone-aware route searches. Should not add per-tick work.

## How to Test the Changes

1. Build worldserver with this branch on the Playerbot AC fork.
2. Run a few hundred random bots with travel/WalkingRPG enabled (I use 250 to 300).
3. Let them roam and do long-range pathing for a while so hearthstone-aware `getRoute` actually runs.
4. **Before:** RSS climbs for the life of the process. In my setup that means weekly restarts.
5. **After:** RSS should stop the unbounded climb from this path. You may still see map grids fill in over time as bots visit more of the world, but that tends to plateau.
6. Optional: heap profile/heaptrack and watch for stacks in `TravelNodeMap::getRoute`/`PortalNode`/`TravelNode` constructors. Those should not keep growing after bots are online.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - [x] No, not at all
    - [ ] Minimal impact (**explain below**)
    - [ ] Moderate impact (**explain below**)

- Does this change modify default bot behavior?
    - [x] No
    - [ ] Yes (**explain why**)

- Does this change add new decision branches or increase maintenance complexity?
    - [x] No
    - [ ] Yes (**explain below**)

## AI Assistance

Was AI assistance used while working on this change?
- [ ] No
- [x] Yes (**explain below**)

I was chasing week-long worldserver RSS growth in my homelab (250 to 300 bots). Here's what I saw in my Grafana metrics:

<img width="1855" height="837" alt="Screenshot From 2026-08-20 21-48-58" src="https://github.com/user-attachments/assets/2a5453cd-d1d2-45a4-a475-0276d353802c" />

 I had already confirmed DontCache was actually applied and that turning off mod-ollama-chat did not change the slope. I then used ai (cursor in ask mode for this use-case) to help dig through the mod-playerbots travel code, find the always-`new` `teleportNodes` pattern, and check upstream issues/PRs so we were not walking into something maintainers had already rejected. The fix was then manually written.

## Code Provenance / Attribution

Was any code in this PR copied or adapted from a sister / upstream project?
- [x] No, all code in this PR is original
- [ ] Yes (**name the project and the original author(s) below**)

## Final Checklist

- [x] Stability is not compromised.
- [x] Performance impact is understood, tested, and acceptable.
- [x] Added logic complexity is justified and explained.
- [x] Any new bot dialogue lines are translated. (N/A)
- [x] Any code ported/adapted from another project is attributed. (N/A)
- [x] New source files use the GPLv2 header. (N/A, no new files)
- [x] Documentation updated if needed. (N/A, no config surface change)
- [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers

- There's a sort-of-related thread I saw that had some wariness about hearthstone injection mutating the travel graph (for example PR #2312). This PR intentionally does not change that design. It only stops leaking the cached temp nodes that master already creates.
- I intentionally left out any logout cleanup. Once we stop reallocating, each bot only keeps up to two of these nodes for the process lifetime, which is enough to stop the unbounded growth, I believe.