### PR TITLE
Replace some calls to fork-specific functions with core equivalents

### DIFF
--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -668,7 +668,7 @@ void PlayerbotAI::HandleCommand(uint32 type, const std::string& text, Player& fr
     {
         std::string response = HandleRemoteCommand(filtered.substr(6));
         WorldPacket data;
-        ChatHandler::BuildChatPacket(data, CHAT_MSG_ADDON, response.c_str(), LANG_ADDON, CHAT_TAG_NONE, bot->GetGUID(),
+        ChatHandler::BuildChatPacket(data, CHAT_MSG_ADDON, LANG_ADDON, bot->GetGUID(), {}, response, CHAT_TAG_NONE,
                                      bot->GetName());
         ServerFacade::instance().SendPacket(&fromPlayer, &data);
         return;
@@ -2916,7 +2916,7 @@ bool PlayerbotAI::SayToParty(const std::string& msg)
         return false;
 
     WorldPacket data;
-    ChatHandler::BuildChatPacket(data, CHAT_MSG_PARTY, msg.c_str(), LANG_UNIVERSAL, CHAT_TAG_NONE, bot->GetGUID(),
+    ChatHandler::BuildChatPacket(data, CHAT_MSG_PARTY, LANG_UNIVERSAL, bot->GetGUID(), {}, msg, CHAT_TAG_NONE,
                                  bot->GetName());
 
     for (auto receiver : GetRealPlayersInGroup())
@@ -2933,7 +2933,7 @@ bool PlayerbotAI::SayToRaid(const std::string& msg)
         return false;
 
     WorldPacket data;
-    ChatHandler::BuildChatPacket(data, CHAT_MSG_RAID, msg.c_str(), LANG_UNIVERSAL, CHAT_TAG_NONE, bot->GetGUID(),
+    ChatHandler::BuildChatPacket(data, CHAT_MSG_RAID, LANG_UNIVERSAL, bot->GetGUID(), {}, msg, CHAT_TAG_NONE,
                                  bot->GetName());
 
     for (auto receiver : GetRealPlayersInGroup())


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

A minor rabbit hole led me to discover that the mod-playerbots fork of `azerothcore-wotlk` changes a couple of files that aren't needed if we just call the core overload of this function that does exactly the same thing.

<details>
<summary>Click to expand more details I found that mostly explain how it looks like we got here</summary>

I was looking into why I have two `ChatHandler::BuildChatPacket` overloads that look basically identical in my workspace (just with some slight parameter reordering and a weird `LANG_ADDON` guard in only one of them), and then I noticed that one was added by the mod-playerbots fork.

Doing some archaeology, it looks like the one added by the fork more closely matches [the version from mangostwo](https://github.com/mangostwo/server/blob/2a6e444a3e311b61dd279cc522c94b84c60821c4/src/game/WorldHandlers/ChatMessage.cpp#L189-L265). Which makes sense, because at least some callers also match what they looked like in ike3/mangosbot-bots:
- https://github.com/ike3/mangosbot-bots/blob/7500dad2c7c1afcc3630fbe6c2fd2ba6760776f1/playerbot/PlayerbotAI.cpp#L323-L331 looks like it became https://github.com/mod-playerbots/mod-playerbots/blob/5397110cba484a9b7209bc9f632652e9d4bd6a70/src/Bot/PlayerbotAI.cpp#L665-L673 and also https://github.com/mod-playerbots/mod-playerbots/blob/5397110cba484a9b7209bc9f632652e9d4bd6a70/src/Bot/PlayerbotAI.cpp#L1008-L1016

So I think what most likely happened was that the overload was added as just a "make it compile on AzerothCore, move on" thing without looking into it too much.

The part I don't perfectly understand is why mod-playerbots/azerothcore-wotlk@bba6c863 added the `language != LANG_ADDON` check - it wasn't needed for [the ike3/mangosbot version either](https://github.com/ike3/mangosbot/blob/mangos-two-ai/src/game/WorldHandlers/Chat.cpp#L4010-L4086) (not a permalink so you can see the branch and click around on it; the file hasn't changed in years, so it should be stable enough) - but seeing the `LANG_ADDON` guard in only the `mod-playerbots` fork with no justification provided AND no `mod-playerbots` callers that actually USE both `CHAT_TAG_GM` and `LANG_ADDON`, I'm inclined to say that it's safe to ignore that and make the next guy prove why it's needed if they feel the same way.
</details>

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

None. The change is to just call a different overloads in a couple of places.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

I'm sure there's a much better way than this, but it's what I could think up at the time:

1. make a new character
2. `.levelup 79`
3. queue for a random Lich King dungeon, enter when it pops
4. if you didn't get partied with an appropriate class, try again
5. delete all their group spell reagents (I used the MultiBot addon to do this easily)
6. remove the relevant aura from everyone (I threw on a `.unaura` macro)
7. they should eventually say like:

<img width="800" height="50" alt="image" src="https://github.com/user-attachments/assets/4ca30d5b-4ea9-4613-a76e-45b503ef90d4" />

That got the Party one... then I got a bit smarter and did this for the raid one:
1. make a priest
2. `.levelup 79`
3. make a third character and log on that guy
4. `.playerbots bot add ThePriest`
5. `.playerbots bot add TheFirstCharacterYouMadeAbove`
6. convert to raid
7. run maintenance
8. delete the priest's reagents
9. `.unaura` the fort and spirit from the party
10. eventually he does the same:

<img width="800" height="31" alt="image" src="https://github.com/user-attachments/assets/89c2d99d-a1da-4928-a8c4-8e44e7c5faa9" />

can't find anything that calls this specific `HandleCommand` overload (other than a recursive call within itself), so I think it's dead code. even if something does, it's a pretty safe change since it's identical to the other two, so I'm fine with it.

## Impact Assessment
<!--
As a generic test, pmon checks before and after your edits are helpful. To standardize the measurement, set the configs
BotActiveAlone = 100 & botActiveAloneSmartScale = 0. After server boot, enable the monitor `playerbot pmon toggle`
right after the bots finished logging-in, and run the stack command `playerbot pmon stack` 5 minutes after that.
The last "Total" line is the main result to look for.
-->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

> - Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).

I used the Pi coding agent with a local Qwen3.8-27B-Q5_K_M to do the busy work of searching through the Git histories of all the different repos involved to pinpoint the timeline of when which bits started showing up where.

> - Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.

Absolutely none of the actual "code" was "written" by the agent. The useful and intended output was just a list of commit IDs in specific Git repositories, so the "review" started and ended with "do these commits exist? yes".

## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/Ai/Base/Actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated.
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


