### PR TITLE
Rename assistant role parameter

### DIFF
--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -1956,14 +1956,20 @@ bool PlayerbotAI::IsCombo(Player* player)
            (player->getClass() == CLASS_DRUID && player->HasAura(768));  // cat druid
 }
 
-bool PlayerbotAI::IsRangedDps(Player* player, bool bySpec) { return IsRanged(player, bySpec) && IsDps(player, bySpec); }
+bool PlayerbotAI::IsRangedDps(Player* player, bool bySpec)
+{
+    return IsRanged(player, bySpec) && IsDps(player, bySpec);
+}
 
-bool PlayerbotAI::IsAssistHealOfIndex(Player* player, uint8 index, bool ignoreDeadPlayers)
+// If true, indexLivingOnly excludes dead group members from the index, meaning living members shift
+// up to fill the gap. Example: if assist heal 0 dies, then assist heal 1 becomes assist heal 0.
+// By default, it is false, meaning roles remain stable across deaths.
+bool PlayerbotAI::IsAssistHealOfIndex(Player* player, uint8 index, bool indexLivingOnly)
 {
     if (!IsHeal(player))
         return false;
 
-    if (ignoreDeadPlayers && !player->IsAlive())
+    if (indexLivingOnly && !player->IsAlive())
         return false;
 
     Group* group = player->GetGroup();
@@ -1978,7 +1984,7 @@ bool PlayerbotAI::IsAssistHealOfIndex(Player* player, uint8 index, bool ignoreDe
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
         Player* member = ref->GetSource();
-        if (!member || (ignoreDeadPlayers && !member->IsAlive()) || !IsHeal(member))
+        if (!member || (indexLivingOnly && !member->IsAlive()) || !IsHeal(member))
             continue;
 
         bool isAssistant = group->IsAssistant(member->GetGUID());
@@ -2008,12 +2014,15 @@ bool PlayerbotAI::IsAssistHealOfIndex(Player* player, uint8 index, bool ignoreDe
     return playerIndex == index;
 }
 
-bool PlayerbotAI::IsAssistRangedDpsOfIndex(Player* player, uint8 index, bool ignoreDeadPlayers)
+// If true, indexLivingOnly excludes dead group members from the index, meaning living members shift
+// up to fill the gap. Example: if assist ranged dps 0 dies, then assist ranged dps 1 becomes assist
+// ranged dps 0. By default, it is false, meaning roles remain stable across deaths.
+bool PlayerbotAI::IsAssistRangedDpsOfIndex(Player* player, uint8 index, bool indexLivingOnly)
 {
     if (!IsRangedDps(player))
         return false;
 
-    if (ignoreDeadPlayers && !player->IsAlive())
+    if (indexLivingOnly && !player->IsAlive())
         return false;
 
     Group* group = player->GetGroup();
@@ -2028,7 +2037,7 @@ bool PlayerbotAI::IsAssistRangedDpsOfIndex(Player* player, uint8 index, bool ign
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
         Player* member = ref->GetSource();
-        if (!member || (ignoreDeadPlayers && !member->IsAlive()) || !IsRangedDps(member))
+        if (!member || (indexLivingOnly && !member->IsAlive()) || !IsRangedDps(member))
             continue;
 
         bool isAssistant = group->IsAssistant(member->GetGUID());
@@ -2520,7 +2529,10 @@ bool PlayerbotAI::IsAssistTank(Player* player)
     return player->GetGUID() != GetMainTankGuid(group);
 }
 
-bool PlayerbotAI::IsAssistTankOfIndex(Player* player, uint8 index, bool ignoreDeadPlayers)
+// If true, indexLivingOnly excludes dead group members from the index, meaning living members shift
+// up to fill the gap. Example: if assist tank 0 dies, then assist tank 1 becomes assist tank 0.
+// By default, it is false, meaning roles remain stable across deaths.
+bool PlayerbotAI::IsAssistTankOfIndex(Player* player, uint8 index, bool indexLivingOnly)
 {
     if (!IsTank(player))
         return false;
@@ -2534,7 +2546,7 @@ bool PlayerbotAI::IsAssistTankOfIndex(Player* player, uint8 index, bool ignoreDe
     if (player->GetGUID() == mainTankGuid)
         return false;
 
-    if (ignoreDeadPlayers && !player->IsAlive())
+    if (indexLivingOnly && !player->IsAlive())
         return false;
 
     uint8 totalAssistants = 0;
@@ -2545,7 +2557,7 @@ bool PlayerbotAI::IsAssistTankOfIndex(Player* player, uint8 index, bool ignoreDe
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
         Player* member = ref->GetSource();
-        if (!member || (ignoreDeadPlayers && !member->IsAlive()) || !IsTank(member) ||
+        if (!member || (indexLivingOnly && !member->IsAlive()) || !IsTank(member) ||
             member->GetGUID() == mainTankGuid)
         {
             continue;

--- a/src/Bot/PlayerbotAI.h
+++ b/src/Bot/PlayerbotAI.h
@@ -435,9 +435,9 @@ public:
     static bool IsBotMainTank(Player* player);
     static uint32 GetGroupTankNum(Player* player);
     static bool IsAssistTank(Player* player);
-    static bool IsAssistTankOfIndex(Player* player, uint8 index, bool ignoreDeadPlayers = false);
-    static bool IsAssistHealOfIndex(Player* player, uint8 index, bool ignoreDeadPlayers = false);
-    static bool IsAssistRangedDpsOfIndex(Player* player, uint8 index, bool ignoreDeadPlayers = false);
+    static bool IsAssistTankOfIndex(Player* player, uint8 index, bool indexLivingOnly = false);
+    static bool IsAssistHealOfIndex(Player* player, uint8 index, bool indexLivingOnly = false);
+    static bool IsAssistRangedDpsOfIndex(Player* player, uint8 index, bool indexLivingOnly = false);
     bool HasAggro(Unit* unit);
     bool IsMovementImpaired(Unit* unit);
     static int32 GetAssistTankIndex(Player* player);


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

I've always found the third parameter of IsAssistTankOfIndex(), IsAssistHealOfIndex(), and IsAssistRangedDpsOfIndex() to be super confusing. It is ```bool ignoreDeadPlayers```, which can be read in two opposing ways: (1) ignore the fact that a player is dead so index them normally, or (2) ignore dead players entirely so don't index them. The actual meaning is the second, but to this day I still get confused about it.

I've proposed renaming the parameter as "indexLivingOnly," which I think can't really be misinterpreted. If we wanted to stick with something closer to what it is now, I guess "excludeDeadPlayers" is okay, but referring to the indexing is clearer to me since the central purpose of the parameter is to determine whether the slots are stable across deaths or if instead a living group member will step into the role of a dead group member.

I also added comments to try to clarify, and I made a minor adjacent change to break IsRangedDps across multiple lines.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.



## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->



## Impact Assessment
<!--
As a generic test, pmon checks before and after your edits are helpful. To standardize the measurement, set the configs
BotActiveAlone = 100 & botActiveAloneSmartScale = 0. After server boot, enable the monitor `playerbot pmon toggle`
right after the bots finished logging-in, and run the stack command `playerbot pmon stack` 5 minutes after that.
The last "Total" line is the main result to look for.
-->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)

The point is to greatly simplify maintenance complexity, or so I hope.

## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [x] No
- - [ ] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->



## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/Ai/Base/Actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated.
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


