### PR TITLE
fix(gundrak): rework the Slad'ran encounter

### DIFF
--- a/src/Ai/Dungeon/GD/GDActionContext.h
+++ b/src/Ai/Dungeon/GD/GDActionContext.h
@@ -17,11 +17,15 @@ class WotlkDungeonGDActionContext : public NamedObjectContext<Action>
         WotlkDungeonGDActionContext() {
             creators["avoid poison nova"] = &WotlkDungeonGDActionContext::avoid_poison_nova;
             creators["attack snake wrap"] = &WotlkDungeonGDActionContext::attack_snake_wrap;
+            creators["slad'ran stack on tank"] = &WotlkDungeonGDActionContext::sladran_stack_on_tank;
+            creators["slad'ran tank hold"] = &WotlkDungeonGDActionContext::sladran_tank_hold;
             creators["avoid whirling slash"] = &WotlkDungeonGDActionContext::avoid_whirling_slash;
         }
     private:
         static Action* avoid_poison_nova(PlayerbotAI* ai) { return new AvoidPoisonNovaAction(ai); }
         static Action* attack_snake_wrap(PlayerbotAI* ai) { return new AttackSnakeWrapAction(ai); }
+        static Action* sladran_stack_on_tank(PlayerbotAI* ai) { return new SladranStackOnTankAction(ai); }
+        static Action* sladran_tank_hold(PlayerbotAI* ai) { return new SladranTankHoldAction(ai); }
         static Action* avoid_whirling_slash(PlayerbotAI* ai) { return new AvoidWhirlingSlashAction(ai); }
 };
 

--- a/src/Ai/Dungeon/GD/GDActions.cpp
+++ b/src/Ai/Dungeon/GD/GDActions.cpp
@@ -26,27 +26,28 @@ bool AvoidPoisonNovaAction::Execute(Event /*event*/)
 
 bool AttackSnakeWrapAction::Execute(Event /*event*/)
 {
-    Unit* boss = AI_VALUE2(Unit*, "find target", "slad'ran");
+    Unit* snakeWrap = GundrakSladran::GetAssignedSnakeWrap(botAI);
+    if (!snakeWrap) { return false; }
+
+    if (AI_VALUE(Unit*, "current target") == snakeWrap) { return false; }
+
+    return Attack(snakeWrap);
+}
+
+bool SladranStackOnTankAction::Execute(Event /*event*/)
+{
+    Player* tank = GundrakSladran::GetStackTank(botAI);
+    if (!tank) { return false; }
+
+    return MoveTo(tank, GundrakSladran::STACK_CLOSE_TO_YD, MovementPriority::MOVEMENT_COMBAT);
+}
+
+bool SladranTankHoldAction::Execute(Event /*event*/)
+{
+    Unit* boss = GundrakSladran::GetTankHoldTarget(botAI);
     if (!boss) { return false; }
 
-    // Target is not findable from threat table using AI_VALUE2(),
-    // therefore need to search manually for the unit name
-    GuidVector targets = AI_VALUE(GuidVector, "possible targets no los");
-
-    for (auto& target : targets)
-    {
-        Unit* unit = botAI->GetUnit(target);
-        if (unit && unit->GetEntry() == NPC_SNAKE_WRAP)
-        {
-            Unit* currentTarget = AI_VALUE(Unit*, "current target");
-            if (!currentTarget || currentTarget->GetEntry() != NPC_SNAKE_WRAP)
-            {
-            return Attack(unit);
-            }
-        }
-    }
-
-    return false;
+    return Attack(boss);
 }
 
 bool AvoidWhirlingSlashAction::Execute(Event /*event*/)

--- a/src/Ai/Dungeon/GD/GDActions.h
+++ b/src/Ai/Dungeon/GD/GDActions.h
@@ -27,6 +27,20 @@ public:
     bool Execute(Event event) override;
 };
 
