### PR TITLE
fix(rpg): let a wandering bot pick up the quest it is standing next to

### DIFF
--- a/src/Ai/World/Rpg/Action/NewRpgAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.cpp
@@ -370,6 +370,12 @@ bool NewRpgWanderRandomAction::Execute(Event /*event*/)
 
 bool NewRpgWanderNpcAction::Execute(Event /*event*/)
 {
+    // WANDER_NPC was the only status that never looked for a quest giver: the bot locked
+    // onto the one NPC it had chosen and walked past every quest it could have taken on the
+    // way, including the one it was standing next to. The four other statuses all start here.
+    if (SearchQuestGiverAndAcceptOrReward())
+        return true;
+
     NewRpgInfo& info = botAI->rpgInfo;
     auto* dataPtr = std::get_if<NewRpgInfo::WanderNpc>(&info.data);
     if (!dataPtr)

--- a/src/Ai/World/Rpg/NewRpgInfo.cpp
+++ b/src/Ai/World/Rpg/NewRpgInfo.cpp
@@ -146,7 +146,10 @@ std::string NewRpgInfo::ToString()
         else if constexpr (std::is_same_v<T, WanderNpc>)
         {
             out << "WANDER_NPC";
-            out << "\nnpcOrGoEntry: " << arg.npcOrGo.GetCounter();
+            // GetCounter() is the runtime low guid, which resolves to nothing outside this
+            // process; the entry is what identifies the target. Print both, labelled.
+            out << "\nnpcOrGo: entry " << arg.npcOrGo.GetEntry() << " (guid " << arg.npcOrGo.GetCounter()
+                << ")";
             out << "\nlastWanderNpc: " << startT;
             out << "\nlastReachNpcOrGo: " << arg.lastReach;
         }


### PR DESCRIPTION
## Pull Request Description
`NewRpgWanderNpcAction` is the only status action that never calls `SearchQuestGiverAndAcceptOrReward()` — the four sibling actions (`GO_GRIND`, `GO_CAMP`, `DO_QUEST`, moving/near-npc paths) all do. A bot locked onto its wander NPC walks right past a quest giver without taking the quest, while `attack anything` has it kill that quest's mobs for no credit. One line, same form as the neighbours.

While reading the status output I also noticed `rpg status` printed `npcOrGoEntry` with `GetCounter()` (a low guid, not resolvable in the DB) instead of `GetEntry()` — fixed in the same commit since it is the tool used to observe this behaviour.

## Feature Evaluation
- Minimum logic: one early-out call already used by the four sibling status actions.
- Processing cost: identical to the other status actions; `SearchQuestGiverAndAcceptOrReward()` is already rate-limited by the status machine.

## How to Test the Changes
1. Put a bot in `WANDER_NPC` near a quest giver (`rpg status` to check).
2. Before: the bot interacts with its target NPC only and never accepts the quest.
3. After: it accepts/rewards quests it stands next to, like grinding/camping bots do.

## Impact Assessment
No new per-tick work; the call sits behind the existing status cadence. Behaviour matches what the other four statuses already do.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Wandering NPC behavior now checks for available quests along the route, allowing quests to be accepted or rewards collected instead of being missed.
  - Wandering NPC status details now display both the NPC or object entry and its runtime identifier for clearer tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->