### PR TITLE
Test staging

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -509,6 +509,22 @@ AiPlayerbot.TellWhenMissingBuffReagents = 1
 # Default: 300 (5 minutes)
 AiPlayerbot.MissingBuffReagentMessageCooldown = 300
 
+# When a ready check is issued out of combat, bots refresh missing/short buffs before reporting ready.
+# A bot that still has buff work it can perform stays not-ready until the ready check ends; this
+# includes missing reagents (the cast is attempted and fails). Uses the always-on "force rebuff"
+# strategy: bots with strategy sets saved before this feature keep their saved set - reset their
+# strategies or use "nc +force rebuff" to opt them in. The "rebuff" chat command starts the same
+# buff pass without a ready check and works regardless of this setting.
+# Default: 0 (disabled)
+AiPlayerbot.ForceRebuffOnReadyCheck = 0
+
+# During a force-rebuff pass (ready check or the "rebuff" command), a buff is topped off (recast)
+# once it drops more than this many seconds below its full duration, so buffs are refreshed toward
+# maximum remaining time to last the fight. The effective margin never drops below the time the
+# pass has already run, so small values are safe.
+# Default: 60
+AiPlayerbot.ForceRebuffMarginSecs = 60
+
 # Bots can flee from enemies
 AiPlayerbot.FleeingEnabled = 1
 

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1681,7 +1681,9 @@ AiPlayerbot.RandomBotArenaTeam5v5Count = 5
 AiPlayerbot.RandomBotArenaTeamMaxRating = 2000
 AiPlayerbot.RandomBotArenaTeamMinRating = 1000
 
-# Delete all randombot arena teams
+# Delete all random bot arena teams on startup. While enabled, no new random bot
+# arena teams are created or joined. Set back to 0 and restart the server to
+# resume normal random bot arena team assignment.
 AiPlayerbot.DeleteRandomBotArenaTeams = 0
 
 # PvP Restricted Zones (bots will not initiate PvP or defend themselves if attacked)

--- a/src/Ai/Base/Actions/GenericSpellActions.cpp
+++ b/src/Ai/Base/Actions/GenericSpellActions.cpp
@@ -20,6 +20,7 @@
 #include <ctime>
 #include <unordered_set>
 
+using ai::buff::BuffBelowRefreshTarget;
 using ai::buff::MakeAuraQualifierForBuff;
 using ai::spell::HasSpellOrCategoryCooldown;
 
@@ -268,10 +269,7 @@ bool CastAuraSpellAction::isUseful()
         return false;
 
     Aura* aura = botAI->GetAura(spell, GetTarget(), isOwner, checkDuration);
-    if (!aura || (beforeDuration && uint32(aura->GetDuration()) < beforeDuration))
-        return true;
-
-    return false;
+    return BuffBelowRefreshTarget(botAI, aura, beforeDuration);
 }
 
 bool CastBuffSpellAction::isUseful()
@@ -281,11 +279,13 @@ bool CastBuffSpellAction::isUseful()
         return false;
 
     Aura* aura = botAI->GetAura(spell, target, isOwner, checkDuration);
-    return !aura || (beforeDuration && uint32(aura->GetDuration()) < beforeDuration);
+    return BuffBelowRefreshTarget(botAI, aura, beforeDuration);
 }
 
 bool CastBuffSpellAction::Execute(Event /*event*/)
 {
+    botAI->forceRebuff.NoteBuffWork();
+
     return botAI->CastSpell(spell, GetTarget());
 }
 
@@ -298,19 +298,19 @@ bool GroupBuffSpellAction::isUseful()
     if (ai::buff::IsGroupVariantEnabled(bot, spell))
     {
         std::string const groupVariant = ai::buff::GroupVariantFor(spell);
-        if (!groupVariant.empty() && botAI->HasAura(groupVariant, target, false, isOwner, -1, checkDuration))
+        if (!groupVariant.empty() && !BuffBelowRefreshTarget(
+                botAI, botAI->GetAura(groupVariant, target, isOwner, checkDuration), beforeDuration))
             return false;
     }
 
     Aura* aura = botAI->GetAura(spell, target, isOwner, checkDuration);
-    if (!aura || (beforeDuration && uint32(aura->GetDuration()) < beforeDuration))
-        return true;
-
-    return false;
+    return BuffBelowRefreshTarget(botAI, aura, beforeDuration);
 }
 
 bool GroupBuffSpellAction::Execute(Event /*event*/)
 {
+    botAI->forceRebuff.NoteBuffWork();
+
     std::string missingReagentGroupName;
     std::string const castName = ai::buff::UpgradeToGroupIfAppropriate(
         bot, botAI, spell, &missingReagentGroupName);

--- a/src/Ai/Base/Actions/NonCombatActions.cpp
+++ b/src/Ai/Base/Actions/NonCombatActions.cpp
@@ -7,8 +7,6 @@
 #include "NonCombatActions.h"
 #include "Event.h"
 #include "Playerbots.h"
-#include <algorithm>
-#include <cmath>
 
 namespace
 {
@@ -47,16 +45,22 @@ bool DrinkAction::Execute(Event event)
 
         if (bot->isMoving())
         {
-            bot->GetMotionMaster()->Clear(false);
             bot->StopMoving();
+            // botAI->SetNextCheckDelay(sPlayerbotAIConfig->globalCoolDown);
+            // return false;
         }
         bot->SetStandState(UNIT_STAND_STATE_SIT);
         botAI->InterruptSpell();
 
+        // float hp = bot->GetHealthPercent();
+        float mp = bot->GetPowerPct(POWER_MANA);
+        float p = mp;
         float delay;
 
-        // 25990 restores 5% per 2s tick; wait whole ticks so the drink finishes.
-        delay = std::max(1.0f, std::ceil((100.0f - bot->GetPowerPct(POWER_MANA)) / 5.0f)) * 2 * IN_MILLISECONDS;
+        if (!bot->InBattleground())
+            delay = 18000.0f * (100 - p) / 100.0f;
+        else
+            delay = 12000.0f * (100 - p) / 100.0f;
 
         botAI->SetNextCheckDelay(delay);
 
@@ -100,17 +104,23 @@ bool EatAction::Execute(Event event)
 
         if (bot->isMoving())
         {
-            bot->GetMotionMaster()->Clear(false);
             bot->StopMoving();
+            // botAI->SetNextCheckDelay(sPlayerbotAIConfig.globalCoolDown);
+            // return false;
         }
 
         bot->SetStandState(UNIT_STAND_STATE_SIT);
         botAI->InterruptSpell();
 
+        float hp = bot->GetHealthPct();
+        // float mp = bot->HasMana() ? bot->GetPowerPercent() : 0.f;
+        float p = hp;
         float delay;
 
-        // 25990 restores 5% per 2s tick; wait whole ticks so the meal finishes.
-        delay = std::max(1.0f, std::ceil((100.0f - bot->GetHealthPct()) / 5.0f)) * 2 * IN_MILLISECONDS;
+        if (!bot->InBattleground())
+            delay = 18000.0f * (100 - p) / 100.0f;
+        else
+            delay = 12000.0f * (100 - p) / 100.0f;
 
         botAI->SetNextCheckDelay(delay);
 

--- a/src/Ai/Base/Actions/ReadyCheckAction.cpp
+++ b/src/Ai/Base/Actions/ReadyCheckAction.cpp
@@ -11,6 +11,14 @@
 #include <mutex>
 #include <vector>
 
+static void SendReadyConfirm(Player* bot)
+{
+    WorldPacket packet(MSG_RAID_READY_CHECK);
+    packet << bot->GetGUID();
+    packet << uint8(1);
+    bot->GetSession()->HandleRaidReadyCheckOpcode(packet);
+}
+
 std::string const formatPercent(std::string const name, uint8 value, float percent)
 {
     std::ostringstream out;
@@ -159,12 +167,21 @@ bool ReadyCheckAction::Execute(Event event)
         p >> player;
         if (player == bot->GetGUID())
             return false;
+
+        // Defer the ready reply until buffs are topped off.
+        if (sPlayerbotAIConfig.forceRebuffOnReadyCheck && !bot->IsInCombat() &&
+            botAI->HasStrategy("force rebuff", BOT_STATE_NON_COMBAT))
+        {
+            ReportReadinessToMaster();
+            botAI->forceRebuff.Begin(true);
+            return true;
+        }
     }
 
     return ReadyCheck();
 }
 
-bool ReadyCheckAction::ReadyCheck()
+void ReadyCheckAction::ReportReadinessToMaster()
 {
     std::call_once(
         ReadyChecker::initFlag,
@@ -214,11 +231,15 @@ bool ReadyCheckAction::ReadyCheck()
     }
 
     botAI->TellMaster(out);
+}
 
-    WorldPacket packet(MSG_RAID_READY_CHECK);
-    packet << bot->GetGUID();
-    packet << uint8(1);
-    bot->GetSession()->HandleRaidReadyCheckOpcode(packet);
+bool ReadyCheckAction::ReadyCheck()
+{
+    ReportReadinessToMaster();
+
+    SendReadyConfirm(bot);
+
+    botAI->forceRebuff.End();
 
     botAI->ChangeStrategy("-ready check", BOT_STATE_NON_COMBAT);
 
@@ -226,3 +247,30 @@ bool ReadyCheckAction::ReadyCheck()
 }
 
 bool FinishReadyCheckAction::Execute(Event /*event*/) { return ReadyCheck(); }
+
+// Manual "rebuff" command: opens a rebuff window with no ready check to answer.
+bool ForceRebuffAction::Execute(Event /*event*/)
+{
+    if (bot->IsInCombat() || !botAI->HasStrategy("force rebuff", BOT_STATE_NON_COMBAT))
+        return false;
+
+    botAI->forceRebuff.Begin(false);
+    return true;
+}
+
+bool ReadyReplyAction::isUseful()
+{
+    ForceRebuffState const& rebuff = botAI->forceRebuff;
+    return rebuff.IsPending() && !rebuff.IsOnGlobalCooldown() &&
+           !bot->GetCurrentSpell(CURRENT_GENERIC_SPELL) && !bot->GetCurrentSpell(CURRENT_CHANNELED_SPELL) &&
+           !rebuff.IsBuffPendingThisCycle();
+}
+
+bool ReadyReplyAction::Execute(Event /*event*/)
+{
+    if (botAI->forceRebuff.ShouldReplyToReadyCheck())
+        SendReadyConfirm(bot);
+
+    botAI->forceRebuff.End();
+    return true;
+}

--- a/src/Ai/Base/Actions/ReadyCheckAction.h
+++ b/src/Ai/Base/Actions/ReadyCheckAction.h
@@ -20,6 +20,7 @@ public:
 
 protected:
     bool ReadyCheck();
+    void ReportReadinessToMaster();
 };
 
 class FinishReadyCheckAction : public ReadyCheckAction
@@ -27,6 +28,23 @@ class FinishReadyCheckAction : public ReadyCheckAction
 public:
     FinishReadyCheckAction(PlayerbotAI* botAI) : ReadyCheckAction(botAI, "finish ready check") {}
 
+    bool Execute(Event event) override;
+};
+
+class ForceRebuffAction : public Action
+{
+public:
+    ForceRebuffAction(PlayerbotAI* botAI) : Action(botAI, "force rebuff") {}
+
+    bool Execute(Event event) override;
+};
+
+class ReadyReplyAction : public Action
+{
+public:
+    ReadyReplyAction(PlayerbotAI* botAI) : Action(botAI, "ready reply") {}
+
+    bool isUseful() override;
     bool Execute(Event event) override;
 };
 

--- a/src/Ai/Base/Actions/TradeStatusAction.cpp
+++ b/src/Ai/Base/Actions/TradeStatusAction.cpp
@@ -19,39 +19,47 @@
 
 bool TradeStatusAction::Execute(Event event)
 {
+    if (IsSelfBot(bot))
+        return false;
+
+    if (!bot->GetSession())
+        return false;
+
     Player* trader = bot->GetTrader();
-    Player* master = GetMaster();
     if (!trader)
         return false;
 
-    PlayerbotAI* traderBotAI = GET_PLAYERBOT_AI(trader);
+    bool const traderIsGameClientPlayer = IsRealPlayer(trader) || IsSelfBot(trader);
+    Player* master = GetMaster();
 
-    // Allow the master and group members to trade
-    if (trader != master && !traderBotAI && (!bot->GetGroup() || !bot->GetGroup()->IsMember(trader->GetGUID())))
+    // Bots refuse to trade with a person (whether active or selfbotting) who is neither their
+    // master nor a group member. Bot traders (other than selfbots) are handled further down.
+    if (trader != master && traderIsGameClientPlayer &&
+        (!bot->GetGroup() || !bot->GetGroup()->IsMember(trader->GetGUID())))
     {
         bot->Whisper(PlayerbotTextMgr::instance().GetBotTextOrDefault(
                          "trade_busy_now", "I'm kind of busy now", {}),
                      LANG_UNIVERSAL, trader);
+        CancelTrade();
         return false;
     }
 
-    if (sPlayerbotAIConfig.enableRandomBotTrading == 0 && (sRandomPlayerbotMgr.IsRandomBot(bot)|| sRandomPlayerbotMgr.IsAddclassBot(bot)))
+    if (sPlayerbotAIConfig.enableRandomBotTrading == 0 &&
+        (sRandomPlayerbotMgr.IsRandomBot(bot)|| sRandomPlayerbotMgr.IsAddclassBot(bot)))
     {
         bot->Whisper(PlayerbotTextMgr::instance().GetBotTextOrDefault(
                          "trade_disabled", "Trading is disabled", {}),
                      LANG_UNIVERSAL, trader);
+        CancelTrade();
         return false;
     }
 
-    // Allow trades from group members or bots
+    // Bots also refuse their own master when ungrouped and security withholds full access.
     if ((!bot->GetGroup() || !bot->GetGroup()->IsMember(trader->GetGUID())) &&
         (trader != master || !botAI->GetSecurity()->CheckLevelFor(PLAYERBOT_SECURITY_ALLOW_ALL, true, master)) &&
-        !traderBotAI)
+        traderIsGameClientPlayer)
     {
-        WorldPacket p;
-        uint32 status = 0;
-        p << status;
-        bot->GetSession()->HandleCancelTradeOpcode(p);
+        CancelTrade();
         return false;
     }
 
@@ -60,7 +68,9 @@ bool TradeStatusAction::Execute(Event event)
     uint32 status;
     p >> status;
 
-    if (status == TRADE_STATUS_TRADE_ACCEPT || (status == TRADE_STATUS_BACK_TO_TRADE && trader->GetTradeData() && trader->GetTradeData()->IsAccepted()))
+    if (status == TRADE_STATUS_TRADE_ACCEPT ||
+        (status == TRADE_STATUS_BACK_TO_TRADE &&
+         trader->GetTradeData() && trader->GetTradeData()->IsAccepted()))
     {
         WorldPacket p;
         uint32 status = 0;
@@ -95,9 +105,7 @@ bool TradeStatusAction::Execute(Event event)
 
                 CraftData& craftData = AI_VALUE(CraftData&, "craft");
                 if (!craftData.IsEmpty() && craftData.IsRequired(itemId))
-                {
                     craftData.AddObtained(itemId, count);
-                }
 
                 GuildTaskMgr::instance().CheckItemTask(itemId, count, trader, bot);
             }
@@ -109,9 +117,7 @@ bool TradeStatusAction::Execute(Event event)
 
                 CraftData& craftData = AI_VALUE(CraftData&, "craft");
                 if (!craftData.IsEmpty() && craftData.itemId == itemId)
-                {
                     craftData.Crafted(count);
-                }
             }
 
             return true;
@@ -123,7 +129,6 @@ bool TradeStatusAction::Execute(Event event)
             bot->SetFacingToObject(trader);
 
         BeginTrade();
-
         return true;
     }
     return false;
@@ -132,7 +137,7 @@ bool TradeStatusAction::Execute(Event event)
 void TradeStatusAction::BeginTrade()
 {
     Player* trader = bot->GetTrader();
-    if (!trader || GET_PLAYERBOT_AI(bot->GetTrader()))
+    if (!trader || (GET_PLAYERBOT_AI(trader) && !IsSelfBot(trader)))
         return;
 
     WorldPacket p;
@@ -156,13 +161,20 @@ void TradeStatusAction::BeginTrade()
     }
 }
 
+void TradeStatusAction::CancelTrade()
+{
+    WorldPacket p;
+    bot->GetSession()->HandleCancelTradeOpcode(p);
+}
+
 bool TradeStatusAction::CheckTrade()
 {
     Player* trader = bot->GetTrader();
     if (!bot->GetTradeData() || !trader || !trader->GetTradeData())
         return false;
 
-    if (!IsRealPlayer(botAI->GetMaster()) && GET_PLAYERBOT_AI(bot->GetTrader()))
+    if (!botAI->HasGameClientMaster() && GET_PLAYERBOT_AI(bot->GetTrader()) &&
+        !IsSelfBot(bot->GetTrader()))
     {
         for (uint32 slot = 0; slot < TRADE_SLOT_TRADED_COUNT; ++slot)
         {
@@ -185,23 +197,24 @@ bool TradeStatusAction::CheckTrade()
         {
             if (bot->GetGroup() && bot->GetGroup()->IsMember(bot->GetTrader()->GetGUID()) &&
                 botAI->HasGameClientMaster())
+            {
                 botAI->TellMasterNoFacing(PlayerbotTextMgr::instance().GetBotTextOrDefault(
                     "trade_thank_you_player",
                     "Thank you %player",
                     {{"%player", chat->FormatWorldobject(bot->GetTrader())}}));
+            }
             else
+            {
                 bot->Say(PlayerbotTextMgr::instance().GetBotTextOrDefault(
                              "trade_thank_you_player",
                              "Thank you %player",
                              {{"%player", chat->FormatWorldobject(bot->GetTrader())}}),
                          (bot->GetTeamId() == TEAM_ALLIANCE ? LANG_COMMON : LANG_ORCISH));
+            }
         }
         return isGettingItem;
     }
-    if (!bot->GetSession())
-    {
-        return false;
-    }
+
     uint32 accountId = bot->GetSession()->GetAccountId();
     if (!sPlayerbotAIConfig.IsInRandomAccountList(accountId))
     {
@@ -219,14 +232,16 @@ bool TradeStatusAction::CheckTrade()
     int32 botMoney = bot->GetTradeData()->GetMoney() + botItemsMoney;
     int32 playerItemsMoney = CalculateCost(trader, false);
     int32 playerMoney = trader->GetTradeData()->GetMoney() + playerItemsMoney;
-    if (botItemsMoney > 0 && sPlayerbotAIConfig.enableRandomBotTrading == 2 && (sRandomPlayerbotMgr.IsRandomBot(bot)|| sRandomPlayerbotMgr.IsAddclassBot(bot)))
+    if (botItemsMoney > 0 && sPlayerbotAIConfig.enableRandomBotTrading == 2 &&
+        (sRandomPlayerbotMgr.IsRandomBot(bot)|| sRandomPlayerbotMgr.IsAddclassBot(bot)))
     {
         bot->Whisper(PlayerbotTextMgr::instance().GetBotTextOrDefault(
                          "trade_selling_disabled", "Selling is disabled.", {}),
                      LANG_UNIVERSAL, trader);
         return false;
     }
-    if (playerItemsMoney && sPlayerbotAIConfig.enableRandomBotTrading == 3 && (sRandomPlayerbotMgr.IsRandomBot(bot)|| sRandomPlayerbotMgr.IsAddclassBot(bot)))
+    if (playerItemsMoney && sPlayerbotAIConfig.enableRandomBotTrading == 3 &&
+        (sRandomPlayerbotMgr.IsRandomBot(bot)|| sRandomPlayerbotMgr.IsAddclassBot(bot)))
     {
         bot->Whisper(PlayerbotTextMgr::instance().GetBotTextOrDefault(
                          "trade_buying_disabled", "Buying is disabled.", {}),

--- a/src/Ai/Base/Actions/TradeStatusAction.h
+++ b/src/Ai/Base/Actions/TradeStatusAction.h
@@ -21,6 +21,7 @@ public:
 
 private:
     void BeginTrade();
+    void CancelTrade();
     bool CheckTrade();
     int32 CalculateCost(Player* player, bool sell);
 };

--- a/src/Ai/Base/ChatTriggerContext.h
+++ b/src/Ai/Base/ChatTriggerContext.h
@@ -122,6 +122,7 @@ public:
         creators["outfit"] = &ChatTriggerContext::outfit;
         creators["go"] = &ChatTriggerContext::go;
         creators["ready"] = &ChatTriggerContext::ready_check;
+        creators["rebuff"] = &ChatTriggerContext::rebuff;
         creators["debug"] = &ChatTriggerContext::debug;
         creators["cdebug"] = &ChatTriggerContext::cdebug;
         creators["cs"] = &ChatTriggerContext::cs;
@@ -262,6 +263,7 @@ private:
     static Trigger* reset_ai(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "reset botAI"); }
     static Trigger* spell(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "spell"); }
     static Trigger* ready_check(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "ready check"); }
+    static Trigger* rebuff(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "rebuff"); }
     static Trigger* give_leader(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "give leader"); }
     static Trigger* cheat(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "cheat"); }
     static Trigger* ginvite(PlayerbotAI* botAI) { return new ChatCommandTrigger(botAI, "ginvite"); }

--- a/src/Ai/Base/Strategy/ChatCommandHandlerStrategy.cpp
+++ b/src/Ai/Base/Strategy/ChatCommandHandlerStrategy.cpp
@@ -71,6 +71,7 @@ void ChatCommandHandlerStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
     triggers.push_back(new TriggerNode("pull back", { NextAction("pull my target", relevance) }));
     triggers.push_back(new TriggerNode("pull rti", { NextAction("pull rti target", relevance) }));
     triggers.push_back(new TriggerNode("ready", { NextAction("ready check", relevance) }));
+    triggers.push_back(new TriggerNode("rebuff", { NextAction("force rebuff", relevance) }));
     triggers.push_back(new TriggerNode("naxx", {NextAction("naxx chat shortcut", relevance) }));
     triggers.push_back(new TriggerNode("bwl", { NextAction("bwl chat shortcut", relevance) }));
     triggers.push_back(new TriggerNode("dps", { NextAction("tell estimated dps", relevance) }));

--- a/src/Ai/Base/Strategy/WorldPacketHandlerStrategy.cpp
+++ b/src/Ai/Base/Strategy/WorldPacketHandlerStrategy.cpp
@@ -44,7 +44,7 @@ void WorldPacketHandlerStrategy::InitTriggers(std::vector<TriggerNode*>& trigger
                                                                                 NextAction("equip upgrades packet action", relevance) }));
     triggers.push_back(new TriggerNode("item push result", { NextAction("quest item push result", relevance) }));
     triggers.push_back(new TriggerNode("loot roll won", { NextAction("equip upgrades packet action", relevance) }));
-    triggers.push_back(new TriggerNode("ready check finished", { NextAction("finish ready check", relevance) }));
+    triggers.push_back(new TriggerNode("ready check finished", { NextAction("ready check finished", relevance) }));
     // triggers.push_back(new TriggerNode("often", { NextAction("security check", relevance), NextAction("check mail", relevance) }));
     triggers.push_back(new TriggerNode("guild invite", { NextAction("guild accept", relevance) }));
     triggers.push_back(new TriggerNode("petition offer", { NextAction("petition sign", relevance) }));

--- a/src/Ai/Base/StrategyContext.h
+++ b/src/Ai/Base/StrategyContext.h
@@ -23,6 +23,7 @@
 #include "FleeStrategy.h"
 #include "FocusTargetStrategy.h"
 #include "FollowMasterStrategy.h"
+#include "ForceRebuff.h"
 #include "GrindingStrategy.h"
 #include "GroupStrategy.h"
 #include "GuardStrategy.h"
@@ -72,6 +73,7 @@ public:
         creators["chat"] = &StrategyContext::chat;
         creators["default"] = &StrategyContext::world_packet;
         creators["ready check"] = &StrategyContext::ready_check;
+        creators["force rebuff"] = &StrategyContext::force_rebuff;
         creators["dead"] = &StrategyContext::dead;
         creators["flee"] = &StrategyContext::flee;
         creators["duel"] = &StrategyContext::duel;
@@ -160,6 +162,7 @@ private:
     static Strategy* chat(PlayerbotAI* botAI) { return new ChatCommandHandlerStrategy(botAI); }
     static Strategy* world_packet(PlayerbotAI* botAI) { return new WorldPacketHandlerStrategy(botAI); }
     static Strategy* ready_check(PlayerbotAI* botAI) { return new ReadyCheckStrategy(botAI); }
+    static Strategy* force_rebuff(PlayerbotAI* botAI) { return new ForceRebuffStrategy(botAI); }
     static Strategy* pvp(PlayerbotAI* botAI) { return new AttackEnemyPlayersStrategy(botAI); }
     static Strategy* _return(PlayerbotAI* botAI) { return new ReturnStrategy(botAI); }
     static Strategy* lfg(PlayerbotAI* botAI) { return new LfgStrategy(botAI); }

