### PR TITLE
fix(loot): stop before casting the opening spell instead of casting while moving

### DIFF
--- a/src/Ai/Base/Actions/LootAction.cpp
+++ b/src/Ai/Base/Actions/LootAction.cpp
@@ -106,9 +106,16 @@ bool OpenLootAction::DoLoot(LootObject& lootObject)
         return true;
     }
 
+    // Everything below this point casts, and every opening or gathering spell has a cast
+    // time -- PlayerbotAI::CastSpell refuses outright while isMoving(). StopMoving() only
+    // asks the spline to end, so casting in the same tick burns the attempt and the bot
+    // walks off and comes back: measured at seven refused casts in one second, all with
+    // isMoving() still true. Stop, then retry on a later tick, standing still.
     if (bot->isMoving())
     {
         bot->StopMoving();
+        botAI->SetNextCheckDelay(sPlayerbotAIConfig.lootDelay);
+        return false;
     }
 
     if (creature)


### PR DESCRIPTION
## Pull Request Description
In `StoreLootAction`/`OpenLootAction` (`DoLoot`), the opening/gathering cast is issued in the same tick as `StopMoving()`. `StopMoving()` only asks the spline to end, so `isMoving()` is still true when `CastSpell` runs — and `PlayerbotAI::CastSpell` refuses outright while moving, because every opening or gathering spell has a cast time. The attempt is burned, the bot walks off and comes back, and the loop repeats.

Measured on a played character standing on a quest gameobject: seven refused casts in one second, all with `isMoving()` still true.

The fix: when the bot is moving, stop, set the loot delay and return `false`, so the cast is retried on a later tick while standing still.

## Feature Evaluation
- Minimum logic: one early return in the existing branch.
- Processing cost: none added — it replaces a guaranteed-to-fail cast attempt with a short wait.

## How to Test the Changes
1. Send a bot to loot/gather anything with a cast-time opening spell (herb, vein, quest chest).
2. Before: with the bot arriving in motion, the open attempt silently fails and the bot oscillates around the object.
3. After: the bot stops, waits one loot delay, then opens it.

## Impact Assessment
Fewer wasted `CastSpell` calls per loot approach; no behaviour change when the bot is already standing still.
