### PR TITLE
Gruul Bug Fixes & Improvements

### DIFF
--- a/src/Ai/Raid/Gruul/GruulActionContext.h
+++ b/src/Ai/Raid/Gruul/GruulActionContext.h
@@ -15,15 +15,13 @@ class RaidGruulsLairActionContext : public NamedObjectContext<Action>
 public:
     RaidGruulsLairActionContext()
     {
+        // General
+        creators["gruul's lair reset encounter states"] =
+            &RaidGruulsLairActionContext::gruuls_lair_reset_encounter_states;
+
         // High King Maulgar
-        creators["high king maulgar main tank attack maulgar"] =
-            &RaidGruulsLairActionContext::high_king_maulgar_main_tank_attack_maulgar;
-
-        creators["high king maulgar first assist tank attack olm"] =
-            &RaidGruulsLairActionContext::high_king_maulgar_first_assist_tank_attack_olm;
-
-        creators["high king maulgar second assist tank attack blindeye"] =
-            &RaidGruulsLairActionContext::high_king_maulgar_second_assist_tank_attack_blindeye;
+        creators["high king maulgar melee tanks position bosses"] =
+            &RaidGruulsLairActionContext::high_king_maulgar_melee_tanks_position_bosses;
 
         creators["high king maulgar mage tank attack krosh"] =
             &RaidGruulsLairActionContext::high_king_maulgar_mage_tank_attack_krosh;
@@ -37,14 +35,17 @@ public:
         creators["high king maulgar run away from whirlwind"] =
             &RaidGruulsLairActionContext::high_king_maulgar_run_away_from_whirlwind;
 
-        creators["high king maulgar move away from blast nova danger"] =
-            &RaidGruulsLairActionContext::high_king_maulgar_move_away_from_blast_nova_danger;
+        creators["high king maulgar flee from blast wave danger"] =
+            &RaidGruulsLairActionContext::high_king_maulgar_flee_from_blast_wave_danger;
 
         creators["high king maulgar banish fel stalker"] =
             &RaidGruulsLairActionContext::high_king_maulgar_banish_fel_stalker;
 
         creators["high king maulgar misdirect ogres to tanks"] =
             &RaidGruulsLairActionContext::high_king_maulgar_misdirect_ogres_to_tanks;
+
+        creators["high king maulgar cast fear ward on main tank"] =
+            &RaidGruulsLairActionContext::high_king_maulgar_cast_fear_ward_on_main_tank;
 
         // Gruul the Dragonkiller
         creators["gruul the dragonkiller tanks position boss"] =
@@ -58,15 +59,14 @@ public:
     }
 
 private:
+    // General
+    static Action* gruuls_lair_reset_encounter_states(PlayerbotAI* botAI) {
+        return new GruulsLairResetEncounterStatesAction(botAI);
+    }
+
     // High King Maulgar
-    static Action* high_king_maulgar_main_tank_attack_maulgar(PlayerbotAI* botAI) {
-        return new HighKingMaulgarMainTankAttackMaulgarAction(botAI);
-    }
-    static Action* high_king_maulgar_first_assist_tank_attack_olm(PlayerbotAI* botAI) {
-        return new HighKingMaulgarFirstAssistTankAttackOlmAction(botAI);
-    }
-    static Action* high_king_maulgar_second_assist_tank_attack_blindeye(PlayerbotAI* botAI) {
-        return new HighKingMaulgarSecondAssistTankAttackBlindeyeAction(botAI);
+    static Action* high_king_maulgar_melee_tanks_position_bosses(PlayerbotAI* botAI) {
+        return new HighKingMaulgarMeleeTanksPositionBossesAction(botAI);
     }
     static Action* high_king_maulgar_mage_tank_attack_krosh(PlayerbotAI* botAI) {
         return new HighKingMaulgarMageTankAttackKroshAction(botAI);
@@ -75,19 +75,22 @@ private:
         return new HighKingMaulgarMoonkinTankAttackKigglerAction(botAI);
     }
     static Action* high_king_maulgar_assign_dps_priority(PlayerbotAI* botAI) {
-        return new HighKingMaulgarAssignDPSPriorityAction(botAI);
+        return new HighKingMaulgarAssignDpsPriorityAction(botAI);
     }
     static Action* high_king_maulgar_run_away_from_whirlwind(PlayerbotAI* botAI) {
         return new HighKingMaulgarRunAwayFromWhirlwindAction(botAI);
     }
-    static Action* high_king_maulgar_move_away_from_blast_nova_danger(PlayerbotAI* botAI) {
-        return new HighKingMaulgarMoveAwayFromBlastNovaDangerAction(botAI);
+    static Action* high_king_maulgar_flee_from_blast_wave_danger(PlayerbotAI* botAI) {
+        return new HighKingMaulgarFleeFromBlastWaveDangerAction(botAI);
     }
     static Action* high_king_maulgar_banish_fel_stalker(PlayerbotAI* botAI) {
         return new HighKingMaulgarBanishFelStalkerAction(botAI);
     }
     static Action* high_king_maulgar_misdirect_ogres_to_tanks(PlayerbotAI* botAI) {
         return new HighKingMaulgarMisdirectOgresToTanksAction(botAI);
+    }
+    static Action* high_king_maulgar_cast_fear_ward_on_main_tank(PlayerbotAI* botAI) {
+        return new HighKingMaulgarCastFearWardOnMainTankAction(botAI);
     }
 
     // Gruul the Dragonkiller

--- a/src/Ai/Raid/Gruul/GruulActions.cpp
+++ b/src/Ai/Raid/Gruul/GruulActions.cpp
@@ -24,17 +24,17 @@ bool GruulsLairResetEncounterStatesAction::Execute(Event /*event*/)
 {
     bool reset = false;
 
-    if (!AI_VALUE2(bool, "combat", "self target"))
-    {
-        reset |= ClearTargetIcon(bot, RtiTargetValue::skullIndex);
-        reset |= ClearTargetIcon(bot, RtiTargetValue::crossIndex);
-    }
-
     Action* action = context->GetAction("gruul the dragonkiller spread ranged");
     if (action &&
         static_cast<GruulTheDragonkillerSpreadRangedAction*>(action)->ResetInitialPosition())
     {
         reset = true;
+    }
+
+    if (IsMechanicTrackerBot(bot, GRUUL_MAP_ID) && !AI_VALUE2(bool, "combat", "self target"))
+    {
+        reset |= ClearTargetIcon(bot, RtiTargetValue::skullIndex);
+        reset |= ClearTargetIcon(bot, RtiTargetValue::crossIndex);
     }
 
     return reset;
@@ -71,23 +71,12 @@ bool HighKingMaulgarMeleeTanksPositionBossesAction::Execute(Event /*event*/)
     if (target->GetVictim() != bot || !bot->IsWithinMeleeRange(target))
         return false;
 
-    float const distToPosition = bot->GetExactDist2d(position);
-    if (distToPosition <= 3.0f)
+    constexpr float arrivalDist = 3.0f;
+    float moveX;
+    float moveY;
+    bool backwards;
+    if (!GetTankPositionStep(bot, position, arrivalDist, target, moveX, moveY, backwards))
         return false;
-
-    float const botX = bot->GetPositionX();
-    float const botY = bot->GetPositionY();
-    float const toPosX = position.GetPositionX() - botX;
-    float const toPosY = position.GetPositionY() - botY;
-
-    float const toBossX = target->GetPositionX() - botX;
-    float const toBossY = target->GetPositionY() - botY;
-    bool const backwards = (toPosX * toBossX + toPosY * toBossY) < 0.0f;
-
-    float const maxMoveDist = backwards ? 2.25f : 3.5f;
-    float const moveDist = std::min(maxMoveDist, distToPosition);
-    float const moveX = botX + (toPosX / distToPosition) * moveDist;
-    float const moveY = botY + (toPosY / distToPosition) * moveDist;
 
     return MoveTo(
         GRUUL_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false, false, false,
@@ -387,25 +376,12 @@ bool GruulTheDragonkillerTanksPositionBossAction::Execute(Event /*event*/)
     if (gruul->GetVictim() != bot || !bot->IsWithinMeleeRange(gruul))
         return false;
 
-    Position const& position = GRUUL_TANK_POSITION;
-    float const distToPosition = bot->GetExactDist2d(position);
-
-    if (distToPosition <= 3.0f)
+    constexpr float arrivalDist = 3.0f;
+    float moveX;
+    float moveY;
+    bool backwards;
+    if (!GetTankPositionStep(bot, GRUUL_TANK_POSITION, arrivalDist, gruul, moveX, moveY, backwards))
         return false;
-
-    float const botX = bot->GetPositionX();
-    float const botY = bot->GetPositionY();
-    float const toPosX = position.GetPositionX() - botX;
-    float const toPosY = position.GetPositionY() - botY;
-
-    float const toBossX = gruul->GetPositionX() - botX;
-    float const toBossY = gruul->GetPositionY() - botY;
-    bool const backwards = (toPosX * toBossX + toPosY * toBossY) < 0.0f;
-
-    float const maxMoveDist = backwards ? 2.25f : 3.5f;
-    float const moveDist = std::min(maxMoveDist, distToPosition);
-    float const moveX = botX + (toPosX / distToPosition) * moveDist;
-    float const moveY = botY + (toPosY / distToPosition) * moveDist;
 
     return MoveTo(
         GRUUL_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false, false, false,

--- a/src/Ai/Raid/Gruul/GruulActions.cpp
+++ b/src/Ai/Raid/Gruul/GruulActions.cpp
@@ -9,284 +9,210 @@
 #include "EncounterHelpers.h"
 #include "GruulHelpers.h"
 #include "Playerbots.h"
-#include "Unit.h"
+#include "RtiTargetValue.h"
+#include <algorithm>
+#include <iterator>
+#include <list>
+#include <vector>
 
-using namespace GruulsLairHelpers;
+using namespace GruulHelpers;
 using namespace EncounterHelpers;
 
-// High King Maulgar Actions
+// General
 
-// Main tank on Maulgar
-bool HighKingMaulgarMainTankAttackMaulgarAction::Execute(Event /*event*/)
+bool GruulsLairResetEncounterStatesAction::Execute(Event /*event*/)
 {
-    Unit* maulgar = AI_VALUE2(Unit*, "find target", "high king maulgar");
-    if (!maulgar)
-        return false;
+    bool reset = false;
 
-    if (MarkTargetWithSquare(bot, maulgar))
-        return true;
-
-    SetRtiTarget(botAI, "square");
-
-    if (AI_VALUE(Unit*, "current target") != maulgar)
-        return Attack(maulgar);
-
-    if (maulgar->GetVictim() == bot)
+    if (!AI_VALUE2(bool, "combat", "self target"))
     {
-        const Position& position = MAULGAR_TANK_POSITION;
-        const float distToPosition =
-            bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY());
-
-        if (distToPosition > 3.0f)
-        {
-            const float dX = position.GetPositionX() - bot->GetPositionX();
-            const float dY = position.GetPositionY() - bot->GetPositionY();
-            const float moveDist = std::min(5.0f, distToPosition);
-            const float moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
-            const float moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
-
-            return MoveTo(GRUULS_LAIR_MAP_ID, moveX, moveY, position.GetPositionZ(), false, false,
-                          false, false, MovementPriority::MOVEMENT_COMBAT, true, true);
-        }
+        reset |= ClearTargetIcon(bot, RtiTargetValue::skullIndex);
+        reset |= ClearTargetIcon(bot, RtiTargetValue::crossIndex);
     }
 
-    return false;
-}
-
-// First offtank on Olm
-bool HighKingMaulgarFirstAssistTankAttackOlmAction::Execute(Event /*event*/)
-{
-    Unit* olm = AI_VALUE2(Unit*, "find target", "olm the summoner");
-    if (!olm)
-        return false;
-
-    if (MarkTargetWithCircle(bot, olm))
-        return true;
-
-    SetRtiTarget(botAI, "circle");
-
-    if (AI_VALUE(Unit*, "current target") != olm)
-        return Attack(olm);
-
-    if (olm->GetVictim() == bot)
+    Action* action = context->GetAction("gruul the dragonkiller spread ranged");
+    if (action &&
+        static_cast<GruulTheDragonkillerSpreadRangedAction*>(action)->ResetInitialPosition())
     {
-        const Position& position = OLM_TANK_POSITION;
-        const float distToPosition =
-            bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY());
-
-        if (distToPosition > 3.0f)
-        {
-            const float dX = position.GetPositionX() - bot->GetPositionX();
-            const float dY = position.GetPositionY() - bot->GetPositionY();
-            const float moveDist = std::min(5.0f, distToPosition);
-            const float moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
-            const float moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
-
-            return MoveTo(GRUULS_LAIR_MAP_ID, moveX, moveY, position.GetPositionZ(), false, false,
-                          false, false, MovementPriority::MOVEMENT_COMBAT, true, true);
-        }
+        reset = true;
     }
 
-    return false;
+    return reset;
 }
 
-// Second offtank on Blindeye
-bool HighKingMaulgarSecondAssistTankAttackBlindeyeAction::Execute(Event /*event*/)
+// High King Maulgar
+
+bool HighKingMaulgarMeleeTanksPositionBossesAction::Execute(Event /*event*/)
 {
-    Unit* blindeye = AI_VALUE2(Unit*, "find target", "blindeye the seer");
-    if (!blindeye)
-        return false;
-
-    if (MarkTargetWithStar(bot, blindeye))
-        return true;
-
-    SetRtiTarget(botAI, "star");
-
-    if (AI_VALUE(Unit*, "current target") != blindeye)
-        return Attack(blindeye);
-
-    if (blindeye->GetVictim() == bot)
+    Unit* target = nullptr;
+    Position position;
+    if (IsMaulgarTank(bot))
     {
-        const Position& position = BLINDEYE_TANK_POSITION;
-        const float distToPosition =
-            bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY());
-
-        if (distToPosition > 3.0f)
-        {
-            const float dX = position.GetPositionX() - bot->GetPositionX();
-            const float dY = position.GetPositionY() - bot->GetPositionY();
-            const float moveDist = std::min(5.0f, distToPosition);
-            const float moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
-            const float moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
-
-            return MoveTo(GRUULS_LAIR_MAP_ID, moveX, moveY, position.GetPositionZ(), false, false,
-                          false, false, MovementPriority::MOVEMENT_COMBAT, true, true);
-        }
+        target = AI_VALUE2(Unit*, "find target", "high king maulgar");
+        position = MAULGAR_TANK_POSITION;
+    }
+    else if (IsOlmTank(bot))
+    {
+        target = AI_VALUE2(Unit*, "find target", "olm the summoner");
+        position = OLM_TANK_POSITION;
+    }
+    else if (IsBlindeyeTank(bot))
+    {
+        target = AI_VALUE2(Unit*, "find target", "blindeye the seer");
+        position = BLINDEYE_TANK_POSITION;
     }
 
-    return false;
+    if (!target)
+        return false;
+
+    if (AI_VALUE(Unit*, "current target") != target)
+        return Attack(target);
+
+    if (target->GetVictim() != bot || !bot->IsWithinMeleeRange(target))
+        return false;
+
+    float const distToPosition = bot->GetExactDist2d(position);
+    if (distToPosition <= 3.0f)
+        return false;
+
+    float const botX = bot->GetPositionX();
+    float const botY = bot->GetPositionY();
+    float const toPosX = position.GetPositionX() - botX;
+    float const toPosY = position.GetPositionY() - botY;
+
+    float const toBossX = target->GetPositionX() - botX;
+    float const toBossY = target->GetPositionY() - botY;
+    bool const backwards = (toPosX * toBossX + toPosY * toBossY) < 0.0f;
+
+    float const maxMoveDist = backwards ? 2.25f : 3.5f;
+    float const moveDist = std::min(maxMoveDist, distToPosition);
+    float const moveX = botX + (toPosX / distToPosition) * moveDist;
+    float const moveY = botY + (toPosY / distToPosition) * moveDist;
+
+    return MoveTo(
+        GRUUL_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false, false, false,
+        MovementPriority::MOVEMENT_COMBAT, true, backwards);
 }
 
-// Mage with highest max HP on Krosh
 bool HighKingMaulgarMageTankAttackKroshAction::Execute(Event /*event*/)
 {
     Unit* krosh = AI_VALUE2(Unit*, "find target", "krosh firehand");
     if (!krosh)
         return false;
 
-    if (MarkTargetWithTriangle(bot, krosh))
+    if (AttackAndCast(krosh))
         return true;
 
-    SetRtiTarget(botAI, "triangle");
+    if (krosh->GetVictim() != bot)
+        return false;
 
-    if (krosh->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_SPELL_SHIELD)) &&
-        botAI->CanCastSpell("spellsteal", krosh))
-    {
-        return botAI->CastSpell("spellsteal", krosh);
-    }
+    return MoveToDesiredDistance(krosh);
+}
 