+class SladranStackOnTankAction : public MovementAction
+{
+public:
+    SladranStackOnTankAction(PlayerbotAI* ai) : MovementAction(ai, "slad'ran stack on tank") {}
+    bool Execute(Event event) override;
+};
+
+class SladranTankHoldAction : public AttackAction
+{
+public:
+    SladranTankHoldAction(PlayerbotAI* ai) : AttackAction(ai, "slad'ran tank hold") {}
+    bool Execute(Event event) override;
+};
+
 class AvoidWhirlingSlashAction : public MovementAction
 {
 public:

--- a/src/Ai/Dungeon/GD/GDMultipliers.cpp
+++ b/src/Ai/Dungeon/GD/GDMultipliers.cpp
@@ -11,6 +11,8 @@
 #include "GDTriggers.h"
 #include "GenericSpellActions.h"
 #include "MovementActions.h"
+#include "Playerbots.h"
+#include "ReachTargetActions.h"
 
 float SladranMultiplier::GetValue(Action* action)
 {
@@ -19,32 +21,54 @@ float SladranMultiplier::GetValue(Action* action)
 
     if (boss->FindCurrentSpellBySpellId(SPELL_POISON_NOVA))
     {
-        if (dynamic_cast<MovementAction*>(action) && !dynamic_cast<AvoidPoisonNovaAction*>(action))
+        if (dynamic_cast<AvoidPoisonNovaAction*>(action)) { return 1.0f; }
+
+        if (dynamic_cast<MovementAction*>(action))
         {
             return 0.0f;
         }
     }
 
-    if (!botAI->IsDps(bot)) { return 1.0f; }
-
-    if (action->getThreatType() == Action::ActionThreatType::Aoe)
+    if (dynamic_cast<FleeAction*>(action) ||
+        dynamic_cast<RunAwayAction*>(action) ||
+        dynamic_cast<MoveRandomAction*>(action) ||
+        dynamic_cast<MoveFromGroupAction*>(action))
     {
         return 0.0f;
     }
 
-    Unit* snakeWrap = nullptr;
-    GuidVector targets = AI_VALUE(GuidVector, "possible targets no los");
-    for (auto& target : targets)
+    if (PlayerbotAI::IsTank(bot))
     {
-        Unit* unit = botAI->GetUnit(target);
-        if (unit && unit->GetEntry() == NPC_SNAKE_WRAP)
+        if (dynamic_cast<TankAssistAction*>(action))
         {
-            snakeWrap = unit;
-            break;
+            Unit* tankTarget = AI_VALUE(Unit*, "tank target");
+            if (tankTarget && GundrakSladran::IsAdd(tankTarget) &&
+                bot->GetExactDist2d(tankTarget) > GundrakSladran::TANK_PICKUP_YD)
+            {
+                return 0.0f;
+            }
         }
+
+        if (dynamic_cast<ReachTargetAction*>(action))
+        {
+            Unit* currentTarget = AI_VALUE(Unit*, "current target");
+            if (currentTarget && GundrakSladran::IsAdd(currentTarget) &&
+                bot->GetExactDist2d(currentTarget) > GundrakSladran::TANK_PICKUP_YD)
+            {
+                return 0.0f;
+            }
+        }
+
+        return 1.0f;
     }
-    // Prevent auto-target acquisition during snake wraps
-    if (snakeWrap && dynamic_cast<DpsAssistAction*>(action))
+
+    if (dynamic_cast<CombatFormationMoveAction*>(action) &&
+        !dynamic_cast<SetBehindTargetAction*>(action))
+    {
+        return 0.0f;
+    }
+
+    if (dynamic_cast<DpsAssistAction*>(action) && GundrakSladran::GetAssignedSnakeWrap(botAI))
     {
         return 0.0f;
     }

--- a/src/Ai/Dungeon/GD/GDStrategy.cpp
+++ b/src/Ai/Dungeon/GD/GDStrategy.cpp
@@ -20,6 +20,10 @@ void WotlkDungeonGDStrategy::InitTriggers(std::vector<TriggerNode*> &triggers)
         { NextAction("avoid poison nova", ACTION_RAID + 5) }));
     triggers.push_back(new TriggerNode("snake wrap",
         { NextAction("attack snake wrap", ACTION_RAID + 4) }));
