### PR TITLE
fix(bots): skip creature templates with no world spawn when picking pets

### DIFF
--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -36,6 +36,7 @@
 #include "StatsWeightCalculator.h"
 #include "World.h"
 #include <array>
+#include <unordered_set>
 #include <utility>
 
 #include <array>
@@ -110,6 +111,29 @@ constexpr uint32 SPELL_IMPROVED_HOWL_OF_TERROR = 30057;
 constexpr uint32 SPELL_NEMESIS = 63123;
 constexpr uint32 SPELL_INTENSITY = 18136;
 constexpr uint32 SPELL_NETHER_PROTECTION = 30302;
+
+// Some creature_template rows are Blizzard developer leftovers or placeholders that carry the tameable
+// flag but have no spawn in the world - e.g. 5596 "Twain Test Prop", a wolf family beast wearing a
+// dragon whelp model. No player can ever tame those, so bots should not end up with them either.
+bool HasCreatureSpawnRow(uint32 entry)
+{
+    static std::unordered_set<uint32> const spawnedEntries = []  // built once, at first use
+    {
+        std::unordered_set<uint32> entries;
+        for (auto const& itr : sObjectMgr->GetAllCreatureData())
+        {
+            CreatureData const& data = itr.second;
+            entries.insert(data.id);
+            if (data.id2)
+                entries.insert(data.id2);
+            if (data.id3)
+                entries.insert(data.id3);
+        }
+        return entries;
+    }();
+
+    return spawnedEntries.find(entry) != spawnedEntries.end();
+}
 }
 
 bool PlayerbotFactory::IsPrimaryTradeSkill(uint16 skillId)