-    if (!bot->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_SPELL_SHIELD)) &&
-        botAI->CanCastSpell("fire ward", bot))
+bool HighKingMaulgarMageTankAttackKroshAction::AttackAndCast(Unit* krosh)
+{
+    if (krosh->HasAura(Id(GruulSpells::SPELL_SPELL_SHIELD)) &&
+        botAI->CanCastSpell(Id(GruulSpells::SPELL_SPELLSTEAL), krosh) &&
+        botAI->CastSpell(Id(GruulSpells::SPELL_SPELLSTEAL), krosh))
     {
-        return botAI->CastSpell("fire ward", bot);
+        return true;
     }
 
     if (AI_VALUE(Unit*, "current target") != krosh)
         return Attack(krosh);
 
-    if (krosh->GetVictim() == bot)
-    {
-        const Position& position = KROSH_TANK_POSITION;
-        const float distanceKroshToPosition =
-            krosh->GetExactDist2d(position.GetPositionX(), position.GetPositionY());
-        constexpr float minDistance = 17.0f;
-        constexpr float maxDistance = 30.0f;
+    if (bot->HasAura(Id(GruulSpells::SPELL_SPELL_SHIELD)))
+        return false;
 
-        if (distanceKroshToPosition > minDistance && distanceKroshToPosition < maxDistance &&
-            bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY()) > 1.0f)
-        {
-            return MoveTo(GRUULS_LAIR_MAP_ID, position.GetPositionX(), position.GetPositionY(),
-                          position.GetPositionZ(), false, false, false, false,
-                          MovementPriority::MOVEMENT_COMBAT, true, false);
-        }
-        else
-        {
-            constexpr float safeDistance = 15.0f;
-            const float currentDistance = bot->GetDistance2d(krosh);
-
-            if (currentDistance < safeDistance)
-            {
-                botAI->InterruptSpell();
-                return MoveAway(krosh, safeDistance - currentDistance);
-            }
-        }
-    }
-
-    return false;
+    return botAI->CanCastSpell("fire ward", bot) && botAI->CastSpell("fire ward", bot);
 }
 
-// Moonkin with highest max HP on Kiggler
+// The Mage tank moves to a designated position only if Krosh is 17-30y from the position in order
+// to tank Krosh without being in Blast Wave range.
+bool HighKingMaulgarMageTankAttackKroshAction::MoveToDesiredDistance(Unit* krosh)
+{
+    Position const& position = KROSH_TANK_POSITION;
+    float const distanceKroshToPosition = krosh->GetExactDist2d(position);
+    constexpr float minDistance = 17.0f;
+    constexpr float maxDistance = 30.0f;
+
+    if (distanceKroshToPosition > minDistance && distanceKroshToPosition < maxDistance &&
+        bot->GetExactDist2d(position) > 1.0f)
+    {
+        return MoveTo(
+            GRUUL_MAP_ID, position.GetPositionX(), position.GetPositionY(), position.GetPositionZ(),
+            false, false, false, false, MovementPriority::MOVEMENT_COMBAT, true, false);
+    }
+
+    constexpr float safeDistance = 15.0f;
+    float const currentDistance = bot->GetDistance(krosh);
+
+    if (currentDistance >= safeDistance)
+        return false;
+
+    bot->CastStop();
+    return MoveAway(krosh, safeDistance - currentDistance);
+}
+
+// The moonkin tank has no tank position, but usually Kiggler remains close to where he starts.
 bool HighKingMaulgarMoonkinTankAttackKigglerAction::Execute(Event /*event*/)
 {
     Unit* kiggler = AI_VALUE2(Unit*, "find target", "kiggler the crazed");
     if (!kiggler)
         return false;
 
-    if (MarkTargetWithDiamond(bot, kiggler))
-        return true;
-
-    SetRtiTarget(botAI, "diamond");
-
     if (AI_VALUE(Unit*, "current target") != kiggler)
         return Attack(kiggler);
 
-    if (kiggler->GetVictim() == bot)
-    {
-        constexpr float safeDistance = 28.5f;
-        const float currentDistance = bot->GetDistance2d(kiggler);
+    if (kiggler->GetVictim() != bot)
+        return false;
 
-        if (currentDistance < safeDistance)
-        {
-            botAI->InterruptSpell();
-            return MoveAway(kiggler, safeDistance - currentDistance);
-        }
-    }
+    constexpr float safeDistance = 28.5f;
+    float const currentDistance = bot->GetDistance(kiggler);
 
-    return false;
+    if (currentDistance >= safeDistance)
+        return false;
+
+    return MoveAway(kiggler, safeDistance - currentDistance);
 }
 
-bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
+// Priority: (1) Blindeye, (2) Olm, (3) Krosh (ranged only), (4) Kiggler, and (5) Maulgar
+bool HighKingMaulgarAssignDpsPriorityAction::Execute(Event /*event*/)
 {
-    // Target priority 1: Blindeye
+    Unit* target = AI_VALUE2(Unit*, "find target", "high king maulgar");
+    Unit* krosh = nullptr;
     if (Unit* blindeye = AI_VALUE2(Unit*, "find target", "blindeye the seer"))
     {
-        if (MarkTargetWithStar(bot, blindeye))
-            return true;
-
-        SetRtiTarget(botAI, "star");
-
-        if (AI_VALUE(Unit*, "current target") != blindeye)
-            return Attack(blindeye);
-
-        return false;
+        target = blindeye;
     }
-
-    // Target priority 2: Olm
-    if (Unit* olm = AI_VALUE2(Unit*, "find target", "olm the summoner"))
+    else if (Unit* olm = AI_VALUE2(Unit*, "find target", "olm the summoner"))
     {
-        if (MarkTargetWithCircle(bot, olm))
-            return true;
-
-        SetRtiTarget(botAI, "circle");
-
-        if (AI_VALUE(Unit*, "current target") != olm)
-            return Attack(olm);
-
-        return false;
+        target = olm;
     }
-
-    // Target priority 3a: Krosh (ranged only)
-    if (Unit* krosh = AI_VALUE2(Unit*, "find target", "krosh firehand");
-        krosh && botAI->IsRanged(bot))
+    else if ((krosh = AI_VALUE2(Unit*, "find target", "krosh firehand")) &&
+        PlayerbotAI::IsRanged(bot))
     {
-        if (MarkTargetWithTriangle(bot, krosh))
-            return true;
-
-        SetRtiTarget(botAI, "triangle");
-
-        if (AI_VALUE(Unit*, "current target") != krosh)
-            return Attack(krosh);
-
-        return false;
+        target = krosh;
     }
-
-    // Target priority 3b: Kiggler
-    if (Unit* kiggler = AI_VALUE2(Unit*, "find target", "kiggler the crazed"))
+    else if (Unit* kiggler = AI_VALUE2(Unit*, "find target", "kiggler the crazed"))
     {
-        if (MarkTargetWithDiamond(bot, kiggler))
-            return true;
+        target = kiggler;
+    }
 
-        SetRtiTarget(botAI, "diamond");
-
-        if (AI_VALUE(Unit*, "current target") != kiggler)
-            return Attack(kiggler);
-
+    if (!target)
         return false;
-    }
 
-    // Target priority 4: Maulgar
-    if (Unit* maulgar = AI_VALUE2(Unit*, "find target", "high king maulgar"))
+    if (target == krosh)
     {
-        if (MarkTargetWithSquare(bot, maulgar))
+        if (MarkTargetWithCross(bot, target))
             return true;
-
-        SetRtiTarget(botAI, "square");
-
-        if (AI_VALUE(Unit*, "current target") != maulgar)
-            return Attack(maulgar);
+    }
+    else if (MarkTargetWithSkull(bot, target))
+    {
+        return true;
     }
 
-    return false;
+    return AI_VALUE(Unit*, "current target") != target && Attack(target);
 }
 
 bool HighKingMaulgarRunAwayFromWhirlwindAction::Execute(Event /*event*/)
@@ -295,35 +221,28 @@ bool HighKingMaulgarRunAwayFromWhirlwindAction::Execute(Event /*event*/)
     if (!maulgar)
         return false;
 
-    constexpr float safeDistance = 8.0f;
-    const float currentDistance = bot->GetDistance2d(maulgar);
+    float const currentDistance = bot->GetDistance2d(maulgar);
+    if (currentDistance >= WHIRLWIND_SAFE_DISTANCE)
+        return false;
 
-    if (currentDistance < safeDistance)
-    {
-        botAI->InterruptSpell();
-        return MoveAway(maulgar, safeDistance - currentDistance);
-    }
-
-    return false;
+    bot->CastStop();
+    return MoveAway(maulgar, WHIRLWIND_SAFE_DISTANCE - currentDistance);
 }
 
-bool HighKingMaulgarMoveAwayFromBlastNovaDangerAction::Execute(Event /*event*/)
+bool HighKingMaulgarFleeFromBlastWaveDangerAction::Execute(Event /*event*/)
 {
     Unit* krosh = AI_VALUE2(Unit*, "find target", "krosh firehand");
     if (!krosh)
         return false;
 
     constexpr float safeDistance = 20.0f;
-    constexpr uint32 minInterval = 1000;
-    const float currentDistance = bot->GetDistance2d(krosh);
+    float const currentDistance = bot->GetDistance2d(krosh);
 
-    if (currentDistance < safeDistance)
-    {
-        botAI->InterruptSpell();
-        return FleePosition(krosh->GetPosition(), safeDistance, minInterval);
-    }
+    if (currentDistance >= safeDistance)
+        return false;
 
-    return false;
+    bot->CastStop();
+    return FleePosition(krosh->GetPosition(), safeDistance);
 }
 
 bool HighKingMaulgarBanishFelStalkerAction::Execute(Event /*event*/)
@@ -336,7 +255,7 @@ bool HighKingMaulgarBanishFelStalkerAction::Execute(Event /*event*/)
     std::list<Creature*> creatureList;
     constexpr float searchRadius = 50.0f;
     bot->GetCreatureListWithEntryInGrid(
-        creatureList, static_cast<uint32>(GruulsLairNpcs::NPC_WILD_FEL_STALKER), searchRadius);
+        creatureList, Id(GruulNpcs::NPC_WILD_FEL_STALKER), searchRadius);
 
     for (Creature* creature : creatureList)
     {
@@ -348,8 +267,8 @@ bool HighKingMaulgarBanishFelStalkerAction::Execute(Event /*event*/)
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
         Player* member = ref->GetSource();
-        if (member && member->IsAlive() && member->getClass() == CLASS_WARLOCK &&
-            GET_PLAYERBOT_AI(member))
+        if (member && member->IsAlive() && member->GetMapId() == GRUUL_MAP_ID &&
+            member->getClass() == CLASS_WARLOCK && GET_PLAYERBOT_AI(member))
         {
             warlocks.push_back(member);
         }
@@ -365,25 +284,18 @@ bool HighKingMaulgarBanishFelStalkerAction::Execute(Event /*event*/)
         }
     }
 
-    const uint8 felStalkersSize = felStalkers.size();
+    if (warlockIndex < 0 || warlockIndex >= felStalkers.size())
+        return false;
 
-    if (warlockIndex >= 0 && warlockIndex < felStalkersSize)
-    {
-        Unit* assignedFelStalker = felStalkers[warlockIndex];
-        if (!botAI->HasAura("banish", assignedFelStalker) &&
-            botAI->CanCastSpell("banish", assignedFelStalker))
-        {
-            return botAI->CastSpell("banish", assignedFelStalker);
-        }
-    }
+    Unit* assignedFelStalker = felStalkers[warlockIndex];
+    if (botAI->HasAura("banish", assignedFelStalker))
+        return false;
 
-    return false;
+    return botAI->CanCastSpell("banish", assignedFelStalker) &&
+        botAI->CastSpell("banish", assignedFelStalker);
 }
 
-// Hunter 1: Misdirect Blindeye to second offtank
-// Hunter 2: Misdirect Olm to first offtank
-// Hunter 3: Misdirect Kiggler to Moonkin tank
-// Hunter 4: Misdirect Krosh to Mage tank
+// Misdirect order: Blindeye, Olm, Kiggler, Krosh
 bool HighKingMaulgarMisdirectOgresToTanksAction::Execute(Event /*event*/)
 {
     Group* group = bot->GetGroup();
@@ -416,68 +328,53 @@ bool HighKingMaulgarMisdirectOgresToTanksAction::Execute(Event /*event*/)
     if (hunterIndex == -1)
         return false;
 
-    Unit* ogreTarget = nullptr;
-    Player* tankTarget = nullptr;
+    Unit* ogre = nullptr;
+    Player* tank = nullptr;
     if (hunterIndex == 0)
     {
-        ogreTarget = AI_VALUE2(Unit*, "find target", "blindeye the seer");
-        tankTarget = GetGroupAssistTank(bot, 1);
+        ogre = AI_VALUE2(Unit*, "find target", "blindeye the seer");
+        tank = GetGroupAssistTank(bot, 1);
     }
     else if (hunterIndex == 1)
     {
-        ogreTarget = AI_VALUE2(Unit*, "find target", "olm the summoner");
-        for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
-        {
-            if (Player* member = GetGroupAssistTank(bot, 0))
-            {
-                tankTarget = member;
-                break;
-            }
-        }
+        ogre = AI_VALUE2(Unit*, "find target", "olm the summoner");
+        tank = GetGroupAssistTank(bot, 0);
     }
     else if (hunterIndex == 2)
     {
-        ogreTarget = AI_VALUE2(Unit*, "find target", "kiggler the crazed");
-        for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
-        {
-            if (Player* member = GetKigglerMoonkinTank(bot))
-            {
-                tankTarget = member;
-                break;
-            }
-        }
+        ogre = AI_VALUE2(Unit*, "find target", "kiggler the crazed");
+        tank = GetKigglerMoonkinTank(bot);
     }
     else if (hunterIndex == 3)
     {
-        ogreTarget = AI_VALUE2(Unit*, "find target", "krosh firehand");
-        for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
-        {
-            if (Player* member = GetKroshMageTank(bot))
-            {
-                tankTarget = member;
-                break;
-            }
-        }
+        ogre = AI_VALUE2(Unit*, "find target", "krosh firehand");
+        tank = GetKroshMageTank(bot);
     }
 
-    if (!ogreTarget || !tankTarget || !tankTarget->IsAlive())
+    if (!ogre || !tank || !tank->IsAlive())
         return false;
 
-    if (botAI->CanCastSpell("misdirection", tankTarget))
-        return botAI->CastSpell("misdirection", tankTarget);
+    if (botAI->CanCastSpell("misdirection", tank))
+        return botAI->CastSpell("misdirection", tank);
 
-    if (bot->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_MISDIRECTION)) &&
-        botAI->CanCastSpell("steady shot", ogreTarget))
-    {
-        return botAI->CastSpell("steady shot", ogreTarget);
-    }
+    if (!bot->HasAura(Id(GruulSpells::SPELL_MISDIRECTION)))
+        return false;
 
