### PR TITLE
Fix deleteRandomBotGuilds to match deleteRandomBotArenaTeams behaviour

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1666,8 +1666,7 @@ AiPlayerbot.RandomBotArenaTeam5v5Count = 5
 AiPlayerbot.RandomBotArenaTeamMaxRating = 2000
 AiPlayerbot.RandomBotArenaTeamMinRating = 1000
 
-# Delete all randombot (and any addclass bot) arena teams.
-# New teams are created immediately according to randombot arena team count.
+# Delete all randombot arena teams
 AiPlayerbot.DeleteRandomBotArenaTeams = 0
 
 # PvP Restricted Zones (bots will not initiate PvP or defend themselves if attacked)

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -172,7 +172,8 @@ AiPlayerbot.RandomBotGuildCount = 20
 # Maximum number of members in randombot guilds (minimum is hardcoded to 10)
 AiPlayerbot.RandomBotGuildSizeMax = 15
 
-# Delete all randombot guilds if set to 1
+# Delete all randombot (and any addclass bot) guilds.
+# New guilds are created as bots initialize, according to RandomBotGuildCount.
 AiPlayerbot.DeleteRandomBotGuilds = 0
 
 # Randombots will invite players to groups/raids/guilds

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -172,8 +172,9 @@ AiPlayerbot.RandomBotGuildCount = 20
 # Maximum number of members in randombot guilds (minimum is hardcoded to 10)
 AiPlayerbot.RandomBotGuildSizeMax = 15
 
-# Delete all randombot (and any addclass bot) guilds.
-# New guilds are created as bots initialize, according to RandomBotGuildCount.
+# Delete all randombot (and any addclass bot) guilds on startup. While enabled,
+# no new randombot guilds are created or joined. Set back to 0 and restart the
+# server to resume normal random bot guild assignment.
 AiPlayerbot.DeleteRandomBotGuilds = 0
 
 # Randombots will invite players to groups/raids/guilds

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1665,7 +1665,8 @@ AiPlayerbot.RandomBotArenaTeam5v5Count = 5
 AiPlayerbot.RandomBotArenaTeamMaxRating = 2000
 AiPlayerbot.RandomBotArenaTeamMinRating = 1000
 
-# Delete all randombot arena teams
+# Delete all randombot (and any addclass bot) arena teams.
+# New teams are created immediately according to randombot arena team count.
 AiPlayerbot.DeleteRandomBotArenaTeams = 0
 
 # PvP Restricted Zones (bots will not initiate PvP or defend themselves if attacked)

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1682,9 +1682,9 @@ AiPlayerbot.RandomBotArenaTeam5v5Count = 5
 AiPlayerbot.RandomBotArenaTeamMaxRating = 2000
 AiPlayerbot.RandomBotArenaTeamMinRating = 1000
 
-# Delete all random bot arena teams on startup. While enabled, no new random bot
-# arena teams are created or joined. Set back to 0 and restart the server to
-# resume normal random bot arena team assignment.
+# Delete all randombot (and any addclass bot) arena teams on startup. While enabled,
+# no new randombot arena teams are created or joined. Set back to 0 and restart the
+# server to resume normal randombot arena team assignment.
 AiPlayerbot.DeleteRandomBotArenaTeams = 0
 
 # PvP Restricted Zones (bots will not initiate PvP or defend themselves if attacked)

--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -4769,37 +4769,30 @@ void PlayerbotFactory::InitArenaTeam()
     if (!sPlayerbotAIConfig.IsInRandomAccountList(bot->GetSession()->GetAccountId()))
         return;
 