--- a/src/Ai/Base/Trigger/BossAuraTriggers.cpp
+++ b/src/Ai/Base/Trigger/BossAuraTriggers.cpp
@@ -12,13 +12,13 @@
 
 bool BossFireResistanceTrigger::IsActive()
 {
+    // Check if bot is paladin first: cheap check that filters out most of the raid
+    if (bot->getClass() != CLASS_PALADIN)
+        return false;
+
     // Check boss and it is alive
     Unit* boss = AI_VALUE2(Unit*, "find target", bossName);
     if (!boss || !boss->IsAlive() || boss->IsFriendlyTo(bot))
-        return false;
-
-    // Check if bot is paladin
-    if (bot->getClass() != CLASS_PALADIN)
         return false;
 
     // Check if bot have fire resistance aura
@@ -63,13 +63,13 @@ bool BossFireResistanceTrigger::IsActive()
 
 bool BossFrostResistanceTrigger::IsActive()
 {
+    // Check if bot is paladin first: cheap check that filters out most of the raid
+    if (bot->getClass() != CLASS_PALADIN)
+        return false;
+
     // Check boss and it is alive
     Unit* boss = AI_VALUE2(Unit*, "find target", bossName);
     if (!boss || !boss->IsAlive() || boss->IsFriendlyTo(bot))
-        return false;
-
-    // Check if bot is paladin
-    if (bot->getClass() != CLASS_PALADIN)
         return false;
 
     // Check if bot have frost resistance aura
@@ -114,17 +114,17 @@ bool BossFrostResistanceTrigger::IsActive()
 
 bool BossNatureResistanceTrigger::IsActive()
 {
-    // Check boss and it is alive
-    Unit* boss = AI_VALUE2(Unit*, "find target", bossName);
-    if (!boss || !boss->IsAlive() || boss->IsFriendlyTo(bot))
+    // Check if bot is hunter first: cheap check that filters out most of the raid
+    if (bot->getClass() != CLASS_HUNTER)
         return false;
 
     // Check if bot is alive
     if (!bot->IsAlive())
         return false;
 
-    // Check if bot is hunter
-    if (bot->getClass() != CLASS_HUNTER)
+    // Check boss and it is alive
+    Unit* boss = AI_VALUE2(Unit*, "find target", bossName);
+    if (!boss || !boss->IsAlive() || boss->IsFriendlyTo(bot))
         return false;
 
     // Check if bot have nature resistance aura
@@ -168,13 +168,13 @@ bool BossNatureResistanceTrigger::IsActive()
 
 bool BossShadowResistanceTrigger::IsActive()
 {
+    // Check if bot is paladin first: cheap check that filters out most of the raid
+    if (bot->getClass() != CLASS_PALADIN)
+        return false;
+
     // Check boss and it is alive
     Unit* boss = AI_VALUE2(Unit*, "find target", bossName);
     if (!boss || !boss->IsAlive() || boss->IsFriendlyTo(bot))
-        return false;
-
-    // Check if bot is paladin
-    if (bot->getClass() != CLASS_PALADIN)
         return false;
 
     // Check if bot have shadow resistance aura

--- a/src/Ai/Base/Trigger/GenericTriggers.cpp
+++ b/src/Ai/Base/Trigger/GenericTriggers.cpp
@@ -163,10 +163,7 @@ bool BuffTrigger::IsActive()
         return false;
 
     Aura* aura = botAI->GetAura(spell, target, checkIsOwner, checkDuration);
-    if (!aura || (beforeDuration && uint32(aura->GetDuration()) < beforeDuration))
-        return true;
-
-    return false;
+    return ai::buff::BuffBelowRefreshTarget(botAI, aura, beforeDuration);
 }
 
 Value<Unit*>* BuffOnPartyTrigger::GetTargetValue()
@@ -749,4 +746,9 @@ bool NewPetTrigger::IsActive()
     }
 
     return false;
+}
+
+bool ForceRebuffPendingTrigger::IsActive()
+{
+    return botAI->forceRebuff.IsPending();
 }

--- a/src/Ai/Base/Trigger/GenericTriggers.cpp
+++ b/src/Ai/Base/Trigger/GenericTriggers.cpp
@@ -574,7 +574,23 @@ bool IsNotFacingTargetTrigger::IsActive()
 
 bool HasCcTargetTrigger::IsActive()
 {
-    return AI_VALUE2(Unit*, "cc target", getName()) && !AI_VALUE2(Unit*, "current cc target", getName());
+    Unit* rtiCcTarget = nullptr;
+    if (botAI->IsInNonRaidDungeon())
+    {
+        rtiCcTarget = AI_VALUE(Unit*, "rti cc target");
+        if (!rtiCcTarget)
+            return false;
+    }
+
+    return IsCcTargetFree(AI_VALUE2(Unit*, "cc target", getName()), rtiCcTarget);
+}
+
+bool HasCcTargetTrigger::IsCcTargetFree(Unit* ccTarget, Unit* rtiCcTarget)
+{
+    if (!ccTarget || (rtiCcTarget && ccTarget != rtiCcTarget))
+        return false;
+
+    return !AI_VALUE2(Unit*, "current cc target", getName());
 }
 
 bool NoMovementTrigger::IsActive() { return !AI_VALUE2(bool, "moving", "self target"); }

--- a/src/Ai/Base/Trigger/GenericTriggers.h
+++ b/src/Ai/Base/Trigger/GenericTriggers.h
@@ -321,6 +321,7 @@ public:
 
 public:
     std::string const GetTargetName() override { return "self target"; }
+    bool IsBuffTrigger() override { return true; }
     bool IsActive() override;
 
 protected:
@@ -389,6 +390,7 @@ public:
         : BuffTrigger(botAI, spell, checkInterval, checkIsOwner, false, beforeDuration), needLifeTime(needLifeTime) {}
 
     std::string const GetTargetName() override { return "current target"; }
+    bool IsDebuffTrigger() override { return true; }
     bool IsActive() override;
 
 protected:
@@ -969,6 +971,14 @@ public:
 private:
     ObjectGuid lastPetGuid;
     bool triggered;
+};
+
+class ForceRebuffPendingTrigger : public Trigger
+{
+public:
+    ForceRebuffPendingTrigger(PlayerbotAI* botAI) : Trigger(botAI, "force rebuff pending") {}
+
+    bool IsActive() override;
 };
 
 #endif

--- a/src/Ai/Base/Trigger/GenericTriggers.h
+++ b/src/Ai/Base/Trigger/GenericTriggers.h
@@ -688,6 +688,9 @@ public:
     HasCcTargetTrigger(PlayerbotAI* botAI, std::string const name) : Trigger(botAI, name) {}
 
     bool IsActive() override;
+
+protected:
+    bool IsCcTargetFree(Unit* ccTarget, Unit* rtiCcTarget);
 };
 
 class NoMovementTrigger : public Trigger

--- a/src/Ai/Base/Trigger/RtiTriggers.cpp
+++ b/src/Ai/Base/Trigger/RtiTriggers.cpp
@@ -30,7 +30,7 @@ bool RtiCcTrigger::IsActive()
 
     Unit* ccTarget = AI_VALUE2(Unit*, "cc target", getName());
     if (ccTarget && ccTarget == rtiCcTarget)
-        return HasCcTargetTrigger::IsActive();
+        return IsCcTargetFree(ccTarget, rtiCcTarget);
 
     return botAI->CanCastSpell(getName(), rtiCcTarget);
 }

--- a/src/Ai/Base/TriggerContext.h
+++ b/src/Ai/Base/TriggerContext.h
@@ -45,6 +45,8 @@ public:
         creators["often"] = &TriggerContext::often;
         creators["very often"] = &TriggerContext::very_often;
 
+        creators["force rebuff pending"] = &TriggerContext::force_rebuff_pending;
+
         creators["target critical health"] = &TriggerContext::TargetCriticalHealth;
 
         creators["critical health"] = &TriggerContext::CriticalHealth;
@@ -335,6 +337,7 @@ private:
     static Trigger* TankAssist(PlayerbotAI* botAI) { return new TankAssistTrigger(botAI); }
     static Trigger* Timer(PlayerbotAI* botAI) { return new TimerTrigger(botAI); }
     static Trigger* TimerBG(PlayerbotAI* botAI) { return new TimerBGTrigger(botAI); }
+    static Trigger* force_rebuff_pending(PlayerbotAI* botAI) { return new ForceRebuffPendingTrigger(botAI); }
     static Trigger* NoTarget(PlayerbotAI* botAI) { return new NoTargetTrigger(botAI); }
     static Trigger* TargetInSight(PlayerbotAI* botAI) { return new TargetInSightTrigger(botAI); }
     static Trigger* not_dps_target_active(PlayerbotAI* botAI) { return new NotDpsTargetActiveTrigger(botAI); }

--- a/src/Ai/Base/Util/GenericBuffUtils.cpp
+++ b/src/Ai/Base/Util/GenericBuffUtils.cpp
@@ -11,6 +11,7 @@
 #include "Player.h"
 #include "PlayerbotAI.h"
 #include "PlayerbotAIConfig.h"
+#include "SpellAuras.h"
 #include "SpellMgr.h"
 #include "Unit.h"
 #include "Value.h"
@@ -32,6 +33,15 @@ namespace ai::buff
         }
     }
 
+    bool BuffBelowRefreshTarget(PlayerbotAI* botAI, Aura* aura, uint32 baseBeforeDuration)
+    {
+        if (!aura)
+            return true;
+
+        return botAI->forceRebuff.BuffBelowRefreshTarget(
+            aura->GetDuration(), aura->GetMaxDuration(), baseBeforeDuration);
+    }
+
     static bool HasEnoughSameMapMissingPlayersForGroupVariant(
         Player* bot, PlayerbotAI* botAI, std::string const& baseName,
         std::string const& groupName, uint32 requiredCount = 3)
@@ -50,7 +60,8 @@ namespace ai::buff
                 continue;
             }
 
-            if (botAI->HasAura(baseName, member) || botAI->HasAura(groupName, member))
+            if (!BuffBelowRefreshTarget(botAI, botAI->GetAura(baseName, member), 0) ||
+                !BuffBelowRefreshTarget(botAI, botAI->GetAura(groupName, member), 0))
                 continue;
 
             if (++missingCount >= requiredCount)

--- a/src/Ai/Base/Util/GenericBuffUtils.h
+++ b/src/Ai/Base/Util/GenericBuffUtils.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <unordered_map>
 
+class Aura;
 class Player;
 class PlayerbotAI;
 class Unit;
@@ -19,6 +20,10 @@ namespace ai::buff
 {
 
 typedef std::unordered_map<std::string, uint32> MissingBuffReagentNoticeMap;
+
+// True when the buff should be (re)cast: topped off toward full duration during an
+// out-of-combat force-rebuff, below baseBeforeDuration ms remaining otherwise.
+bool BuffBelowRefreshTarget(PlayerbotAI* botAI, Aura* aura, uint32 baseBeforeDuration);
 
 bool IsGroupVariantEnabled(Player* bot, std::string const& name);
 

--- a/src/Ai/Base/Value/PartyMemberWithoutAuraValue.cpp
+++ b/src/Ai/Base/Value/PartyMemberWithoutAuraValue.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "PartyMemberWithoutAuraValue.h"
+#include "GenericBuffUtils.h"
 #include "Playerbots.h"
 
 extern std::vector<std::string> split(std::string const s, char delim);
@@ -25,7 +26,7 @@ public:
 
         for (std::vector<std::string>::iterator i = auras.begin(); i != auras.end(); ++i)
         {
-            if (botAI->HasAura(*i, unit))
+            if (!ai::buff::BuffBelowRefreshTarget(botAI, botAI->GetAura(*i, unit), 0))
                 return false;
         }
 

--- a/src/Ai/Base/WorldPacketActionContext.h
+++ b/src/Ai/Base/WorldPacketActionContext.h
@@ -95,6 +95,8 @@ public:
         creators["accept duel"] = &WorldPacketActionContext::accept_duel;
         creators["ready check"] = &WorldPacketActionContext::ready_check;
         creators["ready check finished"] = &WorldPacketActionContext::ready_check_finished;
+        creators["force rebuff"] = &WorldPacketActionContext::force_rebuff;
+        creators["ready reply"] = &WorldPacketActionContext::ready_reply;
         creators["uninvite"] = &WorldPacketActionContext::uninvite;
         creators["security check"] = &WorldPacketActionContext::security_check;
         creators["guild accept"] = &WorldPacketActionContext::guild_accept;
@@ -124,6 +126,8 @@ private:
     static Action* ready_check(PlayerbotAI* botAI) { return new ReadyCheckAction(botAI); }
     static Action* accept_duel(PlayerbotAI* botAI) { return new AcceptDuelAction(botAI); }
     static Action* tell_cast_failed(PlayerbotAI* botAI) { return new TellCastFailedAction(botAI); }
+    static Action* force_rebuff(PlayerbotAI* botAI) { return new ForceRebuffAction(botAI); }
+    static Action* ready_reply(PlayerbotAI* botAI) { return new ReadyReplyAction(botAI); }
     static Action* party_command(PlayerbotAI* botAI) { return new PartyCommandAction(botAI); }
     static Action* store_loot(PlayerbotAI* botAI) { return new StoreLootAction(botAI); }
     static Action* accept_trade(PlayerbotAI* botAI) { return new TradeStatusAction(botAI); }

--- a/src/Ai/Class/Mage/Strategy/FireMageStrategy.cpp
+++ b/src/Ai/Class/Mage/Strategy/FireMageStrategy.cpp
@@ -56,6 +56,23 @@ void FireMageStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
             }
         )
     );
+
+    triggers.push_back(
+        new TriggerNode(
+            "enemy too close for spell",
+            {
+                NextAction("dragon's breath", ACTION_INTERRUPT + 1)
+            }
+        )
+    );
+    triggers.push_back(
+        new TriggerNode(
+            "enemy is close",
+            {
+                NextAction("blast wave", ACTION_INTERRUPT)
+            }
+        )
+    );
 }
 
 // Combat strategy to run to melee for Dragon's Breath and Blast Wave

--- a/src/Ai/Class/Mage/Strategy/FrostFireMageStrategy.cpp
+++ b/src/Ai/Class/Mage/Strategy/FrostFireMageStrategy.cpp
@@ -54,4 +54,21 @@ void FrostFireMageStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
             }
         )
     );
+
+    triggers.push_back(
+        new TriggerNode(
+            "enemy too close for spell",
+            {
+                NextAction("dragon's breath", ACTION_INTERRUPT + 1)
+            }
+        )
+    );
+    triggers.push_back(
+        new TriggerNode(
+            "enemy is close",
+            {
+                NextAction("blast wave", ACTION_INTERRUPT)
+            }
+        )
+    );
 }

--- a/src/Ai/Class/Mage/Strategy/GenericMageStrategy.cpp
+++ b/src/Ai/Class/Mage/Strategy/GenericMageStrategy.cpp
@@ -168,14 +168,6 @@ void MageBoostStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 void MageCcStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
     triggers.push_back(new TriggerNode("polymorph", { NextAction("polymorph", 30.0f) }));
-
-    Player* bot = botAI->GetBot();
-    int tab = AiFactory::GetPlayerSpecTab(bot);
-    if (tab == MAGE_TAB_FIRE)
-    {
-        triggers.push_back(new TriggerNode("enemy too close for spell", {NextAction("dragon's breath", ACTION_INTERRUPT + 1)}));
-        triggers.push_back(new TriggerNode("enemy is close", {NextAction("blast wave", ACTION_INTERRUPT)}));
-    }
 }
 
 void MageAoeStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)

--- a/src/Ai/Dungeon/Seth/SethActions.cpp
+++ b/src/Ai/Dungeon/Seth/SethActions.cpp
@@ -5,13 +5,14 @@
  */
 
 #include "SethActions.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "SethData.h"
 #include <array>
 #include <cmath>
 
 using namespace SethData;