-    return false;
+    return botAI->CanCastSpell("steady shot", ogre) && botAI->CastSpell("steady shot", ogre);
 }
 
-// Gruul the Dragonkiller Actions
+bool HighKingMaulgarCastFearWardOnMainTankAction::Execute(Event /*event*/)
+{
+    constexpr uint32 fearWard = Id(GruulSpells::SPELL_FEAR_WARD);
+    Player* mainTank = GetGroupMainTank(bot);
+    if (!mainTank || mainTank->HasAura(fearWard))
+        return false;
 
-// Position in center of the room
+    return botAI->CanCastSpell(fearWard, mainTank) && botAI->CastSpell(fearWard, mainTank);
+}
+
+// Gruul the Dragonkiller
+
 bool GruulTheDragonkillerTanksPositionBossAction::Execute(Event /*event*/)
 {
     Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
@@ -487,69 +384,54 @@ bool GruulTheDragonkillerTanksPositionBossAction::Execute(Event /*event*/)
     if (AI_VALUE(Unit*, "current target") != gruul)
         return Attack(gruul);
 
-    if (gruul->GetVictim() == bot)
-    {
-        const Position& position = GRUUL_TANK_POSITION;
-        const float distToPosition =
-            bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY());
-
-        if (distToPosition > 3.0f)
-        {
-            const float dX = position.GetPositionX() - bot->GetPositionX();
-            const float dY = position.GetPositionY() - bot->GetPositionY();
-            const float moveDist = std::min(5.0f, distToPosition);
-            const float moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
-            const float moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
-
-            return MoveTo(GRUULS_LAIR_MAP_ID, moveX, moveY, position.GetPositionZ(), false, false,
-                          false, false, MovementPriority::MOVEMENT_COMBAT, true, true);
-        }
-    }
-
-    return false;
-}
-
-// Ranged will take initial positions around the middle of the room, 25-40 yards from center
-// Ranged should spread out 10 yards from each other
-bool GruulTheDragonkillerSpreadRangedAction::Execute(Event /*event*/)
-{
-    Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
-    if (!gruul)
+    if (gruul->GetVictim() != bot || !bot->IsWithinMeleeRange(gruul))
         return false;
 
-    if (gruul->GetHealth() == gruul->GetMaxHealth())
-        _hasReachedInitialPosition = false;
+    Position const& position = GRUUL_TANK_POSITION;
+    float const distToPosition = bot->GetExactDist2d(position);
 
+    if (distToPosition <= 3.0f)
+        return false;
+
+    float const botX = bot->GetPositionX();
+    float const botY = bot->GetPositionY();
+    float const toPosX = position.GetPositionX() - botX;
+    float const toPosY = position.GetPositionY() - botY;
+
+    float const toBossX = gruul->GetPositionX() - botX;
+    float const toBossY = gruul->GetPositionY() - botY;
+    bool const backwards = (toPosX * toBossX + toPosY * toBossY) < 0.0f;
+
+    float const maxMoveDist = backwards ? 2.25f : 3.5f;
+    float const moveDist = std::min(maxMoveDist, distToPosition);
+    float const moveX = botX + (toPosX / distToPosition) * moveDist;
+    float const moveY = botY + (toPosY / distToPosition) * moveDist;
+
+    return MoveTo(
+        GRUUL_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false, false, false,
+        MovementPriority::MOVEMENT_COMBAT, true, backwards);
+}
+
+bool GruulTheDragonkillerSpreadRangedAction::Execute(Event /*event*/)
+{
     Group* group = bot->GetGroup();
     if (!group)
         return false;
 
-    std::vector<Player*> members;
-    Player* closestMember = nullptr;
-    float closestDist = std::numeric_limits<float>::max();
-    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    Position const& position = GRUUL_TANK_POSITION;
+
+    if (!_hasInitialPosition)
     {
-        Player* member = ref->GetSource();
-        if (!member || !member->IsAlive())
-            continue;
-
-        members.push_back(member);
-
-        if (member != bot)
+        std::vector<Player*> members;
+        for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
         {
-            float dist = bot->GetExactDist2d(member);
-            if (dist < closestDist)
-            {
-                closestDist = dist;
-                closestMember = member;
-            }
+            Player* member = ref->GetSource();
+            if (!member || !member->IsAlive())
+                continue;
+
+            members.push_back(member);
         }
-    }
 
-    const Position& position = GRUUL_TANK_POSITION;
-
-    if (_initialPosition.GetPositionX() == 0.0f && _initialPosition.GetPositionY() == 0.0f)
-    {
         auto it = std::find(members.begin(), members.end(), bot);
         uint8 botIndex = (it != members.end()) ? std::distance(members.begin(), it) : 0;
         uint8 count = members.size();
@@ -558,53 +440,50 @@ bool GruulTheDragonkillerSpreadRangedAction::Execute(Event /*event*/)
         constexpr float maxRadius = 40.0f;
         float angle = 2 * M_PI * botIndex / count;
         float radius = minRadius + static_cast<float>(rand()) /
-                       static_cast<float>(RAND_MAX) * (maxRadius - minRadius);
+            static_cast<float>(RAND_MAX) * (maxRadius - minRadius);
         float targetX = position.GetPositionX() + radius * cos(angle);
         float targetY = position.GetPositionY() + radius * sin(angle);
 
         _initialPosition = Position(targetX, targetY, position.GetPositionZ());
+        _hasInitialPosition = true;
     }
 
     if (!_hasReachedInitialPosition)
     {
-        const float distanceToTarget =
-            bot->GetExactDist2d(_initialPosition.GetPositionX(), _initialPosition.GetPositionY());
-        if (distanceToTarget > 2.0f)
+        float const distToTarget = bot->GetExactDist2d(_initialPosition);
+        if (distToTarget <= 2.0f)
         {
-            float destX = _initialPosition.GetPositionX();
-            float destY = _initialPosition.GetPositionY();
-            float destZ = _initialPosition.GetPositionZ();
-
-            if (!bot->GetMap()->CheckCollisionAndGetValidCoords(bot, bot->GetPositionX(),
-                bot->GetPositionY(), bot->GetPositionZ(), destX, destY, destZ))
-            {
-                return false;
-            }
-
-            return MoveTo(GRUULS_LAIR_MAP_ID, destX, destY, destZ, false, false, false,
-                          false, MovementPriority::MOVEMENT_COMBAT, true, false);
+             _hasReachedInitialPosition = true;
+            return false;
         }
 
-        _hasReachedInitialPosition = true;
-    }
-    else
-    {
-        constexpr float minSpreadDistance = 10.0f;
-        constexpr uint32 minInterval = 1000;
-        if (closestMember && closestDist < minSpreadDistance)
-            return FleePosition(closestMember->GetPosition(), minSpreadDistance, minInterval);
+        float const moveDist = std::min(3.5f, distToTarget);
+        float const botX = bot->GetPositionX();
+        float const botY = bot->GetPositionY();
+        float const moveX =
+            botX + ((_initialPosition.GetPositionX() - botX) / distToTarget) * moveDist;
+        float const moveY =
+            botY + ((_initialPosition.GetPositionY() - botY) / distToTarget) * moveDist;
+
+        return MoveTo(
+            GRUUL_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false, false, false,
+            MovementPriority::MOVEMENT_COMBAT, true, false);
     }
 
-    return false;
+    constexpr float minSpreadDistance = 10.0f;
+    Player* nearestPlayer = GetNearestPlayerInRadius(bot, minSpreadDistance);
+    return nearestPlayer && FleePosition(nearestPlayer->GetPosition(), minSpreadDistance);
 }
 
-// Try to get away from other group members when Ground Slam is cast
 bool GruulTheDragonkillerShatterSpreadAction::Execute(Event /*event*/)
 {
-    constexpr float safeDistance = 10.0f;
-    constexpr uint32 minInterval = 0;
-    if (Player* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance))
-        return FleePosition(nearestPlayer->GetPosition(), safeDistance, minInterval);
+    constexpr float safeDistance = 20.0f;
+    Player* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance);
+    if (!nearestPlayer)
+        return false;
 
-    return false;
+    float const distToNearest = bot->GetExactDist2d(nearestPlayer);
+    float const moveDist = std::min(3.5f, safeDistance - distToNearest);
+
+    return MoveAway(nearestPlayer, moveDist);
 }

--- a/src/Ai/Raid/Gruul/GruulActions.h
+++ b/src/Ai/Raid/Gruul/GruulActions.h
@@ -10,112 +10,127 @@
 #include "Action.h"
 #include "AttackAction.h"
 #include "MovementActions.h"
+#include "Position.h"
 
-class HighKingMaulgarMainTankAttackMaulgarAction : public AttackAction
+class GruulsLairResetEncounterStatesAction : public Action
 {
 public:
-    HighKingMaulgarMainTankAttackMaulgarAction(
-        PlayerbotAI* botAI, std::string const name = "high king maulgar main tank attack maulgar") : AttackAction(botAI, name) {};
+    GruulsLairResetEncounterStatesAction(PlayerbotAI* botAI)
+        : Action(botAI, "gruul's lair reset encounter states") {}
     bool Execute(Event event) override;
 };
 
-class HighKingMaulgarFirstAssistTankAttackOlmAction : public AttackAction
+class HighKingMaulgarMeleeTanksPositionBossesAction : public AttackAction
 {
 public:
-    HighKingMaulgarFirstAssistTankAttackOlmAction(
-        PlayerbotAI* botAI, std::string const name = "high king maulgar first assist tank attack olm") : AttackAction(botAI, name) {};
-    bool Execute(Event event) override;
-};
-
-class HighKingMaulgarSecondAssistTankAttackBlindeyeAction : public AttackAction
-{
-public:
-    HighKingMaulgarSecondAssistTankAttackBlindeyeAction(
-        PlayerbotAI* botAI, std::string const name = "high king maulgar second assist tank attack blindeye") : AttackAction(botAI, name) {};
+    HighKingMaulgarMeleeTanksPositionBossesAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "high king maulgar melee tanks position bosses") {}
     bool Execute(Event event) override;
 };
 
 class HighKingMaulgarMageTankAttackKroshAction : public AttackAction
 {
 public:
-    HighKingMaulgarMageTankAttackKroshAction(
-        PlayerbotAI* botAI, std::string const name = "high king maulgar mage tank attack krosh") : AttackAction(botAI, name) {};
+    HighKingMaulgarMageTankAttackKroshAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "high king maulgar mage tank attack krosh") {}
     bool Execute(Event event) override;
+
+private:
+    bool AttackAndCast(Unit* krosh);
+    bool MoveToDesiredDistance(Unit* krosh);
 };
 
 class HighKingMaulgarMoonkinTankAttackKigglerAction : public AttackAction
 {
 public:
-    HighKingMaulgarMoonkinTankAttackKigglerAction(
-        PlayerbotAI* botAI, std::string const name = "high king maulgar moonkin tank attack kiggler") : AttackAction(botAI, name) {};
+    HighKingMaulgarMoonkinTankAttackKigglerAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "high king maulgar moonkin tank attack kiggler") {}
     bool Execute(Event event) override;
 };
 
-class HighKingMaulgarAssignDPSPriorityAction : public AttackAction
+class HighKingMaulgarAssignDpsPriorityAction : public AttackAction
 {
 public:
-    HighKingMaulgarAssignDPSPriorityAction(
-        PlayerbotAI* botAI, std::string const name = "high king maulgar assign dps priority") : AttackAction(botAI, name) {};
+    HighKingMaulgarAssignDpsPriorityAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "high king maulgar assign dps priority") {}
     bool Execute(Event event) override;
 };
 
 class HighKingMaulgarRunAwayFromWhirlwindAction : public MovementAction
 {
 public:
-    HighKingMaulgarRunAwayFromWhirlwindAction(
-        PlayerbotAI* botAI, std::string const name = "high king maulgar run away from whirlwind") : MovementAction(botAI, name) {};
+    HighKingMaulgarRunAwayFromWhirlwindAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "high king maulgar run away from whirlwind") {}
     bool Execute(Event event) override;
 };
 
-class HighKingMaulgarMoveAwayFromBlastNovaDangerAction : public MovementAction
+class HighKingMaulgarFleeFromBlastWaveDangerAction : public MovementAction
 {
 public:
-    HighKingMaulgarMoveAwayFromBlastNovaDangerAction(
-        PlayerbotAI* botAI, std::string const name = "high king maulgar move away from blast nova danger") : MovementAction(botAI, name) {};
+    HighKingMaulgarFleeFromBlastWaveDangerAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "high king maulgar flee from blast wave danger") {}
     bool Execute(Event event) override;
 };
 
-class HighKingMaulgarBanishFelStalkerAction : public AttackAction
+class HighKingMaulgarBanishFelStalkerAction : public Action
 {
 public:
-    HighKingMaulgarBanishFelStalkerAction(
-        PlayerbotAI* botAI, std::string const name = "high king maulgar banish fel stalker") : AttackAction(botAI, name) {};
+    HighKingMaulgarBanishFelStalkerAction(PlayerbotAI* botAI)
+        : Action(botAI, "high king maulgar banish fel stalker") {}
     bool Execute(Event event) override;
 };
 
-class HighKingMaulgarMisdirectOgresToTanksAction : public AttackAction
+class HighKingMaulgarMisdirectOgresToTanksAction : public Action
 {
 public:
-    HighKingMaulgarMisdirectOgresToTanksAction(
-        PlayerbotAI* botAI, std::string const name = "high king maulgar misdirect ogres to tanks") : AttackAction(botAI, name) {};
+    HighKingMaulgarMisdirectOgresToTanksAction(PlayerbotAI* botAI)
+        : Action(botAI, "high king maulgar misdirect ogres to tanks") {}
+    bool Execute(Event event) override;
+};
+
+class HighKingMaulgarCastFearWardOnMainTankAction : public Action
+{
+public:
+    HighKingMaulgarCastFearWardOnMainTankAction(PlayerbotAI* botAI)
+        : Action(botAI, "high king maulgar cast fear ward on main tank") {}
     bool Execute(Event event) override;
 };
 
 class GruulTheDragonkillerTanksPositionBossAction : public AttackAction
 {
 public:
-    GruulTheDragonkillerTanksPositionBossAction(
-        PlayerbotAI* botAI, std::string const name = "gruul the dragonkiller tanks position boss") : AttackAction(botAI, name) {};
+    GruulTheDragonkillerTanksPositionBossAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "gruul the dragonkiller tanks position boss") {}
     bool Execute(Event event) override;
 };
 
 class GruulTheDragonkillerSpreadRangedAction : public MovementAction
 {
 public:
-    GruulTheDragonkillerSpreadRangedAction(
-        PlayerbotAI* botAI, std::string const name = "gruul the dragonkiller spread ranged") : MovementAction(botAI, name) {};
+    GruulTheDragonkillerSpreadRangedAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "gruul the dragonkiller spread ranged") {}
     bool Execute(Event event) override;
+    bool ResetInitialPosition()
+    {
+        if (!_hasReachedInitialPosition && !_hasInitialPosition)
+            return false;
+
+        _hasReachedInitialPosition = false;
+        _hasInitialPosition = false;
+        return true;
+    }
 
 private:
     Position _initialPosition;