+    triggers.push_back(new TriggerNode("slad'ran stack on tank",
+        { NextAction("slad'ran stack on tank", ACTION_RAID + 1) }));
+    triggers.push_back(new TriggerNode("slad'ran tank hold",
+        { NextAction("slad'ran tank hold", ACTION_RAID + 1) }));
 
     // Gal'darah
     triggers.push_back(new TriggerNode("whirling slash",

--- a/src/Ai/Dungeon/GD/GDTriggerContext.h
+++ b/src/Ai/Dungeon/GD/GDTriggerContext.h
@@ -17,11 +17,15 @@ class WotlkDungeonGDTriggerContext : public NamedObjectContext<Trigger>
         {
             creators["poison nova"] = &WotlkDungeonGDTriggerContext::poison_nova;
             creators["snake wrap"] = &WotlkDungeonGDTriggerContext::snake_wrap;
+            creators["slad'ran stack on tank"] = &WotlkDungeonGDTriggerContext::sladran_stack_on_tank;
+            creators["slad'ran tank hold"] = &WotlkDungeonGDTriggerContext::sladran_tank_hold;
             creators["whirling slash"] = &WotlkDungeonGDTriggerContext::whirling_slash;
         }
     private:
         static Trigger* poison_nova(PlayerbotAI* ai) { return new SladranPoisonNovaTrigger(ai); }
         static Trigger* snake_wrap(PlayerbotAI* ai) { return new SladranSnakeWrapTrigger(ai); }
+        static Trigger* sladran_stack_on_tank(PlayerbotAI* ai) { return new SladranStackOnTankTrigger(ai); }
+        static Trigger* sladran_tank_hold(PlayerbotAI* ai) { return new SladranTankHoldTrigger(ai); }
         static Trigger* whirling_slash(PlayerbotAI* ai) { return new GaldarahWhirlingSlashTrigger(ai); }
 };
 

--- a/src/Ai/Dungeon/GD/GDTriggers.cpp
+++ b/src/Ai/Dungeon/GD/GDTriggers.cpp
@@ -6,7 +6,184 @@
 
 #include "GDTriggers.h"
 #include "AiObjectContext.h"
+#include "AttackersValue.h"
+#include "Creature.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
+#include <algorithm>
+#include <list>
+#include <utility>
+#include <vector>
+
+using namespace EncounterHelpers;
+
+namespace GundrakSladran
+{
+
+static bool IsClosestSnakeWrapFreer(Player* bot, Unit* snakeWrap, float distance)
+{
+    Group* group = bot->GetGroup();
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member || member == bot || !member->IsAlive() || !member->IsInCombat() ||
+            !GET_PLAYERBOT_AI(member) || member->GetMap() != bot->GetMap() ||
+            !PlayerbotAI::IsDps(member) || member->HasAura(SPELL_SNAKE_WRAP))
+        {
+            continue;
+        }
+
+        float memberDistance = member->GetExactDist2d(snakeWrap);
+        if (memberDistance > distance ||
+            (memberDistance == distance && bot->GetGUID() < member->GetGUID()))
+        {
+            continue;
+        }
+
+        if (!member->IsWithinLOSInMap(snakeWrap))
+        {
+            continue;
+        }
+
+        return false;
+    }
+
+    return true;
+}
+
+bool IsAdd(Unit* unit)
+{
+    if (!unit) { return false; }
+
+    uint32 entry = unit->GetEntry();
+    return entry == NPC_SLADRAN_VIPER || entry == NPC_SLADRAN_CONSTRICTOR;
+}
+
+ObjectGuid CalculateAssignedSnakeWrap(PlayerbotAI* botAI)
+{
+    Player* bot = botAI->GetBot();
+    if (!bot->IsAlive() || !bot->IsInCombat() || !PlayerbotAI::IsDps(bot) ||
+        bot->HasAura(SPELL_SNAKE_WRAP) || !bot->GetGroup())
+    {
+        return ObjectGuid::Empty;
+    }
+
+    std::list<Creature*> wraps;
+    bot->GetCreatureListWithEntryInGrid(wraps, NPC_SNAKE_WRAP, sPlayerbotAIConfig.sightDistance);
+
+    std::vector<std::pair<float, Creature*>> candidates;
+    candidates.reserve(wraps.size());
+    for (Creature* snakeWrap : wraps)
+    {
+        if (!snakeWrap->IsAlive() || !AttackersValue::IsPossibleTarget(snakeWrap, bot)) { continue; }
+
+        candidates.emplace_back(bot->GetExactDist2d(snakeWrap), snakeWrap);
+    }
+
+    std::sort(candidates.begin(), candidates.end(),
+              [](std::pair<float, Creature*> const& lhs, std::pair<float, Creature*> const& rhs)
+              { return lhs.first < rhs.first; });
+
+    for (auto const& candidate : candidates)
+    {
+        if (!bot->IsWithinLOSInMap(candidate.second)) { continue; }
+
+        if (IsClosestSnakeWrapFreer(bot, candidate.second, candidate.first))
+        {
+            return candidate.second->GetGUID();
+        }
+    }
+
+    return ObjectGuid::Empty;
+}
+
+Unit* GetAssignedSnakeWrap(PlayerbotAI* botAI)
+{
+    ObjectGuid guid =
+        botAI->GetAiObjectContext()->GetValue<ObjectGuid>("slad'ran snake wrap target")->Get();
+    if (guid.IsEmpty()) { return nullptr; }
+
+    Unit* snakeWrap = botAI->GetUnit(guid);
+    if (!snakeWrap || !snakeWrap->IsAlive() || snakeWrap->GetEntry() != NPC_SNAKE_WRAP)
+    {
+        return nullptr;
+    }
+
+    return snakeWrap;
+}
+
+Player* GetStackTank(PlayerbotAI* botAI)
+{
+    Player* bot = botAI->GetBot();
+    if (!bot->IsAlive() || PlayerbotAI::IsTank(bot))
+    {
+        return nullptr;
+    }
+
+    AiObjectContext* context = botAI->GetAiObjectContext();
+    if (!context->GetValue<Unit*>("find target", "slad'ran")->Get())
+    {
+        return nullptr;
+    }
+
+    if (GetAssignedSnakeWrap(botAI))
+    {
+        return nullptr;
+    }
+
+    Unit* currentTarget = context->GetValue<Unit*>("current target")->Get();
+    if (currentTarget && currentTarget->IsAlive() && currentTarget->GetEntry() == NPC_SNAKE_WRAP)
+    {
+        return nullptr;
+    }
+
+    Player* tank = GetGroupMainTank(bot);
+    if (!tank || tank == bot || tank->GetMap() != bot->GetMap())
+    {
+        return nullptr;
+    }
+
+    if (bot->GetExactDist2d(tank) <= STACK_LEASH_YD)
+    {
+        return nullptr;
+    }
+
+    return tank;
+}
+
+Unit* GetTankHoldTarget(PlayerbotAI* botAI)
+{
+    Player* bot = botAI->GetBot();
+    if (!bot->IsAlive() || !PlayerbotAI::IsTank(bot))
+    {
+        return nullptr;
+    }
+
+    AiObjectContext* context = botAI->GetAiObjectContext();
+    Unit* boss = context->GetValue<Unit*>("find target", "slad'ran")->Get();
+    if (!boss || !boss->IsAlive())
+    {
+        return nullptr;
+    }
+
+    Unit* currentTarget = context->GetValue<Unit*>("current target")->Get();
+    if (currentTarget && currentTarget->IsAlive())
+    {
+        if (currentTarget == boss)
+        {
+            return nullptr;
+        }
+
+        if (IsAdd(currentTarget) && bot->GetExactDist2d(currentTarget) <= TANK_PICKUP_YD)
+        {
+            return nullptr;
+        }
+    }
+
+    return boss;
+}
+
+}
 
 bool SladranPoisonNovaTrigger::IsActive()
 {
@@ -18,21 +195,17 @@ bool SladranPoisonNovaTrigger::IsActive()
 
 bool SladranSnakeWrapTrigger::IsActive()
 {
-    if (!botAI->IsDps(bot)) { return false; }
+    return GundrakSladran::GetAssignedSnakeWrap(botAI) != nullptr;
+}
 
-    // Target is not findable from threat table using AI_VALUE2(),
-    // therefore need to search manually for the unit name
-    GuidVector targets = AI_VALUE(GuidVector, "possible targets");
+bool SladranStackOnTankTrigger::IsActive()
+{
+    return GundrakSladran::GetStackTank(botAI) != nullptr;
+}
 
-    for (auto& target : targets)
-    {
-        Unit* unit = botAI->GetUnit(target);
-        if (unit && unit->GetEntry() == NPC_SNAKE_WRAP)
-        {
-            return true;
-        }
-    }
-    return false;
+bool SladranTankHoldTrigger::IsActive()
+{
+    return GundrakSladran::GetTankHoldTarget(botAI) != nullptr;
 }
 
 bool GaldarahWhirlingSlashTrigger::IsActive()

--- a/src/Ai/Dungeon/GD/GDTriggers.h
+++ b/src/Ai/Dungeon/GD/GDTriggers.h
@@ -9,6 +9,7 @@
 
 #include "DungeonStrategyUtils.h"
 #include "GenericTriggers.h"
+#include "ObjectGuid.h"
 #include "PlayerbotAIConfig.h"
 #include "Trigger.h"
 
@@ -17,7 +18,10 @@ enum GundrakIDs
     // Slad'ran
     SPELL_POISON_NOVA_N             = 55081,
     SPELL_POISON_NOVA_H             = 59842,
+    SPELL_SNAKE_WRAP                = 55126,
     NPC_SNAKE_WRAP                  = 29742,
+    NPC_SLADRAN_VIPER               = 29680,
+    NPC_SLADRAN_CONSTRICTOR         = 29713,
 
     // Gal'darah
     SPELL_WHIRLING_SLASH_N          = 55250,
@@ -26,6 +30,20 @@ enum GundrakIDs
 
 #define SPELL_POISON_NOVA           DUNGEON_MODE(bot, SPELL_POISON_NOVA_N, SPELL_POISON_NOVA_H)
 #define SPELL_WHIRLING_SLASH        DUNGEON_MODE(bot, SPELL_WHIRLING_SLASH_N, SPELL_WHIRLING_SLASH_H)
+
+namespace GundrakSladran
+{
+constexpr float STACK_LEASH_YD = 10.0f;
+constexpr float STACK_CLOSE_TO_YD = 5.0f;
+constexpr float TANK_PICKUP_YD = 12.0f;
+constexpr uint32 SNAKE_WRAP_SCAN_INTERVAL = 200;
+
+bool IsAdd(Unit* unit);
+ObjectGuid CalculateAssignedSnakeWrap(PlayerbotAI* botAI);
+Unit* GetAssignedSnakeWrap(PlayerbotAI* botAI);
+Player* GetStackTank(PlayerbotAI* botAI);
+Unit* GetTankHoldTarget(PlayerbotAI* botAI);
+}
 
 class SladranPoisonNovaTrigger : public Trigger
 {
@@ -38,6 +56,20 @@ class SladranSnakeWrapTrigger : public Trigger
 {
 public:
     SladranSnakeWrapTrigger(PlayerbotAI* ai) : Trigger(ai, "slad'ran snake wrap") {}
+    bool IsActive() override;
+};
+
+class SladranStackOnTankTrigger : public Trigger
+{
+public:
+    SladranStackOnTankTrigger(PlayerbotAI* ai) : Trigger(ai, "slad'ran stack on tank") {}
+    bool IsActive() override;
+};
+
+class SladranTankHoldTrigger : public Trigger
+{
+public:
+    SladranTankHoldTrigger(PlayerbotAI* ai) : Trigger(ai, "slad'ran tank hold") {}
     bool IsActive() override;
 };
 

--- a/src/Ai/Dungeon/GD/GDValueContext.h
+++ b/src/Ai/Dungeon/GD/GDValueContext.h
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_GDVALUECONTEXT_H
+#define PLAYERBOTS_GDVALUECONTEXT_H
+
+#include "GDTriggers.h"
+#include "NamedObjectContext.h"
+#include "ObjectGuid.h"
+#include "Value.h"
+
+class SladranAssignedSnakeWrapValue : public CalculatedValue<ObjectGuid>
+{
+public:
+    SladranAssignedSnakeWrapValue(PlayerbotAI* botAI)
+        : CalculatedValue<ObjectGuid>(botAI, "slad'ran snake wrap target", GundrakSladran::SNAKE_WRAP_SCAN_INTERVAL)
+    {
+    }
+
+protected:
+    ObjectGuid Calculate() override { return GundrakSladran::CalculateAssignedSnakeWrap(botAI); }
+};
+
+class WotlkDungeonGDValueContext : public NamedObjectContext<UntypedValue>
+{
+public:
+    WotlkDungeonGDValueContext()
+    {
+        creators["slad'ran snake wrap target"] = &WotlkDungeonGDValueContext::sladran_snake_wrap_target;
+    }
+
+private:
+    static UntypedValue* sladran_snake_wrap_target(PlayerbotAI* botAI)
+    {
+        return new SladranAssignedSnakeWrapValue(botAI);
+    }
+};
+
+#endif

--- a/src/Bot/Engine/BuildSharedValueContexts.cpp
+++ b/src/Bot/Engine/BuildSharedValueContexts.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "AiObjectContext.h"
+#include "GDValueContext.h"
 #include "MechValueContext.h"
 #include "UBValueContext.h"
 #include "ValueContext.h"
@@ -14,4 +15,5 @@ void AiObjectContext::BuildSharedValueContexts(SharedNamedObjectContextList<Unty
     valueContexts.Add(new ValueContext());
     valueContexts.Add(new TbcDungeonMechValueContext());
     valueContexts.Add(new TbcDungeonUnderbogValueContext());
+    valueContexts.Add(new WotlkDungeonGDValueContext());
 }


### PR DESCRIPTION
Branch: `fix/gundrak-sladran-encounter` (base: `test-staging`)

---

## Pull Request Description

Three things were wrong with the Slad'ran fight, and the snake wrap search was
expensive.

**The tank chased the summons.** `FindTankTargetSmartStrategy` ranks untanked units
above everything else, so every new snake outranked Slad'ran. The tank ran off to
taunt it, dragged the boss along behind, and then the next spawn outranked that one.
The snakes are melee mobs that walk to the party on their own, so the tank only has
to stand still. `SladranMultiplier` now zeroes `TankAssistAction` and
`ReachTargetAction` for snakes further than 12yd out, and `SladranTankHoldTrigger`
puts the tank back on the boss when nothing is in reach.

**The group was spread out.** The generic combat formation scattered the dps and
healers, so the snakes split up chasing them. Formation moves are zeroed for
non-tanks and `SladranStackOnTankTrigger` walks them to within 10yd of the tank, so
the snakes arrive in one pile. Flee, run away, move random and move from group are
zeroed too.

**Dps AoE was off.** The multiplier zeroed anything declaring
`ActionThreatType::Aoe` for the whole fight. That enum is a threat hint, not an AoE
flag, and it barely matches the abilities that matter here. Dropped.

**The snake wrap search.** It read the uncached `"possible targets"` value, so every
call swept the grid out to sight range with the `IsPossibleTarget` filter, from two
triggers plus once per action in the multiplier. It is now a cached value on a 200ms
interval, gated on combat, scanning by creature entry. Line of sight is still
raycast because `Attack()` fails without it.

## Feature Evaluation

Minimum logic: the multiplier bails on `find target slad'ran` outside the fight.
Inside it, two `dynamic_cast` chains and a distance check. The triggers are predicate
reads, and the wrap trigger's real work sits behind the cached value.

Cost: lower than before. A per-tick sight-range grid sweep becomes one
entry-filtered scan per bot every 200ms. Bots outside Gundrak pay nothing, since
`NamedObjectContext` only builds a value when something reads it and only this
strategy reads this one.

## How to Test the Changes

Five bots (tank, healer, 3 dps) in Gundrak, normal or heroic. Pull Slad'ran and watch
the summons at 90% and 50% (75% heroic).

- Tank stays on the boss, picks up only snakes that reach it, returns to the boss
  when one dies.
- Boss stays put instead of touring the room.
- Dps and healer stay within ~10yd of the tank, and the snakes arrive together.
- Dps use AoE on the pile.
- A wrapped player gets freed: the nearest dps with line of sight kills the Snake
  Wrap, and only one bot goes for each.

Run `playerbot pmon stack` during the fight. The snake wrap trigger should no longer
be near the top.

## Impact Assessment

- **Increases per-bot/per-tick processing?** No, it reduces it.
- **Modifies default behavior?** Yes, but only during Slad'ran and only for bots
  running `wotlk-gd`. Tank targeting, non-tank positioning and the AoE suppression
  all change for that fight.
- **New decision branches?** Yes: two triggers, two actions, one value, and a tank
  branch in the existing multiplier. The shared predicates live in a
  `GundrakSladran` namespace so the trigger, action and multiplier cannot drift
  apart.

## AI Assistance

Yes, for the code and review pass. The diagnosis and the code were checked
against the source and the core's `boss_slad_ran.cpp`.

## Code Provenance / Attribution

All original.

## Final Checklist

- [x] Changes are understood and tested for server stability and performance impact.
- [x] Any new bot dialogue lines are translated. (none added)
- [x] New source files use the GPLv2 header. (`GDValueContext.h`)
- [x] Documentation updated if needed. (none needed)
- [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers

IDs checked against `creature_template`: 29680 Viper, 29713 Constrictor, 29742 Snake
Wrap. `SPELL_SNAKE_WRAP` 55126 matches `boss_slad_ran.cpp`.

Wrap assignment is the nearest eligible dps with line of sight, ties broken by lower
GUID, so exactly one bot goes for each wrap.

Stacking the group on the tank does put everyone inside Poison Nova's radius.
`AvoidPoisonNovaAction` still runs during the cast (the multiplier only zeroes the
other movement actions), so they step out and back. The alternative is the snakes
splitting up to chase spread-out casters.