+using namespace EncounterHelpers;
 
 bool TimeLostControllerMarkCharmingTotemWithSkullAction::Execute(Event /*event*/)
 {

--- a/src/Ai/Dungeon/Seth/SethMultipliers.cpp
+++ b/src/Ai/Dungeon/Seth/SethMultipliers.cpp
@@ -5,18 +5,19 @@
  */
 
 #include "SethMultipliers.h"
+#include "EncounterHelpers.h"
 #include "FollowActions.h"
 #include "GenericSpellActions.h"
 #include "HunterActions.h"
 #include "MageActions.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "ReachTargetActions.h"
 #include "SethActions.h"
 #include "SethData.h"
 #include "ShamanActions.h"
 
 using namespace SethData;
+using namespace EncounterHelpers;
 
 float SethekkProphetSetTremorTotemMultiplier::GetValue(Action* action)
 {
@@ -52,7 +53,7 @@ float AnzuControlSpellCastingWithSpellBombMultiplier::GetValue(Action* action)
         return 0.0f;
 
     // For healer
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (mainTank && mainTank->GetHealthPct() > 50.0f)
         return 0.0f;
 

--- a/src/Ai/Dungeon/Seth/SethTriggers.cpp
+++ b/src/Ai/Dungeon/Seth/SethTriggers.cpp
@@ -5,11 +5,12 @@
  */
 
 #include "SethTriggers.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "SethData.h"
 
 using namespace SethData;
+using namespace EncounterHelpers;
 
 bool TimeLostControllerDropsCharmingTotemTrigger::IsActive()
 {

--- a/src/Ai/Raid/BT/BTActions.cpp
+++ b/src/Ai/Raid/BT/BTActions.cpp
@@ -7,11 +7,12 @@
 #include "BTActions.h"
 #include "BTHelpers.h"
 #include "CreatureAI.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include <vector>
 
 using namespace BlackTempleHelpers;
+using namespace EncounterHelpers;
 
 // General
 
@@ -94,7 +95,7 @@ bool HighWarlordNajentusMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!najentus)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -292,9 +293,9 @@ bool SupremusMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (hunters.empty())
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
-    Player* firstAssistTank = GetGroupAssistTank(botAI, bot, 0);
-    Player* secondAssistTank = GetGroupAssistTank(botAI, bot, 1);
+    Player* mainTank = GetGroupMainTank(bot);
+    Player* firstAssistTank = GetGroupAssistTank(bot, 0);
+    Player* secondAssistTank = GetGroupAssistTank(bot, 1);
 
     Player* misdirectTarget = nullptr;
     if (bot == hunters[0] && mainTank)
@@ -541,7 +542,7 @@ bool TeronGorefiendMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!gorefiend)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -816,7 +817,7 @@ bool GurtoggBloodboilMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!group)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -956,7 +957,7 @@ bool ReliquaryOfSoulsMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!desire && !anger)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -1143,7 +1144,7 @@ bool MotherShahrazMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!shahraz)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -1368,7 +1369,7 @@ bool IllidariCouncilMisdirectBossesToTanksAction::Execute(Event /*event*/)
         councilTarget = AI_VALUE2(Unit*, "find target", "lady malande");
         for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
         {
-            if (Player* member = GetGroupAssistTank(botAI, bot, 0))
+            if (Player* member = GetGroupAssistTank(bot, 0))
             {
                 tankTarget = member;
                 break;
@@ -1380,7 +1381,7 @@ bool IllidariCouncilMisdirectBossesToTanksAction::Execute(Event /*event*/)
         councilTarget = AI_VALUE2(Unit*, "find target", "gathios the shatterer");
         for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
         {
-            if (Player* member = GetGroupMainTank(botAI, bot))
+            if (Player* member = GetGroupMainTank(bot))
             {
                 tankTarget = member;
                 break;
@@ -1392,7 +1393,7 @@ bool IllidariCouncilMisdirectBossesToTanksAction::Execute(Event /*event*/)
         councilTarget = AI_VALUE2(Unit*, "find target", "veras darkshadow");
         for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
         {
-            if (Player* member = GetGroupAssistTank(botAI, bot, 1))
+            if (Player* member = GetGroupAssistTank(bot, 1))
             {
                 tankTarget = member;
                 break;
@@ -1431,7 +1432,7 @@ bool IllidariCouncilMainTankPositionGathiosAction::Execute(Event /*event*/)
     if (MarkTargetWithSquare(bot, gathios))
         return true;
 
-    SetRtiTarget(botAI, "square", gathios);
+    SetRtiTarget(botAI, "square");
 
     if (AI_VALUE(Unit*, "current target") != gathios)
         return Attack(gathios);
@@ -1504,7 +1505,7 @@ bool IllidariCouncilFirstAssistTankFocusMalandeAction::Execute(Event /*event*/)
     if (MarkTargetWithStar(bot, malande))
         return true;
 
-    SetRtiTarget(botAI, "star", malande);
+    SetRtiTarget(botAI, "star");
 
     if (AI_VALUE(Unit*, "current target") != malande)
         return Attack(malande);
@@ -1528,14 +1529,14 @@ bool IllidariCouncilSecondAssistTankPositionDarkshadowAction::Execute(Event /*ev
     if (MarkTargetWithCircle(bot, darkshadow))
         return true;
 
-    SetRtiTarget(botAI, "circle", darkshadow);
+    SetRtiTarget(botAI, "circle");
 
     if (AI_VALUE(Unit*, "current target") != darkshadow)
         return Attack(darkshadow);
 
     if (darkshadow->GetVictim() == bot)
     {
-        Player* mainTank = GetGroupMainTank(botAI, bot);
+        Player* mainTank = GetGroupMainTank(bot);
         if (!mainTank)
             return false;
 
@@ -1573,7 +1574,7 @@ bool IllidariCouncilMageTankPositionZerevorAction::Execute(Event /*event*/)
     if (MarkTargetWithTriangle(bot, zerevor))
         return true;
 
-    SetRtiTarget(botAI, "triangle", zerevor);
+    SetRtiTarget(botAI, "triangle");
 
     if (AI_VALUE(Unit*, "current target") != zerevor)
         return Attack(zerevor);
@@ -1711,7 +1712,7 @@ bool IllidariCouncilAssignDpsTargetsAction::Execute(Event /*event*/)
 
     if (shouldAttackMalande)
     {
-        SetRtiTarget(botAI, "star", malande);
+        SetRtiTarget(botAI, "star");
 
         if (AI_VALUE(Unit*, "current target") != malande)
             return Attack(malande);
@@ -1720,14 +1721,14 @@ bool IllidariCouncilAssignDpsTargetsAction::Execute(Event /*event*/)
              darkshadow && !darkshadow->HasAura(
                 static_cast<uint32>(BlackTempleSpells::SPELL_VANISH)))
     {
-        SetRtiTarget(botAI, "circle", darkshadow);
+        SetRtiTarget(botAI, "circle");
 
         if (AI_VALUE(Unit*, "current target") != darkshadow)
             return Attack(darkshadow);
     }
     else if (Unit* gathios = AI_VALUE2(Unit*, "find target", "gathios the shatterer"))
     {
-        SetRtiTarget(botAI, "square", gathios);
+        SetRtiTarget(botAI, "square");
 
         if (AI_VALUE(Unit*, "current target") != gathios)
             return Attack(gathios);
@@ -1799,8 +1800,8 @@ bool IllidanStormrageMisdirectToTankAction::TryMisdirectToFlameTanks(Group* grou
     if (!eastFlame || !westFlame || eastFlame == westFlame)
         return false;
 
-    Player* firstAssistTank = GetGroupAssistTank(botAI, bot, 0);
-    Player* secondAssistTank = GetGroupAssistTank(botAI, bot, 1);
+    Player* firstAssistTank = GetGroupAssistTank(bot, 0);
+    Player* secondAssistTank = GetGroupAssistTank(bot, 1);
     if (!firstAssistTank || !secondAssistTank)
         return false;
 

--- a/src/Ai/Raid/BT/BTHelpers.cpp
+++ b/src/Ai/Raid/BT/BTHelpers.cpp
@@ -5,8 +5,10 @@
  */
 
 #include "BTHelpers.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
+
+using namespace EncounterHelpers;
 
 namespace BlackTempleHelpers
 {
@@ -104,7 +106,7 @@ std::unordered_map<ObjectGuid, TankPositionState> shahrazTankStep;
 
 TankPositionState GetShahrazTankPositionState(PlayerbotAI* botAI, Player* bot)
 {
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return TankPositionState::Unknown;
 

--- a/src/Ai/Raid/BT/BTMultipliers.cpp
+++ b/src/Ai/Raid/BT/BTMultipliers.cpp
@@ -8,66 +8,51 @@
 #include "BTActions.h"
 #include "BTHelpers.h"
 #include "ChooseTargetActions.h"
-#include "DKActions.h"
-#include "DruidActions.h"
-#include "DruidBearActions.h"
 #include "DruidShapeshiftActions.h"
+#include "EncounterHelpers.h"
 #include "FollowActions.h"
 #include "HunterActions.h"
 #include "MageActions.h"
-#include "PaladinActions.h"
 #include "PriestActions.h"
 #include "ReachTargetActions.h"
 #include "RogueActions.h"
 #include "ShamanActions.h"
-#include "WarlockActions.h"
-#include "WarriorActions.h"
 #include "WipeAction.h"
+#include <array>
+#include <ctime>
 
 using namespace BlackTempleHelpers;
+using namespace EncounterHelpers;
 
-static bool IsDpsCooldownAction(Action* action)
+// General
+
+// Illidan is handled separately
+float BlackTempleDelayDpsCooldownsMultiplier::GetValue(Action* action)
 {
-    return dynamic_cast<CastHeroismAction*>(action) ||
-           dynamic_cast<CastBloodlustAction*>(action) ||
-           dynamic_cast<CastMetamorphosisAction*>(action) ||
-           dynamic_cast<CastAdrenalineRushAction*>(action) ||
-           dynamic_cast<CastBladeFlurryAction*>(action) ||
-           dynamic_cast<CastIcyVeinsAction*>(action) ||
-           dynamic_cast<CastColdSnapAction*>(action) ||
-           dynamic_cast<CastArcanePowerAction*>(action) ||
-           dynamic_cast<CastPresenceOfMindAction*>(action) ||
-           dynamic_cast<CastCombustionAction*>(action) ||
-           dynamic_cast<CastRapidFireAction*>(action) ||
-           dynamic_cast<CastReadinessAction*>(action) ||
-           dynamic_cast<CastAvengingWrathAction*>(action) ||
-           dynamic_cast<CastElementalMasteryAction*>(action) ||
-           dynamic_cast<CastFeralSpiritAction*>(action) ||
-           dynamic_cast<CastFireElementalTotemAction*>(action) ||
-           dynamic_cast<CastFireElementalTotemMeleeAction*>(action) ||
-           dynamic_cast<CastForceOfNatureAction*>(action) ||
-           dynamic_cast<CastArmyOfTheDeadAction*>(action) ||
-           dynamic_cast<CastSummonGargoyleAction*>(action) ||
-           dynamic_cast<CastBerserkingAction*>(action) ||
-           dynamic_cast<CastBloodFuryAction*>(action);
-}
-
-// High Warlord Naj'entus
-
-float HighWarlordNajentusDelayDpsCooldownsMultiplier::GetValue(Action* action)
-{
-    Unit* najentus = AI_VALUE2(Unit*, "find target", "high warlord naj'entus");
-    if (!najentus || najentus->GetHealthPct() < 95.0f)
+    if (!IsDpsCooldownAction(bot, action))
         return 1.0f;
 
-    if (IsDpsCooldownAction(action) ||
-        (botAI->IsDps(bot) && dynamic_cast<UseTrinketAction*>(action)))
+    static constexpr std::array BlackTempleBosses = {
+        "gathios the shatterer", "mother shahraz", "essence of suffering", "gurtogg bloodboil",
+        "teron gorefiend", "supremus", "high warlord naj'entus" };
+
+    Unit* boss = nullptr;
+    for (const char* name : BlackTempleBosses)
     {
-        return 0.0f;
+        if (Unit* candidate = AI_VALUE2(Unit*, "find target", name))
+        {
+            boss = candidate;
+            break;
+        }
     }
+
+    if (boss && boss->GetHealthPct() > 95.0f)
+        return 0.0f;
 
     return 1.0f;
 }
+
+// High Warlord Naj'entus
 
 float HighWarlordNajentusDisableCombatFormationMoveMultiplier::GetValue(Action* action)
 {
@@ -84,21 +69,6 @@ float HighWarlordNajentusDisableCombatFormationMoveMultiplier::GetValue(Action* 
 }
 
 // Supremus
-
-float SupremusDelayDpsCooldownsMultiplier::GetValue(Action* action)
-{
-    Unit* supremus = AI_VALUE2(Unit*, "find target", "supremus");
-    if (!supremus || supremus->GetHealthPct() < 95.0f)
-        return 1.0f;
-
-    if (IsDpsCooldownAction(action) ||
-        (botAI->IsDps(bot) && dynamic_cast<UseTrinketAction*>(action)))
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
-}
 
 float SupremusFocusOnAvoidanceInPhase2Multiplier::GetValue(Action* action)
 {
@@ -134,21 +104,6 @@ float SupremusHitboxIsBuggedMultiplier::GetValue(Action* action)
 }
 
 // Teron Gorefiend
-
-float TeronGorefiendDelayDpsCooldownsMultiplier::GetValue(Action* action)
-{
-    Unit* gorefiend = AI_VALUE2(Unit*, "find target", "teron gorefiend");
-    if (!gorefiend || gorefiend->GetHealthPct() < 95.0f)
-        return 1.0f;
-
-    if (IsDpsCooldownAction(action) ||
-        (botAI->IsDps(bot) && dynamic_cast<UseTrinketAction*>(action)))
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
-}
 
 float TeronGorefiendControlMovementMultiplier::GetValue(Action* action)
 {
@@ -230,21 +185,6 @@ float TeronGorefiendDisableAttackingConstructsMultiplier::GetValue(Action* actio
 
 // Gurtogg Bloodboil
 
-float GurtoggBloodboilDelayDpsCooldownsMultiplier::GetValue(Action* action)
-{
-    Unit* gurtogg = AI_VALUE2(Unit*, "find target", "gurtogg bloodboil");
-    if (!gurtogg || gurtogg->GetHealthPct() < 95.0f)
-        return 1.0f;
-
-    if (IsDpsCooldownAction(action) ||
-        (botAI->IsDps(bot) && dynamic_cast<UseTrinketAction*>(action)))
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
-}
-
 float GurtoggBloodboilControlMovementMultiplier::GetValue(Action* action)
 {
     if (!AI_VALUE2(Unit*, "find target", "gurtogg bloodboil"))
@@ -276,21 +216,6 @@ float GurtoggBloodboilControlMovementMultiplier::GetValue(Action* action)
 
 // Reliquary of Souls
 
-float ReliquaryOfSoulsDelayDpsCooldownsMultiplier::GetValue(Action* action)
-{
-    Unit* suffering = AI_VALUE2(Unit*, "find target", "essence of suffering");
-    if (!suffering || suffering->GetHealthPct() < 95.0f)
-        return 1.0f;
-
-    if (IsDpsCooldownAction(action) ||
-        (botAI->IsDps(bot) && dynamic_cast<UseTrinketAction*>(action)))
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
-}
-
 float ReliquaryOfSoulsDontWasteHealingMultiplier::GetValue(Action* action)
 {
     if (!AI_VALUE2(Unit*, "find target", "essence of suffering"))
@@ -314,21 +239,6 @@ float ReliquaryOfSoulsDontWasteHealingMultiplier::GetValue(Action* action)
 }
 
 // Mother Shahraz
-
-float MotherShahrazDelayDpsCooldownsMultiplier::GetValue(Action* action)
-{
-    Unit* shahraz = AI_VALUE2(Unit*, "find target", "mother shahraz");
-    if (!shahraz || shahraz->GetHealthPct() < 90.0f)
-        return 1.0f;
-
-    if (IsDpsCooldownAction(action) ||
-        (botAI->IsDps(bot) && dynamic_cast<UseTrinketAction*>(action)))
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
-}
 
 float MotherShahrazControlMovementMultiplier::GetValue(Action* action)
 {
@@ -371,47 +281,22 @@ float MotherShahrazBotsWithFatalAttractionOnlyRunAwayMultiplier::GetValue(Action
 
 // Illidari Council
 
-float IllidariCouncilDelayDpsCooldownsMultiplier::GetValue(Action* action)
-{
-    Unit* gathios = AI_VALUE2(Unit*, "find target", "gathios the shatterer");
-    if (!gathios || gathios->GetHealthPct() < 90.0f)
-        return 1.0f;
-
-    if (IsDpsCooldownAction(action) ||
-        (botAI->IsDps(bot) && dynamic_cast<UseTrinketAction*>(action)))
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
-}
-
 float IllidariCouncilDisableTankActionsMultiplier::GetValue(Action* action)
 {
-    if (!botAI->IsTank(bot) ||
-        !AI_VALUE2(Unit*, "find target", "gathios the shatterer"))
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
+        return 1.0f;
+
+    if (!PlayerbotAI::IsTank(bot))
+        return 1.0f;
+
+    if (!dynamic_cast<TankAssistAction*>(action) &&
+        !IsTauntAction(bot, action) && !IsAoeThreatAction(bot, action))
     {
         return 1.0f;
     }
 
-    if (bot->GetVictim() != nullptr && dynamic_cast<TankAssistAction*>(action))
+    if (AI_VALUE2(Unit*, "find target", "gathios the shatterer"))
         return 0.0f;
-
-    if (dynamic_cast<CastTauntAction*>(action) ||
-        dynamic_cast<CastChallengingShoutAction*>(action) ||
-        dynamic_cast<CastShockwaveAction*>(action) ||
-        dynamic_cast<CastCleaveAction*>(action) ||
-        dynamic_cast<CastGrowlAction*>(action) ||
-        dynamic_cast<CastSwipeBearAction*>(action) ||
-        dynamic_cast<CastChallengingRoarAction*>(action) ||
-        dynamic_cast<CastHandOfReckoningAction*>(action) ||
-        dynamic_cast<CastRighteousDefenseAction*>(action) ||
-        dynamic_cast<CastDarkCommandAction*>(action) ||
-        dynamic_cast<CastDeathAndDecayAction*>(action) ||
-        dynamic_cast<CastBloodBoilAction*>(action))
-    {
-        return 0.0f;
-    }
 
     return 1.0f;
 }
@@ -546,27 +431,27 @@ float IllidariCouncilWaitForDpsMultiplier::GetValue(Action* action)
 
 float IllidanStormrageDelayDpsCooldownsMultiplier::GetValue(Action* action)
 {
+    if (!IsDpsCooldownAction(bot, action))
+        return 1.0f;
+
     Unit* illidan = AI_VALUE2(Unit*, "find target", "illidan stormrage");
     if (!illidan)
         return 1.0f;
 
-    if (illidan->GetHealthPct() > 62.0f &&
+    if (illidan->GetHealthPct() <= 62.0f)
+        return 1.0f;
+
+    if (bot->getClass() == CLASS_SHAMAN &&
         (dynamic_cast<CastHeroismAction*>(action) ||
          dynamic_cast<CastBloodlustAction*>(action)))
     {
         return 0.0f;
     }
 
-    if (illidan->GetHealthPct() <= 62.0f || illidan->GetHealthPct() > 95.0f)
+    if (illidan->GetHealthPct() > 95.0f)
         return 1.0f;
 
-    if (IsDpsCooldownAction(action) ||
-        (botAI->IsDps(bot) && dynamic_cast<UseTrinketAction*>(action)))
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
+    return 0.0f;
 }
 
 float IllidanStormrageControlTankActionsMultiplier::GetValue(Action* action)
@@ -616,7 +501,7 @@ float IllidanStormrageControlTankActionsMultiplier::GetValue(Action* action)
 
 float IllidanStormrageDisableDefaultTargetingMultiplier::GetValue(Action* action)
 {
-    if (bot->GetVictim() == nullptr)
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
         return 1.0f;
 
     Unit* illidan = AI_VALUE2(Unit*, "find target", "illidan stormrage");

--- a/src/Ai/Raid/BT/BTMultipliers.h
+++ b/src/Ai/Raid/BT/BTMultipliers.h
@@ -11,11 +11,11 @@
 
 // High Warlord Naj'entus
 
-class HighWarlordNajentusDelayDpsCooldownsMultiplier : public Multiplier
+class BlackTempleDelayDpsCooldownsMultiplier : public Multiplier
 {
 public:
-    HighWarlordNajentusDelayDpsCooldownsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "high warlord naj'entus delay dps cooldowns multiplier") {}
+    BlackTempleDelayDpsCooldownsMultiplier(
+        PlayerbotAI* botAI) : Multiplier(botAI, "black temple delay dps cooldowns multiplier") {}
     float GetValue(Action* action) override;
 };
 
@@ -28,14 +28,6 @@ public:
 };
 
 // Supremus
-
-class SupremusDelayDpsCooldownsMultiplier : public Multiplier
-{
-public:
-    SupremusDelayDpsCooldownsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "supremus delay dps cooldowns multiplier") {}
-    float GetValue(Action* action) override;
-};
 
 class SupremusFocusOnAvoidanceInPhase2Multiplier : public Multiplier
 {
@@ -54,14 +46,6 @@ public:
 };
 
 // Teron Gorefiend
-
-class TeronGorefiendDelayDpsCooldownsMultiplier : public Multiplier
-{
-public:
-    TeronGorefiendDelayDpsCooldownsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "teron gorefiend delay dps cooldowns multiplier") {}
-    float GetValue(Action* action) override;
-};
 
 class TeronGorefiendControlMovementMultiplier : public Multiplier
 {
@@ -97,14 +81,6 @@ public:
 
 // Gurtogg Bloodboil
 
-class GurtoggBloodboilDelayDpsCooldownsMultiplier : public Multiplier
-{
-public:
-    GurtoggBloodboilDelayDpsCooldownsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "gurtogg bloodboil delay dps cooldowns multiplier") {}
-    float GetValue(Action* action) override;
-};
-
 class GurtoggBloodboilControlMovementMultiplier : public Multiplier
 {
 public:
@@ -115,14 +91,6 @@ public:
 
 // Reliquary of Souls
 
-class ReliquaryOfSoulsDelayDpsCooldownsMultiplier : public Multiplier
-{
-public:
-    ReliquaryOfSoulsDelayDpsCooldownsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "reliquary of souls delay dps cooldowns multiplier") {}
-    float GetValue(Action* action) override;
-};
-
 class ReliquaryOfSoulsDontWasteHealingMultiplier : public Multiplier
 {
 public:
@@ -132,14 +100,6 @@ public:
 };
 
 // Mother Shahraz
-
-class MotherShahrazDelayDpsCooldownsMultiplier : public Multiplier
-{
-public:
-    MotherShahrazDelayDpsCooldownsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "mother shahraz delay dps cooldowns multiplier") {}
-    float GetValue(Action* action) override;
-};
 
 class MotherShahrazControlMovementMultiplier : public Multiplier
 {
@@ -158,14 +118,6 @@ public:
 };
 
 // Illidari Council
-
-class IllidariCouncilDelayDpsCooldownsMultiplier : public Multiplier
-{
-public:
-    IllidariCouncilDelayDpsCooldownsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "illidari council delay dps cooldowns multiplier") {}
-    float GetValue(Action* action) override;
-};
 
 class IllidariCouncilDisableTankActionsMultiplier : public Multiplier
 {

--- a/src/Ai/Raid/BT/BTStrategy.cpp
+++ b/src/Ai/Raid/BT/BTStrategy.cpp
@@ -205,37 +205,33 @@ void RaidBlackTempleStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 
 void RaidBlackTempleStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
 {
+    // General
+    multipliers.push_back(new BlackTempleDelayDpsCooldownsMultiplier(botAI));
+
     // High Warlord Naj'entus
-    multipliers.push_back(new HighWarlordNajentusDelayDpsCooldownsMultiplier(botAI));
     multipliers.push_back(new HighWarlordNajentusDisableCombatFormationMoveMultiplier(botAI));
 
     // Supremus
-    multipliers.push_back(new SupremusDelayDpsCooldownsMultiplier(botAI));
     multipliers.push_back(new SupremusFocusOnAvoidanceInPhase2Multiplier(botAI));
     multipliers.push_back(new SupremusHitboxIsBuggedMultiplier(botAI));
 
     // Teron Gorefiend
-    multipliers.push_back(new TeronGorefiendDelayDpsCooldownsMultiplier(botAI));
     multipliers.push_back(new TeronGorefiendControlMovementMultiplier(botAI));
     multipliers.push_back(new TeronGorefiendMarkedBotOnlyMoveToDieMultiplier(botAI));
     multipliers.push_back(new TeronGorefiendSpiritsAttackOnlyShadowyConstructsMultiplier(botAI));
     multipliers.push_back(new TeronGorefiendDisableAttackingConstructsMultiplier(botAI));
 
     // Gurtogg Bloodboil
-    multipliers.push_back(new GurtoggBloodboilDelayDpsCooldownsMultiplier(botAI));
     multipliers.push_back(new GurtoggBloodboilControlMovementMultiplier(botAI));
 
     // Reliquary of Souls
-    multipliers.push_back(new ReliquaryOfSoulsDelayDpsCooldownsMultiplier(botAI));
     multipliers.push_back(new ReliquaryOfSoulsDontWasteHealingMultiplier(botAI));
 
     // Mother Shahraz
-    multipliers.push_back(new MotherShahrazDelayDpsCooldownsMultiplier(botAI));
     multipliers.push_back(new MotherShahrazControlMovementMultiplier(botAI));
     multipliers.push_back(new MotherShahrazBotsWithFatalAttractionOnlyRunAwayMultiplier(botAI));
 
     // Illidari Council
-    multipliers.push_back(new IllidariCouncilDelayDpsCooldownsMultiplier(botAI));
     multipliers.push_back(new IllidariCouncilDisableTankActionsMultiplier(botAI));
     multipliers.push_back(new IllidariCouncilControlMovementMultiplier(botAI));
     multipliers.push_back(new IllidariCouncilControlMisdirectionMultiplier(botAI));

--- a/src/Ai/Raid/BT/BTTriggers.cpp
+++ b/src/Ai/Raid/BT/BTTriggers.cpp
@@ -8,11 +8,12 @@
 #include "AiFactory.h"
 #include "BTActions.h"
 #include "BTHelpers.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "SharedDefines.h"
 
 using namespace BlackTempleHelpers;
+using namespace EncounterHelpers;
 
 // General
 

--- a/src/Ai/Raid/BWL/BWLActionContext.h
+++ b/src/Ai/Raid/BWL/BWLActionContext.h
@@ -27,6 +27,11 @@ public:
         creators["bwl vaelastrasz fire resistance"] = &RaidBwlActionContext::bwl_vaelastrasz_fire_resistance_action;
         creators["bwl vaelastrasz move away"] = &RaidBwlActionContext::bwl_vaelastrasz_move_away;
 
+        creators["bwl broodlord fire resistance"] = &RaidBwlActionContext::bwl_broodlord_fire_resistance_action;
+
+        creators["bwl firemaw fire resistance"] = &RaidBwlActionContext::bwl_firemaw_fire_resistance_action;
+        creators["bwl flamegor fire resistance"] = &RaidBwlActionContext::bwl_flamegor_fire_resistance_action;
+
         creators["bwl use hourglass sand"] = &RaidBwlActionContext::bwl_use_hourglass_sand;
         creators["bwl nefarian fear ward"] = &RaidBwlActionContext::bwl_nefarian_fear_ward;
         creators["bwl death talon wyrmguard tank move away"] = &RaidBwlActionContext::bwl_death_talon_wyrmguard_tank_move_away;
@@ -41,6 +46,9 @@ private:
     static Action* bwl_razorgore_mark_boss(PlayerbotAI* ai) { return new BwlRazorgoreMarkBossAction(ai); }
     static Action* bwl_vaelastrasz_fire_resistance_action(PlayerbotAI* ai) { return new BossFireResistanceAction(ai, "vaelastrasz the corrupt"); }
     static Action* bwl_vaelastrasz_move_away(PlayerbotAI* ai) { return new BwlVaelastraszMoveAwayAction(ai); }
+    static Action* bwl_broodlord_fire_resistance_action(PlayerbotAI* ai) { return new BossFireResistanceAction(ai, "broodlord lashlayer"); }
+    static Action* bwl_firemaw_fire_resistance_action(PlayerbotAI* ai) { return new BossFireResistanceAction(ai, "firemaw"); }
+    static Action* bwl_flamegor_fire_resistance_action(PlayerbotAI* ai) { return new BossFireResistanceAction(ai, "flamegor"); }
     static Action* bwl_use_hourglass_sand(PlayerbotAI* ai) { return new BwlUseHourglassSandAction(ai); }
     static Action* bwl_nefarian_fear_ward(PlayerbotAI* ai) { return new BwlNefarianFearWardAction(ai); }
     static Action* bwl_death_talon_wyrmguard_tank_move_away(PlayerbotAI* ai) { return new BwlDeathTalonWyrmguardTankMoveAwayAction(ai); }

--- a/src/Ai/Raid/BWL/BWLActions.cpp
+++ b/src/Ai/Raid/BWL/BWLActions.cpp
@@ -6,11 +6,12 @@
 
 #include "BWLActions.h"
 #include "BWLHelpers.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "RtiTargetValue.h"
 
 using namespace BlackwingLairHelpers;
+using namespace EncounterHelpers;
 
 static constexpr float INCREMENTAL_MOVE_STEP_DISTANCE = 3.0f;
 
@@ -117,7 +118,7 @@ bool BwlRazorgoreMarkBossAction::Execute(Event /*event*/)
             if (MarkTargetWithMoon(bot, boss))
                 return true;
 
-            SetRtiTarget(botAI, "moon", boss);
+            SetRtiTarget(botAI, "moon");
 
             if (AI_VALUE(Unit*, "current target") != boss)
                 return Attack(boss);

--- a/src/Ai/Raid/BWL/BWLStrategy.cpp
+++ b/src/Ai/Raid/BWL/BWLStrategy.cpp
@@ -28,6 +28,14 @@ void RaidBwlStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(new TriggerNode("bwl vaelastrasz burning adrenaline", {
         NextAction("bwl vaelastrasz move away", ACTION_RAID + 5) }));
 
+    triggers.push_back(new TriggerNode("bwl broodlord fire resistance", {
+        NextAction("bwl broodlord fire resistance", ACTION_RAID) }));
+
+    triggers.push_back(new TriggerNode("bwl firemaw fire resistance", {
+        NextAction("bwl firemaw fire resistance", ACTION_RAID) }));
+    triggers.push_back(new TriggerNode("bwl flamegor fire resistance", {
+        NextAction("bwl flamegor fire resistance", ACTION_RAID) }));
+
     triggers.push_back(new TriggerNode("bwl affliction bronze", {
         NextAction("bwl use hourglass sand", ACTION_RAID) }));
 

--- a/src/Ai/Raid/BWL/BWLTriggerContext.h
+++ b/src/Ai/Raid/BWL/BWLTriggerContext.h
@@ -25,6 +25,11 @@ public:
         creators["bwl vaelastrasz positioning"] = &RaidBwlTriggerContext::bwl_vaelastrasz_positioning;
         creators["bwl vaelastrasz burning adrenaline"] = &RaidBwlTriggerContext::bwl_vaelastrasz_burning_adrenaline;
 
+        creators["bwl broodlord fire resistance"] = &RaidBwlTriggerContext::bwl_broodlord_fire_resistance_trigger;
+
+        creators["bwl firemaw fire resistance"] = &RaidBwlTriggerContext::bwl_firemaw_fire_resistance_trigger;
+        creators["bwl flamegor fire resistance"] = &RaidBwlTriggerContext::bwl_flamegor_fire_resistance_trigger;
+
         creators["bwl affliction bronze"] = &RaidBwlTriggerContext::bwl_affliction_bronze;
         creators["bwl wild magic"] = &RaidBwlTriggerContext::bwl_wild_magic;
         creators["bwl nefarian fear ward"] = &RaidBwlTriggerContext::bwl_nefarian_fear_ward;
@@ -39,6 +44,9 @@ private:
     static Trigger* bwl_vaelastrasz_fire_resistance_trigger(PlayerbotAI* ai) { return new BossFireResistanceTrigger(ai, "vaelastrasz the corrupt"); }
     static Trigger* bwl_vaelastrasz_positioning(PlayerbotAI* ai) { return new BwlVaelastraszPositioningTrigger(ai); }
     static Trigger* bwl_vaelastrasz_burning_adrenaline(PlayerbotAI* ai) { return new BwlVaelastraszBurningAdrenalineTrigger(ai); }
+    static Trigger* bwl_broodlord_fire_resistance_trigger(PlayerbotAI* ai) { return new BossFireResistanceTrigger(ai, "broodlord lashlayer"); }
+    static Trigger* bwl_firemaw_fire_resistance_trigger(PlayerbotAI* ai) { return new BossFireResistanceTrigger(ai, "firemaw"); }
+    static Trigger* bwl_flamegor_fire_resistance_trigger(PlayerbotAI* ai) { return new BossFireResistanceTrigger(ai, "flamegor"); }
     static Trigger* bwl_affliction_bronze(PlayerbotAI* ai) { return new BwlAfflictionBronzeTrigger(ai); }
     static Trigger* bwl_wild_magic(PlayerbotAI* ai) { return new BwlWildMagicTrigger(ai); }
     static Trigger* bwl_nefarian_fear_ward(PlayerbotAI* ai) { return new BwlNefarianFearWardTrigger(ai); }

--- a/src/Ai/Raid/Gruul/GruulActions.cpp
+++ b/src/Ai/Raid/Gruul/GruulActions.cpp
@@ -6,12 +6,13 @@
 
 #include "GruulActions.h"
 #include "CreatureAI.h"
+#include "EncounterHelpers.h"
 #include "GruulHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "Unit.h"
 
 using namespace GruulsLairHelpers;
+using namespace EncounterHelpers;
 
 // High King Maulgar Actions
 
@@ -25,7 +26,7 @@ bool HighKingMaulgarMainTankAttackMaulgarAction::Execute(Event /*event*/)
     if (MarkTargetWithSquare(bot, maulgar))
         return true;
 
-    SetRtiTarget(botAI, "square", maulgar);
+    SetRtiTarget(botAI, "square");
 
     if (AI_VALUE(Unit*, "current target") != maulgar)
         return Attack(maulgar);
@@ -62,7 +63,7 @@ bool HighKingMaulgarFirstAssistTankAttackOlmAction::Execute(Event /*event*/)
     if (MarkTargetWithCircle(bot, olm))
         return true;
 
-    SetRtiTarget(botAI, "circle", olm);
+    SetRtiTarget(botAI, "circle");
 
     if (AI_VALUE(Unit*, "current target") != olm)
         return Attack(olm);
@@ -99,7 +100,7 @@ bool HighKingMaulgarSecondAssistTankAttackBlindeyeAction::Execute(Event /*event*
     if (MarkTargetWithStar(bot, blindeye))
         return true;
 
-    SetRtiTarget(botAI, "star", blindeye);
+    SetRtiTarget(botAI, "star");
 
     if (AI_VALUE(Unit*, "current target") != blindeye)
         return Attack(blindeye);
@@ -136,7 +137,7 @@ bool HighKingMaulgarMageTankAttackKroshAction::Execute(Event /*event*/)
     if (MarkTargetWithTriangle(bot, krosh))
         return true;
 
-    SetRtiTarget(botAI, "triangle", krosh);
+    SetRtiTarget(botAI, "triangle");
 
     if (krosh->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_SPELL_SHIELD)) &&
         botAI->CanCastSpell("spellsteal", krosh))
@@ -194,7 +195,7 @@ bool HighKingMaulgarMoonkinTankAttackKigglerAction::Execute(Event /*event*/)
     if (MarkTargetWithDiamond(bot, kiggler))
         return true;
 
-    SetRtiTarget(botAI, "diamond", kiggler);
+    SetRtiTarget(botAI, "diamond");
 
     if (AI_VALUE(Unit*, "current target") != kiggler)
         return Attack(kiggler);
@@ -222,7 +223,7 @@ bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithStar(bot, blindeye))
             return true;
 
-        SetRtiTarget(botAI, "star", blindeye);
+        SetRtiTarget(botAI, "star");
 
         if (AI_VALUE(Unit*, "current target") != blindeye)
             return Attack(blindeye);
@@ -236,7 +237,7 @@ bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithCircle(bot, olm))
             return true;
 
-        SetRtiTarget(botAI, "circle", olm);
+        SetRtiTarget(botAI, "circle");
 
         if (AI_VALUE(Unit*, "current target") != olm)
             return Attack(olm);
@@ -251,7 +252,7 @@ bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithTriangle(bot, krosh))
             return true;
 
-        SetRtiTarget(botAI, "triangle", krosh);
+        SetRtiTarget(botAI, "triangle");
 
         if (AI_VALUE(Unit*, "current target") != krosh)
             return Attack(krosh);
@@ -265,7 +266,7 @@ bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithDiamond(bot, kiggler))
             return true;
 
-        SetRtiTarget(botAI, "diamond", kiggler);
+        SetRtiTarget(botAI, "diamond");
 
         if (AI_VALUE(Unit*, "current target") != kiggler)
             return Attack(kiggler);
@@ -279,7 +280,7 @@ bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithSquare(bot, maulgar))
             return true;
 
-        SetRtiTarget(botAI, "square", maulgar);
+        SetRtiTarget(botAI, "square");
 
         if (AI_VALUE(Unit*, "current target") != maulgar)
             return Attack(maulgar);
@@ -420,14 +421,14 @@ bool HighKingMaulgarMisdirectOgresToTanksAction::Execute(Event /*event*/)
     if (hunterIndex == 0)
     {
         ogreTarget = AI_VALUE2(Unit*, "find target", "blindeye the seer");
-        tankTarget = GetGroupAssistTank(botAI, bot, 1);
+        tankTarget = GetGroupAssistTank(bot, 1);
     }
     else if (hunterIndex == 1)
     {
         ogreTarget = AI_VALUE2(Unit*, "find target", "olm the summoner");
         for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
         {
-            if (Player* member = GetGroupAssistTank(botAI, bot, 0))
+            if (Player* member = GetGroupAssistTank(bot, 0))
             {
                 tankTarget = member;
                 break;

--- a/src/Ai/Raid/Hyjal/HyjalActions.cpp
+++ b/src/Ai/Raid/Hyjal/HyjalActions.cpp
@@ -5,12 +5,13 @@
  */
 
 #include "HyjalActions.h"
+#include "EncounterHelpers.h"
 #include "HyjalHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "Timer.h"
 
 using namespace HyjalSummitHelpers;
+using namespace EncounterHelpers;
 
 // General
 
@@ -77,7 +78,7 @@ bool RageWinterchillMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!winterchill)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -226,7 +227,7 @@ bool AnetheronMisdirectBossAndInfernalsToTanksAction::Execute(Event /*event*/)
 
     if (anetheron->GetHealthPct() > 95.0f)
     {
-        Player* mainTank = GetGroupMainTank(botAI, bot);
+        Player* mainTank = GetGroupMainTank(bot);
         if (!mainTank)
             return false;
 
@@ -241,7 +242,7 @@ bool AnetheronMisdirectBossAndInfernalsToTanksAction::Execute(Event /*event*/)
     if (Unit* infernal = AI_VALUE2(Unit*, "find target", "towering infernal");
         infernal && infernal->GetHealthPct() > 50.0f)
     {
-        Player* firstAssistTank = GetGroupAssistTank(botAI, bot, 0);
+        Player* firstAssistTank = GetGroupAssistTank(bot, 0);
         if (!firstAssistTank)
             return false;
 
@@ -266,7 +267,7 @@ bool AnetheronMainTankPositionBossAction::Execute(Event /*event*/)
     if (MarkTargetWithSquare(bot, anetheron))
         return true;
 
-    SetRtiTarget(botAI, "square", anetheron);
+    SetRtiTarget(botAI, "square");
 
     if (AI_VALUE(Unit*, "current target") != anetheron)
         return Attack(anetheron);
@@ -398,7 +399,7 @@ bool AnetheronFirstAssistTankPickUpInfernalsAction::Execute(Event /*event*/)
     if (MarkTargetWithDiamond(bot, infernal))
         return true;
 
-    SetRtiTarget(botAI, "diamond", infernal);
+    SetRtiTarget(botAI, "diamond");
 
     if (AI_VALUE(Unit*, "current target") != infernal)
         return Attack(infernal);
@@ -435,7 +436,7 @@ bool AnetheronAssignDpsPriorityAction::Execute(Event /*event*/)
 
     if (botAI->IsMelee(bot))
     {
-        SetRtiTarget(botAI, "square", anetheron);
+        SetRtiTarget(botAI, "square");
 
         if (AI_VALUE(Unit*, "current target") != anetheron)
             return Attack(anetheron);
@@ -455,10 +456,10 @@ bool AnetheronAssignDpsPriorityAction::Execute(Event /*event*/)
         if (anetheron->GetHealthPct() > 10.0f && botAI->IsRangedDps(bot) &&
             bot->GetDistance2d(infernal) < 50.0f)
         {
-            if (Player* firstAssistTank = GetGroupAssistTank(botAI, bot, 0);
+            if (Player* firstAssistTank = GetGroupAssistTank(bot, 0);
                 !firstAssistTank || infernal->GetVictim() == firstAssistTank)
             {
-                SetRtiTarget(botAI, "diamond", infernal);
+                SetRtiTarget(botAI, "diamond");
 
                 if (AI_VALUE(Unit*, "current target") != infernal)
                     return Attack(infernal);
@@ -467,7 +468,7 @@ bool AnetheronAssignDpsPriorityAction::Execute(Event /*event*/)
     }
     else if (botAI->IsRangedDps(bot))
     {
-        SetRtiTarget(botAI, "square", anetheron);
+        SetRtiTarget(botAI, "square");
 
         if (AI_VALUE(Unit*, "current target") != anetheron)
             return Attack(anetheron);
@@ -484,7 +485,7 @@ bool KazrogalMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!kazrogal)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -551,7 +552,7 @@ bool KazrogalMainTankPositionBossAction::Execute(Event /*event*/)
 // To spread cleave damage
 bool KazrogalAssistTanksMoveInFrontOfBossAction::Execute(Event /*event*/)
 {
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -714,7 +715,7 @@ bool AzgalorMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!azgalor)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -739,7 +740,7 @@ bool AzgalorMainTankPositionBossAction::Execute(Event /*event*/)
     if (MarkTargetWithStar(bot, azgalor))
         return true;
 
-    SetRtiTarget(botAI, "star", azgalor);
+    SetRtiTarget(botAI, "star");
 
     if (AI_VALUE(Unit*, "current target") != azgalor)
         return Attack(azgalor);
@@ -827,7 +828,7 @@ bool AzgalorMeleeGetOutOfFireAndSwapTargetsAction::Execute(Event /*event*/)
     constexpr float singleTickMoveAwayDist = 6.0f;
     if (!IsInRainOfFire(bot, RAIN_OF_FIRE_RADIUS + singleTickMoveAwayDist))
     {
-        SetRtiTarget(botAI, "star", azgalor);
+        SetRtiTarget(botAI, "star");
         return false;
     }
 
@@ -836,11 +837,11 @@ bool AzgalorMeleeGetOutOfFireAndSwapTargetsAction::Execute(Event /*event*/)
 
     if (!desiredTarget)
     {
-        SetRtiTarget(botAI, "star", azgalor);
+        SetRtiTarget(botAI, "star");
         return MoveAway(azgalor, 5.0f);
     }
 
-    SetRtiTarget(botAI, "circle", desiredTarget);
+    SetRtiTarget(botAI, "circle");
 
     if (!bot->IsWithinMeleeRange(desiredTarget))
     {
@@ -869,7 +870,7 @@ bool AzgalorWaitAtSafePositionAction::Execute(Event /*event*/)
     if (!azgalor)
         return false;
 
-    SetRtiTarget(botAI, "star", azgalor);
+    SetRtiTarget(botAI, "star");
 
     const Position& position = AZGALOR_DOOMGUARD_POSITION;
     constexpr float moveDist = 10.0f;
@@ -919,7 +920,7 @@ bool AzgalorFirstAssistTankPositionDoomguardAction::Execute(Event /*event*/)
         if (MarkTargetWithCircle(bot, doomguard))
             return true;
 
-        SetRtiTarget(botAI, "circle", doomguard);
+        SetRtiTarget(botAI, "circle");
 
         if (AI_VALUE(Unit*, "current target") != doomguard)
             return Attack(doomguard);
@@ -970,7 +971,7 @@ bool AzgalorRangedDpsPrioritizeDoomguardsAction::Execute(Event /*event*/)
         if (Unit* doomguard = AI_VALUE2(Unit*, "find target", "lesser doomguard");
             doomguard && bot->GetDistance2d(doomguard) < 65.0f)
         {
-            SetRtiTarget(botAI, "circle", doomguard);
+            SetRtiTarget(botAI, "circle");
 
             if (AI_VALUE(Unit*, "current target") != doomguard)
                 return Attack(doomguard);
@@ -978,7 +979,7 @@ bool AzgalorRangedDpsPrioritizeDoomguardsAction::Execute(Event /*event*/)
     }
     else
     {
-        SetRtiTarget(botAI, "star", azgalor);
+        SetRtiTarget(botAI, "star");
 
         if (AI_VALUE(Unit*, "current target") != azgalor)
             return Attack(azgalor);
@@ -995,7 +996,7 @@ bool ArchimondeMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!archimonde)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -1052,7 +1053,7 @@ bool ArchimondeCastFearImmunitySpellAction::Execute(Event /*event*/)
 
 bool ArchimondeCastFearImmunitySpellAction::CastFearWardOnMainTank()
 {
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (mainTank && botAI->CanCastSpell("fear ward", mainTank))
         return botAI->CastSpell("fear ward", mainTank);
 
@@ -1078,7 +1079,7 @@ bool ArchimondeSpreadToAvoidAirBurstAction::Execute(Event /*event*/)
     if (!archimonde)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (mainTank && bot != mainTank)
     {
         const float distanceToMainTank = bot->GetDistance2d(mainTank);

--- a/src/Ai/Raid/Hyjal/HyjalMultipliers.cpp
+++ b/src/Ai/Raid/Hyjal/HyjalMultipliers.cpp
@@ -9,16 +9,17 @@
 #include "ChooseTargetActions.h"
 #include "DKActions.h"
 #include "DruidBearActions.h"
+#include "EncounterHelpers.h"
 #include "HunterActions.h"
 #include "HyjalActions.h"
 #include "HyjalHelpers.h"
 #include "PaladinActions.h"
-#include "RaidBossHelpers.h"
 #include "ReachTargetActions.h"
 #include "ShamanActions.h"
 #include "WarriorActions.h"
 
 using namespace HyjalSummitHelpers;
+using namespace EncounterHelpers;
 
 // Without this multiplier, Bloodlust/Heroism will not be available for
 // bosses because it will be used on cooldown during trash waves
@@ -265,7 +266,7 @@ float AzgalorMeleeDpsControlAvoidanceMultiplier::GetValue(Action* action)
             return 0.0f;
     }
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank || !GET_PLAYERBOT_AI(mainTank))
         return 1.0f;
 

--- a/src/Ai/Raid/Hyjal/HyjalTriggers.cpp
+++ b/src/Ai/Raid/Hyjal/HyjalTriggers.cpp
@@ -6,12 +6,13 @@
 
 #include "HyjalTriggers.h"
 #include "AiFactory.h"
+#include "EncounterHelpers.h"
 #include "HyjalActions.h"
 #include "HyjalHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 
 using namespace HyjalSummitHelpers;
+using namespace EncounterHelpers;
 
 // General
 
@@ -226,7 +227,7 @@ bool AzgalorMainTankIsPositioningBossTrigger::IsActive()
     if (!azgalor || azgalor->GetVictim() == bot)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank || !GET_PLAYERBOT_AI(mainTank) || botAI->IsMainTank(bot))
         return false;
 
@@ -278,7 +279,7 @@ bool AzgalorDoomguardsMustBeControlledTrigger::IsActive()
     if (botAI->IsAssistTankOfIndex(bot, 1, true))
     {
         // Trigger for second assist tank only if first assist tank has Doom
-        Player* firstAssistTank = GetGroupAssistTank(botAI, bot, 0);
+        Player* firstAssistTank = GetGroupAssistTank(bot, 0);
         if (firstAssistTank &&
             !firstAssistTank->HasAura(static_cast<uint32>(HyjalSummitSpells::SPELL_DOOM)))
             return false;

--- a/src/Ai/Raid/Hyjal/Util/HyjalHelpers.cpp
+++ b/src/Ai/Raid/Hyjal/Util/HyjalHelpers.cpp
@@ -5,10 +5,12 @@
  */
 
 #include "HyjalHelpers.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "Timer.h"
 #include <algorithm>
+
+using namespace EncounterHelpers;
 
 namespace HyjalSummitHelpers
 {
@@ -165,7 +167,7 @@ std::unordered_map<ObjectGuid, bool> isBelowManaThreshold;
 
 TankPositionState GetKazrogalTankPositionState(PlayerbotAI* botAI, Player* bot)
 {
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return TankPositionState::Unknown;
 
@@ -206,7 +208,7 @@ RainOfFireData* GetActiveAzgalorRainOfFire(uint32 instanceId)
 
 TankPositionState GetAzgalorTankPositionState(PlayerbotAI* botAI, Player* bot)
 {
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return TankPositionState::Unknown;
 

--- a/src/Ai/Raid/Hyjal/Util/HyjalScripts.cpp
+++ b/src/Ai/Raid/Hyjal/Util/HyjalScripts.cpp
@@ -6,16 +6,17 @@
 
 #include "AllCreatureScript.h"
 #include "DynamicObjectScript.h"
+#include "EncounterHelpers.h"
 #include "HyjalHelpers.h"
 #include "ObjectAccessor.h"
 #include "Player.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "ScriptMgr.h"
 #include "Spell.h"
 #include "Timer.h"
 
 using namespace HyjalSummitHelpers;
+using namespace EncounterHelpers;
 
 static Player* GetFirstPlayerSpellTarget(Spell* spell, Unit* caster)
 {
@@ -40,7 +41,7 @@ static bool ShouldInterruptForArchimondeAirBurst(PlayerbotAI* botAI, Player* bot
     if (!target)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank || bot == mainTank)
         return false;
 

--- a/src/Ai/Raid/Kara/KaraActions.cpp
+++ b/src/Ai/Raid/Kara/KaraActions.cpp
@@ -5,10 +5,10 @@
  */
 
 #include "KaraActions.h"
+#include "EncounterHelpers.h"
 #include "KaraHelpers.h"
 #include "PlayerbotTextMgr.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -19,6 +19,7 @@
 #include <string>
 
 using namespace KaraHelpers;
+using namespace EncounterHelpers;
 
 // General
 
@@ -105,7 +106,7 @@ bool KarazhanCastFearProtectionSpellAction::Execute(Event /*event*/)
 
 bool KarazhanCastFearProtectionSpellAction::CastFearWardOnMainTank()
 {
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank || mainTank->HasAura(Id(KaraSpells::SPELL_FEAR_WARD)))
         return false;
 

--- a/src/Ai/Raid/Kara/KaraTriggers.cpp
+++ b/src/Ai/Raid/Kara/KaraTriggers.cpp
@@ -5,12 +5,13 @@
  */
 
 #include "KaraTriggers.h"
+#include "EncounterHelpers.h"
 #include "KaraActions.h"
 #include "KaraHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 
 using namespace KaraHelpers;
+using namespace EncounterHelpers;
 
 // General
 

--- a/src/Ai/Raid/MC/MCActionContext.h
+++ b/src/Ai/Raid/MC/MCActionContext.h
@@ -33,6 +33,9 @@ public:
         creators["mc majordomo shadow resistance"] = &RaidMcActionContext::majordomo_shadow_resistance;
         creators["mc ragnaros fire resistance"] = &RaidMcActionContext::ragnaros_fire_resistance;
         creators["mc core hound mark"] = &RaidMcActionContext::core_hound_mark;
+        creators["mc move from lava"] = &RaidMcActionContext::move_from_lava;
+        creators["mc golemagg back off"] = &RaidMcActionContext::golemagg_back_off;
+        creators["mc golemagg healer position"] = &RaidMcActionContext::golemagg_healer_position;
     }
 
 private:
@@ -52,6 +55,9 @@ private:
     static Action* majordomo_shadow_resistance(PlayerbotAI* botAI) { return new BossShadowResistanceAction(botAI, "majordomo executus"); }
     static Action* ragnaros_fire_resistance(PlayerbotAI* botAI) { return new BossFireResistanceAction(botAI, "ragnaros"); }
     static Action* core_hound_mark(PlayerbotAI* botAI) { return new McCoreHoundMarkAction(botAI); }
+    static Action* move_from_lava(PlayerbotAI* botAI) { return new McMoveFromLavaAction(botAI); }
+    static Action* golemagg_back_off(PlayerbotAI* botAI) { return new McGolemaggBackOffAction(botAI); }
+    static Action* golemagg_healer_position(PlayerbotAI* botAI) { return new McGolemaggHealerPositionAction(botAI); }
 };
 
 #endif

--- a/src/Ai/Raid/MC/MCActions.cpp
+++ b/src/Ai/Raid/MC/MCActions.cpp
@@ -9,15 +9,18 @@
 #include "Playerbots.h"
 #include "RtiTargetValue.h"
 
+#include <algorithm>
+
 static constexpr float LIVING_BOMB_DISTANCE = 20.0f;
 static constexpr float INFERNO_DISTANCE = 20.0f;
-
-// don't get hit by Arcane Explosion but still be in casting range
-static constexpr float ARCANE_EXPLOSION_DISTANCE = 26.0f;
 
 // dedicated tank positions; prevents assist tanks from positioning Core Ragers on steep walls on pull
 static const Position GOLEMAGG_TANK_POSITION{795.7308, -994.8848, -207.18661};
 static const Position CORE_RAGER_TANK_POSITION{846.6453, -1019.0639, -198.9819};
+
+// Midpoint of the two tank camps (56y apart): healers standing here reach both
+static const Position GOLEMAGG_HEALER_POSITION{821.2f, -1007.0f, -203.0f};
+static constexpr float HEALER_POSITION_TOLERANCE = 8.0f;
 
 static constexpr float GOLEMAGGS_TRUST_DISTANCE = 30.0f;
 static constexpr float CORE_RAGER_STEP_DISTANCE = 5.0f;
@@ -55,6 +58,75 @@ bool McShazzrahMoveAwayAction::Execute(Event /*event*/)
             return MoveAway(boss, distToTravel);
     }
     return false;
+}
+
+bool McMoveFromLavaAction::Execute(Event /*event*/)
+{
+    // Escape to the nearest raid member on dry ground: raids fight on the
+    // rock shelves, so a dry teammate marks the closest safe floor.
+    Unit* dryTarget = nullptr;
+    float bestDist = 100.0f;
+
+    if (Group* group = bot->GetGroup())
+    {
+        for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+        {
+            Player* member = ref->GetSource();
+            if (!member || member == bot || !member->IsAlive() || member->GetMapId() != bot->GetMapId())
+                continue;
+
+            if (member->GetLiquidData().Flags & MAP_LIQUID_TYPE_MAGMA)
+                continue;
+
+            float dist = bot->GetDistance(member);
+            if (dist < bestDist)
+            {
+                bestDist = dist;
+                dryTarget = member;
+            }
+        }
+    }
+
+    // No dry raid member in range: stay put and let the in-lava trigger fire
+    // again — any other destination (the current target included) can path
+    // straight back into the pool.
+    if (!dryTarget)
+        return false;
+
+    botAI->InterruptSpell();
+
+    if (!MoveTo(dryTarget->GetMapId(), dryTarget->GetPositionX(), dryTarget->GetPositionY(),
+                dryTarget->GetPositionZ(), false, false, false, true, MovementPriority::MOVEMENT_FORCED))
+        return false;
+
+    // Hold the AI so rotation/facing actions can't cancel the escape spline
+    // mid-lava. Capped at 2s on purpose: the in-lava trigger refires and
+    // re-issues the escape while the bot is still swimming.
+    constexpr uint32 MAX_ESCAPE_HOLD_MS = 2000;
+    constexpr float MIN_ESCAPE_SPEED = 0.1f;
+
+    float const speed = bot->GetSpeed(MOVE_RUN);
+    if (speed > MIN_ESCAPE_SPEED)
+        botAI->SetNextCheckDelay(std::min(MAX_ESCAPE_HOLD_MS, uint32(1000.0f * bot->GetDistance(dryTarget) / speed)));
+
+    return true;
+}
+
+bool McGolemaggBackOffAction::Execute(Event /*event*/)
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", "golemagg the incinerator");
+    if (!boss)
+        return false;
+
+    // Out of swing range the stack stops growing and expires 30s after
+    // the last application; the multiplier blocks re-engaging until then.
+    botAI->InterruptSpell();
+
+    float distToTravel = MAGMA_SPLASH_BACK_OFF_DISTANCE - bot->GetDistance2d(boss);
+    if (distToTravel <= 0.0f)
+        return true;
+
+    return MoveAway(boss, distToTravel);
 }
 
 bool McGolemaggMarkBossAction::Execute(Event /*event*/)
@@ -134,6 +206,16 @@ bool McGolemaggMainTankAttackGolemaggAction::Execute(Event /*event*/)
             return MoveUnitToPosition(boss, GOLEMAGG_TANK_POSITION, boss->GetCombatReach());
     }
     return false;
+}
+
+bool McGolemaggHealerPositionAction::Execute(Event /*event*/)
+{
+    if (bot->GetExactDist2d(GOLEMAGG_HEALER_POSITION) <= HEALER_POSITION_TOLERANCE)
+        return false;
+
+    return MoveTo(bot->GetMapId(), GOLEMAGG_HEALER_POSITION.GetPositionX(), GOLEMAGG_HEALER_POSITION.GetPositionY(),
+                  GOLEMAGG_HEALER_POSITION.GetPositionZ(), false, false, false, false,
+                  MovementPriority::MOVEMENT_COMBAT, true, false);
 }
 
 bool McGolemaggAssistTankAttackCoreRagerAction::Execute(Event event)

--- a/src/Ai/Raid/MC/MCActions.h
+++ b/src/Ai/Raid/MC/MCActions.h
@@ -36,6 +36,22 @@ public:
     bool Execute(Event event) override;
 };
 
+class McMoveFromLavaAction : public MovementAction
+{
+public:
+    McMoveFromLavaAction(PlayerbotAI* botAI, std::string const name = "mc move from lava")
+        : MovementAction(botAI, name) {}
+    bool Execute(Event event) override;
+};
+
+class McGolemaggBackOffAction : public MovementAction
+{
+public:
+    McGolemaggBackOffAction(PlayerbotAI* botAI, std::string const name = "mc golemagg back off")
+        : MovementAction(botAI, name) {}
+    bool Execute(Event event) override;
+};
+
 class McGolemaggMarkBossAction : public Action
 {
 public:
@@ -67,6 +83,14 @@ class McGolemaggAssistTankAttackCoreRagerAction : public McGolemaggTankAction
 public:
     McGolemaggAssistTankAttackCoreRagerAction(PlayerbotAI* botAI, std::string const name = "mc golemagg assist tank attack core rager")
         : McGolemaggTankAction(botAI, name) {};
+    bool Execute(Event event) override;
+};
+
+class McGolemaggHealerPositionAction : public MovementAction
+{
+public:
+    McGolemaggHealerPositionAction(PlayerbotAI* botAI, std::string const name = "mc golemagg healer position")
+        : MovementAction(botAI, name) {}
     bool Execute(Event event) override;
 };
 

--- a/src/Ai/Raid/MC/MCHelpers.h
+++ b/src/Ai/Raid/MC/MCHelpers.h
@@ -14,6 +14,9 @@ enum MoltenCoreNPCs
     // Golemagg
     NPC_CORE_RAGER = 11672,
 
+    // Majordomo Executus
+    NPC_MAJORDOMO_EXECUTUS = 12018,
+
     // Core Hound (trash)
     NPC_CORE_HOUND = 11671,
 };
@@ -25,7 +28,14 @@ enum MoltenCoreSpells
 
     // Golemagg
     SPELL_GOLEMAGGS_TRUST = 20553,
+    SPELL_MAGMA_SPLASH = 13880,
 };
+
+constexpr uint32 MAGMA_SPLASH_BACK_OFF_STACKS = 20;
+constexpr float MAGMA_SPLASH_BACK_OFF_DISTANCE = 12.0f;
+
+// Shazzrah's Arcane Explosion radius
+constexpr float ARCANE_EXPLOSION_DISTANCE = 26.0f;
 }
 
 #endif

--- a/src/Ai/Raid/MC/MCMultipliers.cpp
+++ b/src/Ai/Raid/MC/MCMultipliers.cpp
@@ -5,16 +5,21 @@
  */
 
 #include "MCMultipliers.h"
+#include "AttackAction.h"
 #include "ChooseTargetActions.h"
 #include "DKActions.h"
 #include "DruidActions.h"
+#include "GenericActions.h"
 #include "GenericSpellActions.h"
 #include "HunterActions.h"
 #include "MCActions.h"
 #include "MCHelpers.h"
+#include "MovementActions.h"
 #include "PaladinActions.h"
 #include "Playerbots.h"
+#include "ReachTargetActions.h"
 #include "ShamanActions.h"
+#include "SpellAuras.h"
 #include "WarriorActions.h"
 
 using namespace MoltenCoreHelpers;
@@ -100,8 +105,11 @@ static bool IsSingleLivingTankInGroup(Player* bot)
 
 float GolemaggMultiplier::GetValue(Action* action)
 {
-    if (AI_VALUE2(Unit*, "find target", "golemagg the incinerator"))
+    if (Unit* golemagg = AI_VALUE2(Unit*, "find target", "golemagg the incinerator"))
     {
+        // Below 10% (soft enrage: Earthquake + converging Core Ragers) the
+        // fight is a burn race, everyone dps, no splash management.
+        bool burnPhase = golemagg->GetHealthPct() <= 10.0f;
         if (PlayerbotAI::IsTank(bot) && IsSingleLivingTankInGroup(bot))
         {
             // Only one tank => Pick up Golemagg and the two Core Ragers
@@ -116,6 +124,21 @@ float GolemaggMultiplier::GetValue(Action* action)
                 return 0.0f;
         }
         if (IsDpsBotWithAoeAction(bot, action))
+            return 0.0f;
+
+        // Golemagg's Magma Splash stacks an uncapped 30s dot on anyone striking
+        // him in melee. This blocks the default "melee when out of mana / in dead zone" fallback
+        // that walks casters and hunters onto the boss.
+        if (!burnPhase && PlayerbotAI::IsRanged(bot) && dynamic_cast<MeleeAction*>(action))
+            return 0.0f;
+
+        // Backed-off melee stay out until their whole Magma Splash stack expires (30s after the last application).
+        Aura* splash = bot->GetAura(SPELL_MAGMA_SPLASH);
+        bool backedOff = splash && splash->GetStackAmount() >= MAGMA_SPLASH_BACK_OFF_STACKS;
+        bool engagesBoss = !dynamic_cast<McGolemaggBackOffAction*>(action) &&
+                           (dynamic_cast<AttackAction*>(action) || dynamic_cast<MeleeAction*>(action) ||
+                            dynamic_cast<CastReachTargetSpellAction*>(action));
+        if (!burnPhase && !PlayerbotAI::IsTank(bot) && backedOff && engagesBoss)
             return 0.0f;
     }
     return 1.0f;

--- a/src/Ai/Raid/MC/MCStrategy.cpp
+++ b/src/Ai/Raid/MC/MCStrategy.cpp
@@ -5,8 +5,12 @@
  */
 
 #include "MCStrategy.h"
+#include "MCHelpers.h"
 #include "MCMultipliers.h"
+#include "Playerbots.h"
 #include "Strategy.h"
+
+using namespace MoltenCoreHelpers;
 
 void RaidMcStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
@@ -66,6 +70,12 @@ void RaidMcStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(
         new TriggerNode("mc golemagg is assist tank",
                         { NextAction("mc golemagg assist tank attack core rager", ACTION_RAID) }));
+    triggers.push_back(
+        new TriggerNode("mc golemagg magma splash",
+                        { NextAction("mc golemagg back off", ACTION_RAID + 1) }));
+    triggers.push_back(
+        new TriggerNode("mc golemagg is healer",
+                        { NextAction("mc golemagg healer position", ACTION_RAID) }));
 
     // Majordomo Executus
     triggers.push_back(
@@ -81,6 +91,11 @@ void RaidMcStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     triggers.push_back(
         new TriggerNode("mc core hound mark",
                         { NextAction("mc core hound mark", ACTION_RAID) }));
+
+    // Anywhere in MC: escaping a lava pool outranks everything else.
+    triggers.push_back(
+        new TriggerNode("mc in lava",
+                        { NextAction("mc move from lava", ACTION_RAID + 1) }));
 }
 
 void RaidMcStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
@@ -88,4 +103,26 @@ void RaidMcStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
     multipliers.push_back(new GarrDisableDpsAoeMultiplier(botAI));
     multipliers.push_back(new BaronGeddonAbilityMultiplier(botAI));
     multipliers.push_back(new GolemaggMultiplier(botAI));
+}
+
+void RaidMcStrategy::AppendTargetExclusions(GuidSet& exclusions, TargetValueExclusionType type)
+{
+    if (type != TargetValueExclusionType::Dps && type != TargetValueExclusionType::Attacker)
+        return;
+
+    // Damage into these is wasted: Core Ragers are unkillable while Golemagg
+    // lives (full heal at 50%), and Majordomo reflects and cannot die; his
+    // encounter ends when the eight adds are dead. Tanks still pick them up
+    // through their own target selection.
+    AiObjectContext* context = botAI->GetAiObjectContext();
+    bool const golemaggAlive = AI_VALUE2(Unit*, "find target", "golemagg the incinerator") != nullptr;
+    for (ObjectGuid const guid : AI_VALUE(GuidVector, "attackers"))
+    {
+        Unit* unit = botAI->GetUnit(guid);
+        if (!unit)
+            continue;
+
+        if ((golemaggAlive && unit->GetEntry() == NPC_CORE_RAGER) || unit->GetEntry() == NPC_MAJORDOMO_EXECUTUS)
+            exclusions.insert(guid);
+    }
 }

--- a/src/Ai/Raid/MC/MCStrategy.h
+++ b/src/Ai/Raid/MC/MCStrategy.h
@@ -16,6 +16,8 @@ public:
     std::string const getName() override { return "moltencore"; }
     void InitTriggers(std::vector<TriggerNode*>& triggers) override;
     void InitMultipliers(std::vector<Multiplier*> &multipliers) override;
+    void AppendTargetExclusions(GuidSet& exclusions, TargetValueExclusionType type) override;
+    bool HasTargetExclusions() const override { return true; }
 };
 
 #endif

--- a/src/Ai/Raid/MC/MCTriggerContext.h
+++ b/src/Ai/Raid/MC/MCTriggerContext.h
@@ -32,6 +32,9 @@ public:
         creators["mc majordomo shadow resistance"] = &RaidMcTriggerContext::majordomo_shadow_resistance;
         creators["mc ragnaros fire resistance"] = &RaidMcTriggerContext::ragnaros_fire_resistance;
         creators["mc core hound mark"] = &RaidMcTriggerContext::core_hound_mark;
+        creators["mc in lava"] = &RaidMcTriggerContext::in_lava;
+        creators["mc golemagg magma splash"] = &RaidMcTriggerContext::golemagg_magma_splash;
+        creators["mc golemagg is healer"] = &RaidMcTriggerContext::golemagg_is_healer;
     }
 
 private:
@@ -51,6 +54,9 @@ private:
     static Trigger* majordomo_shadow_resistance(PlayerbotAI* botAI) { return new BossShadowResistanceTrigger(botAI, "majordomo executus"); }
     static Trigger* ragnaros_fire_resistance(PlayerbotAI* botAI) { return new BossFireResistanceTrigger(botAI, "ragnaros"); }
     static Trigger* core_hound_mark(PlayerbotAI* botAI) { return new McCoreHoundMarkTrigger(botAI); }
+    static Trigger* in_lava(PlayerbotAI* botAI) { return new McInLavaTrigger(botAI); }
+    static Trigger* golemagg_magma_splash(PlayerbotAI* botAI) { return new McGolemaggMagmaSplashTrigger(botAI); }
+    static Trigger* golemagg_is_healer(PlayerbotAI* botAI) { return new McGolemaggIsHealerTrigger(botAI); }
 };
 
 #endif

--- a/src/Ai/Raid/MC/MCTriggers.cpp
+++ b/src/Ai/Raid/MC/MCTriggers.cpp
@@ -7,6 +7,7 @@
 #include "MCTriggers.h"
 #include "MCHelpers.h"
 #include "SharedDefines.h"
+#include "SpellAuras.h"
 
 using namespace MoltenCoreHelpers;
 
@@ -25,23 +26,65 @@ bool McBaronGeddonInfernoTrigger::IsActive()
 
 bool McShazzrahRangedTrigger::IsActive()
 {
-    return AI_VALUE2(Unit*, "find target", "shazzrah") && PlayerbotAI::IsRanged(bot);
+    // Only fire inside Arcane Explosion range. The move-away action no-ops
+    // beyond it, so an unconditional trigger makes every already-safe ranged
+    // bot attempt a failing move each tick.
+    if (!PlayerbotAI::IsRanged(bot))
+        return false;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "shazzrah");
+    return boss && bot->GetDistance2d(boss) < ARCANE_EXPLOSION_DISTANCE;
+}
+
+bool McInLavaTrigger::IsActive()
+{
+    LiquidData const& liquid = bot->GetLiquidData();
+    return (liquid.Flags & MAP_LIQUID_TYPE_MAGMA) &&
+           (liquid.Status & (LIQUID_MAP_WATER_WALK | LIQUID_MAP_IN_WATER | LIQUID_MAP_UNDER_WATER));
+}
+
+bool McGolemaggMagmaSplashTrigger::IsActive()
+{
+    if (PlayerbotAI::IsTank(bot))
+        return false;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", "golemagg the incinerator");
+    if (!boss)
+        return false;
+
+    // Below 10% the fight is a burn race (Earthquake pulses, Core Ragers
+    // converge): stack management stops mattering, melee return to dps.
+    if (boss->GetHealthPct() <= 10.0f)
+        return false;
+
+    Aura* splash = bot->GetAura(SPELL_MAGMA_SPLASH);
+    if (!splash || splash->GetStackAmount() < MAGMA_SPLASH_BACK_OFF_STACKS)
+        return false;
+
+    // Only fire while still inside swing range; once the bot has backed off,
+    // the multiplier keeps it from re-engaging until the stack expires.
+    return bot->GetDistance2d(boss) < MAGMA_SPLASH_BACK_OFF_DISTANCE;
 }
 
 bool McGolemaggMarkBossTrigger::IsActive()
 {
     // any tank may mark the boss
-    return AI_VALUE2(Unit*, "find target", "golemagg the incinerator") && PlayerbotAI::IsTank(bot);
+    return PlayerbotAI::IsTank(bot) && AI_VALUE2(Unit*, "find target", "golemagg the incinerator");
 }
 
 bool McGolemaggIsMainTankTrigger::IsActive()
 {
-    return AI_VALUE2(Unit*, "find target", "golemagg the incinerator") && PlayerbotAI::IsMainTank(bot);
+    return PlayerbotAI::IsMainTank(bot) && AI_VALUE2(Unit*, "find target", "golemagg the incinerator");
 }
 
 bool McGolemaggIsAssistTankTrigger::IsActive()
 {
-    return AI_VALUE2(Unit*, "find target", "golemagg the incinerator") && PlayerbotAI::IsAssistTank(bot);
+    return PlayerbotAI::IsAssistTank(bot) && AI_VALUE2(Unit*, "find target", "golemagg the incinerator");
+}
+
+bool McGolemaggIsHealerTrigger::IsActive()
+{
+    return PlayerbotAI::IsHeal(bot) && AI_VALUE2(Unit*, "find target", "golemagg the incinerator");
 }
 
 bool McCoreHoundMarkTrigger::IsActive()

--- a/src/Ai/Raid/MC/MCTriggers.h
+++ b/src/Ai/Raid/MC/MCTriggers.h
@@ -53,10 +53,32 @@ public:
     bool IsActive() override;
 };
 
+class McGolemaggIsHealerTrigger : public Trigger
+{
+public:
+    McGolemaggIsHealerTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mc golemagg is healer") {}
+    bool IsActive() override;
+};
+
 class McCoreHoundMarkTrigger : public Trigger
 {
 public:
     McCoreHoundMarkTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mc core hound mark") {}
+    bool IsActive() override;
+};
+
+// Standing/swimming in magma (knocked into a lava pool by Ragnaros' Wrath or an Eruption)
+class McInLavaTrigger : public Trigger
+{
+public:
+    McInLavaTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mc in lava") {}
+    bool IsActive() override;
+};
+
+class McGolemaggMagmaSplashTrigger : public Trigger
+{
+public:
+    McGolemaggMagmaSplashTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mc golemagg magma splash") {}
     bool IsActive() override;
 };
 

--- a/src/Ai/Raid/Mag/MagActions.cpp
+++ b/src/Ai/Raid/Mag/MagActions.cpp
@@ -6,13 +6,14 @@
 
 #include "MagActions.h"
 #include "Creature.h"
+#include "EncounterHelpers.h"
 #include "MagHelpers.h"
 #include "ObjectAccessor.h"
 #include "ObjectGuid.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 
 using namespace MagtheridonHelpers;
+using namespace EncounterHelpers;
 
 bool MagtheridonMainTankAttackFirstThreeChannelersAction::Execute(Event /*event*/)
 {
@@ -23,7 +24,7 @@ bool MagtheridonMainTankAttackFirstThreeChannelersAction::Execute(Event /*event*
         if (MarkTargetWithSquare(bot, channelerSquare))
             return true;
 
-        SetRtiTarget(botAI, "square", channelerSquare);
+        SetRtiTarget(botAI, "square");
     }
     else if (Creature* channelerStar = GetChanneler(bot, WEST_CHANNELER))
     {
@@ -31,7 +32,7 @@ bool MagtheridonMainTankAttackFirstThreeChannelersAction::Execute(Event /*event*
         if (MarkTargetWithStar(bot, channelerStar))
             return true;
 
-        SetRtiTarget(botAI, "star", channelerStar);
+        SetRtiTarget(botAI, "star");
     }
     else if (Creature* channelerCircle = GetChanneler(bot, EAST_CHANNELER))
     {
@@ -39,7 +40,7 @@ bool MagtheridonMainTankAttackFirstThreeChannelersAction::Execute(Event /*event*
         if (MarkTargetWithCircle(bot, channelerCircle))
             return true;
 
-        SetRtiTarget(botAI, "circle", channelerCircle);
+        SetRtiTarget(botAI, "circle");
     }
 
     if (channelerTarget && AI_VALUE(Unit*, "current target") != channelerTarget)
@@ -72,7 +73,7 @@ bool MagtheridonFirstAssistTankAttackNWChannelerAction::Execute(Event /*event*/)
     if (MarkTargetWithDiamond(bot, channelerDiamond))
         return true;
 
-    SetRtiTarget(botAI, "diamond", channelerDiamond);
+    SetRtiTarget(botAI, "diamond");
 
     if (AI_VALUE(Unit*, "current target") != channelerDiamond)
         return Attack(channelerDiamond);
@@ -108,7 +109,7 @@ bool MagtheridonSecondAssistTankAttackNEChannelerAction::Execute(Event /*event*/
     if (MarkTargetWithTriangle(bot, channelerTriangle))
         return true;
 
-    SetRtiTarget(botAI, "triangle", channelerTriangle);
+    SetRtiTarget(botAI, "triangle");
 
     if (AI_VALUE(Unit*, "current target") != channelerTriangle)
         return Attack(channelerTriangle);
@@ -163,7 +164,7 @@ bool MagtheridonMisdirectHellfireChannelersToMainTankAction::Execute(Event /*eve
         }
     }
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
 
     Creature* targetChanneler = nullptr;
     if (hunterIndex == 0)
@@ -194,7 +195,7 @@ bool MagtheridonAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithSquare(bot, channelerSquare))
             return true;
 
-        SetRtiTarget(botAI, "square", channelerSquare);
+        SetRtiTarget(botAI, "square");
 
         if (AI_VALUE(Unit*, "current target") != channelerSquare)
             return Attack(channelerSquare);
@@ -204,7 +205,7 @@ bool MagtheridonAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithStar(bot, channelerStar))
             return true;
 
-        SetRtiTarget(botAI, "star", channelerStar);
+        SetRtiTarget(botAI, "star");
 
         if (AI_VALUE(Unit*, "current target") != channelerStar)
             return Attack(channelerStar);
@@ -214,7 +215,7 @@ bool MagtheridonAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithCircle(bot, channelerCircle))
             return true;
 
-        SetRtiTarget(botAI, "circle", channelerCircle);
+        SetRtiTarget(botAI, "circle");
 
         if (AI_VALUE(Unit*, "current target") != channelerCircle)
             return Attack(channelerCircle);
@@ -224,7 +225,7 @@ bool MagtheridonAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithDiamond(bot, channelerDiamond))
             return true;
 
-        SetRtiTarget(botAI, "diamond", channelerDiamond);
+        SetRtiTarget(botAI, "diamond");
 
         if (AI_VALUE(Unit*, "current target") != channelerDiamond)
             return Attack(channelerDiamond);
@@ -234,14 +235,14 @@ bool MagtheridonAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithTriangle(bot, channelerTriangle))
             return true;
 
-        SetRtiTarget(botAI, "triangle", channelerTriangle);
+        SetRtiTarget(botAI, "triangle");
 
         if (AI_VALUE(Unit*, "current target") != channelerTriangle)
             return Attack(channelerTriangle);
     }
     else if (Unit* magtheridon = AI_VALUE2(Unit*, "find target", "magtheridon"))
     {
-        SetRtiTarget(botAI, "cross", magtheridon);
+        SetRtiTarget(botAI, "cross");
 
         if (AI_VALUE(Unit*, "current target") != magtheridon)
             return Attack(magtheridon);
@@ -326,7 +327,7 @@ bool MagtheridonMainTankPositionBossAction::Execute(Event /*event*/)
     if (MarkTargetWithCross(bot, magtheridon))
         return true;
 
-    SetRtiTarget(botAI, "cross", magtheridon);
+    SetRtiTarget(botAI, "cross");
 
     if (AI_VALUE(Unit*, "current target") != magtheridon)
         return Attack(magtheridon);

--- a/src/Ai/Raid/Mag/MagTriggers.cpp
+++ b/src/Ai/Raid/Mag/MagTriggers.cpp
@@ -5,11 +5,12 @@
  */
 
 #include "MagTriggers.h"
+#include "EncounterHelpers.h"
 #include "MagHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 
 using namespace MagtheridonHelpers;
+using namespace EncounterHelpers;
 
 bool MagtheridonFirstThreeChannelersEngagedByMainTankTrigger::IsActive()
 {

--- a/src/Ai/Raid/SSC/SSCActions.cpp
+++ b/src/Ai/Raid/SSC/SSCActions.cpp
@@ -7,15 +7,16 @@
 #include "SSCActions.h"
 #include "AiFactory.h"
 #include "Corpse.h"
+#include "EncounterHelpers.h"
 #include "LootAction.h"
 #include "LootObjectStack.h"
 #include "ObjectAccessor.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "RtiTargetValue.h"
 #include "SSCHelpers.h"
 
 using namespace SerpentShrineCavernHelpers;
+using namespace EncounterHelpers;
 
 // General
 
@@ -152,7 +153,7 @@ bool HydrossTheUnstablePositionFrostTankAction::Execute(Event /*event*/)
         if (MarkTargetWithSquare(bot, hydross))
             return true;
 
-        SetRtiTarget(botAI, "square", hydross);
+        SetRtiTarget(botAI, "square");
 
         if (AI_VALUE(Unit*, "current target") != hydross)
             return Attack(hydross);
@@ -234,7 +235,7 @@ bool HydrossTheUnstablePositionNatureTankAction::Execute(Event /*event*/)
         if (MarkTargetWithTriangle(bot, hydross))
             return true;
 
-        SetRtiTarget(botAI, "triangle", hydross);
+        SetRtiTarget(botAI, "triangle");
 
         if (AI_VALUE(Unit*, "current target") != hydross)
             return Attack(hydross);
@@ -309,7 +310,7 @@ bool HydrossTheUnstablePrioritizeElementalAddsAction::Execute(Event /*event*/)
         if (MarkTargetWithSkull(bot, waterElemental))
             return true;
 
-        SetRtiTarget(botAI, "skull", waterElemental);
+        SetRtiTarget(botAI, "skull");
 
         if (AI_VALUE(Unit*, "current target") != waterElemental)
             return Attack(waterElemental);
@@ -319,7 +320,7 @@ bool HydrossTheUnstablePrioritizeElementalAddsAction::Execute(Event /*event*/)
         if (MarkTargetWithSkull(bot, natureElemental))
             return true;
 
-        SetRtiTarget(botAI, "skull", natureElemental);
+        SetRtiTarget(botAI, "skull");
 
         if (AI_VALUE(Unit*, "current target") != natureElemental)
             return Attack(natureElemental);
@@ -354,7 +355,7 @@ bool HydrossTheUnstableMisdirectBossToTankAction::Execute(Event /*event*/)
 bool HydrossTheUnstableMisdirectBossToTankAction::TryMisdirectToFrostTank(
     Unit* hydross)
 {
-    Player* frostTank = GetGroupMainTank(botAI, bot);
+    Player* frostTank = GetGroupMainTank(bot);
     if (!frostTank)
         return false;
 
@@ -373,7 +374,7 @@ bool HydrossTheUnstableMisdirectBossToTankAction::TryMisdirectToFrostTank(
 bool HydrossTheUnstableMisdirectBossToTankAction::TryMisdirectToNatureTank(
     Unit* hydross)
 {
-    Player* natureTank = GetGroupAssistTank(botAI, bot, 0);
+    Player* natureTank = GetGroupAssistTank(bot, 0);
     if (!natureTank)
         return false;
 
@@ -601,9 +602,9 @@ bool TheLurkerBelowSpreadRangedInArcAction::Execute(Event /*event*/)
 // the first 3 will each pick up 1 Guardian
 bool TheLurkerBelowTanksPickUpAddsAction::Execute(Event /*event*/)
 {
-    Player* mainTank = GetGroupMainTank(botAI, bot);
-    Player* firstAssistTank = GetGroupAssistTank(botAI, bot, 0);
-    Player* secondAssistTank = GetGroupAssistTank(botAI, bot, 1);
+    Player* mainTank = GetGroupMainTank(bot);
+    Player* firstAssistTank = GetGroupAssistTank(bot, 0);
+    Player* secondAssistTank = GetGroupAssistTank(bot, 1);
     if (!mainTank || !firstAssistTank || !secondAssistTank)
         return false;
 
@@ -642,7 +643,7 @@ bool TheLurkerBelowTanksPickUpAddsAction::Execute(Event /*event*/)
             if (MarkTargetWithIcon(bot, guardian, rtiIndices[i]))
                 return true;
 
-            SetRtiTarget(botAI, rtiNames[i], guardian);
+            SetRtiTarget(botAI, rtiNames[i]);
 
             if (AI_VALUE(Unit*, "current target") != guardian)
                 return Attack(guardian);
@@ -720,7 +721,7 @@ bool LeotherasTheBlindDemonFormTankAttackBossAction::Execute(Event /*event*/)
         if (MarkTargetWithSquare(bot, leotherasDemon))
             return true;
 
-        SetRtiTarget(botAI, "square", leotherasDemon);
+        SetRtiTarget(botAI, "square");
 
         if (botAI->CanCastSpell("searing pain", leotherasDemon))
             return botAI->CastSpell("searing pain", leotherasDemon);
@@ -986,7 +987,7 @@ bool LeotherasTheBlindFinalPhaseAssignDpsPriorityAction::Execute(Event /*event*/
     if (MarkTargetWithStar(bot, leotherasHuman))
         return true;
 
-    SetRtiTarget(botAI, "star", leotherasHuman);
+    SetRtiTarget(botAI, "star");
 
     if (AI_VALUE(Unit*, "current target") != leotherasHuman)
         return Attack(leotherasHuman);
@@ -1026,7 +1027,7 @@ bool LeotherasTheBlindMisdirectBossToDemonFormTankAction::Execute(Event /*event*
 
     Player* targetTank = GetLeotherasDemonFormTank(bot);
     if (!targetTank)
-        targetTank = GetGroupMainTank(botAI, bot);
+        targetTank = GetGroupMainTank(bot);
 
     if (!targetTank)
         return false;
@@ -1102,7 +1103,7 @@ bool FathomLordKarathressMainTankPositionBossAction::Execute(Event /*event*/)
     if (MarkTargetWithTriangle(bot, karathress))
         return true;
 
-    SetRtiTarget(botAI, "triangle", karathress);
+    SetRtiTarget(botAI, "triangle");
 
     if (AI_VALUE(Unit*, "current target") != karathress)
         return Attack(karathress);
@@ -1140,7 +1141,7 @@ bool FathomLordKarathressFirstAssistTankPositionCaribdisAction::Execute(Event /*
     if (MarkTargetWithDiamond(bot, caribdis))
         return true;
 
-    SetRtiTarget(botAI, "diamond", caribdis);
+    SetRtiTarget(botAI, "diamond");
 
     if (AI_VALUE(Unit*, "current target") != caribdis)
         return Attack(caribdis);
@@ -1177,7 +1178,7 @@ bool FathomLordKarathressSecondAssistTankPositionSharkkisAction::Execute(Event /
     if (MarkTargetWithStar(bot, sharkkis))
         return true;
 
-    SetRtiTarget(botAI, "star", sharkkis);
+    SetRtiTarget(botAI, "star");
 
     if (AI_VALUE(Unit*, "current target") != sharkkis)
         return Attack(sharkkis);
@@ -1214,7 +1215,7 @@ bool FathomLordKarathressThirdAssistTankPositionTidalvessAction::Execute(Event /
     if (MarkTargetWithCircle(bot, tidalvess))
         return true;
 
-    SetRtiTarget(botAI, "circle", tidalvess);
+    SetRtiTarget(botAI, "circle");
 
     if (AI_VALUE(Unit*, "current target") != tidalvess)
         return Attack(tidalvess);
@@ -1304,17 +1305,17 @@ bool FathomLordKarathressMisdirectBossesToTanksAction::Execute(Event /*event*/)
     if (hunterIndex == 0)
     {
         bossTarget = AI_VALUE2(Unit*, "find target", "fathom-guard caribdis");
-        tankTarget = GetGroupAssistTank(botAI, bot, 0);
+        tankTarget = GetGroupAssistTank(bot, 0);
     }
     else if (hunterIndex == 1)
     {
         bossTarget = AI_VALUE2(Unit*, "find target", "fathom-guard tidalvess");
-        tankTarget = GetGroupAssistTank(botAI, bot, 2);
+        tankTarget = GetGroupAssistTank(bot, 2);
     }
     else if (hunterIndex == 2)
     {
         bossTarget = AI_VALUE2(Unit*, "find target", "fathom-guard sharkkis");
-        tankTarget = GetGroupAssistTank(botAI, bot, 1);
+        tankTarget = GetGroupAssistTank(bot, 1);
     }
 
     if (!bossTarget || !tankTarget)
@@ -1340,7 +1341,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithSkull(bot, totem))
             return true;
 
-        SetRtiTarget(botAI, "skull", totem);
+        SetRtiTarget(botAI, "skull");
 
         if (AI_VALUE(Unit*, "current target") != totem)
             return Attack(totem);
@@ -1363,7 +1364,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithCircle(bot, tidalvess))
             return true;
 
-        SetRtiTarget(botAI, "circle", tidalvess);
+        SetRtiTarget(botAI, "circle");
 
         if (AI_VALUE(Unit*, "current target") != tidalvess)
             return Attack(tidalvess);
@@ -1378,7 +1379,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithDiamond(bot, caribdis))
             return true;
 
-        SetRtiTarget(botAI, "diamond", caribdis);
+        SetRtiTarget(botAI, "diamond");
 
         const Position& position = CARIBDIS_RANGED_DPS_POSITION;
         if (bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY()) > 2.0f)
@@ -1400,7 +1401,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithStar(bot, sharkkis))
             return true;
 
-        SetRtiTarget(botAI, "star", sharkkis);
+        SetRtiTarget(botAI, "star");
 
         if (AI_VALUE(Unit*, "current target") != sharkkis)
             return Attack(sharkkis);
@@ -1415,7 +1416,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithCross(bot, fathomSporebat))
             return true;
 
-        SetRtiTarget(botAI, "cross", fathomSporebat);
+        SetRtiTarget(botAI, "cross");
 
         if (AI_VALUE(Unit*, "current target") != fathomSporebat)
             return Attack(fathomSporebat);
@@ -1429,7 +1430,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithSquare(bot, fathomLurker))
             return true;
 
-        SetRtiTarget(botAI, "square", fathomLurker);
+        SetRtiTarget(botAI, "square");
 
         if (AI_VALUE(Unit*, "current target") != fathomLurker)
             return Attack(fathomLurker);
@@ -1444,7 +1445,7 @@ bool FathomLordKarathressAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithTriangle(bot, karathress))
             return true;
 
-        SetRtiTarget(botAI, "triangle", karathress);
+        SetRtiTarget(botAI, "triangle");
 
         if (AI_VALUE(Unit*, "current target") != karathress)
             return Attack(karathress);
@@ -1471,7 +1472,7 @@ bool MorogrimTidewalkerMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!tidewalker)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -1740,7 +1741,7 @@ bool LadyVashjPhase1SpreadRangedInArcAction::Execute(Event /*event*/)
 // For absorbing Shock Burst
 bool LadyVashjSetGroundingTotemInMainTankGroupAction::Execute(Event /*event*/)
 {
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -1761,7 +1762,7 @@ bool LadyVashjMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!vashj)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -1781,7 +1782,7 @@ bool LadyVashjStaticChargeMoveAwayFromGroupAction::Execute(Event /*event*/)
         return false;
 
     // If the main tank has Static Charge, other group members should move away
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (mainTank && bot != mainTank && mainTank->HasAura(SPELL_STATIC_CHARGE))
     {
         float currentDistance = bot->GetExactDist2d(mainTank);
@@ -1917,7 +1918,7 @@ bool LadyVashjAssignPhase2AndPhase3DpsPriorityAction::Execute(Event /*event*/)
                 if (MarkTargetWithDiamond(bot, vashj))
                     return true;
 
-                SetRtiTarget(botAI, "diamond", vashj);
+                SetRtiTarget(botAI, "diamond");
                 targets = { vashj };
             }
             else if (botAI->HasCheat(BotCheatMask::raid) &&
@@ -1988,7 +1989,7 @@ bool LadyVashjMisdirectStriderToFirstAssistTankAction::Execute(Event /*event*/)
     if (!strider)
         return false;
 
-    Player* firstAssistTank = GetGroupAssistTank(botAI, bot, 0);
+    Player* firstAssistTank = GetGroupAssistTank(bot, 0);
     if (!firstAssistTank || strider->GetVictim() == firstAssistTank)
         return false;
 
@@ -2081,7 +2082,7 @@ bool LadyVashjTeleportToTaintedElementalAction::Execute(Event /*event*/)
         if (MarkTargetWithStar(bot, tainted))
             return true;
 
-        SetRtiTarget(botAI, "star", tainted);
+        SetRtiTarget(botAI, "star");
         return Attack(tainted);
     }
 

--- a/src/Ai/Raid/SSC/SSCHelpers.cpp
+++ b/src/Ai/Raid/SSC/SSCHelpers.cpp
@@ -9,7 +9,6 @@
 #include "Creature.h"
 #include "ObjectAccessor.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 
 namespace SerpentShrineCavernHelpers
 {

--- a/src/Ai/Raid/SSC/SSCTriggers.cpp
+++ b/src/Ai/Raid/SSC/SSCTriggers.cpp
@@ -7,14 +7,15 @@
 #include "SSCTriggers.h"
 #include "AiFactory.h"
 #include "Corpse.h"
+#include "EncounterHelpers.h"
 #include "LootObjectStack.h"
 #include "ObjectAccessor.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "SSCActions.h"
 #include "SSCHelpers.h"
 
 using namespace SerpentShrineCavernHelpers;
+using namespace EncounterHelpers;
 
 // General
 bool SerpentShrineCavernBotIsNotInCombatTrigger::IsActive()
@@ -150,9 +151,9 @@ bool TheLurkerBelowBossIsSubmergedTrigger::IsActive()
     if (!lurker || lurker->getStandState() != UNIT_STAND_STATE_SUBMERGED)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
-    Player* firstAssistTank = GetGroupAssistTank(botAI, bot, 0);
-    Player* secondAssistTank = GetGroupAssistTank(botAI, bot, 1);
+    Player* mainTank = GetGroupMainTank(bot);
+    Player* firstAssistTank = GetGroupAssistTank(bot, 0);
+    Player* secondAssistTank = GetGroupAssistTank(bot, 1);
 
     if (!mainTank || !firstAssistTank || !secondAssistTank)
         return false;

--- a/src/Ai/Raid/TK/TKActions.cpp
+++ b/src/Ai/Raid/TK/TKActions.cpp
@@ -6,16 +6,17 @@
 
 #include "TKActions.h"
 #include "AiFactory.h"
+#include "EncounterHelpers.h"
 #include "EquipAction.h"
 #include "LootAction.h"
 #include "LootObjectStack.h"
 #include "ObjectAccessor.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "TKHelpers.h"
 #include "TKKaelthasBossAI.h"
 
 using namespace TempestKeepHelpers;
+using namespace EncounterHelpers;
 
 // Trash
 
@@ -48,7 +49,7 @@ bool AlarMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!alar)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (mainTank && botAI->CanCastSpell("misdirection", mainTank))
         return botAI->CastSpell("misdirection", mainTank);
 
@@ -70,7 +71,7 @@ bool AlarBossTanksMoveBetweenPlatformsAction::Execute(Event /*event*/)
     if (MarkTargetWithStar(bot, alar))
         return true;
 
-    SetRtiTarget(botAI, "star", alar);
+    SetRtiTarget(botAI, "star");
 
     int8 locationIndex = GetAlarCurrentLocationIndex(alar);
     if (locationIndex == LOCATION_NONE)
@@ -140,7 +141,7 @@ bool AlarMeleeDpsMoveBetweenPlatformsAction::Execute(Event /*event*/)
     if (!alar)
         return false;
 
-    SetRtiTarget(botAI, "star", alar);
+    SetRtiTarget(botAI, "star");
 
     int8 locationIndex = GetAlarCurrentLocationIndex(alar);
     if (locationIndex == LOCATION_NONE)
@@ -235,7 +236,7 @@ bool AlarAssistTanksPickUpEmbersAction::HandlePhase1Embers(Unit* alar)
         if (MarkTargetWithSquare(bot, ember))
             return true;
 
-        SetRtiTarget(botAI, "square", ember);
+        SetRtiTarget(botAI, "square");
 
         if (AI_VALUE(Unit*, "current target") != ember)
             return Attack(ember);
@@ -294,7 +295,7 @@ bool AlarAssistTanksPickUpEmbersAction::HandlePhase2Embers()
         if (MarkTargetWithSquare(bot, firstEmber))
             return true;
 
-        SetRtiTarget(botAI, "square", firstEmber);
+        SetRtiTarget(botAI, "square");
 
         if (firstEmber->GetVictim() != bot)
         {
@@ -310,12 +311,12 @@ bool AlarAssistTanksPickUpEmbersAction::HandlePhase2Embers()
                 return MoveFromGroup(safeDistance);
         }
     }
-    else if (GetSecondEmberTank(botAI) == bot && secondEmber)
+    else if (GetSecondEmberTank(bot) == bot && secondEmber)
     {
         if (MarkTargetWithCircle(bot, secondEmber))
             return true;
 
-        SetRtiTarget(botAI, "circle", secondEmber);
+        SetRtiTarget(botAI, "circle");
 
         if (secondEmber->GetVictim() != bot)
         {
@@ -349,7 +350,7 @@ bool AlarRangedDpsPrioritizeEmbersAction::Execute(Event /*event*/)
             return MoveAway(firstEmber, safeDistance - bot->GetDistance2d(firstEmber));
         }
 
-        SetRtiTarget(botAI, "square", firstEmber);
+        SetRtiTarget(botAI, "square");
         if (AI_VALUE(Unit*, "current target") != firstEmber)
             return Attack(firstEmber);
     }
@@ -362,13 +363,13 @@ bool AlarRangedDpsPrioritizeEmbersAction::Execute(Event /*event*/)
             return MoveAway(secondEmber, safeDistance - bot->GetDistance2d(secondEmber));
         }
 