+    bool _hasInitialPosition = false;
     bool _hasReachedInitialPosition = false;
 };
 
 class GruulTheDragonkillerShatterSpreadAction : public MovementAction
 {
 public:
-    GruulTheDragonkillerShatterSpreadAction(
-        PlayerbotAI* botAI, std::string const name = "gruul the dragonkiller shatter spread") : MovementAction(botAI, name) {};
+    GruulTheDragonkillerShatterSpreadAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "gruul the dragonkiller shatter spread") {}
     bool Execute(Event event) override;
 };
 

--- a/src/Ai/Raid/Gruul/GruulHelpers.cpp
+++ b/src/Ai/Raid/Gruul/GruulHelpers.cpp
@@ -6,19 +6,28 @@
 
 #include "GruulHelpers.h"
 #include "AiFactory.h"
-#include "GroupReference.h"
 #include "Playerbots.h"
-#include "Unit.h"
 
-namespace GruulsLairHelpers
+namespace GruulHelpers
 {
 
-const Position MAULGAR_TANK_POSITION  = {  90.686f, 167.047f, -13.234f };
-const Position OLM_TANK_POSITION      = { 101.050f, 219.359f,  -9.503f };
-const Position BLINDEYE_TANK_POSITION = {  99.681f, 213.989f, -10.345f };
-const Position KROSH_TANK_POSITION    = { 116.880f, 166.208f, -14.231f };
-const Position MAULGAR_ROOM_CENTER    = {  88.754f, 150.759f, -11.569f };
-const Position GRUUL_TANK_POSITION    = { 241.238f, 365.025f,  -4.220f };
+bool IsMaulgarTank(Player* bot)
+{
+    // Note: IsMainTank() is not necessarily a tank (by either strategy or spec). It can be anybody
+    // with the main tank flag. Raid strategies will have problems with non-tank main tanks so this
+    // assumes you are using a real tank for your main tank.
+    return PlayerbotAI::IsTank(bot) && PlayerbotAI::IsMainTank(bot);
+}
+
+bool IsOlmTank(Player* bot)
+{
+    return PlayerbotAI::IsAssistTankOfIndex(bot, 0, true);
+}
+
+bool IsBlindeyeTank(Player* bot)
+{
+    return PlayerbotAI::IsAssistTankOfIndex(bot, 1, true);
+}
 
 Player* GetKroshMageTank(Player* bot)
 {
@@ -26,40 +35,40 @@ Player* GetKroshMageTank(Player* bot)
     if (!group)
         return nullptr;
 
-    // (1) First loop: Return the first assistant Mage (real player or bot)
-    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
-    {
-        Player* member = ref->GetSource();
-        if (!member || !member->IsAlive() || member->getClass() != CLASS_MAGE)
-            continue;
-
-        if (group->IsAssistant(member->GetGUID()))
-            return member;
-
-    }
-
-    // (2) Fall back to bot Mage with highest HP
-    Player* highestHpMage = nullptr;
+    // If an assistant Mage (player or bot) is found, return immediately.
+    // Otherwise, return the bot Mage with the highest HP as fallback.
+    Player* highestHpBotMage = nullptr;
     uint32 highestHp = 0;
 
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
         Player* member = ref->GetSource();
-        if (!member || !member->IsAlive() || !GET_PLAYERBOT_AI(member) ||
+        if (!member || !member->IsAlive() || member->GetMapId() != GRUUL_MAP_ID ||
             member->getClass() != CLASS_MAGE)
         {
             continue;
         }
 
-        uint32 hp = member->GetMaxHealth();
-        if (!highestHpMage || hp > highestHp)
+        if (group->IsAssistant(member->GetGUID()))
+            return member;
+
+        if (!GET_PLAYERBOT_AI(member))
+            continue;
+
+        uint32 const hp = member->GetMaxHealth();
+        if (!highestHpBotMage || hp > highestHp)
         {
-            highestHpMage = member;
+            highestHpBotMage = member;
             highestHp = hp;
         }
     }
 
-    return highestHpMage;
+    return highestHpBotMage;
+}
+
+bool IsKroshMageTank(Player* bot)
+{
+    return bot->getClass() == CLASS_MAGE && GetKroshMageTank(bot) == bot;
 }
 
 Player* GetKigglerMoonkinTank(Player* bot)
@@ -68,40 +77,47 @@ Player* GetKigglerMoonkinTank(Player* bot)
     if (!group)
         return nullptr;
 
-    uint8 tab = AiFactory::GetPlayerSpecTab(bot);
-
-    // (1) First loop: Return the first assistant Moonkin (real player or bot)
-    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
-    {
-        Player* member = ref->GetSource();
-        if (!member || !member->IsAlive() || member->getClass() != CLASS_DRUID)
-            continue;
-
-        if (group->IsAssistant(member->GetGUID()) && tab == DRUID_TAB_BALANCE)
-            return member;
-    }
-
-    // (2) Fall back to bot Moonkin with highest HP
-    Player* highestHpMoonkin = nullptr;
+    // If an assistant Balance Druid (player or bot) is found, return immediately.
+    // Otherwise, return the bot Balance Druid with the highest HP as fallback.
+    Player* highestHpBotMoonkin = nullptr;
     uint32 highestHp = 0;
+
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
         Player* member = ref->GetSource();
-        if (!member || !member->IsAlive() || member->getClass() != CLASS_DRUID ||
-            !GET_PLAYERBOT_AI(member) || tab != DRUID_TAB_BALANCE)
+        if (!member || !member->IsAlive() || member->GetMapId() != GRUUL_MAP_ID ||
+            member->getClass() != CLASS_DRUID ||
+            AiFactory::GetPlayerSpecTab(member) != DRUID_TAB_BALANCE)
         {
             continue;
         }
 
-        uint32 hp = member->GetMaxHealth();
-        if (!highestHpMoonkin || hp > highestHp)
+        if (group->IsAssistant(member->GetGUID()))
+            return member;
+
+        if (!GET_PLAYERBOT_AI(member))
+            continue;
+
+        uint32 const hp = member->GetMaxHealth();
+        if (!highestHpBotMoonkin || hp > highestHp)
         {
-            highestHpMoonkin = member;
+            highestHpBotMoonkin = member;
             highestHp = hp;
         }
     }
 
-    return highestHpMoonkin;
+    return highestHpBotMoonkin;
+}
+
+bool IsKigglerMoonkinTank(Player* bot)
+{
+    return bot->getClass() == CLASS_DRUID && GetKigglerMoonkinTank(bot) == bot;
+}
+
+bool HasGroundSlam(Player* bot)
+{
+    return bot->HasAura(Id(GruulSpells::SPELL_GROUND_SLAM_1)) ||
+        bot->HasAura(Id(GruulSpells::SPELL_GROUND_SLAM_2));
 }
 
 }

--- a/src/Ai/Raid/Gruul/GruulHelpers.h
+++ b/src/Ai/Raid/Gruul/GruulHelpers.h
@@ -51,7 +51,7 @@ enum class GruulNpcs : uint32
 
 inline constexpr uint32 GRUUL_MAP_ID = 565;
 inline constexpr float WHIRLWIND_SAFE_DISTANCE = 8.0f;
-inline constexpr float BLINDEYE_PULL_COMPLETE_HP_PERCENT = 75.0f;
+inline constexpr float BLINDEYE_ENGAGED_HEALTH_PCT = 75.0f;
 
 inline Position const MAULGAR_TANK_POSITION  = {  90.686f, 167.047f, -13.234f };
 inline Position const OLM_TANK_POSITION      = { 101.050f, 219.359f,  -9.503f };

--- a/src/Ai/Raid/Gruul/GruulHelpers.h
+++ b/src/Ai/Raid/Gruul/GruulHelpers.h
@@ -7,12 +7,22 @@
 #ifndef PLAYERBOTS_GRUULHELPERS_H
 #define PLAYERBOTS_GRUULHELPERS_H
 
-#include "PlayerbotAI.h"
+#include "Common.h"
+#include "Position.h"
+#include <type_traits>
 
-namespace GruulsLairHelpers
+class Player;
+
+namespace GruulHelpers
 {
 
-enum class GruulsLairSpells : uint32
+template <typename T, std::enable_if_t<std::is_enum_v<T>, int> = 0>
+constexpr uint32 Id(T value)
+{
+    return static_cast<uint32>(value);
+}
+
+enum class GruulSpells : uint32
 {
     // High King Maulgar
     SPELL_WHIRLWIND     = 33238,
@@ -23,27 +33,40 @@ enum class GruulsLairSpells : uint32
     // Hunter
     SPELL_MISDIRECTION  = 35079,
 
+    // Mage
+    SPELL_SPELLSTEAL    = 30449,
+
+    // Priest
+    SPELL_FEAR_WARD     = 6346,
+
     // Gruul the Dragonkiller
     SPELL_GROUND_SLAM_1 = 33525,
     SPELL_GROUND_SLAM_2 = 39187,
 };
 
-enum class GruulsLairNpcs : uint32
+enum class GruulNpcs : uint32
 {
     NPC_WILD_FEL_STALKER = 18847,
 };
 
-constexpr uint32 GRUULS_LAIR_MAP_ID = 565;
+inline constexpr uint32 GRUUL_MAP_ID = 565;
+inline constexpr float WHIRLWIND_SAFE_DISTANCE = 8.0f;
+inline constexpr float BLINDEYE_PULL_COMPLETE_HP_PERCENT = 75.0f;
 
+inline Position const MAULGAR_TANK_POSITION  = {  90.686f, 167.047f, -13.234f };
+inline Position const OLM_TANK_POSITION      = { 101.050f, 219.359f,  -9.503f };
+inline Position const BLINDEYE_TANK_POSITION = {  99.681f, 213.989f, -10.345f };
+inline Position const KROSH_TANK_POSITION    = { 116.880f, 166.208f, -14.231f };
+inline Position const GRUUL_TANK_POSITION    = { 241.238f, 365.025f,  -4.220f };
+
+bool IsMaulgarTank(Player* bot);
+bool IsOlmTank(Player* bot);
+bool IsBlindeyeTank(Player* bot);
 Player* GetKroshMageTank(Player* bot);
+bool IsKroshMageTank(Player* bot);
 Player* GetKigglerMoonkinTank(Player* bot);
-
-extern const Position MAULGAR_TANK_POSITION;
-extern const Position OLM_TANK_POSITION;
-extern const Position BLINDEYE_TANK_POSITION;
-extern const Position KROSH_TANK_POSITION;
-extern const Position MAULGAR_ROOM_CENTER;
-extern const Position GRUUL_TANK_POSITION;
+bool IsKigglerMoonkinTank(Player* bot);
+bool HasGroundSlam(Player* bot);
 
 }
 

--- a/src/Ai/Raid/Gruul/GruulMultipliers.cpp
+++ b/src/Ai/Raid/Gruul/GruulMultipliers.cpp
@@ -31,7 +31,7 @@ float GruulsLairDelayDpsCooldownsMultiplier::GetValue(Action* action)
         return 0.0f;
 
     Unit* blindeye = AI_VALUE2(Unit*, "find target", "blindeye the seer");
-    return blindeye && blindeye->GetHealthPct() > BLINDEYE_PULL_COMPLETE_HP_PERCENT ? 0.0f : 1.0f;
+    return blindeye && blindeye->GetHealthPct() > BLINDEYE_ENGAGED_HEALTH_PCT ? 0.0f : 1.0f;
 }
 
 float HighKingMaulgarControlTankActionsMultiplier::GetValue(Action* action)

--- a/src/Ai/Raid/Gruul/GruulMultipliers.cpp
+++ b/src/Ai/Raid/Gruul/GruulMultipliers.cpp
@@ -27,7 +27,7 @@ float GruulsLairDelayDpsCooldownsMultiplier::GetValue(Action* action)
         return 1.0f;
 
     Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
-    if (gruul && gruul->GetHealthPct() > 95.0f)
+    if (gruul && gruul->GetHealthPct() > BOSS_ENGAGED_HEALTH_PCT)
         return 0.0f;
 
     Unit* blindeye = AI_VALUE2(Unit*, "find target", "blindeye the seer");

--- a/src/Ai/Raid/Gruul/GruulMultipliers.cpp
+++ b/src/Ai/Raid/Gruul/GruulMultipliers.cpp
@@ -6,157 +6,215 @@
 
 #include "GruulMultipliers.h"
 #include "ChooseTargetActions.h"
-#include "GenericSpellActions.h"
+#include "EncounterHelpers.h"
 #include "GruulActions.h"
 #include "GruulHelpers.h"
 #include "HunterActions.h"
+#include "MageActions.h"
 #include "Playerbots.h"
 #include "ReachTargetActions.h"
 #include "ShamanActions.h"
 
-using namespace GruulsLairHelpers;
+using namespace GruulHelpers;
+using namespace EncounterHelpers;
 
-float HighKingMaulgarDelayBloodlustAndHeroismMultiplier::GetValue(Action* action)
+float GruulsLairDelayDpsCooldownsMultiplier::GetValue(Action* action)
 {
-    if (bot->getClass() != CLASS_SHAMAN)
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
         return 1.0f;
+
+    if (!IsDpsCooldownAction(bot, action))
+        return 1.0f;
+
+    Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
+    if (gruul && gruul->GetHealthPct() > 95.0f)
+        return 0.0f;
 
     Unit* blindeye = AI_VALUE2(Unit*, "find target", "blindeye the seer");
-    if (!blindeye || blindeye->GetHealthPct() < 75.0f)
-        return 1.0f;
-
-    if (dynamic_cast<CastHeroismAction*>(action) ||
-        dynamic_cast<CastBloodlustAction*>(action))
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
+    return blindeye && blindeye->GetHealthPct() > BLINDEYE_PULL_COMPLETE_HP_PERCENT ? 0.0f : 1.0f;
 }
 
 float HighKingMaulgarControlTankActionsMultiplier::GetValue(Action* action)
 {
-    if (!botAI->IsTank(bot))
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
         return 1.0f;
 
-    if (!AI_VALUE2(Unit*, "find target", "high king maulgar"))
+    if (!PlayerbotAI::IsTank(bot))
         return 1.0f;
 
-    if (dynamic_cast<CombatFormationMoveAction*>(action) ||
-        (bot->GetVictim() != nullptr && dynamic_cast<TankAssistAction*>(action)))
+    if (!dynamic_cast<TankAssistAction*>(action) &&
+        !dynamic_cast<CombatFormationMoveAction*>(action))
     {
-        return 0.0f;
+        return 1.0f;
     }
 
-    return 1.0f;
+    return AI_VALUE2(Unit*, "find target", "high king maulgar") ? 0.0f : 1.0f;
+}
+
+float HighKingMaulgarRestrictTauntingMultiplier::GetValue(Action* action)
+{
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
+        return 1.0f;
+
+    if (!PlayerbotAI::IsTank(bot))
+        return 1.0f;
+
+    bool const isAoeThreat = IsAoeThreatAction(bot, action);
+    if (!isAoeThreat && !IsTauntAction(bot, action))
+        return 1.0f;
+
+    // The main tank stays on Maulgar the whole time so it can do whatever.
+    if (PlayerbotAI::IsMainTank(bot))
+        return 1.0f;
+
+    // Blindeye and Olm are tanked next to each other by separate tanks; until Blindeye is dead,
+    // don't use AoE threat abilities.
+    if (isAoeThreat && AI_VALUE2(Unit*, "find target", "blindeye the seer"))
+        return 0.0f;
+
+    // Kiggler is the only ogre for which taunting is a problem because he is the only one that is
+    // both (1) tanked by a non-traditional-tank and (2) directed to be attacked by traditional
+    // tanks (the Blindeye and Olm tanks after both are down).
+    Unit* kiggler = AI_VALUE2(Unit*, "find target", "kiggler the crazed");
+    if (!kiggler)
+        return 1.0f;
+
+    if (!GetKigglerMoonkinTank(bot))
+        return 1.0f;
+
+    return AI_VALUE(Unit*, "current target") == kiggler ? 0.0f : 1.0f;
+}
+
+float HighKingMaulgarDisableDpsAssistMultiplier::GetValue(Action* action)
+{
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
+        return 1.0f;
+
+    if (PlayerbotAI::IsTank(bot))
+        return 1.0f;
+
+    if (!dynamic_cast<DpsAssistAction*>(action))
+        return 1.0f;
+
+    return AI_VALUE2(Unit*, "find target", "high king maulgar") ? 0.0f : 1.0f;
 }
 
 float HighKingMaulgarAvoidWhirlwindMultiplier::GetValue(Action* action)
 {
+    if (!dynamic_cast<MovementAction*>(action) &&
+        !dynamic_cast<CastReachTargetSpellAction*>(action))
+    {
+        return 1.0f;
+    }
+
+    if (dynamic_cast<AttackAction*>(action))
+        return 1.0f;
+
+    if (dynamic_cast<HighKingMaulgarRunAwayFromWhirlwindAction*>(action))
+        return 1.0f;
+
     Unit* maulgar = AI_VALUE2(Unit*, "find target", "high king maulgar");
-    if (!maulgar ||
-        !maulgar->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_WHIRLWIND)))
-    {
-        return 1.0f;
-    }
-
-    if (AI_VALUE(Unit*, "current target") != maulgar)
+    if (!maulgar || !maulgar->HasAura(Id(GruulSpells::SPELL_WHIRLWIND)))
         return 1.0f;
 
