### PR TITLE
Stop food cheat rest at full health or mana

### DIFF
--- a/src/Ai/Base/Actions/NonCombatActions.cpp
+++ b/src/Ai/Base/Actions/NonCombatActions.cpp
@@ -7,6 +7,8 @@
 #include "NonCombatActions.h"
 #include "Event.h"
 #include "Playerbots.h"
+#include <algorithm>
+#include <cmath>
 
 namespace
 {
@@ -52,19 +54,14 @@ bool DrinkAction::Execute(Event event)
         bot->SetStandState(UNIT_STAND_STATE_SIT);
         botAI->InterruptSpell();
 
-        // float hp = bot->GetHealthPercent();
-        float mp = bot->GetPowerPct(POWER_MANA);
-        float p = mp;
-        float delay;
-
-        if (!bot->InBattleground())
-            delay = 18000.0f * (100 - p) / 100.0f;
-        else
-            delay = 12000.0f * (100 - p) / 100.0f;
+        // 25990 restores 5% per 2s tick. This delay is a fallback because UpdateAI releases the bot at full mana.
+        float const delay =
+            std::max(1.0f, std::ceil((100.0f - bot->GetPowerPct(POWER_MANA)) / 5.0f)) * 2 * IN_MILLISECONDS;
 
         botAI->SetNextCheckDelay(delay);
 
         bot->AddAura(25990, bot);
+        botAI->BeginRestRecovery(RestRecoveryObjective::Mana);
         return true;
         // return botAI->CastSpell(24707, bot);
     }
@@ -112,19 +109,14 @@ bool EatAction::Execute(Event event)
         bot->SetStandState(UNIT_STAND_STATE_SIT);
         botAI->InterruptSpell();
 
-        float hp = bot->GetHealthPct();
-        // float mp = bot->HasMana() ? bot->GetPowerPercent() : 0.f;
-        float p = hp;
-        float delay;
-
-        if (!bot->InBattleground())
-            delay = 18000.0f * (100 - p) / 100.0f;
-        else
-            delay = 12000.0f * (100 - p) / 100.0f;
+        // 25990 restores 5% per 2s tick. This delay is a fallback because UpdateAI releases the bot at full health.
+        float const delay =
+            std::max(1.0f, std::ceil((100.0f - bot->GetHealthPct()) / 5.0f)) * 2 * IN_MILLISECONDS;
 
         botAI->SetNextCheckDelay(delay);
 
         bot->AddAura(25990, bot);
+        botAI->BeginRestRecovery(RestRecoveryObjective::Health);
         return true;
     }
 

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -63,6 +63,7 @@ constexpr uint32 SPELL_TITAN_GRIP = 49152;
 constexpr uint32 SPELL_DK_FROST_PRESENCE = 48263;
 constexpr uint32 SPELL_GRAVITY_LAPSE_TK = 39432;
 constexpr uint32 SPELL_GRAVITY_LAPSE_MGT = 44226;
+constexpr uint32 SPELL_FOOD_CHEAT_RECOVERY = 25990;
 }
 
 std::vector<std::string> PlayerbotAI::dispel_whitelist = {
@@ -242,6 +243,28 @@ PlayerbotAI::~PlayerbotAI()
         PlayerbotsMgr::instance().RemovePlayerBotData(bot->GetGUID(), true);
 }
 
+void PlayerbotAI::UpdateRestRecovery()
+{
+    if (restRecoveryObjective == RestRecoveryObjective::None)
+        return;
+
+    bool const recoveryComplete =
+        (restRecoveryObjective == RestRecoveryObjective::Health && bot->IsFullHealth()) ||
+        (restRecoveryObjective == RestRecoveryObjective::Mana &&
+         bot->GetPower(POWER_MANA) >= bot->GetMaxPower(POWER_MANA));
+    if (recoveryComplete)
+    {
+        restRecoveryObjective = RestRecoveryObjective::None;
+        nextAICheckDelay = 0;
+        bot->RemoveAurasDueToSpell(SPELL_FOOD_CHEAT_RECOVERY);
+        bot->SetStandState(UNIT_STAND_STATE_STAND);
+        return;
+    }
+
+    if (!nextAICheckDelay)
+        restRecoveryObjective = RestRecoveryObjective::None;
+}
+
 void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
 {
     // Handle the AI check delay
@@ -268,6 +291,8 @@ void PlayerbotAI::UpdateAI(uint32 elapsed, bool minimal)
         if (HasCheat(BotCheatMask::power) && bot->getPowerType() != POWER_MANA)
             bot->SetPower(bot->getPowerType(), bot->GetMaxPower(bot->getPowerType()));
     }