-    // Currently the teams are only remade after a server restart and if deleteRandomBotArenaTeams = 1, this
-    // is because randomBotArenaTeams is only empty on server restart.
-    // A manual reinitialization (.playerbots rndbot init) is also required after the teams have been deleted.
+    // Currently the teams are only remade after a server restart and if deleteRandomBotArenaTeams = 1
+    // This is because randomBotArenaTeams is only empty on server restart.
+    // A manual reinitalization (.playerbots rndbot init) is also required after the teams have been deleted.
     if (sPlayerbotAIConfig.randomBotArenaTeams.empty())
     {
         if (sPlayerbotAIConfig.deleteRandomBotArenaTeams)
         {
-            LOG_INFO("playerbots", "Deleting randombot arena teams...");
+            LOG_INFO("playerbots", "Deleting random bot arena teams...");
 
-            // Disband() in ArenaTeam.cpp erases the team from ArenaTeamStore, invalidating the loop
-            // iterator, so the ids are collected before any team is disbanded.
-            std::vector<uint32> teamsToDisband;
-            for (auto const& [teamId, arenateam] : sArenaTeamMgr->GetArenaTeams())
+            for (auto it = sArenaTeamMgr->GetArenaTeams().begin(); it != sArenaTeamMgr->GetArenaTeams().end(); ++it)
             {
-                ObjectGuid captain = arenateam->GetCaptain();
-                if (!captain || !captain.IsPlayer())
-                    continue;
-
-                // The captain's account is checked instead of the 'add' event or anything else that depends on the
-                // bot being online.
-                if (sPlayerbotAIConfig.IsInRandomAccountList(sCharacterCache->GetCharacterAccountIdByGuid(captain)))
-                    teamsToDisband.push_back(teamId);
+                ArenaTeam* arenateam = it->second;
+                if (arenateam->GetCaptain() && arenateam->GetCaptain().IsPlayer())
+                {
+                    Player* bot = ObjectAccessor::FindPlayer(arenateam->GetCaptain());
+                    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+                    if (!botAI || IsSelfBot(bot))
+                        continue;
+                    else
+                        arenateam->Disband(nullptr);
+                }
             }
 
-            for (uint32 teamId : teamsToDisband)
-            {
-                if (ArenaTeam* arenateam = sArenaTeamMgr->GetArenaTeamById(teamId))
-                    arenateam->Disband(nullptr);
-            }
-
-            LOG_INFO("playerbots", "Randombot arena teams deleted");
+            LOG_INFO("playerbots", "Random bot arena teams deleted");
         }
 
         RandomPlayerbotFactory::CreateRandomArenaTeams(ARENA_TYPE_2v2, sPlayerbotAIConfig.randomBotArenaTeam2v2Count);
@@ -4816,7 +4809,7 @@ void PlayerbotFactory::InitArenaTeam()
 
          if (arenateams.empty())
          {
-             LOG_ERROR("playerbots", "No randombot arena team available");
+             LOG_ERROR("playerbots", "No random arena team available");
              return;
          }
 

--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -4776,7 +4776,7 @@ void PlayerbotFactory::InitArenaTeam()
     {
         if (sPlayerbotAIConfig.deleteRandomBotArenaTeams)
         {
-            LOG_INFO("playerbots", "Deleting random bot arena teams...");
+            LOG_INFO("playerbots", "Deleting randombot arena teams...");
 
             for (auto it = sArenaTeamMgr->GetArenaTeams().begin(); it != sArenaTeamMgr->GetArenaTeams().end(); ++it)
             {
@@ -4784,15 +4784,14 @@ void PlayerbotFactory::InitArenaTeam()
                 if (arenateam->GetCaptain() && arenateam->GetCaptain().IsPlayer())
                 {
                     Player* bot = ObjectAccessor::FindPlayer(arenateam->GetCaptain());
-                    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
-                    if (!botAI || IsSelfBot(bot))
+                    if (!sRandomPlayerbotMgr.IsRandomBot(bot))
                         continue;
                     else
                         arenateam->Disband(nullptr);
                 }
             }
 
-            LOG_INFO("playerbots", "Random bot arena teams deleted");
+            LOG_INFO("playerbots", "Randombot arena teams deleted");
         }
 
         RandomPlayerbotFactory::CreateRandomArenaTeams(ARENA_TYPE_2v2, sPlayerbotAIConfig.randomBotArenaTeam2v2Count);
@@ -4809,7 +4808,7 @@ void PlayerbotFactory::InitArenaTeam()
 
          if (arenateams.empty())
          {
-             LOG_ERROR("playerbots", "No random arena team available");
+             LOG_ERROR("playerbots", "No randombot arena team available");
              return;
          }
 

--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -4778,9 +4778,11 @@ void PlayerbotFactory::InitArenaTeam()
         {
             LOG_INFO("playerbots", "Deleting randombot arena teams...");
 
-            for (auto it = sArenaTeamMgr->GetArenaTeams().begin(); it != sArenaTeamMgr->GetArenaTeams().end(); ++it)
+            // Disband() in ArenaTeam.cpp erases the team from ArenaTeamStore, invalidating the loop
+            // iterator, so the ids are collected before any team is disbanded.
+            std::vector<uint32> teamsToDisband;
+            for (auto const& [teamId, arenateam] : sArenaTeamMgr->GetArenaTeams())
             {
-                ArenaTeam* arenateam = it->second;
                 ObjectGuid captain = arenateam->GetCaptain();
                 if (!captain || !captain.IsPlayer())
                     continue;
@@ -4788,6 +4790,12 @@ void PlayerbotFactory::InitArenaTeam()
                 // The captain's account is checked instead of the 'add' event or anything else that depends on the
                 // bot being online.
                 if (sPlayerbotAIConfig.IsInRandomAccountList(sCharacterCache->GetCharacterAccountIdByGuid(captain)))
+                    teamsToDisband.push_back(teamId);
+            }
+
+            for (uint32 teamId : teamsToDisband)
+            {
+                if (ArenaTeam* arenateam = sArenaTeamMgr->GetArenaTeamById(teamId))
                     arenateam->Disband(nullptr);
             }
 

--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -4652,6 +4652,9 @@ void PlayerbotFactory::InitGuild()
         return;
     }
 
+    if (sPlayerbotAIConfig.deleteRandomBotGuilds)
+        return;
+
     std::string guildName = PlayerbotGuildMgr::instance().AssignToGuild(bot);
     if (guildName.empty())
         return;

--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -4769,9 +4769,9 @@ void PlayerbotFactory::InitArenaTeam()
     if (!sPlayerbotAIConfig.IsInRandomAccountList(bot->GetSession()->GetAccountId()))
         return;
 
-    // Currently the teams are only remade after a server restart and if deleteRandomBotArenaTeams = 1
-    // This is because randomBotArenaTeams is only empty on server restart.
-    // A manual reinitalization (.playerbots rndbot init) is also required after the teams have been deleted.
+    // Currently the teams are only remade after a server restart and if deleteRandomBotArenaTeams = 1, this
+    // is because randomBotArenaTeams is only empty on server restart.
+    // A manual reinitialization (.playerbots rndbot init) is also required after the teams have been deleted.
     if (sPlayerbotAIConfig.randomBotArenaTeams.empty())
     {
         if (sPlayerbotAIConfig.deleteRandomBotArenaTeams)
@@ -4781,14 +4781,14 @@ void PlayerbotFactory::InitArenaTeam()
             for (auto it = sArenaTeamMgr->GetArenaTeams().begin(); it != sArenaTeamMgr->GetArenaTeams().end(); ++it)
             {
                 ArenaTeam* arenateam = it->second;
-                if (arenateam->GetCaptain() && arenateam->GetCaptain().IsPlayer())
-                {
-                    Player* bot = ObjectAccessor::FindPlayer(arenateam->GetCaptain());
-                    if (!sRandomPlayerbotMgr.IsRandomBot(bot))
-                        continue;
-                    else
-                        arenateam->Disband(nullptr);
-                }
+                ObjectGuid captain = arenateam->GetCaptain();
+                if (!captain || !captain.IsPlayer())
+                    continue;
+
+                // The captain's account is checked instead of the 'add' event or anything else that depends on the
+                // bot being online.
+                if (sPlayerbotAIConfig.IsInRandomAccountList(sCharacterCache->GetCharacterAccountIdByGuid(captain)))
+                    arenateam->Disband(nullptr);
             }
 
             LOG_INFO("playerbots", "Randombot arena teams deleted");

--- a/src/Mgr/Guild/PlayerbotGuildMgr.cpp
+++ b/src/Mgr/Guild/PlayerbotGuildMgr.cpp
@@ -16,7 +16,7 @@ void PlayerbotGuildMgr::Init()
 {
     _guildCache.clear();
     if (sPlayerbotAIConfig.deleteRandomBotGuilds)
-        DeleteBotGuilds();
+        DeleteRandomBotGuilds();
 
     LoadGuildNames();
     ValidateGuildCache();
@@ -245,12 +245,13 @@ void PlayerbotGuildMgr::ValidateGuildCache()
     }
 }
 
-void PlayerbotGuildMgr::DeleteBotGuilds()
+void PlayerbotGuildMgr::DeleteRandomBotGuilds()
 {
-    LOG_INFO("playerbots", "Deleting random bot guilds...");
+    LOG_INFO("playerbots", "Deleting randombot guilds...");
     std::vector<uint32> randomBots;
 
-    PlayerbotsDatabasePreparedStatement* stmt = PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_SEL_RANDOM_BOTS_BOT);
+    PlayerbotsDatabasePreparedStatement* stmt =
+        PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_SEL_RANDOM_BOTS_BOT);
     stmt->SetData(0, "add");
     if (PreparedQueryResult result = PlayerbotsDatabase.Query(stmt))
     {
@@ -267,7 +268,7 @@ void PlayerbotGuildMgr::DeleteBotGuilds()
         if (Guild* guild = sGuildMgr->GetGuildByLeader(ObjectGuid::Create<HighGuid::Player>(*i)))
             guild->Disband();
     }
-    LOG_INFO("playerbots", "Random bot guilds deleted");
+    LOG_INFO("playerbots", "Randombot guilds deleted");
 }
 
 bool PlayerbotGuildMgr::IsRealGuild(Player* bot)