-    if (botAI->IsMainTank(bot))
+    if (PlayerbotAI::IsMainTank(bot))
         return 1.0f;
 
-    if (dynamic_cast<CastReachTargetSpellAction*>(action) ||
-        (dynamic_cast<MovementAction*>(action) &&
-         !dynamic_cast<HighKingMaulgarRunAwayFromWhirlwindAction*>(action)))
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
+    return bot->GetDistance2d(maulgar) < WHIRLWIND_SAFE_DISTANCE + 5.0f ? 0.0f : 1.0f;
 }
 
-// Arcane Shot will remove Spell Shield, which the mage tank needs to survive
-float HighKingMaulgarDisableArcaneShotOnKroshMultiplier::GetValue(Action* action)
+float HighKingMaulgarControlHunterActionsMultiplier::GetValue(Action* action)
 {
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
+        return 1.0f;
+
     if (bot->getClass() != CLASS_HUNTER)
         return 1.0f;
 
-    Unit* krosh = AI_VALUE2(Unit*, "find target", "krosh firehand");
-    if (!krosh || AI_VALUE(Unit*, "current target") != krosh)
+    bool const isMainTankMisdirect = dynamic_cast<CastMisdirectionOnMainTankAction*>(action);
+    if (!isMainTankMisdirect && !dynamic_cast<CastArcaneShotAction*>(action))
         return 1.0f;
 
-    if (dynamic_cast<CastArcaneShotAction*>(action))
+    // Krosh/Kiggler will be the last to die before Maulgar
+    // When only Maulgar is left, the standard Misdirection strategy is fine
+    if (isMainTankMisdirect &&
+        ((AI_VALUE2(Unit*, "find target", "krosh firehand")) ||
+         (AI_VALUE2(Unit*, "find target", "kiggler the crazed"))))
+    {
         return 0.0f;
+    }
 
-    return 1.0f;
+    // Arcane Shot removes Spell Shield, which the mage tank needs to survive
+    Unit* krosh = AI_VALUE2(Unit*, "find target", "krosh firehand");
+    return krosh && action->GetTarget() == krosh ? 0.0f : 1.0f;
 }
 
-float HighKingMaulgarDisableMageTankAoeMultiplier::GetValue(Action* action)
+float HighKingMaulgarControlMageTankActionsMultiplier::GetValue(Action* action)
 {
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
+        return 1.0f;
+
     if (bot->getClass() != CLASS_MAGE)
         return 1.0f;
+
+    if (action->getThreatType() != Action::ActionThreatType::Aoe &&
+        !dynamic_cast<CastIceBlockAction*>(action) &&
+        !dynamic_cast<CastInvisibilityAction*>(action))
+    {
+        return 1.0f;
+    }
 
     if (!AI_VALUE2(Unit*, "find target", "krosh firehand"))
         return 1.0f;
 
-    auto castSpellAction = dynamic_cast<CastSpellAction*>(action);
-    if (castSpellAction &&
-        castSpellAction->getThreatType() == Action::ActionThreatType::Aoe)
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
-}
-
-float GruulTheDragonkillerDelayBloodlustAndHeroismMultiplier::GetValue(Action* action)
-{
-    if (bot->getClass() != CLASS_SHAMAN)
-        return 1.0f;
-
-    Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
-    if (!gruul || gruul->GetHealthPct() < 95.0f)
-        return 1.0f;
-
-    if (dynamic_cast<CastHeroismAction*>(action) ||
-        dynamic_cast<CastBloodlustAction*>(action))
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
+    return GetKroshMageTank(bot) == bot ? 0.0f : 1.0f;
 }
 
 float GruulTheDragonkillerControlTankMovementMultiplier::GetValue(Action* action)
 {
-    Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
-    if (!gruul || gruul->GetVictim() != bot)
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
         return 1.0f;
 
-    if (dynamic_cast<CombatFormationMoveAction*>(action) ||
-        dynamic_cast<AvoidAoeAction*>(action))
+    if (!PlayerbotAI::IsTank(bot))
+        return 1.0f;
+
+    if (!dynamic_cast<CombatFormationMoveAction*>(action) &&
+        !dynamic_cast<AvoidAoeAction*>(action))
     {
-        return 0.0f;
+        return 1.0f;
     }
 
-    return 1.0f;
+    Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
+    return gruul && gruul->GetVictim() == bot ? 0.0f : 1.0f;
 }
 
 float GruulTheDragonkillerStaySpreadForShatterMultiplier::GetValue(Action* action)
 {
-    if (!bot->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_GROUND_SLAM_1)) &&
-        !bot->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_GROUND_SLAM_2)))
+    if (!HasGroundSlam(bot))
+        return 1.0f;
+
+    if (!dynamic_cast<MovementAction*>(action) &&
+        !dynamic_cast<CastReachTargetSpellAction*>(action))
     {
         return 1.0f;
     }
 
-    if (dynamic_cast<CastReachTargetSpellAction*>(action) ||
-        (dynamic_cast<MovementAction*>(action) &&
-         !dynamic_cast<GruulTheDragonkillerShatterSpreadAction*>(action)))
-    {
-         return 0.0f;
-    }
+    return dynamic_cast<GruulTheDragonkillerShatterSpreadAction*>(action) ? 1.0f : 0.0f;
+}
 
-    return 1.0f;
+// MoveTo does not check speed, and thus even with a snare of -100% or more, it starts a spline
+// and calculates IsWaitingForLastMove from distance / speed, which is infinite in that case and
+// clamps to MaxWaitForMove (5s), blocking all movements for that duration. This multiplier is
+// needed to solve the issue for Gruul because the snare he applies (Gronn Lord's Grasp) persists
+// 300ms beyond the Shatter sequence, meaning that bots would otherwise be unable to move for 5s
+// after the Shatter sequence, even though no in-game factors would prevent their movement.
+float GruulTheDragonkillerHoldWhileSnaredMultiplier::GetValue(Action* action)
+{
+    if (bot->GetSpeed(MOVE_RUN) > 0.0f)
+        return 1.0f;
+
+    if (!AI_VALUE2(Unit*, "find target", "gruul the dragonkiller"))
+        return 1.0f;
+
+    return dynamic_cast<MovementAction*>(action) ? 0.0f : 1.0f;
 }

--- a/src/Ai/Raid/Gruul/GruulMultipliers.h
+++ b/src/Ai/Raid/Gruul/GruulMultipliers.h
@@ -9,67 +9,83 @@
 
 #include "Multiplier.h"
 
-class HighKingMaulgarDelayBloodlustAndHeroismMultiplier : public Multiplier
+class GruulsLairDelayDpsCooldownsMultiplier : public Multiplier
 {
 public:
-    HighKingMaulgarDelayBloodlustAndHeroismMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "high king maulgar delay bloodlust and heroism multiplier") {}
+    GruulsLairDelayDpsCooldownsMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "gruul's lair delay dps cooldowns") {}
     float GetValue(Action* action) override;
 };
 
 class HighKingMaulgarControlTankActionsMultiplier : public Multiplier
 {
 public:
-    HighKingMaulgarControlTankActionsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "high king maulgar control tank actions multiplier") {}
+    HighKingMaulgarControlTankActionsMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "high king maulgar control tank actions") {}
+    float GetValue(Action* action) override;
+};
+
+class HighKingMaulgarRestrictTauntingMultiplier : public Multiplier
+{
+public:
+    HighKingMaulgarRestrictTauntingMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "high king maulgar restrict taunting") {}
+    float GetValue(Action* action) override;
+};
+
+class HighKingMaulgarDisableDpsAssistMultiplier : public Multiplier
+{
+public:
+    HighKingMaulgarDisableDpsAssistMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "high king maulgar disable dps assist") {}
     float GetValue(Action* action) override;
 };
 
 class HighKingMaulgarAvoidWhirlwindMultiplier : public Multiplier
 {
 public:
-    HighKingMaulgarAvoidWhirlwindMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "high king maulgar avoid whirlwind multiplier") {}
+    HighKingMaulgarAvoidWhirlwindMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "high king maulgar avoid whirlwind") {}
     float GetValue(Action* action) override;
 };
 
-class HighKingMaulgarDisableArcaneShotOnKroshMultiplier : public Multiplier
+class HighKingMaulgarControlHunterActionsMultiplier : public Multiplier
 {
 public:
-    HighKingMaulgarDisableArcaneShotOnKroshMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "high king maulgar disable arcane shot on krosh multiplier") {}
+    HighKingMaulgarControlHunterActionsMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "high king maulgar control hunter actions") {}
     float GetValue(Action* action) override;
 };
 
-class HighKingMaulgarDisableMageTankAoeMultiplier : public Multiplier
+class HighKingMaulgarControlMageTankActionsMultiplier : public Multiplier
 {
 public:
-    HighKingMaulgarDisableMageTankAoeMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "high king maulgar disable mage tank aoe multiplier") {}
-    float GetValue(Action* action) override;
-};
-
-class GruulTheDragonkillerDelayBloodlustAndHeroismMultiplier : public Multiplier
-{
-public:
-    GruulTheDragonkillerDelayBloodlustAndHeroismMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "gruul the dragonkiller delay bloodlust and heroism multiplier") {}
+    HighKingMaulgarControlMageTankActionsMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "high king maulgar control mage tank actions") {}
     float GetValue(Action* action) override;
 };
 
 class GruulTheDragonkillerControlTankMovementMultiplier : public Multiplier
 {
 public:
-    GruulTheDragonkillerControlTankMovementMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "gruul the dragonkiller control tank movement multiplier") {}
+    GruulTheDragonkillerControlTankMovementMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "gruul the dragonkiller control tank movement") {}
     float GetValue(Action* action) override;
 };
 
 class GruulTheDragonkillerStaySpreadForShatterMultiplier : public Multiplier
 {
 public:
-    GruulTheDragonkillerStaySpreadForShatterMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "gruul the dragonkiller stay spread for shatter multiplier") {}
+    GruulTheDragonkillerStaySpreadForShatterMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "gruul the dragonkiller stay spread for shatter") {}
+    float GetValue(Action* action) override;
+};
+
+class GruulTheDragonkillerHoldWhileSnaredMultiplier : public Multiplier
+{
+public:
+    GruulTheDragonkillerHoldWhileSnaredMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "gruul the dragonkiller hold while snared") {}
     float GetValue(Action* action) override;
 };
 

--- a/src/Ai/Raid/Gruul/GruulStrategy.cpp
+++ b/src/Ai/Raid/Gruul/GruulStrategy.cpp
@@ -9,43 +9,44 @@
 
 void RaidGruulsLairStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
+    // General
+    triggers.push_back(new TriggerNode("gruul's lair no encounter in progress", {
+        NextAction("gruul's lair reset encounter states", ACTION_EMERGENCY + 10) }));
+
     // High King Maulgar
-    triggers.push_back(new TriggerNode("high king maulgar boss engaged by main tank", {
-        NextAction("high king maulgar main tank attack maulgar", ACTION_RAID + 1) }));
+    triggers.push_back(new TriggerNode("high king maulgar three ogres need melee tanks", {
+        NextAction("high king maulgar melee tanks position bosses", ACTION_RAID + 1) }));
 
-    triggers.push_back(new TriggerNode("high king maulgar olm engaged by first assist tank", {
-        NextAction("high king maulgar first assist tank attack olm", ACTION_RAID + 1) }));
-
-    triggers.push_back(new TriggerNode("high king maulgar blindeye engaged by second assist tank", {
-        NextAction("high king maulgar second assist tank attack blindeye", ACTION_RAID + 1) }));
-
-    triggers.push_back(new TriggerNode("high king maulgar krosh engaged by mage tank", {
+    triggers.push_back(new TriggerNode("high king maulgar krosh needs mage tank", {
         NextAction("high king maulgar mage tank attack krosh", ACTION_RAID + 1) }));
 
-    triggers.push_back(new TriggerNode("high king maulgar kiggler engaged by moonkin tank", {
+    triggers.push_back(new TriggerNode("high king maulgar kiggler needs moonkin tank", {
         NextAction("high king maulgar moonkin tank attack kiggler", ACTION_RAID + 1) }));
 
     triggers.push_back(new TriggerNode("high king maulgar determining kill order", {
-        NextAction("high king maulgar assign dps priority", ACTION_RAID + 1) }));
+        NextAction("high king maulgar assign dps priority", ACTION_RAID) }));
 
     triggers.push_back(new TriggerNode("high king maulgar boss channeling whirlwind", {
-        NextAction("high king maulgar run away from whirlwind", ACTION_EMERGENCY + 7) }));
+        NextAction("high king maulgar run away from whirlwind", ACTION_EMERGENCY + 6) }));
 
     triggers.push_back(new TriggerNode("high king maulgar krosh casts blast wave", {
-        NextAction("high king maulgar move away from blast nova danger", ACTION_EMERGENCY + 6) }));
+        NextAction("high king maulgar flee from blast wave danger", ACTION_RAID + 3) }));
 
     triggers.push_back(new TriggerNode("high king maulgar wild fel stalker spawned", {
-        NextAction("high king maulgar banish fel stalker", ACTION_RAID + 2) }));
+        NextAction("high king maulgar banish fel stalker", ACTION_RAID + 1) }));
 
     triggers.push_back(new TriggerNode("high king maulgar pulling ogre council", {
-        NextAction("high king maulgar misdirect ogres to tanks", ACTION_RAID + 2) }));
+        NextAction("high king maulgar misdirect ogres to tanks", ACTION_RAID + 1) }));
+
+    triggers.push_back(new TriggerNode("high king maulgar boss casts intimidating roar", {
+        NextAction("high king maulgar cast fear ward on main tank", ACTION_RAID + 2) }));
 
     // Gruul the Dragonkiller
-    triggers.push_back(new TriggerNode("gruul the dragonkiller boss engaged by tanks", {
-        NextAction("gruul the dragonkiller tanks position boss", ACTION_RAID + 1) }));
+    triggers.push_back(new TriggerNode("gruul the dragonkiller should be tanked", {
+        NextAction("gruul the dragonkiller tanks position boss", ACTION_RAID) }));
 