-        SetRtiTarget(botAI, "circle", secondEmber);
+        SetRtiTarget(botAI, "circle");
         if (AI_VALUE(Unit*, "current target") != secondEmber)
             return Attack(secondEmber);
     }
     else if (Unit* alar = AI_VALUE2(Unit*, "find target", "al'ar"))
     {
-        SetRtiTarget(botAI, "star", alar);
+        SetRtiTarget(botAI, "star");
         if (AI_VALUE(Unit*, "current target") != alar)
             return Attack(alar);
     }
@@ -482,15 +483,15 @@ bool AlarSwapTanksOnBossAction::Execute(Event /*event*/)
 
     if (alar->GetHealth() == alar->GetMaxHealth())
     {
-        SetRtiTarget(botAI, "star", alar);
+        SetRtiTarget(botAI, "star");
         if (AI_VALUE(Unit*, "current target") != alar)
             return Attack(alar);
     }
 
-    Player* secondEmberTank = GetSecondEmberTank(botAI);
+    Player* secondEmberTank = GetSecondEmberTank(bot);
     if (secondEmberTank && secondEmberTank != bot)
     {
-        SetRtiTarget(botAI, "star", alar);
+        SetRtiTarget(botAI, "star");
         if (AI_VALUE(Unit*, "current target") != alar)
             return Attack(alar);
         else if (alar->GetVictim() != bot)
@@ -895,14 +896,14 @@ bool HighAstromancerSolarianTargetSolariumPriestsAction::Execute(Event /*event*/
         if (MarkTargetWithSquare(bot, targetPriest))
             return true;
 
-        SetRtiTarget(botAI, "square", targetPriest);
+        SetRtiTarget(botAI, "square");
     }
     else
     {
         if (MarkTargetWithStar(bot, targetPriest))
             return true;
 
-        SetRtiTarget(botAI, "star", targetPriest);
+        SetRtiTarget(botAI, "star");
     }
 
     if (AI_VALUE(Unit*, "current target") != targetPriest)
@@ -972,7 +973,7 @@ Unit* HighAstromancerSolarianTargetSolariumPriestsAction::AssignSolariumPriestsT
 
 bool HighAstromancerSolarianCastFearWardOnMainTankAction::Execute(Event /*event*/)
 {
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (mainTank && botAI->CanCastSpell("fear ward", mainTank))
         return botAI->CastSpell("fear ward", mainTank);
 
@@ -1035,7 +1036,7 @@ bool KaelthasSunstriderMisdirectAdvisorsToTanksAction::Execute(Event /*event*/)
     else if (hunterIndex == 1)
     {
         advisorTarget = AI_VALUE2(Unit*, "find target", "master engineer telonicus");
-        tankTarget = GetGroupAssistTank(botAI, bot, 0);
+        tankTarget = GetGroupAssistTank(bot, 0);
     }
 
     if (!advisorTarget ||
@@ -1065,7 +1066,7 @@ bool KaelthasSunstriderMainTankPositionSanguinarAction::Execute(Event /*event*/)
     if (MarkTargetWithStar(bot, sanguinar))
         return true;
 
-    SetRtiTarget(botAI, "star", sanguinar);
+    SetRtiTarget(botAI, "star");
 
     if (AI_VALUE(Unit*, "current target") != sanguinar)
         return Attack(sanguinar);
@@ -1094,7 +1095,7 @@ bool KaelthasSunstriderMainTankPositionSanguinarAction::Execute(Event /*event*/)
 
 bool KaelthasSunstriderCastFearWardOnSanguinarTankAction::Execute(Event /*event*/)
 {
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (mainTank && botAI->CanCastSpell("fear ward", mainTank))
         return botAI->CastSpell("fear ward", mainTank);
 
@@ -1110,7 +1111,7 @@ bool KaelthasSunstriderWarlockTankPositionCapernianAction::Execute(Event /*event
     if (MarkTargetWithCircle(bot, capernian))
         return true;
 
-    SetRtiTarget(botAI, "circle", capernian);
+    SetRtiTarget(botAI, "circle");
 
     if (AI_VALUE(Unit*, "current target") != capernian &&
         botAI->CanCastSpell("searing pain", capernian) &&
@@ -1273,7 +1274,7 @@ bool KaelthasSunstriderFirstAssistTankPositionTelonicusAction::Execute(Event /*e
     if (MarkTargetWithTriangle(bot, telonicus))
         return true;
 
-    SetRtiTarget(botAI, "triangle", telonicus);
+    SetRtiTarget(botAI, "triangle");
 
     if (AI_VALUE(Unit*, "current target") != telonicus)
         return Attack(telonicus);
@@ -1355,7 +1356,7 @@ bool KaelthasSunstriderAssignAdvisorDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithSquare(bot, thaladred))
             return true;
 
-        SetRtiTarget(botAI, "square", thaladred);
+        SetRtiTarget(botAI, "square");
 
         if (AI_VALUE(Unit*, "current target") != thaladred)
             return Attack(thaladred);
@@ -1370,7 +1371,7 @@ bool KaelthasSunstriderAssignAdvisorDpsPriorityAction::Execute(Event /*event*/)
         capernian && !capernian->HasUnitFlag(UNIT_FLAG_NON_ATTACKABLE) &&
         !capernian->HasAura(SPELL_PERMANENT_FEIGN_DEATH))
     {
-        SetRtiTarget(botAI, "circle", capernian);
+        SetRtiTarget(botAI, "circle");
 
         if (AI_VALUE(Unit*, "current target") != capernian)
             return Attack(capernian);
@@ -1384,7 +1385,7 @@ bool KaelthasSunstriderAssignAdvisorDpsPriorityAction::Execute(Event /*event*/)
     if (sanguinar && !sanguinar->HasUnitFlag(UNIT_FLAG_NON_ATTACKABLE) &&
         !sanguinar->HasAura(SPELL_PERMANENT_FEIGN_DEATH))
     {
-        SetRtiTarget(botAI, "star", sanguinar);
+        SetRtiTarget(botAI, "star");
 
         if (AI_VALUE(Unit*, "current target") != sanguinar)
             return Attack(sanguinar);
@@ -1398,7 +1399,7 @@ bool KaelthasSunstriderAssignAdvisorDpsPriorityAction::Execute(Event /*event*/)
     if (telonicus && !telonicus->HasUnitFlag(UNIT_FLAG_NON_ATTACKABLE) &&
         !telonicus->HasAura(SPELL_PERMANENT_FEIGN_DEATH))
     {
-        SetRtiTarget(botAI, "triangle", telonicus);
+        SetRtiTarget(botAI, "triangle");
         if (AI_VALUE(Unit*, "current target") != telonicus)
             return Attack(telonicus);
 
@@ -1455,7 +1456,7 @@ bool KaelthasSunstriderManageAdvisorDpsTimerAction::Execute(Event /*event*/)
 bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*event*/)
 {
     if (botAI->IsAssistTank(bot))
-        SetRtiTarget(botAI, "moon", nullptr);
+        SetRtiTarget(botAI, "moon");
 
     // Priority 0: Everybody other than the main tank needs to stay away from the axe
     // But this applies to assist tanks only after they get aggro on the mace, dagger, or sword
@@ -1487,7 +1488,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
             if (MarkTargetWithSkull(bot, staff))
                 return true;
 
-            SetRtiTarget(botAI, "skull", staff);
+            SetRtiTarget(botAI, "skull");
 
             if (AI_VALUE(Unit*, "current target") != staff)
                 return Attack(staff);
@@ -1498,7 +1499,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
             if (MarkTargetWithSkull(bot, mace))
                 return true;
 
-            SetRtiTarget(botAI, "skull", mace);
+            SetRtiTarget(botAI, "skull");
 
             if (AI_VALUE(Unit*, "current target") != mace)
                 return Attack(mace);
@@ -1509,7 +1510,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
             if (MarkTargetWithSkull(bot, sword))
                 return true;
 
-            SetRtiTarget(botAI, "skull", sword);
+            SetRtiTarget(botAI, "skull");
 
             if (AI_VALUE(Unit*, "current target") != sword)
                 return Attack(sword);
@@ -1520,7 +1521,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
             if (MarkTargetWithSkull(bot, dagger))
                 return true;
 
-            SetRtiTarget(botAI, "skull", dagger);
+            SetRtiTarget(botAI, "skull");
 
             if (AI_VALUE(Unit*, "current target") != dagger)
                 return Attack(dagger);
@@ -1528,7 +1529,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
         // Priority 5: Devastation - ranged only (Diamond--marked in other method by main tank)
         else if (axe && botAI->IsRangedDps(bot))
         {
-            SetRtiTarget(botAI, "diamond", axe);
+            SetRtiTarget(botAI, "diamond");
 
             if (AI_VALUE(Unit*, "current target") != axe)
                 return Attack(axe);
@@ -1539,7 +1540,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
             if (MarkTargetWithSkull(bot, longbow))
                 return true;
 
-            SetRtiTarget(botAI, "skull", longbow);
+            SetRtiTarget(botAI, "skull");
 
             if (AI_VALUE(Unit*, "current target") != longbow)
                 return Attack(longbow);
@@ -1550,7 +1551,7 @@ bool KaelthasSunstriderAssignLegendaryWeaponDpsPriorityAction::Execute(Event /*e
             if (MarkTargetWithSkull(bot, shield))
                 return true;
 
-            SetRtiTarget(botAI, "skull", shield);
+            SetRtiTarget(botAI, "skull");
 
             if (AI_VALUE(Unit*, "current target") != shield)
                 return Attack(shield);
@@ -1569,7 +1570,7 @@ bool KaelthasSunstriderMoveDevastationAwayAction::Execute(Event /*event*/)
     if (MarkTargetWithDiamond(bot, axe))
         return true;
 
-    SetRtiTarget(botAI, "diamond", axe);
+    SetRtiTarget(botAI, "diamond");
 
     if (AI_VALUE(Unit*, "current target") != axe)
         return Attack(axe);
@@ -1804,7 +1805,7 @@ bool KaelthasSunstriderMainTankPositionBossAction::Execute(Event /*event*/)
     if (MarkTargetWithStar(bot, kaelthas))
         return true;
 
-    SetRtiTarget(botAI, "star", kaelthas);
+    SetRtiTarget(botAI, "star");
 
     if (AI_VALUE(Unit*, "current target") != kaelthas)
         return Attack(kaelthas);
@@ -1895,7 +1896,7 @@ bool KaelthasSunstriderHandlePhoenixesAndEggsAction::AssistTanksPickUpPhoenixes(
         if (MarkTargetWithSquare(bot, targetPhoenix))
             return true;
 
-        SetRtiTarget(botAI, "square", targetPhoenix);
+        SetRtiTarget(botAI, "square");
     }
     else if (botAI->IsAssistTankOfIndex(bot, 1, true) && phoenixes.size() >= 2)
     {
@@ -1904,7 +1905,7 @@ bool KaelthasSunstriderHandlePhoenixesAndEggsAction::AssistTanksPickUpPhoenixes(
         if (MarkTargetWithCircle(bot, targetPhoenix))
             return true;
 
-        SetRtiTarget(botAI, "circle", targetPhoenix);
+        SetRtiTarget(botAI, "circle");
     }
 
     if (!targetPhoenix)
@@ -1934,7 +1935,7 @@ bool KaelthasSunstriderHandlePhoenixesAndEggsAction::NonTanksDestroyEggsAndAvoid
             if (MarkTargetWithDiamond(bot, phoenixEgg))
                 return true;
 
-            SetRtiTarget(botAI, "diamond", phoenixEgg);
+            SetRtiTarget(botAI, "diamond");
 
             if (AI_VALUE(Unit*, "current target") != phoenixEgg)
                 return Attack(phoenixEgg);
@@ -2043,7 +2044,7 @@ bool KaelthasSunstriderBreakThroughShockBarrierAction::Execute(Event /*event*/)
     }
     else if (AI_VALUE(Unit*, "current target") != kaelthas)
     {
-        SetRtiTarget(botAI, "star", kaelthas);
+        SetRtiTarget(botAI, "star");
         return Attack(kaelthas);
     }
 

--- a/src/Ai/Raid/TK/TKTriggers.cpp
+++ b/src/Ai/Raid/TK/TKTriggers.cpp
@@ -5,13 +5,14 @@
  */
 
 #include "TKTriggers.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "TKActions.h"
 #include "TKHelpers.h"
 #include "TKKaelthasBossAI.h"
 
 using namespace TempestKeepHelpers;
+using namespace EncounterHelpers;
 
 // Trash
 
@@ -295,7 +296,7 @@ bool KaelthasSunstriderSanguinarCastsBellowingRoarTrigger::IsActive()
         kaelAI->GetPhase() != PHASE_ALL_ADVISORS)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank || mainTank->HasAura(SPELL_FEAR_WARD))
         return false;
 

--- a/src/Ai/Raid/TK/Util/TKHelpers.cpp
+++ b/src/Ai/Raid/TK/Util/TKHelpers.cpp
@@ -5,10 +5,12 @@
  */
 
 #include "TKHelpers.h"
+#include "EncounterHelpers.h"
 #include "LootObjectStack.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "TKActions.h"
+
+using namespace EncounterHelpers;
 
 namespace TempestKeepHelpers
 {
@@ -288,10 +290,10 @@ std::pair<Unit*, Unit*> GetFirstTwoEmbersOfAlar(PlayerbotAI* botAI)
     return { firstEmber, secondEmber };
 }
 
-Player* GetSecondEmberTank(PlayerbotAI* botAI)
+Player* GetSecondEmberTank(Player* bot)
 {
-    Player* mainTank = GetGroupMainTank(botAI, botAI->GetBot());
-    Player* assistTank = GetGroupAssistTank(botAI, botAI->GetBot(), 0);
+    Player* mainTank = GetGroupMainTank(bot);
+    Player* assistTank = GetGroupAssistTank(bot, 0);
 
     bool mainTankHasMelt = mainTank && mainTank->HasAura(SPELL_MELT_ARMOR);
     bool assistTankHasMelt = assistTank && assistTank->HasAura(SPELL_MELT_ARMOR);

--- a/src/Ai/Raid/TK/Util/TKHelpers.h
+++ b/src/Ai/Raid/TK/Util/TKHelpers.h
@@ -133,7 +133,7 @@ namespace TempestKeepHelpers
     void GetClosestPlatformAndGround(
         const Position& botPos, int8& closestPlatform, Position& ground);
     std::pair<Unit*, Unit*> GetFirstTwoEmbersOfAlar(PlayerbotAI* botAI);
-    Player* GetSecondEmberTank(PlayerbotAI* botAI);
+    Player* GetSecondEmberTank(Player* bot);
 
     // Void Reaver
     extern const Position VOID_REAVER_TANK_POSITION;

--- a/src/Ai/Raid/ZA/ZAActions.cpp
+++ b/src/Ai/Raid/ZA/ZAActions.cpp
@@ -5,11 +5,12 @@
  */
 
 #include "ZAActions.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "ZAHelpers.h"
 
 using namespace ZulAmanHelpers;
+using namespace EncounterHelpers;
 
 // Trash
 
@@ -38,7 +39,7 @@ bool AkilzonMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!akilzon)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -97,7 +98,7 @@ bool AkilzonMoveToEyeOfTheStormAction::Execute(Event /*event*/)
 {
     Player* target = GetElectricalStormTarget(bot);
     if (!target && !botAI->IsMainTank(bot))
-        target = GetGroupMainTank(botAI, bot);
+        target = GetGroupMainTank(bot);
 
     if (target && bot->GetExactDist2d(target) > 2.0f)
     {
@@ -137,7 +138,7 @@ bool NalorakkMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!nalorakk)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -244,7 +245,7 @@ bool JanalaiMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!janalai)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -387,7 +388,7 @@ bool HalazziMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!halazzi)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -410,7 +411,7 @@ bool HalazziMainTankPositionBossAction::Execute(Event /*event*/)
     if (MarkTargetWithStar(bot, halazzi))
         return true;
 
-    SetRtiTarget(botAI, "star", halazzi);
+    SetRtiTarget(botAI, "star");
 
     if (AI_VALUE(Unit*, "current target") != halazzi)
         return Attack(halazzi);
@@ -446,7 +447,7 @@ bool HalazziFirstAssistTankAttackSpiritLynxAction::Execute(Event /*event*/)
         if (MarkTargetWithCircle(bot, lynx))
             return true;
 
-        SetRtiTarget(botAI, "circle", lynx);
+        SetRtiTarget(botAI, "circle");
 
         if (AI_VALUE(Unit*, "current target") != lynx)
             return Attack(lynx);
@@ -458,7 +459,7 @@ bool HalazziFirstAssistTankAttackSpiritLynxAction::Execute(Event /*event*/)
     }
     else if (Unit* halazzi = AI_VALUE2(Unit*, "find target", "halazzi"))
     {
-        SetRtiTarget(botAI, "star", halazzi);
+        SetRtiTarget(botAI, "star");
 
         if (AI_VALUE(Unit*, "current target") != halazzi)
             return Attack(halazzi);
@@ -497,7 +498,7 @@ bool HalazziAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithSkull(bot, totem))
             return true;
 
-        SetRtiTarget(botAI, "skull", totem);
+        SetRtiTarget(botAI, "skull");
 
         if (AI_VALUE(Unit*, "current target") != totem)
             return Attack(totem);
@@ -508,7 +509,7 @@ bool HalazziAssignDpsPriorityAction::Execute(Event /*event*/)
     // Target priority 2: Halazzi
     if (Unit* halazzi = AI_VALUE2(Unit*, "find target", "halazzi"))
     {
-        SetRtiTarget(botAI, "star", halazzi);
+        SetRtiTarget(botAI, "star");
 
         if (AI_VALUE(Unit*, "current target") != halazzi)
             return Attack(halazzi);
@@ -526,7 +527,7 @@ bool HexLordMalacrassMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!malacrass)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 
@@ -581,7 +582,7 @@ bool HexLordMalacrassAssignDpsPriorityAction::Execute(Event /*event*/)
         if (MarkTargetWithSkull(bot, priorityTarget))
             return true;
 
-        SetRtiTarget(botAI, "skull", priorityTarget);
+        SetRtiTarget(botAI, "skull");
     }
 
     return false;
@@ -646,7 +647,7 @@ bool ZuljinMisdirectBossToMainTankAction::Execute(Event /*event*/)
     if (!zuljin)
         return false;
 
-    Player* mainTank = GetGroupMainTank(botAI, bot);
+    Player* mainTank = GetGroupMainTank(bot);
     if (!mainTank)
         return false;
 

--- a/src/Ai/Raid/ZA/ZAMultipliers.cpp
+++ b/src/Ai/Raid/ZA/ZAMultipliers.cpp
@@ -8,6 +8,7 @@
 #include "ChooseTargetActions.h"
 #include "DKActions.h"
 #include "DruidBearActions.h"
+#include "EncounterHelpers.h"
 #include "FollowActions.h"
 #include "GenericSpellActions.h"
 #include "HunterActions.h"
@@ -15,7 +16,6 @@
 #include "PaladinActions.h"
 #include "Playerbots.h"
 #include "PriestActions.h"
-#include "RaidBossHelpers.h"
 #include "ReachTargetActions.h"
 #include "RogueActions.h"
 #include "ShamanActions.h"
@@ -25,6 +25,7 @@
 #include "ZAHelpers.h"
 
 using namespace ZulAmanHelpers;
+using namespace EncounterHelpers;
 
 // Akil'zon <Eagle Avatar>
 

--- a/src/Ai/Raid/ZA/ZATriggers.cpp
+++ b/src/Ai/Raid/ZA/ZATriggers.cpp
@@ -5,12 +5,13 @@
  */
 
 #include "ZATriggers.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "RaidBossHelpers.h"
 #include "ZAActions.h"
 #include "ZAHelpers.h"
 
 using namespace ZulAmanHelpers;
+using namespace EncounterHelpers;
 
 // Trash
 

--- a/src/Bot/Engine/Engine.cpp
+++ b/src/Bot/Engine/Engine.cpp
@@ -151,6 +151,9 @@ bool Engine::DoNextAction(Unit* /*unit*/, uint32 /*depth*/, bool minimal)
     ActionBasket* basket = nullptr;
     time_t currentTime = time(nullptr);
 
+    if (!minimal)
+        botAI->forceRebuff.RollBuffPendingCycle();
+
     // Update triggers and push default actions
     ProcessTriggers(minimal);
     PushDefaultActions();
@@ -472,6 +475,9 @@ void Engine::ProcessTriggers(bool minimal)
 
             if (!event)
                 continue;
+
+            if (trigger->IsBuffTrigger() && !trigger->IsDebuffTrigger())
+                botAI->forceRebuff.NoteBuffProposed();
 
             fires[trigger] = event;
             LogAction("T:%s", trigger->getName().c_str());

--- a/src/Bot/Engine/Trigger/Trigger.cpp
+++ b/src/Bot/Engine/Trigger/Trigger.cpp
@@ -7,6 +7,7 @@
 #include "Trigger.h"
 #include "AiObjectContext.h"
 #include "Event.h"
+#include "PlayerbotAI.h"
 
 Trigger::Trigger(PlayerbotAI* botAI, std::string const name, int32 checkInterval)
     : AiNamedObject(botAI, name),
@@ -33,6 +34,10 @@ Unit* Trigger::GetTarget() { return GetTargetValue()->Get(); }
 
 bool Trigger::needCheck(uint32 now)
 {
+    // During an out-of-combat force-rebuff, evaluate every buff trigger each tick
+    if (IsBuffTrigger() && !IsDebuffTrigger() && botAI->forceRebuff.IsPending() && !bot->IsInCombat())
+        return true;
+
     if (checkInterval < 2)
         return true;
 

--- a/src/Bot/Engine/Trigger/Trigger.h
+++ b/src/Bot/Engine/Trigger/Trigger.h
@@ -27,6 +27,8 @@ public:
     virtual void ExternalEvent([[maybe_unused]] std::string const param, [[maybe_unused]] Player* owner = nullptr) {}
     virtual void ExternalEvent([[maybe_unused]] WorldPacket& packet, [[maybe_unused]] Player* owner = nullptr) {}
     virtual bool IsActive() { return false; }
+    virtual bool IsBuffTrigger() { return false; }
+    virtual bool IsDebuffTrigger() { return false; }
     virtual std::vector<NextAction> getHandlers() { return {}; }
     void Update() {}
     virtual void Reset() {}

--- a/src/Bot/Factory/AiFactory.cpp
+++ b/src/Bot/Factory/AiFactory.cpp
@@ -581,7 +581,7 @@ void AiFactory::AddDefaultNonCombatStrategies(Player* player, PlayerbotAI* const
 
     if (!player->InBattleground())
     {
-        nonCombatEngine->addStrategiesNoInit("nc", "food", "chat", "follow", "default", "quest", "loot",
+        nonCombatEngine->addStrategiesNoInit("nc", "food", "chat", "follow", "default", "force rebuff", "quest", "loot",
                                             "gather", "duel", "pvp", "buff", "mount", "emote", nullptr);
     }
 
@@ -673,8 +673,8 @@ void AiFactory::AddDefaultNonCombatStrategies(Player* player, PlayerbotAI* const
     // Battleground switch
     if (player->InBattleground() && player->GetBattleground())
     {
-        nonCombatEngine->addStrategiesNoInit("nc", "chat", "default", "buff", "food", "mount", "pvp", "dps assist",
-                                       "attack tagged", "emote", nullptr);
+        nonCombatEngine->addStrategiesNoInit("nc", "chat", "default", "force rebuff", "buff", "food", "mount", "pvp",
+                                       "dps assist", "attack tagged", "emote", nullptr);
         nonCombatEngine->removeStrategy("custom::say", false);
         nonCombatEngine->removeStrategy("travel", false);
         nonCombatEngine->removeStrategy("rpg", false);

--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -38,6 +38,9 @@
 #include <array>
 #include <utility>
 
+#include <array>
+#include <utility>
+
 const uint64 diveMask = (1LL << 7) | (1LL << 44) | (1LL << 37) | (1LL << 38) | (1LL << 26) | (1LL << 30) | (1LL << 27) |
                         (1LL << 33) | (1LL << 24) | (1LL << 34);
 
@@ -839,8 +842,7 @@ void PlayerbotFactory::Randomize(bool incremental)
     if (bot->GetLevel() >= 70)
     {
         pmo = sPerfMonitor.start(PERF_MON_RNDBOT, "PlayerbotFactory_Arenas");
-        // LOG_INFO("playerbots", "Initializing arena teams...");
-        InitArenaTeam();
+        RandomPlayerbotFactory::AssignBotToArenaTeam(bot);
         if (pmo)
             pmo->finish();
     }
@@ -4762,135 +4764,6 @@ void PlayerbotFactory::InitImmersive()
             sRandomPlayerbotMgr.SetValue(owner, name.str(), percentMap[type]);
         }
     }
-}
-
-void PlayerbotFactory::InitArenaTeam()
-{
-    if (!sPlayerbotAIConfig.IsInRandomAccountList(bot->GetSession()->GetAccountId()))
-        return;
-
-    // Currently the teams are only remade after a server restart and if deleteRandomBotArenaTeams = 1
-    // This is because randomBotArenaTeams is only empty on server restart.
-    // A manual reinitalization (.playerbots rndbot init) is also required after the teams have been deleted.
-    if (sPlayerbotAIConfig.randomBotArenaTeams.empty())
-    {
-        if (sPlayerbotAIConfig.deleteRandomBotArenaTeams)
-        {
-            LOG_INFO("playerbots", "Deleting random bot arena teams...");
-
-            for (auto it = sArenaTeamMgr->GetArenaTeams().begin(); it != sArenaTeamMgr->GetArenaTeams().end(); ++it)
-            {
-                ArenaTeam* arenateam = it->second;
-                if (arenateam->GetCaptain() && arenateam->GetCaptain().IsPlayer())
-                {
-                    Player* bot = ObjectAccessor::FindPlayer(arenateam->GetCaptain());
-                    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
-                    if (!botAI || IsSelfBot(bot))
-                        continue;
-                    else
-                        arenateam->Disband(nullptr);
-                }
-            }
-
-            LOG_INFO("playerbots", "Random bot arena teams deleted");
-        }
-
-        RandomPlayerbotFactory::CreateRandomArenaTeams(ARENA_TYPE_2v2, sPlayerbotAIConfig.randomBotArenaTeam2v2Count);
-        RandomPlayerbotFactory::CreateRandomArenaTeams(ARENA_TYPE_3v3, sPlayerbotAIConfig.randomBotArenaTeam3v3Count);
-        RandomPlayerbotFactory::CreateRandomArenaTeams(ARENA_TYPE_5v5, sPlayerbotAIConfig.randomBotArenaTeam5v5Count);
-    }
-
-    std::vector<uint32> arenateams;
-    for (std::vector<uint32>::iterator i = sPlayerbotAIConfig.randomBotArenaTeams.begin();
-         i != sPlayerbotAIConfig.randomBotArenaTeams.end(); ++i)
-         {
-             arenateams.push_back(*i);
-         }
-
-         if (arenateams.empty())
-         {
-             LOG_ERROR("playerbots", "No random arena team available");
-             return;
-         }
-
-         while (!arenateams.empty())
-         {
-             int index = urand(0, arenateams.size() - 1);
-             uint32 arenateamID = arenateams[index];
-             ArenaTeam* arenateam = sArenaTeamMgr->GetArenaTeamById(arenateamID);
-             if (!arenateam)
-             {
-                 LOG_ERROR("playerbots", "Invalid arena team {}", arenateamID);
-                 arenateams.erase(arenateams.begin() + index);
-                 continue;
-             }
-
-             if (arenateam->GetMembersSize() < ((uint32)arenateam->GetType()) && bot->GetLevel() >= 70)
-             {
-                 ObjectGuid capt = arenateam->GetCaptain();
-                 Player* botcaptain = ObjectAccessor::FindPlayer(capt);
-
-                 // To avoid bots removing each other from groups when queueing, force them to only be in one team
-                 for (uint32 arena_slot = 0; arena_slot < MAX_ARENA_SLOT; ++arena_slot)
-                 {
-                     uint32 arenaTeamId = bot->GetArenaTeamId(arena_slot);
-                     if (!arenaTeamId)
-                         continue;
-
-                     ArenaTeam* team = sArenaTeamMgr->GetArenaTeamById(arenaTeamId);
-                     if (team)
-                     {
-                         if (sCharacterCache->GetCharacterArenaTeamIdByGuid(bot->GetGUID(), team->GetSlot()) != 0)
-                         {
-                             return;
-                         }
-                         return;
-                     }
-                 }
-
-                 if (botcaptain && botcaptain->GetTeamId() == bot->GetTeamId())  // need?
-                 {
-                     // Skip if already a member
-                     for (ArenaTeamMember const& member : arenateam->GetMembers())
-                     {
-                         if (member.Guid == bot->GetGUID())
-                         {
-                             return;
-                         }
-                     }
-
-                     // Add bot to arena team
-                     arenateam->AddMember(bot->GetGUID());
-
-                     // Only synchronize ratings once the team is full (avoid redundant work)
-                     // The captain was added with incorrect ratings when the team was created,
-                     // so we fix everyone's ratings once the roster is complete
-                     if (arenateam->GetMembersSize() >= (uint32)arenateam->GetType())
-                     {
-                         uint32 teamRating = arenateam->GetRating();
-
-                         // Use SetRatingForAll to align all members with team rating
-                         arenateam->SetRatingForAll(teamRating);
-
-                         // For bot-only teams, keep MMR synchronized with team rating
-                         // This ensures matchmaking reflects the artificial team strength (1000-2000 range)
-                         // instead of being influenced by the global CONFIG_ARENA_START_MATCHMAKER_RATING
-                         for (auto& member : arenateam->GetMembers())
-                         {
-                             // Set MMR to match personal rating (which already matches team rating)
-                             member.MatchMakerRating = member.PersonalRating;
-                             member.MaxMMR = std::max(member.MaxMMR, member.PersonalRating);
-                         }
-                         // Force save all member data to database
-                         arenateam->SaveToDB(true);
-                     }
-                 }
-             }
-
-             arenateams.erase(arenateams.begin() + index);
-         }
-
-         // bot->SaveToDB(false, false);
 }
 
 void PlayerbotFactory::ApplyEnchantTemplate()

--- a/src/Bot/Factory/PlayerbotFactory.h
+++ b/src/Bot/Factory/PlayerbotFactory.h
@@ -205,7 +205,6 @@ private:
     void InitInventoryEquip();
     void InitInventorySkill();
     Item* StoreItem(uint32 itemId, uint32 count);
-    void InitArenaTeam();
     void InitImmersive();
     static void AddPrevQuests(uint32 questId, std::list<uint32>& questIds);
     void LoadEnchantContainer();

--- a/src/Bot/Factory/RandomPlayerbotFactory.cpp
+++ b/src/Bot/Factory/RandomPlayerbotFactory.cpp
@@ -7,9 +7,15 @@
 #include "RandomPlayerbotFactory.h"
 #include "AccountMgr.h"
 #include "ArenaTeamMgr.h"
+#include "CharacterCache.h"
+#include "ObjectAccessor.h"
+#include "Player.h"
 #include "DatabaseEnv.h"
 #include "Log.h"
 #include "PlayerbotAI.h"
+#include "PlayerbotAIConfig.h"
+#include "PlayerbotOperations.h"
+#include "PlayerbotWorldThreadProcessor.h"
 #include "RaceMgr.h"
 #include "ScriptMgr.h"
 #include "SharedDefines.h"
@@ -783,156 +789,242 @@ std::string const RandomPlayerbotFactory::CreateRandomGuildName()
     return guildName;
 }
 
-void RandomPlayerbotFactory::CreateRandomArenaTeams(ArenaType type, uint32 count)
+bool RandomPlayerbotFactory::IsBotArenaTeam(ArenaTeam const* team)
 {
-    std::vector<uint32> randomBots;
+    if (!team)
+        return false;
 
-    PlayerbotsDatabasePreparedStatement* stmt = PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_SEL_RANDOM_BOTS_BOT);
-    stmt->SetData(0, "add");
-    if (PreparedQueryResult result = PlayerbotsDatabase.Query(stmt))
-    {
-        do
-        {
-            Field* fields = result->Fetch();
-            uint32 bot = fields[0].Get<uint32>();
-            randomBots.push_back(bot);
-        } while (result->NextRow());
-    }
+    ObjectGuid captainGuid = team->GetCaptain();
+    if (!captainGuid || !captainGuid.IsPlayer())
+        return false;
 
-    uint32 arenaTeamNumber = 0;
-    GuidVector availableCaptains;
-    for (std::vector<uint32>::iterator i = randomBots.begin(); i != randomBots.end(); ++i)
-    {
-        ObjectGuid captain = ObjectGuid::Create<HighGuid::Player>(*i);
-        ArenaTeam* arenateam = sArenaTeamMgr->GetArenaTeamByCaptain(captain, type);
-        if (arenateam)
-        {
-            ++arenaTeamNumber;
-            sPlayerbotAIConfig.randomBotArenaTeams.push_back(arenateam->GetId());
-        }
-        else
-        {
-            Player* player = ObjectAccessor::FindConnectedPlayer(captain);
-
-            if (!arenateam && player && player->GetLevel() >= 70)
-                availableCaptains.push_back(captain);
-        }
-    }
-
-    for (; arenaTeamNumber < count; ++arenaTeamNumber)
-    {
-        std::string const arenaTeamName = CreateRandomArenaTeamName();
-        if (arenaTeamName.empty())
-            continue;
-
-        if (availableCaptains.empty())
-        {
-            LOG_ERROR("playerbots", "No captains for random arena teams available");
-            continue;
-        }
-
-        uint32 index = urand(0, availableCaptains.size() - 1);
-        ObjectGuid captain = availableCaptains[index];
-        Player* player = ObjectAccessor::FindConnectedPlayer(captain);
-        if (!player)
-        {
-            LOG_ERROR("playerbots", "Cannot find player for captain {}", captain.ToString().c_str());
-            continue;
-        }
-
-        if (player->GetLevel() < 70)
-        {
-            LOG_ERROR("playerbots", "Bot {} must be level 70 to create an arena team", captain.ToString().c_str());
-            continue;
-        }
-
-        // Below query no longer required as now user has control over the number of each type of arena team they want
-        // to create. Keeping commented for potential future reference. QueryResult results =
-        // CharacterDatabase.Query("SELECT `type` FROM playerbots_arena_team_names WHERE name = '{}'",
-        // arenaTeamName.c_str()); if (!results)
-        // {
-        //     LOG_ERROR("playerbots", "No valid types for arena teams");
-        //     return;
-        // }
-
-        // Field* fields = results->Fetch();
-        // uint8 slot = fields[0].Get<uint8>();
-
-        uint8 arenaSlot = ArenaTeam::GetSlotByType(type);
-
-        if (player->GetArenaTeamId(arenaSlot) ||
-            sCharacterCache->GetCharacterArenaTeamIdByGuid(player->GetGUID(), arenaSlot) != 0)
-        {
-            continue;
-        }
-
-        ArenaTeam* arenateam = new ArenaTeam();
-
-        if (!arenateam->Create(player->GetGUID(), type, arenaTeamName, 0, 0, 0, 0, 0))
-        {
-            LOG_ERROR("playerbots", "Error creating arena team {}", arenaTeamName.c_str());
-
-            delete arenateam;
-            continue;
-        }
-
-        arenateam->SetCaptain(player->GetGUID());
-
-        // set random rating
-        arenateam->SetRatingForAll(
-            urand(sPlayerbotAIConfig.randomBotArenaTeamMinRating, sPlayerbotAIConfig.randomBotArenaTeamMaxRating));
-
-        // set random emblem
-        uint32 backgroundColor = urand(0xFF000000, 0xFFFFFFFF);
-        uint32 emblemStyle = urand(0, 101);
-        uint32 emblemColor = urand(0xFF000000, 0xFFFFFFFF);
-        uint32 borderStyle = urand(0, 5);
-        uint32 borderColor = urand(0xFF000000, 0xFFFFFFFF);
-        arenateam->SetEmblem(backgroundColor, emblemStyle, emblemColor, borderStyle, borderColor);
-
-        // set random kills (wip)
-        // arenateam->SetStats(STAT_TYPE_GAMES_WEEK, urand(0, 30));
-        // arenateam->SetStats(STAT_TYPE_WINS_WEEK, urand(0, arenateam->GetStats().games_week));
-        // arenateam->SetStats(STAT_TYPE_GAMES_SEASON, urand(arenateam->GetStats().games_week,
-        // arenateam->GetStats().games_week * 5)); arenateam->SetStats(STAT_TYPE_WINS_SEASON,
-        // urand(arenateam->GetStats().wins_week, arenateam->GetStats().games
-        arenateam->SaveToDB();
-
-        sArenaTeamMgr->AddArenaTeam(arenateam);
-        sPlayerbotAIConfig.randomBotArenaTeams.push_back(arenateam->GetId());
-    }
-
-    LOG_DEBUG("playerbots", "{} random bot {}vs{} arena teams available", arenaTeamNumber, type, type);
+    uint32 accountId = sCharacterCache->GetCharacterAccountIdByGuid(captainGuid);
+    return accountId && sPlayerbotAIConfig.IsInRandomAccountList(accountId);
 }
 
-std::string const RandomPlayerbotFactory::CreateRandomArenaTeamName()
+void RandomPlayerbotFactory::LoadArenaTeamData()
 {
-    std::string arenaTeamName = "";
+    _configTargets = {
+        {ARENA_TYPE_2v2, sPlayerbotAIConfig.randomBotArenaTeam2v2Count},
+        {ARENA_TYPE_3v3, sPlayerbotAIConfig.randomBotArenaTeam3v3Count},
+        {ARENA_TYPE_5v5, sPlayerbotAIConfig.randomBotArenaTeam5v5Count},
+    };
 
-    QueryResult result = CharacterDatabase.Query("SELECT MAX(name_id) FROM playerbots_arena_team_names");
-    if (!result)
+    _botArenaTeamRegistry.clear();
+
+    for (auto const& [id, team] : sArenaTeamMgr->GetArenaTeams())
     {
-        LOG_ERROR("playerbots", "No more names left for random arena teams");
-        return arenaTeamName;
+        if (!IsBotArenaTeam(team))
+            continue;
+
+        CharacterCacheEntry const* entry = sCharacterCache->GetCharacterCacheByGuid(team->GetCaptain());
+        if (!entry)
+            continue;
+
+        ArenaType type = static_cast<ArenaType>(team->GetType());
+        _botArenaTeamRegistry[type].push_back(id);
     }
 
-    Field* fields = result->Fetch();
-    uint32 maxId = fields[0].Get<uint32>();
+    _availableArenaTeamNames.clear();
 
-    uint32 id = urand(0, maxId);
-    result = CharacterDatabase.Query(
-        "SELECT n.name FROM playerbots_arena_team_names n LEFT OUTER JOIN arena_team e ON e.name = n.name "
-        "WHERE e.arenateamid IS NULL AND n.name_id >= {} LIMIT 1",
-        id);
+    QueryResult result = CharacterDatabase.Query(
+        "SELECT n.name FROM playerbots_arena_team_names n "
+        "LEFT OUTER JOIN arena_team e ON e.name = n.name "
+        "WHERE e.arenateamid IS NULL");
 
     if (!result)
     {
-        LOG_ERROR("playerbots", "No more names left for random arena teams");
-        return arenaTeamName;
+        LOG_WARN("playerbots", "No arena team names left in playerbots_arena_team_names");
+        return;
     }
 
-    fields = result->Fetch();
-    arenaTeamName = fields[0].Get<std::string>();
+    do
+    {
+        Field* fields = result->Fetch();
+        _availableArenaTeamNames.push_back(fields[0].Get<std::string>());
+    } while (result->NextRow());
 
-    return arenaTeamName;
+    for (size_t i = _availableArenaTeamNames.size() - 1; i > 0; --i)
+    {
+        size_t j = urand(0, i);
+        std::swap(_availableArenaTeamNames[i], _availableArenaTeamNames[j]);
+    }
+
+    LOG_INFO("playerbots", "Loaded {} available arena team names", _availableArenaTeamNames.size());
+}
+
+void RandomPlayerbotFactory::AssignBotToArenaTeam(Player* bot)
+{
+    if (!sPlayerbotAIConfig.IsInRandomAccountList(bot->GetSession()->GetAccountId()))
+        return;
+
+    if (sPlayerbotAIConfig.deleteRandomBotArenaTeams)
+        return;
+
+    if (bot->GetLevel() < 70)
+        return;
+
+    for (uint32 arena_slot = 0; arena_slot < MAX_ARENA_SLOT; ++arena_slot)
+    {
+        if (bot->GetArenaTeamId(arena_slot))
+            return;
+    }
+
+    PlayerbotWorldThreadProcessor::instance().QueueOperation(
+        std::make_unique<ArenaTeamAssignOperation>(bot->GetGUID()));
+}
+
+void RandomPlayerbotFactory::AssignBotToArenaTeamInternal(Player* bot)
+{
+    // Check if bot has team, only one per bot to avoid queue conflicts
+    for (uint32 arena_slot = 0; arena_slot < MAX_ARENA_SLOT; ++arena_slot)
+    {
+        if (bot->GetArenaTeamId(arena_slot) ||
+            sCharacterCache->GetCharacterArenaTeamIdByGuid(bot->GetGUID(), arena_slot))
+            return;
+    }
+
+    TeamId const botTeam = bot->GetTeamId();
+
+    // Randomize type order so no single type starves the others
+    std::array<ArenaType, 3> order{ARENA_TYPE_2v2, ARENA_TYPE_3v3, ARENA_TYPE_5v5};
+    for (size_t i = order.size() - 1; i > 0; --i)
+        std::swap(order[i], order[urand(0, i)]);
+
+    std::vector<ArenaTeam*> candidates;
+    for (ArenaType type : order)
+        CollectJoinableBotArenaTeams(type, botTeam, candidates);
+
+    for (size_t i = candidates.size(); i > 0; --i)
+    {
+        size_t const index = urand(0, i - 1);
+        ArenaTeam* team = candidates[index];
+        candidates[index] = candidates[i - 1];
+
+        if (!team->AddMember(bot->GetGUID()))
+        {
+            LOG_DEBUG("playerbots", "Failed to add bot {} to arena team '{}', trying next candidate",
+                      bot->GetName(), team->GetName());
+            continue;
+        }
+
+        if (team->GetMembersSize() >= static_cast<uint32>(team->GetType()))
+        {
+            uint32 teamRating = team->GetRating();
+            team->SetRatingForAll(teamRating);
+
+            // Keep MMR synchronized with team rating so matchmaking reflects artificial bot strength
+            // (1000-2000 range) instead of the global CONFIG_ARENA_START_MATCHMAKER_RATING default.
+            for (auto& member : team->GetMembers())
+            {
+                member.MatchMakerRating = member.PersonalRating;
+                member.MaxMMR = std::max(member.MaxMMR, member.PersonalRating);
+            }
+            team->SaveToDB(true);
+        }
+        return;
+    }
+
+    // No joinable team available, create one if under target count
+    for (ArenaType type : order)
+    {
+        if (GetBotArenaTeamCount(type) < _configTargets[type])
+        {
+            CreateBotArenaTeam(bot, type);
+            return;
+        }
+    }
+}
+
+void RandomPlayerbotFactory::CreateBotArenaTeam(Player* bot, ArenaType type)
+{
+    std::string teamName = CreateRandomArenaTeamName();
+    if (teamName.empty())
+        return;
+
+    ArenaTeam* arenateam = new ArenaTeam();
+    if (!arenateam->Create(bot->GetGUID(), type, teamName, 0, 0, 0, 0, 0))
+    {
+        LOG_ERROR("playerbots", "Error creating arena team {}", teamName);
+        delete arenateam;
+        _availableArenaTeamNames.push_back(std::move(teamName));
+        return;
+    }
+
+    arenateam->SetRatingForAll(
+        urand(sPlayerbotAIConfig.randomBotArenaTeamMinRating, sPlayerbotAIConfig.randomBotArenaTeamMaxRating));
+
+    uint32 backgroundColor = urand(0xFF000000, 0xFFFFFFFF);
+    uint32 emblemStyle = urand(0, 101);
+    uint32 emblemColor = urand(0xFF000000, 0xFFFFFFFF);
+    uint32 borderStyle = urand(0, 5);
+    uint32 borderColor = urand(0xFF000000, 0xFFFFFFFF);
+    arenateam->SetEmblem(backgroundColor, emblemStyle, emblemColor, borderStyle, borderColor);
+
+    arenateam->SaveToDB();
+    sArenaTeamMgr->AddArenaTeam(arenateam);
+    _botArenaTeamRegistry[type].push_back(arenateam->GetId());
+
+    LOG_DEBUG("playerbots", "Created {}v{} arena team '{}' with captain {}",
+              type, type, teamName, bot->GetName());
+}
+
+uint32 RandomPlayerbotFactory::GetBotArenaTeamCount(ArenaType type)
+{
+    auto it = _botArenaTeamRegistry.find(type);
+    return it != _botArenaTeamRegistry.end() ? static_cast<uint32>(it->second.size()) : 0;
+}
+
+void RandomPlayerbotFactory::CollectJoinableBotArenaTeams(ArenaType type, TeamId faction, std::vector<ArenaTeam*>& out)
+{
+    auto it = _botArenaTeamRegistry.find(type);
+    if (it == _botArenaTeamRegistry.end())
+        return;
+
+    uint32 const capacity = static_cast<uint32>(type);
+    for (uint32 teamId : it->second)
+    {
+        ArenaTeam* team = sArenaTeamMgr->GetArenaTeamById(teamId);
+        if (!team || team->GetMembersSize() >= capacity)
+            continue;
+
+        CharacterCacheEntry const* entry = sCharacterCache->GetCharacterCacheByGuid(team->GetCaptain());
+        if (entry && Player::TeamIdForRace(entry->Race) == faction)
+            out.push_back(team);
+    }
+}
+
+void RandomPlayerbotFactory::DeleteBotArenaTeams()
+{
+    LOG_INFO("playerbots", "Deleting random bot arena teams...");
+
+    std::vector<uint32> teamsToDisband;
+    for (auto const& [id, arenateam] : sArenaTeamMgr->GetArenaTeams())
+    {
+        if (IsBotArenaTeam(arenateam))
+            teamsToDisband.push_back(id);
+    }
+
+    for (uint32 teamId : teamsToDisband)
+    {
+        ArenaTeam* team = sArenaTeamMgr->GetArenaTeamById(teamId);
+        if (team)
+            team->Disband(nullptr);
+    }
+
+    _botArenaTeamRegistry.clear();
+    LOG_INFO("playerbots", "Deleted {} random bot arena teams", teamsToDisband.size());
+}
+
+std::string RandomPlayerbotFactory::CreateRandomArenaTeamName()
+{
+    if (_availableArenaTeamNames.empty())
+    {
+        LOG_ERROR("playerbots", "No more names left for random arena teams");
+        return "";
+    }
+
+    std::string name = std::move(_availableArenaTeamNames.back());
+    _availableArenaTeamNames.pop_back();
+    return name;
 }

--- a/src/Bot/Factory/RandomPlayerbotFactory.h
+++ b/src/Bot/Factory/RandomPlayerbotFactory.h
@@ -7,16 +7,18 @@
 #ifndef PLAYERBOTS_RANDOMPLAYERBOTFACTORY_H
 #define PLAYERBOTS_RANDOMPLAYERBOTFACTORY_H
 
+#include "ArenaTeam.h"
+#include "Battleground.h"
 #include "Common.h"
 #include "DBCEnums.h"
+#include "SharedDefines.h"
 #include <map>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
 class Player;
 class WorldSession;
-
-enum ArenaType : uint8;
 
 class RandomPlayerbotFactory
 {
@@ -51,15 +53,31 @@ public:
 
     Player* CreateRandomBot(WorldSession* session, uint8 cls, std::unordered_map<NameRaceAndGender, std::vector<std::string>>& names);
     static void CreateRandomBots();
-    static void CreateRandomArenaTeams(ArenaType slot, uint32 count);
     static std::string const CreateRandomGuildName();
     static uint32 CalculateTotalAccountCount();
     static uint32 CalculateAvailableCharsPerAccount();
 
+    // Arena team management
+    static void AssignBotToArenaTeam(Player* bot);
+    static void DeleteBotArenaTeams();
+    static uint32 GetBotArenaTeamCount(ArenaType type);
+    static void LoadArenaTeamData();
+
 private:
+    friend class ArenaTeamAssignOperation;
+
     static bool IsValidRaceClassCombination(uint8 race, uint8 class_, uint32 expansion);
     std::string const CreateRandomBotName(NameRaceAndGender raceAndGender);
-    static std::string const CreateRandomArenaTeamName();
+
+    static void AssignBotToArenaTeamInternal(Player* bot);
+    static void CollectJoinableBotArenaTeams(ArenaType type, TeamId faction, std::vector<ArenaTeam*>& out);
+    static void CreateBotArenaTeam(Player* bot, ArenaType type);
+    static bool IsBotArenaTeam(ArenaTeam const* team);
+    static std::string CreateRandomArenaTeamName();
+
+    static inline std::vector<std::string> _availableArenaTeamNames;
+    static inline std::map<ArenaType, std::vector<uint32>> _botArenaTeamRegistry;
+    static inline std::map<ArenaType, uint32> _configTargets;
 };
 
 #endif

--- a/src/Bot/ForceRebuff.cpp
+++ b/src/Bot/ForceRebuff.cpp
@@ -1,0 +1,96 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+#include "ForceRebuff.h"
+#include "Common.h"
+#include "GenericSpellActions.h"
+#include "Player.h"
+#include "PlayerbotAI.h"
+#include "PlayerbotAIConfig.h"
+#include "Timer.h"
+#include <algorithm>
+
+static constexpr uint32 REBUFF_WINDOW_TIMEOUT_MS = 2 * MINUTE * IN_MILLISECONDS;
+
+void ForceRebuffState::Begin(bool reply)
+{
+    replyToReadyCheck = reply || (IsPending() && replyToReadyCheck);
+    pending = true;
+    buffPendingThisCycle = true;
+    beginMs = getMSTime();
+}
+
+bool ForceRebuffState::IsOnGlobalCooldown() const
+{
+    return bot && lastGcdSpell && bot->GetGlobalCooldownMgr().HasGlobalCooldown(lastGcdSpell);
+}
+
+bool ForceRebuffState::IsPending() const
+{
+    return pending && getMSTimeDiff(beginMs, getMSTime()) < REBUFF_WINDOW_TIMEOUT_MS;
+}
+
+void ForceRebuffState::NoteBuffWork()
+{
+    if (!bot || !IsPending() || bot->IsInCombat())
+        return;
+
+    buffPendingThisCycle = true;
+}
+
+void ForceRebuffState::NoteBuffProposed()
+{
+    if (!bot || !IsPending() || bot->IsInCombat())
+        return;
+
+    buffProposedThisCycle = true;
+}
+
+bool ForceRebuffState::BuffBelowRefreshTarget(int32 remaining, int32 maxDuration, uint32 baseBeforeDuration) const
+{
+    if (bot && IsPending() && !bot->IsInCombat())
+    {
+        if (remaining <= 0 || maxDuration <= 0)
+            return false;
+
+        // Anything refreshed after the rebuff began counts as topped off
+        uint32 const marginMs = std::max(sPlayerbotAIConfig.forceRebuffMarginSecs * IN_MILLISECONDS,
+                                         getMSTimeDiff(beginMs, getMSTime()) + 5000);
+        return uint32(remaining) + marginMs < uint32(maxDuration);
+    }
+
+    return baseBeforeDuration && uint32(remaining) < baseBeforeDuration;
+}
+
+// During a force-rebuff, healing yields to buffing: heals are suppressed while
+// buff work is proposed or the last cast's GCD runs, so the pass is not stretched
+// by interleaved heals.
+class ForceRebuffBuffFirstMultiplier : public Multiplier
+{
+public:
+    ForceRebuffBuffFirstMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "force rebuff buff first") {}
+
+    float GetValue(Action* action) override
+    {
+        ForceRebuffState const& rebuff = botAI->forceRebuff;
+        if (!action || !rebuff.IsPending() || botAI->GetBot()->IsInCombat())
+            return 1.0f;
+
+        if (!dynamic_cast<CastHealingSpellAction*>(action))
+            return 1.0f;
+
+        return rebuff.IsBuffProposedThisCycle() || rebuff.IsOnGlobalCooldown() ? 0.0f : 1.0f;
+    }
+};
+
+void ForceRebuffStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+{
+    triggers.push_back(new TriggerNode("force rebuff pending", { NextAction("ready reply", 6.0f) }));
+}
+
+void ForceRebuffStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
+{
+    multipliers.push_back(new ForceRebuffBuffFirstMultiplier(botAI));
+}

--- a/src/Bot/ForceRebuff.h
+++ b/src/Bot/ForceRebuff.h
@@ -1,0 +1,62 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+#ifndef PLAYERBOTS_FORCEREBUFF_H
+#define PLAYERBOTS_FORCEREBUFF_H
+
+#include "Define.h"
+#include "Strategy.h"
+#include <string>
+#include <vector>
+
+class Player;
+class PlayerbotAI;
+class SpellInfo;
+
+class ForceRebuffState
+{
+public:
+    explicit ForceRebuffState(Player* owner = nullptr) : bot(owner) {}
+
+    ForceRebuffState(ForceRebuffState const&) = delete;
+    ForceRebuffState& operator=(ForceRebuffState const&) = delete;
+
+    void Begin(bool reply);
+    void End() { pending = false; }
+    bool IsPending() const;
+    bool ShouldReplyToReadyCheck() const { return replyToReadyCheck; }
+
+    void NoteBuffWork();
+    void NoteBuffProposed();
+    void RollBuffPendingCycle() { buffPendingThisCycle = false; buffProposedThisCycle = false; }
+    bool IsBuffPendingThisCycle() const { return buffPendingThisCycle; }
+    bool IsBuffProposedThisCycle() const { return buffProposedThisCycle; }
+
+    void NoteCast(SpellInfo const* spellInfo) { lastGcdSpell = spellInfo; }
+    bool IsOnGlobalCooldown() const;
+
+    bool BuffBelowRefreshTarget(int32 remaining, int32 maxDuration, uint32 baseBeforeDuration) const;
+
+private:
+    Player* bot;
+    bool pending = false;
+    bool replyToReadyCheck = false;
+    bool buffPendingThisCycle = false;
+    bool buffProposedThisCycle = false;
+    SpellInfo const* lastGcdSpell = nullptr;
+    uint32 beginMs = 0;
+};
+
+class ForceRebuffStrategy : public Strategy
+{
+public:
+    ForceRebuffStrategy(PlayerbotAI* botAI) : Strategy(botAI) {}
+
+    std::string const getName() override { return "force rebuff"; }
+    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
+    void InitMultipliers(std::vector<Multiplier*>& multipliers) override;
+};
+
+#endif

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -271,10 +271,6 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
 
     AllowActivity();
 
-    // If we get attacked, drop the pending delay so the engine can switch to combat.
-    if (nextAICheckDelay && bot->IsInCombat() && currentEngine != engines[BOT_STATE_COMBAT])
-        nextAICheckDelay = 0;
-
     if (!CanUpdateAI())
         return;
 

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -133,6 +133,7 @@ PlayerbotAI::PlayerbotAI()
 
 PlayerbotAI::PlayerbotAI(Player* bot)
     : PlayerbotAIBase(true),
+      forceRebuff(bot),
       bot(bot),
       master(nullptr),
       chatHelper(this),
@@ -3826,6 +3827,8 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target, Item* itemTarget)
         out << "Casting " << ChatHelper::FormatSpell(spellInfo);
         TellMasterNoFacing(out);
     }