--- a/src/Mgr/Guild/PlayerbotGuildMgr.cpp
+++ b/src/Mgr/Guild/PlayerbotGuildMgr.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "PlayerbotGuildMgr.h"
+#include "CharacterCache.h"
 #include "DatabaseEnv.h"
 #include "Guild.h"
 #include "GuildMgr.h"
@@ -248,24 +249,26 @@ void PlayerbotGuildMgr::ValidateGuildCache()
 void PlayerbotGuildMgr::DeleteRandomBotGuilds()
 {
     LOG_INFO("playerbots", "Deleting randombot guilds...");
-    std::vector<uint32> randomBots;
+    std::vector<uint32> guildsToDisband;
 
-    PlayerbotsDatabasePreparedStatement* stmt =
-        PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_SEL_RANDOM_BOTS_BOT);
-    stmt->SetData(0, "add");
-    if (PreparedQueryResult result = PlayerbotsDatabase.Query(stmt))
+    if (QueryResult result = CharacterDatabase.Query("SELECT guildid, leaderguid FROM guild"))
     {
         do
         {
             Field* fields = result->Fetch();
-            uint32 bot = fields[0].Get<uint32>();
-            randomBots.push_back(bot);
+            uint32 guildId = fields[0].Get<uint32>();
+            ObjectGuid leader = ObjectGuid::Create<HighGuid::Player>(fields[1].Get<uint32>());
+
+            // The leader's account is checked instead of the 'add' event or anything else that depends on the
+            // bot being online.
+            if (sPlayerbotAIConfig.IsInRandomAccountList(sCharacterCache->GetCharacterAccountIdByGuid(leader)))
+                guildsToDisband.push_back(guildId);
         } while (result->NextRow());
     }
 