-    triggers.push_back(new TriggerNode("gruul the dragonkiller boss engaged by ranged", {
-        NextAction("gruul the dragonkiller spread ranged", ACTION_RAID + 1) }));
+    triggers.push_back(new TriggerNode("gruul the dragonkiller ranged should spread", {
+        NextAction("gruul the dragonkiller spread ranged", ACTION_RAID) }));
 
     triggers.push_back(new TriggerNode("gruul the dragonkiller incoming shatter", {
         NextAction("gruul the dragonkiller shatter spread", ACTION_EMERGENCY + 6) }));
@@ -53,15 +54,19 @@ void RaidGruulsLairStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 
 void RaidGruulsLairStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
 {
+    // General
+    multipliers.push_back(new GruulsLairDelayDpsCooldownsMultiplier(botAI));
+
     // High King Maulgar
-    multipliers.push_back(new HighKingMaulgarDelayBloodlustAndHeroismMultiplier(botAI));
     multipliers.push_back(new HighKingMaulgarControlTankActionsMultiplier(botAI));
+    multipliers.push_back(new HighKingMaulgarRestrictTauntingMultiplier(botAI));
+    multipliers.push_back(new HighKingMaulgarDisableDpsAssistMultiplier(botAI));
     multipliers.push_back(new HighKingMaulgarAvoidWhirlwindMultiplier(botAI));
-    multipliers.push_back(new HighKingMaulgarDisableArcaneShotOnKroshMultiplier(botAI));
-    multipliers.push_back(new HighKingMaulgarDisableMageTankAoeMultiplier(botAI));
+    multipliers.push_back(new HighKingMaulgarControlHunterActionsMultiplier(botAI));
+    multipliers.push_back(new HighKingMaulgarControlMageTankActionsMultiplier(botAI));
 
     // Gruul the Dragonkiller
-    multipliers.push_back(new GruulTheDragonkillerDelayBloodlustAndHeroismMultiplier(botAI));
     multipliers.push_back(new GruulTheDragonkillerControlTankMovementMultiplier(botAI));
     multipliers.push_back(new GruulTheDragonkillerStaySpreadForShatterMultiplier(botAI));
+    multipliers.push_back(new GruulTheDragonkillerHoldWhileSnaredMultiplier(botAI));
 }

--- a/src/Ai/Raid/Gruul/GruulStrategy.h
+++ b/src/Ai/Raid/Gruul/GruulStrategy.h
@@ -8,12 +8,13 @@
 #define PLAYERBOTS_GRUULSTRATEGY_H
 
 #include "Strategy.h"
+#include <string>
+#include <vector>
 
 class RaidGruulsLairStrategy : public Strategy
 {
 public:
     RaidGruulsLairStrategy(PlayerbotAI* botAI) : Strategy(botAI) {}
-
     std::string const getName() override { return "gruulslair"; }
 
     void InitTriggers(std::vector<TriggerNode*>& triggers) override;

--- a/src/Ai/Raid/Gruul/GruulTriggerContext.h
+++ b/src/Ai/Raid/Gruul/GruulTriggerContext.h
@@ -15,21 +15,19 @@ class RaidGruulsLairTriggerContext : public NamedObjectContext<Trigger>
 public:
     RaidGruulsLairTriggerContext() : NamedObjectContext<Trigger>()
     {
+        // General
+        creators["gruul's lair no encounter in progress"] =
+            &RaidGruulsLairTriggerContext::gruuls_lair_no_encounter_in_progress;
+
         // High King Maulgar
-        creators["high king maulgar boss engaged by main tank"] =
-            &RaidGruulsLairTriggerContext::high_king_maulgar_boss_engaged_by_main_tank;
+        creators["high king maulgar three ogres need melee tanks"] =
+            &RaidGruulsLairTriggerContext::high_king_maulgar_three_ogres_need_melee_tanks;
 
-        creators["high king maulgar olm engaged by first assist tank"] =
-            &RaidGruulsLairTriggerContext::high_king_maulgar_olm_engaged_by_first_assist_tank;
+        creators["high king maulgar krosh needs mage tank"] =
+            &RaidGruulsLairTriggerContext::high_king_maulgar_krosh_needs_mage_tank;
 
-        creators["high king maulgar blindeye engaged by second assist tank"] =
-            &RaidGruulsLairTriggerContext::high_king_maulgar_blindeye_engaged_by_second_assist_tank;
-
-        creators["high king maulgar krosh engaged by mage tank"] =
-            &RaidGruulsLairTriggerContext::high_king_maulgar_krosh_engaged_by_mage_tank;
-
-        creators["high king maulgar kiggler engaged by moonkin tank"] =
-            &RaidGruulsLairTriggerContext::high_king_maulgar_kiggler_engaged_by_moonkin_tank;
+        creators["high king maulgar kiggler needs moonkin tank"] =
+            &RaidGruulsLairTriggerContext::high_king_maulgar_kiggler_needs_moonkin_tank;
 
         creators["high king maulgar determining kill order"] =
             &RaidGruulsLairTriggerContext::high_king_maulgar_determining_kill_order;
@@ -46,33 +44,35 @@ public:
         creators["high king maulgar pulling ogre council"] =
             &RaidGruulsLairTriggerContext::high_king_maulgar_pulling_ogre_council;
 
-        // Gruul the Dragonkiller
-        creators["gruul the dragonkiller boss engaged by tanks"] =
-            &RaidGruulsLairTriggerContext::gruul_the_dragonkiller_boss_engaged_by_tanks;
+        creators["high king maulgar boss casts intimidating roar"] =
+            &RaidGruulsLairTriggerContext::high_king_maulgar_boss_casts_intimidating_roar;
 
-        creators["gruul the dragonkiller boss engaged by ranged"] =
-            &RaidGruulsLairTriggerContext::gruul_the_dragonkiller_boss_engaged_by_ranged;
+        // Gruul the Dragonkiller
+        creators["gruul the dragonkiller should be tanked"] =
+            &RaidGruulsLairTriggerContext::gruul_the_dragonkiller_should_be_tanked;
+
+        creators["gruul the dragonkiller ranged should spread"] =
+            &RaidGruulsLairTriggerContext::gruul_the_dragonkiller_ranged_should_spread;
 
         creators["gruul the dragonkiller incoming shatter"] =
             &RaidGruulsLairTriggerContext::gruul_the_dragonkiller_incoming_shatter;
     }
 
 private:
+    // General
+    static Trigger* gruuls_lair_no_encounter_in_progress(PlayerbotAI* botAI) {
+        return new GruulsLairNoEncounterInProgress(botAI);
+    }
+
     // High King Maulgar
-    static Trigger* high_king_maulgar_boss_engaged_by_main_tank(PlayerbotAI* botAI) {
-        return new HighKingMaulgarBossEngagedByMainTankTrigger(botAI);
+    static Trigger* high_king_maulgar_three_ogres_need_melee_tanks(PlayerbotAI* botAI) {
+        return new HighKingMaulgarThreeOgresNeedMeleeTanksTrigger(botAI);
     }
-    static Trigger* high_king_maulgar_olm_engaged_by_first_assist_tank(PlayerbotAI* botAI) {
-        return new HighKingMaulgarOlmEngagedByFirstAssistTankTrigger(botAI);
+    static Trigger* high_king_maulgar_krosh_needs_mage_tank(PlayerbotAI* botAI) {
+        return new HighKingMaulgarKroshNeedsMageTankTrigger(botAI);
     }
-    static Trigger* high_king_maulgar_blindeye_engaged_by_second_assist_tank(PlayerbotAI* botAI) {
-        return new HighKingMaulgarBlindeyeEngagedBySecondAssistTankTrigger(botAI);
-    }
-    static Trigger* high_king_maulgar_krosh_engaged_by_mage_tank(PlayerbotAI* botAI) {
-        return new HighKingMaulgarKroshEngagedByMageTankTrigger(botAI);
-    }
-    static Trigger* high_king_maulgar_kiggler_engaged_by_moonkin_tank(PlayerbotAI* botAI) {
-        return new HighKingMaulgarKigglerEngagedByMoonkinTankTrigger(botAI);
+    static Trigger* high_king_maulgar_kiggler_needs_moonkin_tank(PlayerbotAI* botAI) {
+        return new HighKingMaulgarKigglerNeedsMoonkinTankTrigger(botAI);
     }
     static Trigger* high_king_maulgar_determining_kill_order(PlayerbotAI* botAI) {
         return new HighKingMaulgarDeterminingKillOrderTrigger(botAI);
@@ -89,13 +89,16 @@ private:
     static Trigger* high_king_maulgar_pulling_ogre_council(PlayerbotAI* botAI) {
         return new HighKingMaulgarPullingOgreCouncilTrigger(botAI);
     }
+    static Trigger* high_king_maulgar_boss_casts_intimidating_roar(PlayerbotAI* botAI) {
+        return new HighKingMaulgarBossCastsIntimidatingRoarTrigger(botAI);
+    }
 
     // Gruul the Dragonkiller
-    static Trigger* gruul_the_dragonkiller_boss_engaged_by_tanks(PlayerbotAI* botAI) {
-        return new GruulTheDragonkillerBossEngagedByTanksTrigger(botAI);
+    static Trigger* gruul_the_dragonkiller_should_be_tanked(PlayerbotAI* botAI) {
+        return new GruulTheDragonkillerShouldBeTankedTrigger(botAI);
     }
-    static Trigger* gruul_the_dragonkiller_boss_engaged_by_ranged(PlayerbotAI* botAI) {
-        return new GruulTheDragonkillerBossEngagedByRangedTrigger(botAI);
+    static Trigger* gruul_the_dragonkiller_ranged_should_spread(PlayerbotAI* botAI) {
+        return new GruulTheDragonkillerRangedShouldSpreadTrigger(botAI);
     }
     static Trigger* gruul_the_dragonkiller_incoming_shatter(PlayerbotAI* botAI) {
         return new GruulTheDragonkillerIncomingShatterTrigger(botAI);

--- a/src/Ai/Raid/Gruul/GruulTriggers.cpp
+++ b/src/Ai/Raid/Gruul/GruulTriggers.cpp
@@ -96,7 +96,7 @@ bool HighKingMaulgarPullingOgreCouncilTrigger::IsActive()
         return false;
 
     Unit* blindeye = AI_VALUE2(Unit*, "find target", "blindeye the seer");
-    return blindeye && blindeye->GetHealthPct() > BLINDEYE_PULL_COMPLETE_HP_PERCENT;
+    return blindeye && blindeye->GetHealthPct() > BLINDEYE_ENGAGED_HEALTH_PCT;
 }
 
 bool HighKingMaulgarBossCastsIntimidatingRoarTrigger::IsActive()

--- a/src/Ai/Raid/Gruul/GruulTriggers.cpp
+++ b/src/Ai/Raid/Gruul/GruulTriggers.cpp
@@ -6,63 +6,63 @@
 
 #include "GruulTriggers.h"
 #include "GruulHelpers.h"
+#include "InstanceScript.h"
 #include "Playerbots.h"
 
-using namespace GruulsLairHelpers;
+using namespace GruulHelpers;
 
-// High King Maulgar Triggers
+// General
 
-bool HighKingMaulgarBossEngagedByMainTankTrigger::IsActive()
+bool GruulsLairNoEncounterInProgress::IsActive()
 {
-    return botAI->IsMainTank(bot) &&
-           AI_VALUE2(Unit*, "find target", "high king maulgar");
+    if (bot->GetMapId() != GRUUL_MAP_ID)
+        return false;
+
+    InstanceScript* instance = bot->GetInstanceScript();
+    return instance && !instance->IsEncounterInProgress();
 }
 
-bool HighKingMaulgarOlmEngagedByFirstAssistTankTrigger::IsActive()
+// High King Maulgar
+
+bool HighKingMaulgarThreeOgresNeedMeleeTanksTrigger::IsActive()
 {
-    return botAI->IsAssistTankOfIndex(bot, 0, false) &&
-           AI_VALUE2(Unit*, "find target", "olm the summoner");
+    if (IsBlindeyeTank(bot))
+        return AI_VALUE2(Unit*, "find target", "blindeye the seer");
+
+    if (IsOlmTank(bot))
+        return AI_VALUE2(Unit*, "find target", "olm the summoner");
+
+    return IsMaulgarTank(bot) && AI_VALUE2(Unit*, "find target", "high king maulgar");
 }
 
-bool HighKingMaulgarBlindeyeEngagedBySecondAssistTankTrigger::IsActive()
+bool HighKingMaulgarKroshNeedsMageTankTrigger::IsActive()
 {
-    return botAI->IsAssistTankOfIndex(bot, 1, false) &&
-           AI_VALUE2(Unit*, "find target", "blindeye the seer");
+    return IsKroshMageTank(bot) && AI_VALUE2(Unit*, "find target", "krosh firehand");
 }
 
-bool HighKingMaulgarKroshEngagedByMageTankTrigger::IsActive()
+bool HighKingMaulgarKigglerNeedsMoonkinTankTrigger::IsActive()
 {
-    return bot->getClass() == CLASS_MAGE &&
-           AI_VALUE2(Unit*, "find target", "krosh firehand") &&
-           GetKroshMageTank(bot) == bot;
-}
-
-bool HighKingMaulgarKigglerEngagedByMoonkinTankTrigger::IsActive()
-{
-    return bot->getClass() == CLASS_DRUID &&
-           AI_VALUE2(Unit*, "find target", "kiggler the crazed") &&
-           GetKigglerMoonkinTank(bot) == bot;
+    return IsKigglerMoonkinTank(bot) && AI_VALUE2(Unit*, "find target", "kiggler the crazed");
 }
 
 bool HighKingMaulgarDeterminingKillOrderTrigger::IsActive()
 {
-    if (botAI->IsHeal(bot) || botAI->IsMainTank(bot))
+    if (!AI_VALUE2(Unit*, "find target", "high king maulgar"))
         return false;
 
-    Unit* maulgar = AI_VALUE2(Unit*, "find target", "high king maulgar");
-    if (!maulgar)
+    if (IsMaulgarTank(bot))
         return false;
 
-    if (botAI->IsAssistTankOfIndex(bot, 0, false))
+    if (IsOlmTank(bot))
         return !AI_VALUE2(Unit*, "find target", "olm the summoner");
 
-    if (botAI->IsAssistTankOfIndex(bot, 1, false))
+    if (IsBlindeyeTank(bot))
         return !AI_VALUE2(Unit*, "find target", "blindeye the seer");
 
-    if (bot->getClass() == CLASS_MAGE && GetKroshMageTank(bot) == bot)
+    if (IsKroshMageTank(bot))
         return !AI_VALUE2(Unit*, "find target", "krosh firehand");
 
-    if (bot->getClass() == CLASS_DRUID && GetKigglerMoonkinTank(bot) == bot)
+    if (IsKigglerMoonkinTank(bot))
         return !AI_VALUE2(Unit*, "find target", "kiggler the crazed");
 
     return true;
@@ -71,27 +71,23 @@ bool HighKingMaulgarDeterminingKillOrderTrigger::IsActive()
 bool HighKingMaulgarBossChannelingWhirlwindTrigger::IsActive()
 {
     Unit* maulgar = AI_VALUE2(Unit*, "find target", "high king maulgar");
-    if (!maulgar ||
-        !maulgar->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_WHIRLWIND)))
-    {
+    if (!maulgar || !maulgar->HasAura(Id(GruulSpells::SPELL_WHIRLWIND)))
         return false;
-    }
 
-    return !botAI->IsMainTank(bot);
+    return !IsMaulgarTank(bot);
 }
 
 bool HighKingMaulgarKroshCastsBlastWaveTrigger::IsActive()
 {
-    if (!AI_VALUE2(Unit*, "find target", "krosh firehand"))
+    if (PlayerbotAI::IsTank(bot) || IsKroshMageTank(bot))
         return false;
 
-    return !botAI->IsTank(bot) && GetKroshMageTank(bot) != bot;
+    return AI_VALUE2(Unit*, "find target", "krosh firehand");
 }
 
 bool HighKingMaulgarWildFelStalkerSpawnedTrigger::IsActive()
 {
-    return bot->getClass() == CLASS_WARLOCK &&
-           AI_VALUE2(Unit*, "find target", "wild fel stalker");
+    return bot->getClass() == CLASS_WARLOCK && AI_VALUE2(Unit*, "find target", "wild fel stalker");
 }
 
 bool HighKingMaulgarPullingOgreCouncilTrigger::IsActive()
@@ -100,25 +96,27 @@ bool HighKingMaulgarPullingOgreCouncilTrigger::IsActive()
         return false;
 
     Unit* blindeye = AI_VALUE2(Unit*, "find target", "blindeye the seer");
-    return blindeye && blindeye->GetHealthPct() > 80.0f;
+    return blindeye && blindeye->GetHealthPct() > BLINDEYE_PULL_COMPLETE_HP_PERCENT;
 }
 
-// Gruul the Dragonkiller Triggers
-
-bool GruulTheDragonkillerBossEngagedByTanksTrigger::IsActive()
+bool HighKingMaulgarBossCastsIntimidatingRoarTrigger::IsActive()
 {
-    return botAI->IsTank(bot) &&
-           AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
+    return bot->getClass() == CLASS_PRIEST && AI_VALUE2(Unit*, "find target", "high king maulgar");
 }
 
-bool GruulTheDragonkillerBossEngagedByRangedTrigger::IsActive()
+// Gruul the Dragonkiller
+
+bool GruulTheDragonkillerShouldBeTankedTrigger::IsActive()
 {
-    return botAI->IsRanged(bot) &&
-           AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
+    return PlayerbotAI::IsTank(bot) && AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
+}
+
+bool GruulTheDragonkillerRangedShouldSpreadTrigger::IsActive()
+{
+    return PlayerbotAI::IsRanged(bot) && AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
 }
 
 bool GruulTheDragonkillerIncomingShatterTrigger::IsActive()
 {
-    return bot->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_GROUND_SLAM_1)) ||
-           bot->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_GROUND_SLAM_2));
+    return HasGroundSlam(bot);
 }

--- a/src/Ai/Raid/Gruul/GruulTriggers.h
+++ b/src/Ai/Raid/Gruul/GruulTriggers.h
@@ -9,107 +9,107 @@
 
 #include "Trigger.h"
 
-class HighKingMaulgarBossEngagedByMainTankTrigger : public Trigger
+class GruulsLairNoEncounterInProgress : public Trigger
 {
 public:
-    HighKingMaulgarBossEngagedByMainTankTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar engaged by main tank") {}
+    GruulsLairNoEncounterInProgress(PlayerbotAI* botAI)
+        : Trigger(botAI, "gruul's lair no encounter in progress") {}
     bool IsActive() override;
 };
 
-class HighKingMaulgarOlmEngagedByFirstAssistTankTrigger : public Trigger
+class HighKingMaulgarThreeOgresNeedMeleeTanksTrigger : public Trigger
 {
 public:
-    HighKingMaulgarOlmEngagedByFirstAssistTankTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar olm engaged by first assist tank") {}
+    HighKingMaulgarThreeOgresNeedMeleeTanksTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "high king maulgar three ogres need melee tanks") {}
     bool IsActive() override;
 };
 
