### PR TITLE
feat(selfbot): keep selfbots in the world when the player idles

### DIFF
--- a/src/Ai/Base/Actions/AcceptInvitationAction.cpp
+++ b/src/Ai/Base/Actions/AcceptInvitationAction.cpp
@@ -36,7 +36,7 @@ bool AcceptInvitationAction::Execute(Event event)
         return false;
     }
 
-    if (bot->isAFK())
+    if (bot->isAFK() && !IsSelfBot(bot))
         bot->ToggleAFK();
 
     WorldPacket p;

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -1541,7 +1541,7 @@ void PlayerbotAI::DoNextAction(bool min)
         SetNextCheckDelay(sPlayerbotAIConfig.passiveDelay);
         return;
     }
-    else if (bot->isAFK())
+    else if (bot->isAFK() && !IsSelfBot(bot))
         bot->ToggleAFK();
 
     if (master && master->IsInWorld())

--- a/src/Script/Playerbots.cpp
+++ b/src/Script/Playerbots.cpp
@@ -512,6 +512,7 @@ public:
 };
 
 void AddPlayerbotsSecureLoginScripts();
+void AddPlayerbotsSelfBotAfkScripts();
 
 void AddSC_MagtheridonBotScripts();
 void AddSC_TempestKeepBotScripts();
@@ -531,6 +532,7 @@ void AddPlayerbotsScripts()
     new PlayerbotsScript();
     new PlayerBotsBGScript();
     AddPlayerbotsSecureLoginScripts();
+    AddPlayerbotsSelfBotAfkScripts();
     AddPlayerbotsCommandscripts();
     PlayerBotsGuildValidationScript();
     AddSC_MagtheridonBotScripts();

--- a/src/Script/PlayerbotsSelfBotAfk.cpp
+++ b/src/Script/PlayerbotsSelfBotAfk.cpp
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "CharacterPackets.h"
+#include "Log.h"
+#include "Opcodes.h"
+#include "Player.h"
+#include "Playerbots.h"
+#include "ScriptMgr.h"
+#include "WorldPacket.h"
+#include "WorldSession.h"
+
+class PlayerbotsSelfBotAfkServerScript : public ServerScript
+{
+public:
+    PlayerbotsSelfBotAfkServerScript()
+        : ServerScript("PlayerbotsSelfBotAfkServerScript", { SERVERHOOK_CAN_PACKET_RECEIVE }) {}
+
+    using ServerScript::CanPacketReceive;
+
+    bool CanPacketReceive(WorldSession* session, WorldPacket const& packet) override
+    {
+        if (packet.GetOpcode() != CMSG_LOGOUT_REQUEST)
+            return true;
+
+        Player* player = session ? session->GetPlayer() : nullptr;
+        if (!player || !IsSelfBot(player) || !player->isAFK())
+            return true;
+
+        LOG_DEBUG("playerbots", "Selfbot {} stays in world: refused the AFK logout", player->GetName());
+
+        WorldPackets::Character::LogoutResponse logoutResponse;
+        logoutResponse.LogoutResult = 2;
+        logoutResponse.Instant = false;
+        session->SendPacket(logoutResponse.Write());
+
+        return false;
+    }
+};
+
+void AddPlayerbotsSelfBotAfkScripts()
+{
+    new PlayerbotsSelfBotAfkServerScript();
+}


### PR DESCRIPTION
## Pull Request Description

A selfbot is a real character driven server-side, so it keeps playing while
its owner is away from the keyboard. If a logout request reaches the server
while that character is flagged AFK, the character leaves the world and the
session is over.

Two changes:

1. A `ServerScript` that refuses `CMSG_LOGOUT_REQUEST` when the sender is a
   selfbot and is AFK. It replies with the same response the core sends when
   it blocks a logout, so the client shows the usual message.
2. A fix in `PlayerbotAI::DoNextAction`, which was clearing the AFK flag on
   every bot, selfbots included. On a selfbot the client owns that flag, so
   the server was wiping a flag the client still believed was set.

The refusal is what the core's `PreventAFKLogout = 2` already does, scoped to
selfbots instead of every player on the realm. Clearing AFK still lets you
log out normally.

## Feature Evaluation

**Minimum logic.** One opcode comparison in a `CanPacketReceive` hook. If the
packet is not `CMSG_LOGOUT_REQUEST` the hook returns immediately. The selfbot
and AFK checks are only ever reached by that one opcode.

**Processing cost across many bots.** None. Bots have no client and send no
packets, so the hook never runs for them. In `DoNextAction` the new
`IsSelfBot` call sits behind the existing `bot->isAFK()` test, which is false
for practically every bot, so it almost never evaluates.

## How to Test the Changes

Setup: one selfbot character and one ordinary player character, logged in from
two clients. Leave `PreventAFKLogout = 0` so nothing else is blocking logouts.

The AFK flag sticks:

1. On the selfbot, type `/afk`.
2. Wait a few seconds. Before this change the AI cleared the flag within a
   tick and the `<AFK>` tag vanished. Now it stays.

The logout is refused:

3. Still AFK, press Esc and click Logout on the selfbot. You get "You can't
   log out now" and stay in the world.
4. Do the same on the ordinary character. It logs out as usual.
5. Type `/afk` again on the selfbot to clear the flag, then log out. Normal.

Use the Logout button, not `/camp`. Sending a chat message clears AFK first,
so `/camp` will always log you out and tells you nothing.

If the selfbot has alt bots logged in, step 3 should leave those in the world
too.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

The packet hook only runs for real client sessions. The single added check in
`DoNextAction` is behind an AFK test that is almost always false.

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

Both changes are limited to selfbots: their AFK flag is no longer cleared by
the AI, and they cannot log out while AFK. Altbots and random bots are
untouched. The AFK clear is gated on `IsSelfBot` rather than
`HasGameClientMaster`, so a random bot that went AFK while masterless and is
later picked up by a player still clears the flag as before.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)

One self-contained script file and one added condition.

## AI Assistance

Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)

Used for reviewing the change and for tracing the core's logout handling. The
code is short, was tested in-game, and I understand and stand behind all of it.

## Code Provenance / Attribution

Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated. (none added)
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers

One thing the diff does not show: `PlayerbotMgr::HandleMasterIncomingPacket`
logs out all of a master's bots when it sees `CMSG_LOGOUT_REQUEST`. That runs
from `OnPacketReceived`, which `WorldSession::Update` only reaches after
`CanPacketReceive` has returned true. Refusing the packet therefore keeps the
alt bots in the world as well, which is the behaviour you want here.

`AcceptInvitationAction` also clears the AFK flag unconditionally. It is the
same class of problem as the `DoNextAction` one, but it only fires when a bot
accepts a group invite. I left it out to keep this diff small. Happy to fold
it in if you would rather have both.