+
+    UpdateRestRecovery();
 
     AllowActivity();
 
@@ -870,6 +895,7 @@ void PlayerbotAI::Reset(bool full)
     currentEngine = engines[BOT_STATE_NON_COMBAT];
     currentState = BOT_STATE_NON_COMBAT;
     nextAICheckDelay = 0;
+    restRecoveryObjective = RestRecoveryObjective::None;
     whispers.clear();
 
     aiObjectContext->GetValue<Unit*>("old target")->Set(nullptr);

--- a/src/Bot/PlayerbotAI.h
+++ b/src/Bot/PlayerbotAI.h
@@ -77,6 +77,13 @@ enum BotState
     BOT_STATE_MAX
 };
 
+enum class RestRecoveryObjective
+{
+    None,
+    Health,
+    Mana
+};
+
 bool IsRealPlayer(Player* player);
 bool IsSelfBot(Player* player);
 bool IsAlliance(uint8 race);
@@ -391,6 +398,7 @@ public:
 
     void UpdateAI(uint32 elapsed, bool minimal = false) override;
     void UpdateAIInternal(uint32 elapsed, bool minimal = false) override;
+    void BeginRestRecovery(RestRecoveryObjective objective) { restRecoveryObjective = objective; }
 
     std::string const HandleRemoteCommand(std::string const command);
     void HandleCommand(uint32 type, std::string const text, Player* fromPlayer);
@@ -615,6 +623,8 @@ private:
     static void _fillGearScoreData(Player* player, Item* item, std::vector<uint32>* gearScore, uint32& twoHandScore,
                                    bool mixed = false);
     bool IsTellAllowed(PlayerbotSecurityLevel securityLevel = PLAYERBOT_SECURITY_ALLOW_ALL);
+    void UpdateRestRecovery();
+    RestRecoveryObjective restRecoveryObjective = RestRecoveryObjective::None;
     void UpdateAIGroupMaster();
     Item* FindItemInInventory(std::function<bool(ItemTemplate const*)> checkItem) const;
     void HandleCommands();


### PR DESCRIPTION
## Pull Request Description

The food cheat applies aura 25990, which restores 5% health and mana every two seconds. The current delay can end before recovery completes. A longer fixed estimate can also keep the bot seated after another effect fills the selected resource.

Eating now tracks health. Drinking tracks mana. `UpdateAI` ends the matching rest as soon as that resource reaches 100%, before the normal AI delay gate. The fallback delay covers the aura's remaining whole ticks and clears its tracking state when it expires.

This change does not alter normal item-based food or drink. Combat response remains outside this PR.

PR #2607 corrected the short delay and was later reverted by PR #2701. This version keeps the whole-tick fallback from that change and adds an explicit completion check, so the timer is no longer the only condition that ends rest.

## How to Test the Changes

- Let a damaged bot with the food cheat eat while its mana is low. It should stand when health reaches 100%.
- Let a low-mana bot drink while its health is low. It should stand when mana reaches 100%.
- Confirm that partial recovery keeps the bot seated.
- Confirm that ordinary AI delays remain unchanged.

Validated on a private WotLK realm with separate health and mana cases. The repository C++ style check and focused recovery policy checks pass locally.

## Impact Assessment

- Processing cost is one objective check per active food-cheat rest on each AI update. Bots without an active rest return from the check immediately.
- Default food-cheat behavior changes. A bot completes one recovery cycle and stands at full health or mana.
- No configuration, database, or dialogue changes are required.

## AI Assistance

AI assistance was used to trace the rest delay, prepare tests, port the live-tested change, and draft this description. I reviewed and tested the change.

## Code Provenance / Attribution

All code in this PR is original.