-class HighKingMaulgarBlindeyeEngagedBySecondAssistTankTrigger : public Trigger
+class HighKingMaulgarKroshNeedsMageTankTrigger : public Trigger
 {
 public:
-    HighKingMaulgarBlindeyeEngagedBySecondAssistTankTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar blindeye engaged by second assist tank") {}
+    HighKingMaulgarKroshNeedsMageTankTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "high king maulgar krosh needs mage tank") {}
     bool IsActive() override;
 };
 
-class HighKingMaulgarKroshEngagedByMageTankTrigger : public Trigger
+class HighKingMaulgarKigglerNeedsMoonkinTankTrigger : public Trigger
 {
 public:
-    HighKingMaulgarKroshEngagedByMageTankTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar krosh engaged by mage tank") {}
-    bool IsActive() override;
-};
-
-class HighKingMaulgarKigglerEngagedByMoonkinTankTrigger : public Trigger
-{
-public:
-    HighKingMaulgarKigglerEngagedByMoonkinTankTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar kiggler engaged by moonkin tank") {}
+    HighKingMaulgarKigglerNeedsMoonkinTankTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "high king maulgar kiggler needs moonkin tank") {}
     bool IsActive() override;
 };
 
 class HighKingMaulgarDeterminingKillOrderTrigger : public Trigger
 {
 public:
-    HighKingMaulgarDeterminingKillOrderTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar determining kill order") {}
+    HighKingMaulgarDeterminingKillOrderTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "high king maulgar determining kill order") {}
     bool IsActive() override;
 };
 
 class HighKingMaulgarBossChannelingWhirlwindTrigger : public Trigger
 {
 public:
-    HighKingMaulgarBossChannelingWhirlwindTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar boss channeling whirlwind") {}
+    HighKingMaulgarBossChannelingWhirlwindTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "high king maulgar boss channeling whirlwind") {}
     bool IsActive() override;
 };
 
 class HighKingMaulgarKroshCastsBlastWaveTrigger : public Trigger
 {
 public:
-    HighKingMaulgarKroshCastsBlastWaveTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar krosh casts blast wave") {}
+    HighKingMaulgarKroshCastsBlastWaveTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "high king maulgar krosh casts blast wave") {}
     bool IsActive() override;
 };
 
 class HighKingMaulgarWildFelStalkerSpawnedTrigger : public Trigger
 {
 public:
-    HighKingMaulgarWildFelStalkerSpawnedTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar wild fel stalker spawned") {}
+    HighKingMaulgarWildFelStalkerSpawnedTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "high king maulgar wild fel stalker spawned") {}
     bool IsActive() override;
 };
 
 class HighKingMaulgarPullingOgreCouncilTrigger : public Trigger
 {
 public:
-    HighKingMaulgarPullingOgreCouncilTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar pulling ogre council") {}
+    HighKingMaulgarPullingOgreCouncilTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "high king maulgar pulling ogre council") {}
     bool IsActive() override;
 };
 
-class GruulTheDragonkillerBossEngagedByTanksTrigger : public Trigger
+class HighKingMaulgarBossCastsIntimidatingRoarTrigger : public Trigger
 {
 public:
-    GruulTheDragonkillerBossEngagedByTanksTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "gruul the dragonkiller boss engaged by tanks") {}
+    HighKingMaulgarBossCastsIntimidatingRoarTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "high king maulgar boss casts intimidating roar") {}
     bool IsActive() override;
 };
 
-class GruulTheDragonkillerBossEngagedByRangedTrigger : public Trigger
+class GruulTheDragonkillerShouldBeTankedTrigger : public Trigger
 {
 public:
-    GruulTheDragonkillerBossEngagedByRangedTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "gruul the dragonkiller boss engaged by ranged") {}
+    GruulTheDragonkillerShouldBeTankedTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "gruul the dragonkiller should be tanked") {}
+    bool IsActive() override;
+};
+
+class GruulTheDragonkillerRangedShouldSpreadTrigger : public Trigger
+{
+public:
+    GruulTheDragonkillerRangedShouldSpreadTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "gruul the dragonkiller ranged should spread") {}
     bool IsActive() override;
 };
 
 class GruulTheDragonkillerIncomingShatterTrigger : public Trigger
 {
 public:
-    GruulTheDragonkillerIncomingShatterTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "gruul the dragonkiller incoming shatter") {}
+    GruulTheDragonkillerIncomingShatterTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "gruul the dragonkiller incoming shatter") {}
     bool IsActive() override;
 };
 

--- a/src/Ai/World/Rpg/Action/NewRpgAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.cpp
@@ -8,8 +8,11 @@
 #include "AreaDefines.h"
 #include "BroadcastHelper.h"
 #include "ChatHelper.h"
+#include "DBCStores.h"
 #include "GossipDef.h"
 #include "IVMapMgr.h"
+#include "MotionMaster.h"
+#include "MoveSpline.h"
 #include "NewRpgInfo.h"
 #include "NewRpgStrategy.h"
 #include "Object.h"
@@ -26,6 +29,7 @@
 #include "SharedDefines.h"
 #include "Timer.h"
 #include "TravelMgr.h"
+#include "WaypointMovementGenerator.h"
 #include "G3D/Vector2.h"
 #include <cmath>
 #include <cstdlib>
@@ -639,6 +643,7 @@ bool NewRpgTravelFlightAction::Execute(Event /*event*/)
     if (bot->IsInFlight())
     {
         data.inFlight = true;
+        ContinueCrossMapTaxi();
         return false;
     }
 
@@ -665,9 +670,49 @@ bool NewRpgTravelFlightAction::Execute(Event /*event*/)
     if (!bot->ActivateTaxiPathTo(nodes, flightMaster, 0))
     {
         LOG_DEBUG("playerbots", "[New RPG] {} active taxi path {} (from {} to {}) failed", bot->GetName(),
-                  flightMaster->GetEntry(), nodes[0], nodes[nodes.size() - 1]);
+                  flightMaster->GetEntry(), nodes.empty() ? 0 : nodes.front(), nodes.empty() ? 0 : nodes.back());
         info.ChangeToIdle();
         return true;
     }
     return true;
+}
+
+void NewRpgTravelFlightAction::ContinueCrossMapTaxi()
+{
+    if (bot->IsBeingTeleported())
+        return;
+
+    if (!bot->movespline->Finalized())
+        return;
+
+    MotionMaster* mm = bot->GetMotionMaster();
+    if (!mm || mm->GetCurrentMovementGeneratorType() != FLIGHT_MOTION_TYPE)
+        return;
+
+    // Check if we are at our destination.
+    uint32 nextDest = bot->m_taxi.GetTaxiDestination();
+    if (!nextDest)
+        return;
+
+    // Confirm next node needs different map.
+    TaxiNodesEntry const* nextNode = sTaxiNodesStore.LookupEntry(nextDest);
+    if (!nextNode || nextNode->map_id == bot->GetMapId())
+        return;
+
+    FlightPathMovementGenerator* flight = dynamic_cast<FlightPathMovementGenerator*>(mm->top());
+    if (!flight)
+        return;
+
+    LOG_DEBUG("playerbots", "[New RPG] {} continuing taxi across map boundary (next node {} on map {})",
+              bot->GetName(), nextDest, nextNode->map_id);
+
+    flight->SetCurrentNodeAfterTeleport();
+
+    if (flight->HasArrived())
+        return;
+
+    TaxiPathNodeEntry const* node = flight->GetPath()[flight->GetCurrentNode()];
+    flight->SkipCurrentNode();
+
+    bot->TeleportTo(nextNode->map_id, node->x, node->y, node->z, bot->GetOrientation(), TELE_TO_NOT_LEAVE_TAXI);
 }

--- a/src/Ai/World/Rpg/Action/NewRpgAction.h
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.h
@@ -117,6 +117,9 @@ class NewRpgTravelFlightAction : public NewRpgBaseAction
 public:
     NewRpgTravelFlightAction(PlayerbotAI* botAI) : NewRpgBaseAction(botAI, "new rpg travel flight") {}
     bool Execute(Event event) override;
+
+protected:
+    void ContinueCrossMapTaxi();
 };
 
 #endif

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -806,8 +806,8 @@ void PlayerbotAI::HandleTeleportAck()
         // reset AI state after teleport
         Reset(true);
 
-        // clear movement only AFTER teleport is finalized and bot is in world
-        if (bot->IsInWorld() && bot->GetMotionMaster())
+        // clear movement only AFTER teleport is finalized and bot is in world. Skip during a taxi map-transfer
+        if (bot->IsInWorld() && bot->GetMotionMaster() && !bot->IsInFlight())
         {
             bot->GetMotionMaster()->Clear(true);
             bot->StopMoving();

--- a/src/Mgr/Travel/TravelNode.cpp
+++ b/src/Mgr/Travel/TravelNode.cpp
@@ -2493,7 +2493,6 @@ void TravelNodeMap::BuildTaxiGraph()
             continue;
 
         tempGraph[path->from].insert(path->to);
-        tempGraph[path->to].insert(path->from);
     }
     for (auto const& [node, neighbors] : tempGraph)
         taxiGraph[node] = std::vector<uint32>(neighbors.begin(), neighbors.end());