+
+    forceRebuff.NoteCast(spellInfo);
 
     return true;
 }

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -12,6 +12,7 @@
 #include "CheckMountStateAction.h"
 #include "Common.h"
 #include "CreatureData.h"
+#include "DBCStores.h"
 #include "EmoteAction.h"
 #include "Engine.h"
 #include "EventProcessor.h"
@@ -1779,6 +1780,12 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
         out << "Added " << strategyName << " instance strategy";
         TellMasterNoFacing(out.str());
     }
+}
+
+bool PlayerbotAI::IsInNonRaidDungeon() const
+{
+    MapEntry const* mapEntry = sMapStore.LookupEntry(bot->GetMapId());
+    return mapEntry && mapEntry->IsNonRaidDungeon();
 }
 
 bool PlayerbotAI::HasTargetExclusions() const

--- a/src/Bot/PlayerbotAI.h
+++ b/src/Bot/PlayerbotAI.h
@@ -11,6 +11,7 @@
 #include "ChatHelper.h"
 #include "CreatureData.h"
 #include "Event.h"
+#include "ForceRebuff.h"
 #include "Item.h"
 #include "NewRpgInfo.h"
 #include "NewRpgStrategy.h"
@@ -604,6 +605,7 @@ public:
     NewRpgStatistic rpgStatistic;
     std::unordered_set<uint32> lowPriorityQuest;
     time_t bgReleaseAttemptTime = 0;