-    for (std::vector<uint32>::iterator i = randomBots.begin(); i != randomBots.end(); ++i)
+    for (uint32 guildId : guildsToDisband)
     {
-        if (Guild* guild = sGuildMgr->GetGuildByLeader(ObjectGuid::Create<HighGuid::Player>(*i)))
+        if (Guild* guild = sGuildMgr->GetGuildById(guildId))
             guild->Disband();
     }
     LOG_INFO("playerbots", "Randombot guilds deleted");

--- a/src/Mgr/Guild/PlayerbotGuildMgr.h
+++ b/src/Mgr/Guild/PlayerbotGuildMgr.h
@@ -29,7 +29,7 @@ public:
     bool CreateGuild(Player* player, std::string guildName);
     void OnGuildUpdate  (Guild* guild);
     bool SetGuildEmblem(uint32 guildId);
-    void DeleteBotGuilds();
+    void DeleteRandomBotGuilds();
     bool IsRealGuild(uint32 guildId);
     bool IsRealGuild(Player* bot);
 


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
1. deleteRandomBotGuilds deletes by checking the status of guild leader, who must be online. Changed that to check the account of guild leader, same as how deleteRandomBotArenaTeams works. So the delete configs should work now.
2. deleteRandomBotGuilds already didn't touch anything that was led by something that isn't randombot/addclass bot, but for consistency I renamed DeleteBotGuilds to DeleteRandomBotGuilds .
3. While deleteRandomBotGuilds is set, no new guilds are created on server boot, same as deleteRandomBotArenaTeams.


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.
It might cost slightly more to delete guilds, but it didn't work before. So technically the broken state is cheaper 😂


## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
1. Have a guild whose leader is a logged-in altbot. Toggling `DeleteRandomBotGuilds `should not delete it or any real player's guild.
2. `DeleteRandomBotGuilds `should delete all randombot guilds. No new guilds would be created when the config is true.
3. With `DeleteRandomBotGuilds `disabled, new guilds would be created up to `RandomBotGuildCount`. There might be less, depending on your values of `RandomBotGuildSizeMax `and how many randombots are logged in.



## Impact Assessment
<!--
As a generic test, pmon checks before and after your edits are helpful. To standardize the measurement, set the configs
BotActiveAlone = 100 & botActiveAloneSmartScale = 0. After server boot, enable the monitor `playerbot pmon toggle`
right after the bots finished logging-in, and run the stack command `playerbot pmon stack` 5 minutes after that.
The last "Total" line is the main result to look for.
-->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)
All impact is during server boot.


- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->
Code review. Mostly making sure I didn't mix things up from another PR's branch.


## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/Ai/Base/Actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated.
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->
This PR originally addressed issues to deal with `DeleteRandomBotArenaTeams` too, but I then noticed #2637 which does a better and more comprehensive job, so I stripped things here to guild matter only.

This calls on IsInRandomAccountList which I renamed to IsInBotAccountList in #2642. Will update this or the other depending on which is merged first.
