### PR TITLE
Fix a crash from a whispered item command, and a wrapping loop counter in parseMoney

### DIFF
--- a/src/Ai/Base/Actions/InventoryAction.cpp
+++ b/src/Ai/Base/Actions/InventoryAction.cpp
@@ -327,11 +327,19 @@ std::vector<Item*> InventoryAction::parseItems(std::string const text, IterateIt
         found.insert(visitor.GetResult().begin(), visitor.GetResult().end());
     }
 
-    if (text.find("usage ") != std::string::npos)
+    // "usage <n>" is only meaningful at the start of the qualifier, which is how
+    // isReservedQualifier() reads it. Matching it anywhere handed stoi() the text at a fixed
+    // offset instead of the number, so "bandage usage 3" ended up in stoi("ge usage 3").
+    // At most nine digits so the value always fits an int.
+    if (text.rfind("usage ", 0) == 0)
     {
-        FindItemUsageVisitor visitor(bot, ItemUsage(stoi(text.substr(6))));
-        IterateItems(&visitor, ITERATE_ITEMS_IN_BAGS);
-        found.insert(visitor.GetResult().begin(), visitor.GetResult().end());
+        std::string const usage = text.substr(6, text.find(' ', 6) - 6);
+        if (!usage.empty() && usage.size() <= 9 && usage.find_first_not_of("0123456789") == std::string::npos)
+        {
+            FindItemUsageVisitor visitor(bot, ItemUsage(stoi(usage)));
+            IterateItems(&visitor, ITERATE_ITEMS_IN_BAGS);
+            found.insert(visitor.GetResult().begin(), visitor.GetResult().end());
+        }
     }
 
     if (!isReservedQualifier(text))

--- a/src/Bot/Cmd/ChatHelper.cpp
+++ b/src/Bot/Cmd/ChatHelper.cpp
@@ -253,7 +253,7 @@ uint32 ChatHelper::parseMoney(std::string const text)
     // if user specified money in ##g##s##c format
     std::string acum = "";
     uint32 copper = 0;