+    ForceRebuffState forceRebuff;
 
     // Schedules a callback to run once after <delayMs> milliseconds.
     void AddTimedEvent(std::function<void()> callback, uint32 delayMs);

--- a/src/Bot/PlayerbotAI.h
+++ b/src/Bot/PlayerbotAI.h
@@ -411,6 +411,7 @@ public:
     std::vector<std::string> GetStrategies(BotState type);
     Strategy* GetStrategy(std::string const name, BotState type);
     void ApplyInstanceStrategies(uint32 mapId, bool tellMaster = false);
+    bool IsInNonRaidDungeon() const;
     bool HasTargetExclusions() const;
     void EvaluateHealerDpsStrategy();
     bool ContainsStrategy(StrategyType type);

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -1762,6 +1762,22 @@ void RandomPlayerbotMgr::Init()
     PlayerbotsDatabase.Execute("DELETE FROM playerbots_random_bots WHERE event = 'add'");
 }
 
+void RandomPlayerbotMgr::InitArenaTeams()
+{
+    if (sPlayerbotAIConfig.deleteRandomBotArenaTeams)
+    {
+        RandomPlayerbotFactory::DeleteBotArenaTeams();
+        return;
+    }
+
+    RandomPlayerbotFactory::LoadArenaTeamData();
+
+    LOG_INFO("playerbots", "Bot arena teams: 2v2={}/{}, 3v3={}/{}, 5v5={}/{}",
+             RandomPlayerbotFactory::GetBotArenaTeamCount(ARENA_TYPE_2v2), sPlayerbotAIConfig.randomBotArenaTeam2v2Count,
+             RandomPlayerbotFactory::GetBotArenaTeamCount(ARENA_TYPE_3v3), sPlayerbotAIConfig.randomBotArenaTeam3v3Count,
+             RandomPlayerbotFactory::GetBotArenaTeamCount(ARENA_TYPE_5v5), sPlayerbotAIConfig.randomBotArenaTeam5v5Count);
+}
+
 void RandomPlayerbotMgr::RandomTeleportForLevel(Player* bot)
 {
     if (bot->InBattleground())
@@ -2544,6 +2560,8 @@ void RandomPlayerbotMgr::OnBotLoginInternal(Player* const bot)
         PlayerbotFactory factory(bot, bot->GetLevel());
         factory.InitGuild();
     }
