### PR TITLE
Enhance RemoveAura method to support multiple auras removal

### DIFF
--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -4280,9 +4280,47 @@ void PlayerbotAI::InterruptSpell()
 
 void PlayerbotAI::RemoveAura(std::string const name)
 {
-    uint32 spellid = aiObjectContext->GetValue<uint32>("spell id", name)->Get();
-    if (spellid && bot->HasAura(spellid))
-        bot->RemoveAurasDueToSpell(spellid);
+    if (name.empty())
+        return;
+
+    std::stringstream auraList(name);
+    std::string auraName;
+    while (std::getline(auraList, auraName, ','))
+    {
+        trim(auraName);
+        if (auraName.empty())
+            continue;
+
+        PlayerbotChatHandler handler(bot);
+        uint32 spellid = handler.extractSpellId(auraName);
+
+        if (!spellid)
+        {
+            std::wstring requestedName;
+            if (!Utf8toWStr(auraName, requestedName))
+                continue;
+
+            wstrToLower(requestedName);
+
+            for (Unit::AuraApplicationMap::const_iterator itr = bot->GetAppliedAuras().begin();
+                 itr != bot->GetAppliedAuras().end(); ++itr)
+            {
+                AuraApplication const* application = itr->second;
+                if (!application || !application->GetBase() || !application->GetBase()->GetSpellInfo())
+                    continue;
+
+                SpellInfo const* spellInfo = application->GetBase()->GetSpellInfo();
+                if (Utf8FitTo(spellInfo->SpellName[LOCALE_enUS], requestedName))
+                {
+                    spellid = spellInfo->Id;
+                    break;
+                }
+            }
+        }
+
+        if (spellid)
+            bot->RemoveAurasDueToSpell(spellid);
+    }
 }
 
 void PlayerbotAI::RequestSpellInterrupt()


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
allows the "ra" command to remove a list of aura as well as auras that are not provided by the bot.


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.



## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->
When in a group with a bot, or as a selfbot you can use ra with a comma separated list to remove auras.
You can give spell ids, spell links, or aura names.
example to remove a list of worldbuffs: 
"ra 22888,15366,Spirit of Zandalar"


## Impact Assessment
<!--
As a generic test, pmon checks before and after your edits are helpful. To standardize the measurement, set the configs
BotActiveAlone = 100 & botActiveAloneSmartScale = 0. After server boot, enable the monitor `playerbot pmon toggle`
right after the bots finished logging-in, and run the stack command `playerbot pmon stack` 5 minutes after that.
The last "Total" line is the main result to look for.
-->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->
Copilot for code exploration and suggestions. All code reviewed and modified where necessary before commit.


## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/Ai/Base/Actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated.
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


