### PR TITLE
Guard MoveFarTo against issuing a ground move mid-flight

### DIFF
--- a/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp
@@ -42,6 +42,13 @@ bool NewRpgBaseAction::MoveFarTo(WorldPosition dest)
     if (dest == WorldPosition())
         return false;
 
+    // Don't start a ground move while the bot is on a taxi: the MovePoint issued
+    // below would fight the active flight spline. Returning true consumes the tick
+    // instead of returning false, because the callers of MoveFarTo fall through to
+    // MoveRandomNear, which is also a ground move.
+    if (bot->IsInFlight())
+        return true;
+
     if (dest != botAI->rpgInfo.moveFarPos)
     {
         // clear stuck information if it's a new dest


### PR DESCRIPTION
`NewRpgBaseAction::MoveFarTo` issues a `MovePoint` without checking whether the bot is on a
taxi, starting a ground spline that fights the active flight spline.

Nothing stops it. The flight checks in `MovementAction::MoveTo` are commented out ([MovementActions.cpp#L320](https://github.com/mod-playerbots/mod-playerbots/blob/9f386de/src/Ai/Base/Actions/MovementActions.cpp#L320)),
and the `IsInFlight()` guards that do exist are in `NewRpgTravelFlightAction::Execute`
([NewRpgAction.cpp#L639](https://github.com/mod-playerbots/mod-playerbots/blob/9f386de/src/Ai/World/Rpg/Action/NewRpgAction.cpp#L639)) and the
questgiver interaction path
([NewRpgBaseAction.cpp#L361](https://github.com/mod-playerbots/mod-playerbots/blob/9f386de/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp#L361)),
not at `MoveFarTo`. That's where `GoGrind`, `GoCamp`, `DoQuest`, turn-in travel and
`NewRpgOutdoorPvP` funnel movement, so any of those states persisting across a flight hop
reaches it mid-taxi.

I return `true`, not `false`, on purpose. Callers read `false` as "couldn't move" and fall
through to `MoveRandomNear(10.0f)`, also a ground move, which burns up to 8
`PathGenerator::CalculatePath` calls per tick sampling ground from flight altitude. `true`
consumes the tick and leaves the bot alone until the taxi drops it.

Cost is one bool read per call, ahead of any pathfinding. No config, no new state, no
behavior change outside flight.

On field testing: the guard runs on our 400-bot realm with `AutoTeleportForLevel = 0`, so bots
take flight masters for long travel. It runs returning `false` there. The `true` return is the
correction above and has had no realm soak, so treat that half as reasoned, not measured.