+
+    RandomPlayerbotFactory::AssignBotToArenaTeam(bot);
 
     if (sPlayerbotAIConfig.randomBotFixedLevel)
     {

--- a/src/Bot/RandomPlayerbotMgr.h
+++ b/src/Bot/RandomPlayerbotMgr.h
@@ -122,6 +122,7 @@ public:
     Player* GetRandomPlayer();
     std::vector<Player*> GetPlayers() { return players; };
     PlayerBotMap GetAllBots() { return playerBots; };
+    void InitArenaTeams();
     void PrintStats();
     double GetBuyMultiplier(Player* bot);
     double GetSellMultiplier(Player* bot);

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -161,6 +161,8 @@ bool PlayerbotAIConfig::Initialize()
     tellWhenMissingBuffReagents = sConfigMgr->GetOption<bool>("AiPlayerbot.TellWhenMissingBuffReagents", true);
     missingBuffReagentMessageCooldown = sConfigMgr->GetOption<uint32>(
         "AiPlayerbot.MissingBuffReagentMessageCooldown", 300);
+    forceRebuffOnReadyCheck = sConfigMgr->GetOption<bool>("AiPlayerbot.ForceRebuffOnReadyCheck", false);
+    forceRebuffMarginSecs = std::min(sConfigMgr->GetOption<uint32>("AiPlayerbot.ForceRebuffMarginSecs", 60), 3600u);
     autoAvoidAoe = sConfigMgr->GetOption<bool>("AiPlayerbot.AutoAvoidAoe", true);
     maxAoeAvoidRadius = sConfigMgr->GetOption<float>("AiPlayerbot.MaxAoeAvoidRadius", 15.0f);
     LoadSet<std::set<uint32>>(sConfigMgr->GetOption<std::string>("AiPlayerbot.AoeAvoidSpellWhitelist", "50759,57491,13810,29946"),

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -764,6 +764,7 @@ bool PlayerbotAIConfig::Initialize()
     }
 
     PlayerbotGuildMgr::instance().Init();
+    sRandomPlayerbotMgr.InitArenaTeams();
     sRandomItemMgr.Init();
     sRandomItemMgr.InitAfterAhBot();
     sBisListMgr->LoadAll();

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -121,6 +121,8 @@ public:
     AutoPartyBuffMode autoPartyBuffs;
     bool tellWhenMissingBuffReagents;
     uint32 missingBuffReagentMessageCooldown;
+    bool forceRebuffOnReadyCheck;
+    uint32 forceRebuffMarginSecs;
     bool autoAvoidAoe;
     float maxAoeAvoidRadius;
     std::set<uint32> aoeAvoidSpellWhitelist;

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -399,14 +399,12 @@ public:
     int32 enableRandomBotTrading;
     uint32 tweakValue;  // Debugging config
 
-    uint32 randomBotArenaTeamCount;
     uint32 randomBotArenaTeamMaxRating;
     uint32 randomBotArenaTeamMinRating;
     uint32 randomBotArenaTeam2v2Count;
     uint32 randomBotArenaTeam3v3Count;
     uint32 randomBotArenaTeam5v5Count;
     bool deleteRandomBotArenaTeams;
-    std::vector<uint32> randomBotArenaTeams;
 
     uint32 selfBotLevel;
     bool downgradeMaxLevelBot;

--- a/src/Script/WorldThr/PlayerbotOperations.h
+++ b/src/Script/WorldThr/PlayerbotOperations.h
@@ -18,6 +18,7 @@
 #include "PlayerbotOperation.h"
 #include "PlayerbotRepository.h"
 #include "Playerbots.h"
+#include "RandomPlayerbotFactory.h"
 #include "RandomPlayerbotMgr.h"
 #include "UseMeetingStoneAction.h"
 #include "WorldSession.h"
@@ -521,6 +522,31 @@ public:
 private:
     ObjectGuid m_botGuid;
     uint32 m_masterAccountId = 0;
+};
+
+class ArenaTeamAssignOperation : public PlayerbotOperation
+{
+public:
+    explicit ArenaTeamAssignOperation(ObjectGuid botGuid) : m_botGuid(botGuid) {}
+
+    bool Execute() override
+    {
+        Player* bot = ObjectAccessor::FindPlayer(m_botGuid);
+        if (!bot)
+            return false;
+
+        RandomPlayerbotFactory::AssignBotToArenaTeamInternal(bot);
+        return true;
+    }
+
+    ObjectGuid GetBotGuid() const override { return m_botGuid; }
+
+    std::string GetName() const override { return "ArenaTeamAssign"; }
+
+    bool IsValid() const override { return ObjectAccessor::FindPlayer(m_botGuid) != nullptr; }
+
+private:
+    ObjectGuid m_botGuid;
 };
 
 #endif