-    for (uint8 i = 0; i < text.length(); i++)
+    for (size_t i = 0; i < text.length(); i++)
     {
         if (text[i] == 'g')
         {
@@ -287,7 +287,7 @@ ItemIds ChatHelper::parseItems(std::string const text)
 {
     ItemIds itemIds;
 
-    uint8 pos = 0;
+    size_t pos = 0;
     while (true)
     {
         auto i = text.find("Hitem:", pos);
@@ -509,7 +509,7 @@ GuidVector ChatHelper::parseGameobjects(std::string const text)
     //    |cFFFFFF00|Hfound:" << guid << ':'  << entry << ':'  <<  "|h[" << gInfo->name << "]|h|r";
     //    |cFFFFFF00|Hfound:9582:1731|h[Copper Vein]|h|r
 
-    uint8 pos = 0;
+    size_t pos = 0;
     while (true)
     {
         // extract GO guid


### PR DESCRIPTION
## Pull Request Description

Whispering `who usage x` to a random bot crashes the worldserver.

`InventoryAction::parseItems` matches `"usage "` anywhere in the qualifier, then parses the number at a fixed offset:

```cpp
if (text.find("usage ") != std::string::npos)
{
    FindItemUsageVisitor visitor(bot, ItemUsage(stoi(text.substr(6))));
```

When the two disagree, `stoi` gets something that is not a number and throws `std::invalid_argument`. Nothing catches it. `WhoAction::Execute` -> `Engine::DoNextAction` -> `PlayerbotAI::UpdateAIInternal` -> the `OnPlayerAfterUpdate` hook -> `Player::Update` -> `Map::Update`, all on a map update thread with no handler anywhere on the way out, so it ends at `std::terminate`.

`who` is in `PlayerbotAI::IsAllowedCommand`, so it skips the ALLOW_ALL check and only needs the INVITE level that any bot you could invite to your group already gives you. `WhoAction::QueryTrade` hands the parameter straight to `parseItems`. The commands that do need ALLOW_ALL reach the same line: `c bandage usage 3` on a bot you command does it too.

The fix reads the qualifier the way `isReservedQualifier()` at the top of the same file already reads it, `text.rfind("usage ", 0) == 0`, and skips the branch when the argument is not a plain number. `usage 3` and `usage 3 2` parse to what they parsed before.

The second commit is a different bug next door. `ChatHelper::parseMoney` walks the text with a `uint8`:

```cpp
for (uint8 i = 0; i < text.length(); i++)
```

Every character in `[gcs0-9]` continues the loop, a space breaks it, anything else zeroes and breaks. So at 256 characters drawn only from `[gcs0-9]` the index wraps from 255 back to 0 and the loop never ends, which hangs the map update thread rather than crashing it. `parseMoney` is the last clause of `ChatHelper::parseableItem`, so it runs on every chat command a bot does not recognise. `HandleMessagechatOpcode` drops chat messages over 255 characters, which leaves a whisper one character short of it, and that cap is the only thing in the way. `parseItems` and `parseGameobjects` in the same file keep `uint8` cursors over `find()` results and wrap for the same reason. All three become `size_t`.

## Feature Evaluation

- **Minimum logic:** none added. One `find` becomes an `rfind` anchored at 0, the argument that was about to go into `stoi` gets a digits-only test first, and three loop cursors change type.
- **Processing cost:** unchanged or slightly lower. `rfind(s, 0)` gives up at the first character instead of scanning the whole qualifier, and none of this runs outside chat command handling.

## How to Test the Changes

1. Whisper `who usage x` to a random bot you could invite. Before: the worldserver aborts. After: the bot answers the way it does for any other qualifier it does not know.
2. Invite a bot, whisper it `c bandage usage 3`. Before: the same abort. After: it tells you what it has.
3. Whisper it `c usage 3`. Lists items by ItemUsage 3, unchanged.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

Only for input that used to abort the server or be misread. `bandage usage 3` now goes to the named item search instead of into `stoi`, and a `usage` qualifier with a non-numeric argument is ignored instead of throwing.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)

## AI Assistance

Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)

Used to trace the call path from the chat handler down to the two parse sites, to check the rest of `ChatHelper.cpp` for the same pattern, and to draft this description. Both diffs are small and were read line by line before submitting.

## Code Provenance / Attribution

Was any code in this PR copied or adapted from a sister / upstream project?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated.
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers

What I actually ran: a worldserver build with these two commits in, against mod-playerbots/azerothcore-wotlk `Playerbot` at 4796018, clang, RelWithDebInfo, `-DMODULES=static`, plus a recompile of the two changed files with `-Wall -Wextra`, which is clean. I also ran the two parse snippets outside the server: 255 `g` characters leave `parseMoney` after 255 iterations and 256 never leave it, and `stoi` throws on `"bandage usage 3"` and on `"usage x"` while the patched branch skips both and still returns 3 for `"usage 3"` and `"usage 3 2"`. I have not run this on a live realm.

One thing I left alone. `DebugAction` has about twenty more `stoi(text.substr(N))` calls behind the same find-anywhere guards, and it is reachable: `debug ...` is intercepted by `PlayerbotAI::HandleCommand` and sent to `HandleRemoteCommand`, but `cdebug` is not, so `cdebug quest x` throws in the same way. It needs ALLOW_ALL rather than GM. I did not patch it here because twenty guards seem like the wrong fix for that file, `cdebug sounds 1` sleeps the map update thread a second at a time for a hundred seconds and `cdebug dspell 1` summons sixty creatures, so it probably wants gating instead. Happy to do either as a follow-up, whichever you prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parsing of item usage qualifiers so values are recognized only when correctly formatted.
  * Prevented malformed usage text from being interpreted as a valid quantity.
  * Improved parsing of long chat commands and input strings, preventing errors caused by inputs exceeding 255 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->