### PR TITLE
fix(combat): eat before fighting again instead of pulling while hurt

### DIFF
--- a/src/Ai/Base/Actions/ChooseTargetActions.cpp
+++ b/src/Ai/Base/Actions/ChooseTargetActions.cpp
@@ -115,6 +115,13 @@ bool AttackAnythingAction::isUseful()
     if (bot->IsInCombat())
         return false;
 
+    // Do not open a fresh fight while hurt. Nothing here used to look at the bot's health,
+    // so one that had just fled at 30% picked the next mob on the way out and died to it.
+    // Below this it should be eating -- UseFoodStrategy now outranks this action, and the
+    // bot resumes pulling once it has healed up.
+    if (bot->GetHealthPct() < float(sPlayerbotAIConfig.lowHealth))
+        return false;
+
     Unit* target = GetTarget();
     if (!target || !target->IsInWorld())  // Checks if the target is valid and in the world
         return false;

--- a/src/Ai/Base/Strategy/UseFoodStrategy.cpp
+++ b/src/Ai/Base/Strategy/UseFoodStrategy.cpp
@@ -14,7 +14,8 @@ void UseFoodStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
     // Above "attack anything" (4.0), which is what GrindingStrategy already does with its
     // own 4.1/4.2. Outside grind nobody did, so eating lost the arbitration every time and
     // a bot that had just fled a fight at 30% health walked straight into the next one --
-    // AttackAnythingAction::isUseful never looks at the bot's health.
+    // back then AttackAnythingAction::isUseful did not look at the bot's health (it now
+    // gates on lowHealth as well).
     if (botAI->HasCheat(BotCheatMask::food))
     {
         triggers.push_back(new TriggerNode("medium health", { NextAction("food", 4.1f) }));

--- a/src/Ai/Base/Strategy/UseFoodStrategy.cpp
+++ b/src/Ai/Base/Strategy/UseFoodStrategy.cpp
@@ -11,14 +11,18 @@
 void UseFoodStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
     Strategy::InitTriggers(triggers);
+    // Above "attack anything" (4.0), which is what GrindingStrategy already does with its
+    // own 4.1/4.2. Outside grind nobody did, so eating lost the arbitration every time and
+    // a bot that had just fled a fight at 30% health walked straight into the next one --
+    // AttackAnythingAction::isUseful never looks at the bot's health.
     if (botAI->HasCheat(BotCheatMask::food))
     {
-        triggers.push_back(new TriggerNode("medium health", { NextAction("food", 3.0f) }));
-        triggers.push_back(new TriggerNode("high mana", { NextAction("drink", 3.0f) }));
+        triggers.push_back(new TriggerNode("medium health", { NextAction("food", 4.1f) }));
+        triggers.push_back(new TriggerNode("high mana", { NextAction("drink", 4.2f) }));
     }
     else
     {
-        triggers.push_back(new TriggerNode("low health", { NextAction("food", 3.0f) }));
-        triggers.push_back(new TriggerNode("low mana", { NextAction("drink", 3.0f) }));
+        triggers.push_back(new TriggerNode("low health", { NextAction("food", 4.1f) }));
+        triggers.push_back(new TriggerNode("low mana", { NextAction("drink", 4.2f) }));
     }
 }


### PR DESCRIPTION
## Pull Request Description
Outside grinding, eating never wins the arbitration. `UseFoodStrategy` registers food/drink at priority 3.0 while `attack anything` runs at 4.0 — `GrindingStrategy` already works around this with its own 4.1/4.2 nodes, but for everyone else a bot that just left a fight at 30% health walks straight into the next one, because `AttackAnythingAction::isUseful` never looks at the bot's health.

Two changes:
- `UseFoodStrategy` triggers move to 4.1 (food) / 4.2 (drink), mirroring what `GrindingStrategy` already does.
- `AttackAnythingAction::isUseful` refuses to open a *fresh* fight below `AiPlayerbot.LowHealth` — it should be eating instead, and resumes pulling once healed. Fights already engaged are unaffected.

This complements #2607 (merged): #2607 makes the bot finish its meal once eating; this makes it start eating instead of pulling while hurt.

## Feature Evaluation
- Minimum logic: two priority constants + one health check in an `isUseful` that already runs per evaluation.
- Processing cost: one `GetHealthPct()` read per `attack anything` evaluation.

## How to Test the Changes
1. Take a solo bot without grind strategy, get it to low health near hostile mobs.
2. Before: it pulls the next mob at 30% and usually dies.
3. After: it sits, eats to full (per #2607), then resumes attacking.

## Impact Assessment
No new allocations or scans; changes arbitration order only. Bots in a group with a healer behave as before once above the low-health threshold.