--- a/src/Util/EncounterHelpers.cpp
+++ b/src/Util/EncounterHelpers.cpp
@@ -4,12 +4,29 @@
  * or (at your option) any later version.
  */
 
-#include "RaidBossHelpers.h"
+#include "EncounterHelpers.h"
 #include "CellImpl.h"
+#include "DKActions.h"
+#include "DruidActions.h"
+#include "DruidBearActions.h"
+#include "DruidCatActions.h"
+#include "GenericSpellActions.h"
 #include "GridNotifiers.h"
 #include "GridNotifiersImpl.h"
+#include "HunterActions.h"
+#include "MageActions.h"
+#include "PaladinActions.h"
 #include "Playerbots.h"
+#include "RogueActions.h"
 #include "RtiTargetValue.h"
+#include "ShamanActions.h"
+#include "WarlockActions.h"
+#include "WarriorActions.h"
+#include <list>
+
+namespace EncounterHelpers
+
+{
 
 // Functions to mark targets with raid target icons
 // Note that these functions do not allow the player to change the icon during the encounter
@@ -88,20 +105,14 @@ bool ClearTargetIcon(Player* bot, uint8 iconId)
     return false;
 }
 
-// For bots to set their raid target icon to the specified icon on the specified target
-void SetRtiTarget(PlayerbotAI* botAI, const std::string& rtiName, Unit* target)
+// For bots to set their raid target icon to the specified icon
+void SetRtiTarget(PlayerbotAI* botAI, std::string const& rtiName)
 {
-    if (!target)
-        return;
+    Value<std::string>* rtiValue =
+        botAI->GetAiObjectContext()->GetValue<std::string>("rti");
 
-    std::string currentRti = botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Get();
-    Unit* currentTarget = botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Get();
-
-    if (currentRti != rtiName || currentTarget != target)
-    {
-        botAI->GetAiObjectContext()->GetValue<std::string>("rti")->Set(rtiName);
-        botAI->GetAiObjectContext()->GetValue<Unit*>("rti target")->Set(target);
-    }
+    if (rtiValue->Get() != rtiName)
+        rtiValue->Set(rtiName);
 }
 
 // Return the first alive bot in the specified instance map for purposes of assigning
@@ -128,13 +139,13 @@ bool IsMechanicTrackerBot(Player* bot, uint32 mapId)
 }
 
 // Requires the main tank to be alive
-Player* GetGroupMainTank(PlayerbotAI* botAI, Player* bot)
+Player* GetGroupMainTank(Player* bot)
 {
     Group* group = bot->GetGroup();
     if (!group)
         return nullptr;
 
-    ObjectGuid const mainTankGuid = botAI->GetMainTankGuid(group);
+    ObjectGuid const mainTankGuid = PlayerbotAI::GetMainTankGuid(group);
     if (mainTankGuid.IsEmpty())
         return nullptr;
 
@@ -149,13 +160,13 @@ Player* GetGroupMainTank(PlayerbotAI* botAI, Player* bot)
 }
 
 // Returns the alive assist tank of the specified index (0 = first, 1 = second, etc.)
-Player* GetGroupAssistTank(PlayerbotAI* botAI, Player* bot, uint8 index)
+Player* GetGroupAssistTank(Player* bot, uint8 index)
 {
     Group* group = bot->GetGroup();
     if (!group)
         return nullptr;
 
-    ObjectGuid const mainTankGuid = botAI->GetMainTankGuid(group);
+    ObjectGuid const mainTankGuid = PlayerbotAI::GetMainTankGuid(group);
     if (mainTankGuid.IsEmpty())
         return nullptr;
 
@@ -165,7 +176,7 @@ Player* GetGroupAssistTank(PlayerbotAI* botAI, Player* bot, uint8 index)
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
         Player* member = ref->GetSource();
-        if (!member || !member->IsAlive() || !botAI->IsTank(member) ||
+        if (!member || !member->IsAlive() || !PlayerbotAI::IsTank(member) ||
             member->GetGUID() == mainTankGuid)
         {
             continue;
@@ -259,4 +270,163 @@ std::vector<Position> GetDynamicObjectPositions(Player* bot, float searchRadius,
     }
 
     return dynObjs;
+}
+
+// This function is primarily for use in multipliers during encounters where it is desirable
+// for bots to save cooldowns for particular phases (or for a bit after the pull)
+bool IsDpsCooldownAction(Player* bot, Action* action)
+{
+    if (bot->getClass() == CLASS_SHAMAN && // Before dps gate to capture Resto
+        (dynamic_cast<CastBloodlustAction*>(action) || dynamic_cast<CastHeroismAction*>(action)))
+    {
+        return true;
+    }
+
+    if (!PlayerbotAI::IsDps(bot))
+        return false;
+
+    if (dynamic_cast<UseTrinketAction*>(action))
+        return true;
+
+    bool isClassCooldown = false;
+    switch (bot->getClass())
+    {
+        case CLASS_DEATH_KNIGHT:
+            isClassCooldown = dynamic_cast<CastSummonGargoyleAction*>(action) ||
+                dynamic_cast<CastDeathchillAction*>(action) ||
+                dynamic_cast<CastEmpowerRuneWeaponAction*>(action) ||
+                dynamic_cast<CastArmyOfTheDeadAction*>(action);
+            break;
+
+        case CLASS_DRUID:
+            isClassCooldown = dynamic_cast<CastStarfallAction*>(action) ||
+                dynamic_cast<CastForceOfNatureAction*>(action) ||
+                dynamic_cast<CastBerserkAction*>(action);
+            break;
+
+        case CLASS_HUNTER:
+            isClassCooldown = dynamic_cast<CastKillCommandAction*>(action) ||
+                dynamic_cast<CastRapidFireAction*>(action) ||
+                dynamic_cast<CastReadinessAction*>(action) ||
+                dynamic_cast<CastBestialWrathAction*>(action);
+            break;
+
+        case CLASS_MAGE:
+            isClassCooldown = dynamic_cast<CastArcanePowerAction*>(action) ||
+                dynamic_cast<CastCombustionAction*>(action) ||
+                dynamic_cast<CastIcyVeinsAction*>(action) ||
+                dynamic_cast<CastMirrorImageAction*>(action) ||
+                dynamic_cast<CastColdSnapAction*>(action) ||
+                dynamic_cast<CastPresenceOfMindAction*>(action);
+            break;
+
+        case CLASS_SHAMAN:
+            isClassCooldown = dynamic_cast<CastElementalMasteryAction*>(action) ||
+                dynamic_cast<CastFeralSpiritAction*>(action) ||
+                dynamic_cast<CastFireElementalTotemAction*>(action) ||
+                dynamic_cast<CastFireElementalTotemMeleeAction*>(action);
+            break;
+
+        case CLASS_PALADIN:
+            isClassCooldown = dynamic_cast<CastAvengingWrathAction*>(action);
+            break;
+
+        case CLASS_ROGUE:
+            isClassCooldown = dynamic_cast<CastKillingSpreeAction*>(action) ||
+                dynamic_cast<CastBladeFlurryAction*>(action) ||
+                dynamic_cast<CastAdrenalineRushAction*>(action) ||
+                dynamic_cast<CastColdBloodAction*>(action);
+            break;
+
+        case CLASS_WARLOCK:
+            isClassCooldown = dynamic_cast<CastMetamorphosisAction*>(action);
+            break;
+
+        case CLASS_WARRIOR:
+            isClassCooldown = dynamic_cast<CastDeathWishAction*>(action) ||
+                dynamic_cast<CastBladestormAction*>(action) ||
+                dynamic_cast<CastRecklessnessAction*>(action);
+            break;
+
+        default:
+            break; // Priest =(
+    }
+
+    if (isClassCooldown)
+        return true;
+
+    switch (bot->getRace())
+    {
+        case RACE_BLOODELF:
+            return dynamic_cast<CastArcaneTorrentAction*>(action);
+
+        case RACE_ORC:
+            return dynamic_cast<CastBloodFuryAction*>(action);
+
+        case RACE_TROLL:
+            return dynamic_cast<CastBerserkingAction*>(action);
+
+        default:
+            return false;
+    }
+}
+
+bool IsTauntAction(Player* bot, Action* action)
+{
+    if (!PlayerbotAI::IsTank(bot))
+        return false;
+
+    switch (bot->getClass())
+    {
+        case CLASS_DEATH_KNIGHT:
+            return dynamic_cast<CastDarkCommandAction*>(action) ||
+                dynamic_cast<CastDeathGripAction*>(action);
+
+        case CLASS_DRUID:
+            return dynamic_cast<CastGrowlAction*>(action) ||
+                dynamic_cast<CastChallengingRoarAction*>(action);
+
+        case CLASS_PALADIN:
+            return dynamic_cast<CastHandOfReckoningAction*>(action) ||
+                dynamic_cast<CastRighteousDefenseAction*>(action);
+
+        case CLASS_WARRIOR:
+            return dynamic_cast<CastTauntAction*>(action) ||
+                dynamic_cast<CastChallengingShoutAction*>(action);
+
+        default:
+            return false;
+    }
+}
+
+// These abilities can be particularly problematic on the pull for a council-type boss
+bool IsAoeThreatAction(Player* bot, Action* action)
+{
+    if (!PlayerbotAI::IsTank(bot))
+        return false;
+
+    switch (bot->getClass())
+    {
+        case CLASS_DEATH_KNIGHT:
+            return dynamic_cast<CastDeathAndDecayAction*>(action) ||
+                dynamic_cast<CastPestilenceAction*>(action) ||
+                dynamic_cast<CastBloodBoilAction*>(action);
+
+        case CLASS_DRUID:
+            return dynamic_cast<CastSwipeBearAction*>(action);
+
+        case CLASS_PALADIN:
+            return dynamic_cast<CastAvengersShieldAction*>(action) ||
+                dynamic_cast<CastConsecrationAction*>(action);
+
+        case CLASS_WARRIOR:
+            return dynamic_cast<CastThunderClapAction*>(action) ||
+                dynamic_cast<CastShockwaveAction*>(action) ||
+                dynamic_cast<CastCleaveAction*>(action);
+
+        default:
+            return false;
+    }
+}
+
 }

--- a/src/Util/EncounterHelpers.h
+++ b/src/Util/EncounterHelpers.h
@@ -4,11 +4,22 @@
  * or (at your option) any later version.
  */
 
-#ifndef PLAYERBOTS_RAIDBOSSHELPERS_H
-#define PLAYERBOTS_RAIDBOSSHELPERS_H
+#ifndef PLAYERBOTS_ENCOUNTERHELPERS_H
+#define PLAYERBOTS_ENCOUNTERHELPERS_H
 
-#include "AiObject.h"
-#include "Unit.h"
+#include "Common.h"
+#include "Position.h"
+#include <string>
+#include <vector>
+
+class Action;
+class Player;
+class PlayerbotAI;
+class Unit;
+
+namespace EncounterHelpers
+
+{
 
 bool MarkTargetWithIcon(Player* bot, Unit* target, uint8 iconId);
 bool MarkTargetWithSkull(Player* bot, Unit* target);
@@ -20,12 +31,17 @@ bool MarkTargetWithTriangle(Player* bot, Unit* target);
 bool MarkTargetWithCross(Player* bot, Unit* target);
 bool MarkTargetWithMoon(Player* bot, Unit* target);
 bool ClearTargetIcon(Player* bot, uint8 iconId);
-void SetRtiTarget(PlayerbotAI* botAI, const std::string& rtiName, Unit* target);
+void SetRtiTarget(PlayerbotAI* botAI, std::string const& rtiName);
 bool IsMechanicTrackerBot(Player* bot, uint32 mapId);
-Player* GetGroupMainTank(PlayerbotAI* botAI, Player* bot);
-Player* GetGroupAssistTank(PlayerbotAI* botAI, Player* bot, uint8 index);
+Player* GetGroupMainTank(Player* bot);
+Player* GetGroupAssistTank(Player* bot, uint8 index);
 Unit* GetFirstAliveUnitByEntry(PlayerbotAI* botAI, uint32 entry);
 Player* GetNearestPlayerInRadius(Player* bot, float radius);
 std::vector<Position> GetDynamicObjectPositions(Player* bot, float searchRadius, uint32 spellId);
+bool IsDpsCooldownAction(Player* bot, Action* action);
+bool IsTauntAction(Player* bot, Action* action);
+bool IsAoeThreatAction(Player* bot, Action* action);
+
+}
 
 #endif


### PR DESCRIPTION
Maintenace PR

Changelog:
- Bots can refresh missing or expiring buffs through the new `rebuff` command.
- Ready checks can optionally make out-of-combat bots finish buffing before confirming readiness.
- Paladin blessings are not refreshed by the new rebuff behavior.
- In Molten Core, bots focus Golemagg instead of his Core Ragers until Golemagg is nearly defeated.
- In the Golemagg fight, healers position themselves to better cover both tanks.
- In the Golemagg fight, melee back away before Magma Splash becomes lethal, while casters avoid moving into melee range.
- In the Majordomo Executus encounter, bots focus the adds rather than attacking Majordomo.
- In Molten Core, bots that fall into lava move toward nearby safe ground.
- On Shazzrah, ranged bots reposition only when they are actually too close to Arcane Explosion.
- Arena teams are automatically restored or created as needed when bots log in.
- Bots no longer use generic crowd-control spells in five-player dungeons, while this behavior remains available elsewhere.
- No player-visible behavior change is intended from the encounter-helper cleanup.
- In Blackwing Lair, bots apply fire resistance buffs for Broodlord Lashlayer, Firemaw, and Flamegor.
- Selfbots can initiate trades and receive items from altbots without offering an item in return.
- Random bots treat selfbots like regular players when trading, including normal trade-value checks and refusal rules.
- Refused trades now close properly, allowing another trade to be started immediately.

AzerothCore fork: https://github.com/mod-playerbots/azerothcore-wotlk/tree/test-staging