@@ -2503,7 +2502,10 @@ void TravelNodeMap::ComputeAllPaths()
 {
     std::set<uint32> allNodes;
     for (auto const& [source, neighbors] : taxiGraph)
+    {
         allNodes.insert(source);
+        allNodes.insert(neighbors.begin(), neighbors.end());
+    }
 
     for (uint32 source : allNodes)
     {
@@ -2536,7 +2538,11 @@ std::unordered_map<uint32, uint32> TravelNodeMap::BFS(uint32 fromNode)
         uint32 current = workQueue.front();
         workQueue.pop();
 
-        for (uint32 next : taxiGraph.at(current))
+        auto graphItr = taxiGraph.find(current);
+        if (graphItr == taxiGraph.end())
+            continue;
+
+        for (uint32 next : graphItr->second)
         {
             if (visited.count(next))
                 continue;

--- a/src/Util/EncounterHelpers.cpp
+++ b/src/Util/EncounterHelpers.cpp
@@ -29,62 +29,9 @@
 namespace EncounterHelpers
 {
 
-// For validating ground and collision in connection with issuing incremental movement. The caller
-// gives a destination and how far to travel towards it per tick. The helper projects that step,
-// checks whether the bot can actually take it, and returns where it lands. The returned stepZ is
-// snapped to the ground, so a MoveTo() using this helper should pass stepZ rather than the bot's Z.
-bool CanTakeStepTowards(
-    Player* bot, float destinationX, float destinationY, float moveDist,
-    float& stepX, float& stepY, float& stepZ)
-{
-    constexpr float minMoveDistance = 0.5f;
-
-    float const distance = bot->GetExactDist2d(destinationX, destinationY);
-    if (distance < minMoveDistance)
-        return false;
-
-    float const botX = bot->GetPositionX();
-    float const botY = bot->GetPositionY();
-    float const botZ = bot->GetPositionZ();
-
-    float const ratio = std::min(moveDist, distance) / distance;
-    float candidateX = botX + (destinationX - botX) * ratio;
-    float candidateY = botY + (destinationY - botY) * ratio;
-    float candidateZ = bot->GetMapWaterOrGroundLevel(candidateX, candidateY, botZ);
-
-    if (candidateZ <= INVALID_HEIGHT)
-        candidateZ = botZ;
-
-    // The 9th parameter of CanReachPositionAndGetValidCoords(), failOnSlopes, returns false for a
-    // non-walkable slope, but in my experience, walking downhill is always possible, and thus the
-    // check needlessly rejects descents. This variable gets around that problem.
-    bool const failOnSlopes = candidateZ > botZ;
-
-    // This helper will return false on collision rather than clamping to the contact point so that
-    // the caller can try a different path. Clamping is useless for avoidance since the bot will die
-    // just the same if it is in the middle of a hazard vs. halfway out and returning true.
-    float const requestedX = candidateX;
-    float const requestedY = candidateY;
-
-    if (!bot->GetMap()->CanReachPositionAndGetValidCoords(
-            bot, botX, botY, botZ, candidateX, candidateY, candidateZ, true, failOnSlopes))
-    {
-        return false;
-    }
-
-    constexpr float truncationTolerance = 1.0f;
-    if (std::hypot(candidateX - requestedX, candidateY - requestedY) > truncationTolerance)
-        return false;
-
-    stepX = candidateX;
-    stepY = candidateY;
-    stepZ = candidateZ;
-    return true;
-}
-
-// Calculate incremental movement to a tank position. No ground or collision is validated, unlike
-// CanTakeStepTowards(). The Z position passed for the MoveTo() action using this helper should
-// use the bot's Z, not the position's. Returns false once the bot is within arrivalDist.
+// Calculate incremental movement to a tank position. No ground or collision is validated. The
+// Z position passed for the MoveTo() action using this helper should use the bot's Z, not the
+// position's. Returns false once the bot is within arrivalDist.
 bool GetTankPositionStep(
     Player* bot, Position const& position, float arrivalDist, Unit* facing, float& stepX,
     float& stepY, bool& backwards)
@@ -114,7 +61,9 @@ bool GetTankPositionStep(
     // and 4.5y/s backwards (i.e., 0.7y/0.45y per tick). There is not really benefit to having the
     // step be farther than the distance that can be covered in a single tick. But this helper
     // uses 5x tick distance to account for possible speed boosts, latency, and longer configured
-    // AI ticks. In my experience, this is plenty short enough to navigate poor terrain.
+    // AI ticks. In my experience, this is plenty short enough to navigate poor terrain, but if you
+    // are moving steeply uphill and find that movement is failing, it may be possible that the step
+    // distances would need to be even shorter (in which case you couldn't use this helper).
     constexpr float backwardDistancePerStep = 2.25f;
     constexpr float forwardDistancePerStep = 3.5f;
     float const maxMoveDist = backwards ? backwardDistancePerStep : forwardDistancePerStep;

--- a/src/Util/EncounterHelpers.cpp
+++ b/src/Util/EncounterHelpers.cpp
@@ -45,9 +45,9 @@ bool GetTankPositionStep(
     float const toPosX = position.GetPositionX() - botX;
     float const toPosY = position.GetPositionY() - botY;
 
-    // Move backwards only when the bot (1) has aggro on the mob it is tanking, (2) is in melee
-    // range of the mob, and (3) the destination is on the opposite side of the bot from the mob.
-    // Generally, the entire movement would be gated on (1) and (2) anyway, but there are some
+    // Move backwards only when (1) the bot has aggro on the mob it is tanking, (2) the bot is in
+    // melee range of the mob, and (3) the destination is on the opposite side of the bot from the
+    // mob. Generally, the entire movement would be gated on (1) and (2) anyway, but there are some
     // exceptions and thus the checks are made again in the helper.
     backwards = false;
     if (facing && facing->GetVictim() == bot && bot->IsWithinMeleeRange(facing))

--- a/src/Util/EncounterHelpers.cpp
+++ b/src/Util/EncounterHelpers.cpp
@@ -22,14 +22,112 @@
 #include "ShamanActions.h"
 #include "WarlockActions.h"
 #include "WarriorActions.h"
+#include <algorithm>
+#include <cmath>
 #include <list>
 
 namespace EncounterHelpers
-
 {
 
-// Functions to mark targets with raid target icons
-// Note that these functions do not allow the player to change the icon during the encounter
+// For validating ground and collision in connection with issuing incremental movement. The caller
+// gives a destination and how far to travel towards it per tick. The helper projects that step,
+// checks whether the bot can actually take it, and returns where it lands. The returned stepZ is
+// snapped to the ground, so a MoveTo() using this helper should pass stepZ rather than the bot's Z.
+bool CanTakeStepTowards(
+    Player* bot, float destinationX, float destinationY, float moveDist,
+    float& stepX, float& stepY, float& stepZ)
+{
+    constexpr float minMoveDistance = 0.5f;
+
+    float const distance = bot->GetExactDist2d(destinationX, destinationY);
+    if (distance < minMoveDistance)
+        return false;
+
+    float const botX = bot->GetPositionX();
+    float const botY = bot->GetPositionY();
+    float const botZ = bot->GetPositionZ();
+
+    float const ratio = std::min(moveDist, distance) / distance;
+    float candidateX = botX + (destinationX - botX) * ratio;
+    float candidateY = botY + (destinationY - botY) * ratio;
+    float candidateZ = bot->GetMapWaterOrGroundLevel(candidateX, candidateY, botZ);
+
+    if (candidateZ <= INVALID_HEIGHT)
+        candidateZ = botZ;
+
+    // The 9th parameter of CanReachPositionAndGetValidCoords(), failOnSlopes, returns false for a
+    // non-walkable slope, but in my experience, walking downhill is always possible, and thus the
+    // check needlessly rejects descents. This variable gets around that problem.
+    bool const failOnSlopes = candidateZ > botZ;
+
+    // This helper will return false on collision rather than clamping to the contact point so that
+    // the caller can try a different path. Clamping is useless for avoidance since the bot will die
+    // just the same if it is in the middle of a hazard vs. halfway out and returning true.
+    float const requestedX = candidateX;
+    float const requestedY = candidateY;
+
+    if (!bot->GetMap()->CanReachPositionAndGetValidCoords(
+            bot, botX, botY, botZ, candidateX, candidateY, candidateZ, true, failOnSlopes))
+    {
+        return false;
+    }
+
+    constexpr float truncationTolerance = 1.0f;
+    if (std::hypot(candidateX - requestedX, candidateY - requestedY) > truncationTolerance)
+        return false;
+
+    stepX = candidateX;
+    stepY = candidateY;
+    stepZ = candidateZ;
+    return true;
+}
+
+// Calculate incremental movement to a tank position. No ground or collision is validated, unlike
+// CanTakeStepTowards(). The Z position passed for the MoveTo() action using this helper should
+// use the bot's Z, not the position's. Returns false once the bot is within arrivalDist.
+bool GetTankPositionStep(
+    Player* bot, Position const& position, float arrivalDist, Unit* facing, float& stepX,
+    float& stepY, bool& backwards)
+{
+    float const distToPosition = bot->GetExactDist2d(position);
+    if (distToPosition <= arrivalDist)
+        return false;
+
+    float const botX = bot->GetPositionX();
+    float const botY = bot->GetPositionY();
+    float const toPosX = position.GetPositionX() - botX;
+    float const toPosY = position.GetPositionY() - botY;
+
+    // Move backwards only when the bot (1) has aggro on the mob it is tanking, (2) is in melee
+    // range of the mob, and (3) the destination is on the opposite side of the bot from the mob.
+    // Generally, the entire movement would be gated on (1) and (2) anyway, but there are some
+    // exceptions and thus the checks are made again in the helper.
+    backwards = false;
+    if (facing && facing->GetVictim() == bot && bot->IsWithinMeleeRange(facing))
+    {
+        float const toFacingX = facing->GetPositionX() - botX;
+        float const toFacingY = facing->GetPositionY() - botY;
+        backwards = (toPosX * toFacingX + toPosY * toFacingY) < 0.0f;
+    }
+
+    // Default time between AI ticks is 100ms, and base movement speed for players is 7y/s forwards
+    // and 4.5y/s backwards (i.e., 0.7y/0.45y per tick). There is not really benefit to having the
+    // step be farther than the distance that can be covered in a single tick. But this helper
+    // uses 5x tick distance to account for possible speed boosts, latency, and longer configured
+    // AI ticks. In my experience, this is plenty short enough to navigate poor terrain.
+    constexpr float backwardDistancePerStep = 2.25f;
+    constexpr float forwardDistancePerStep = 3.5f;
+    float const maxMoveDist = backwards ? backwardDistancePerStep : forwardDistancePerStep;
+    float const ratio = std::min(maxMoveDist, distToPosition) / distToPosition;
+
+    stepX = botX + toPosX * ratio;
+    stepY = botY + toPosY * ratio;
+
+    return true;
+}
+
+// Functions to mark targets with raid target icons.
+// Note that these functions do not allow the player to change the icon during the encounter.
 bool MarkTargetWithIcon(Player* bot, Unit* target, uint8 iconId)
 {
     if (!target)
@@ -89,6 +187,8 @@ bool MarkTargetWithMoon(Player* bot, Unit* target)
     return MarkTargetWithIcon(bot, target, RtiTargetValue::moonIndex);
 }
 
+// For clearing marks outside of combat so bots don't Leeroy on sight. This is best used when gated
+// behind an out of combat check (such as with IsInCombatValue).
 bool ClearTargetIcon(Player* bot, uint8 iconId)
 {
     Group* group = bot->GetGroup();
@@ -202,7 +302,7 @@ Player* GetGroupAssistTank(Player* bot, uint8 index)
     return nullptr;
 }
 
-// Return the first matching alive unit from PossibleTargetsValue within sightDistance from config
+// Return the first matching alive unit from PossibleTargetsValue within .sightDistance from config
 // Note that PossibleTargetsValue picks up only hostile units
 Unit* GetFirstAliveUnitByEntry(PlayerbotAI* botAI, uint32 entry)
 {
@@ -219,7 +319,8 @@ Unit* GetFirstAliveUnitByEntry(PlayerbotAI* botAI, uint32 entry)
 }
 
 // Return the nearest alive player (human or bot) within the specified radius. Distance is
-// measured by GetExactDist2d(), which does not take into account player hitboxes (1.5y).
+// measured by GetExactDist2d(), which does not take into account either player's CombatReach
+// (i.e., their hitboxes), which are 1.5y for all races (or 1.95y with Bloodlust/Heroism active).
 Player* GetNearestPlayerInRadius(Player* bot, float radius)
 {
     Group* group = bot->GetGroup();
@@ -246,7 +347,7 @@ Player* GetNearestPlayerInRadius(Player* bot, float radius)
     return nearestPlayer;
 }
 
-// Grid search for dynamic objects for methods to avoid dynobj-based AoE hazards
+// Grid search for dynamic objects for methods to avoid dynobj-based AoE hazards.
 std::vector<Position> GetDynamicObjectPositions(Player* bot, float searchRadius, uint32 spellId)
 {
     std::list<WorldObject*> objs;
@@ -273,7 +374,7 @@ std::vector<Position> GetDynamicObjectPositions(Player* bot, float searchRadius,
 }
 
 // This function is primarily for use in multipliers during encounters where it is desirable
-// for bots to save cooldowns for particular phases (or for a bit after the pull)
+// for bots to save cooldowns for particular phases (or for a bit after the pull).
 bool IsDpsCooldownAction(Player* bot, Action* action)
 {
     if (bot->getClass() == CLASS_SHAMAN && // Before dps gate to capture Resto
@@ -399,7 +500,7 @@ bool IsTauntAction(Player* bot, Action* action)
     }
 }
 
-// These abilities can be particularly problematic on the pull for a council-type boss
+// These abilities can be particularly problematic on the pull for a council-type boss.
 bool IsAoeThreatAction(Player* bot, Action* action)
 {
     if (!PlayerbotAI::IsTank(bot))

--- a/src/Util/EncounterHelpers.h
+++ b/src/Util/EncounterHelpers.h
@@ -20,9 +20,6 @@ class Unit;
 namespace EncounterHelpers
 {
 
-bool CanTakeStepTowards(
-    Player* bot, float destinationX, float destinationY, float moveDist,
-    float& stepX, float& stepY, float& stepZ);
 bool GetTankPositionStep(
     Player* bot, Position const& position, float arrivalDist, Unit* facing, float& stepX,
     float& stepY, bool& backwards);

--- a/src/Util/EncounterHelpers.h
+++ b/src/Util/EncounterHelpers.h
@@ -20,6 +20,12 @@ class Unit;
 namespace EncounterHelpers
 {
 
+// Cheap, rough proxies for how far along an encounter is. 95% HP means the boss and raid are
+// positioned, the tank has threat, and the fight proper has started, so it's time to use cooldowns.
+// 10% means the boss is almost dead, so ignore adds and finish off the boss.
+inline constexpr float BOSS_ENGAGED_HEALTH_PCT = 95.0f;
+inline constexpr float BOSS_BURN_HEALTH_PCT = 10.0f;
+
 bool GetTankPositionStep(
     Player* bot, Position const& position, float arrivalDist, Unit* facing, float& stepX,
     float& stepY, bool& backwards);

--- a/src/Util/EncounterHelpers.h
+++ b/src/Util/EncounterHelpers.h
@@ -18,9 +18,14 @@ class PlayerbotAI;
 class Unit;
 
 namespace EncounterHelpers
-
 {
 
+bool CanTakeStepTowards(
+    Player* bot, float destinationX, float destinationY, float moveDist,
+    float& stepX, float& stepY, float& stepZ);
+bool GetTankPositionStep(
+    Player* bot, Position const& position, float arrivalDist, Unit* facing, float& stepX,
+    float& stepY, bool& backwards);
 bool MarkTargetWithIcon(Player* bot, Unit* target, uint8 iconId);
 bool MarkTargetWithSkull(Player* bot, Unit* target);
 bool MarkTargetWithSquare(Player* bot, Unit* target);


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

The prior version of Gruul had a really bad implementation of the Shatter spread that made it practically useless. First, for the trigger, it used the version of the Ground Slam aura that covered only the first 2s of the sequence (the player is slowed over the course of 7s, frozen at 7s, and then Shatter hits at 9.7s). Second, for the action, it called FleePosition(), which looks for a position from which the bot can attack, meaning it would send all melee back into melee range of Gruul.

Then, Gruul's Shatter itself causes a bug via its interaction with MovementAction::MoveTo(). The tl;dr is that MoveTo has a built in delay based on the speed of the prior movement, and because the immobilization from Gruul's Shatter survives for 300ms _after_ the end of the Shatter sequence, MoveTo() tries to construct a spline during that period, calculates an infinite movement delay due to movement speed being 0, clamps that to a 5s max, and makes it so that bots stand around for 5s after Shatter before any movement is accepted again. This was fixed via a multiplier.

Maulgar also had a bug for the selection of the Kiggler moonkin tank where I had defined a local variable for spec outside of the group loop using bot, meaning that the group loop was actually checking the bot's spec. It still worked if you set the assistant flag on a moonkin, but it wouldn't work properly otherwise.

I added an out-of-encounter reset of variables, a method to clear RTI icons out of encounters, and a Fear Ward action for Maulgar. I also renamed actions/triggers that were incorrectly named or just generally misleading.

Along with this, I made various cleanups that I overlooked last time (like looping a second time to get tank targets for Hunter misdirects, or completely overcomplicating/using redundant logic the Gruul ranged spread action).

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

Two new trigger/action pairs, one new multiplier. Processing cost should be better, particularly due to the removal of several redundant group loops.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

Go to Gruul's Lair and kill the bosses. Bring a moonkin and don't assign any assistant flags. The moonkin should tank Kiggler. Confirm that Shatter spreading works properly on Gruul.

## Impact Assessment
<!--
As a generic test, pmon checks before and after your edits are helpful. To standardize the measurement, set the configs
BotActiveAlone = 100 & botActiveAloneSmartScale = 0. After server boot, enable the monitor `playerbot pmon toggle`
right after the bots finished logging-in, and run the stack command `playerbot pmon stack` 5 minutes after that.
The last "Total" line is the main result to look for.
-->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

Performance should be better.

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

Fixed/improved strategies in Gruul's Lair with the "gruulslair" strategy applied.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

I had AI assist with figuring out the issue that was causing bots not to move after Shatter. Everything else I did myself, as my original objective was to do this without AI, but I got stuck on that one issue.

## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/Ai/Base/Actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated.
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