@@ -1304,6 +1328,9 @@ void PlayerbotFactory::InitPet()
         for (CreatureTemplateContainer::const_iterator itr = creatures->begin(); itr != creatures->end(); ++itr)
         {
             if (!itr->second.IsTameable(bot->CanTameExoticPets()))
+                continue;
+
+            if (!HasCreatureSpawnRow(itr->first))
                 continue;
 
             if (itr->second.minlevel > bot->GetLevel())


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

Hunter bots can end up with pets that no real player could ever tame.

`PlayerbotFactory::InitPet()` picks the pet from `creature_template` and only checks whether the creature is tameable, whether the bot is high enough level, and the configured family rules. It never checks whether the creature actually exists anywhere in the world. Placeholder and leftover rows in `creature_template` pass all of those checks.

I noticed this on my own realm: a bot hunter with a wolf pet that was rendered as a black dragon whelpling. The pet was creature 5596 "Twain Test Prop", which is flagged as a tameable wolf but uses a dragon whelp model. It is stock AC data, not a broken database, and it has no row in the `creature` table, so it is never spawned and cannot be tamed by anyone.

It is not a single bad row. Other examples in the same candidate list are `TEST WOLF (ALPHA FIRST)`, `Twilight Ridge Worg [PH]` and `[UNUSED] Gorilla Test`.

The fix adds one more check to the existing filter: the creature must actually have a spawn in the world. The list of spawned creature entries is read once from `sObjectMgr->GetAllCreatureData()` and kept, so each candidate is just a quick lookup.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

Minimum logic: one extra check in the loop that already goes through `creature_template`. It is a single helper function in the same file, plus one cached list. No new config option, no state stored per bot, and `InitPet()` is the only place that calls it.

Processing cost:

- Once per server run: the list of spawned entries is built the first time a hunter bot needs a pet. That is one pass over the creature spawn data.
- Per bot: one lookup per candidate, inside a loop that was already running. The new check also rejects candidates before the level and family checks, so in the normal case it does slightly less work than before.
- Per tick: nothing. `InitPet()` only runs when a pet is initialized, not from any update or trigger, so this does not grow with the number of bots or with tick rate.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

Setup: a realm with playerbots enabled and enough hunter bots online to get a reasonable sample. I used around 150 bots per run.

Important: filter on `PetType = 1`. `PetType = 0` rows are class summons like Imp, Voidwalker and Water Elemental, which correctly have no spawn entry. If you leave them in, the numbers are meaningless.

1. Before the change, list hunter pets whose creature has no spawn in the world:

   ```sql
   SELECT cp.entry, ct.name, COUNT(*) AS pets
   FROM characters.character_pet cp
   JOIN world.creature_template ct ON ct.entry = cp.entry
   WHERE cp.PetType = 1
     AND NOT (EXISTS (SELECT 1 FROM world.creature c WHERE c.id = ct.entry)
           OR EXISTS (SELECT 1 FROM world.creature_multispawn m WHERE m.entry = ct.entry))
   GROUP BY cp.entry, ct.name
   ORDER BY pets DESC;
   ```

   On my realm this returned 141 pets across 78 different creatures.

2. Note down which bot has which pet, then force the bots to pick new ones. A full randomize does this, because it removes the current pet before initializing a new one:

   ```
   playerbots rndbot init
   ```

   Only bots that are currently online are affected.

3. Shut the realm down cleanly, so the new pets are written to the database, then compare against the result from step 2. Look only at the pets that actually changed, and check those creatures with the query from step 1.

   Expected after the change: none of the new pets is on a creature without a spawn.

4. As a check against over-filtering, make sure the new pets still cover a good spread of creatures and pet families. Only the unspawned ones should disappear.

## Impact Assessment
<!--
As a generic test, pmon checks before and after your edits are helpful. To standardize the measurement, set the configs
BotActiveAlone = 100 & botActiveAloneSmartScale = 0. After server boot, enable the monitor `playerbot pmon toggle`
right after the bots finished logging-in, and run the stack command `playerbot pmon stack` 5 minutes after that.
The last "Total" line is the main result to look for.
-->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

`InitPet()` is not called per tick, only when a pet is initialized. A pmon comparison would not show a difference, so I did not run one. The only added work is the one-time list build and a lookup during pet selection.

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

Hunter bots no longer get pets from creatures that have no spawn in the world. This is on by default. On a 3.3.5 database:

| | Count |
|---|---|
| Tameable beast templates | 1096 |
| Of those, actually spawned in the world | 875 |
| No longer offered to bots | 221 (20%) |

Two of the 875 only appear through `creature_multispawn`, which is why that table is checked as well and not just `creature`.

Every pet family still has candidates left, so `hunterWolfPet` and `excludedHunterPetFamilies` work as before.

Pets that bots already have, are not changed. `InitPet()` returns early if the bot already has a pet, so existing bots keep what they have until they lose it. Cleaning those up is not part of this PR.

- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [x] Yes (**explain below**)

One extra check in `InitPet()` and one helper function in the same file. No new config, no new subsystem, nothing stored between sessions apart from the cached list.

## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

Yes. I used Claude to write the first version of the helper and the check, and for the write-up and the test scripts.

I found the bug on my own realm, went through the change line by line, and it was tested there as described above. It is a small, self-contained change, and I am comfortable owning it.

## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) - add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated.
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

<!-- No bot dialogue and no new source files were added, so those two items do not apply. -->

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->

Test results from my own 3.3.5 realm, around 150 bots online, two runs of `playerbots rndbot init`:

| Pets assigned by | Hunter pets | On creatures with no spawn |
|---|---|---|
| Build without this fix | 803 | 137 (17%) |
| Build with this fix | 25 | 0 |

The first row is the pet population that had built up on the realm before the fix, so it is a comparison against real previous behavior rather than a controlled run. It matches the 20% you would expect from the numbers in the table further up.

In the two test runs, 25 hunter pets were re-picked across 24 different creatures and none of them was an unspawned one. Four bots that had a bad pet ended up with a valid one, and no bot went the other way. The new pets still covered 11 different pet families, so variety looks unaffected.

Two things worth knowing about the cached list:

- It is built once and not refreshed, so a creature spawned into the world at runtime (`.npc add`, spawn SQL on a running server) only becomes a possible pet after the next restart.
- It assumes spawn data is loaded before the first pet is initialized, which is the case because bots log in after world load. If you would rather have that guaranteed, I am happy to add a guard so that an empty list simply disables the filter instead of leaving hunter bots without pets.

Creatures that only spawn during game events are not affected, since all `creature` rows are loaded regardless of the event they belong to.

The build is clean, and the added code produces no new compiler warnings.