### PR TITLE
feat(rpg): add leash/grab strategies for independent bot movement

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -406,6 +406,22 @@ AiPlayerbot.AggroDistance = 22
 AiPlayerbot.TooCloseDistance = 5.0
 AiPlayerbot.MeleeDistance = 0.75
 AiPlayerbot.FollowDistance = 1.5
+
+# AiPlayerbot.LeashDistance
+#     Description: How far (yards) a bot may wander from the group leader while
+#                  the "leash" strategy and an independent-movement strategy
+#                  (e.g. "new rpg", "grind") are both active before being
+#                  recalled. Enable with: nc +leash,+new rpg
+#     Default:     30.0
+AiPlayerbot.LeashDistance = 30.0
+
+# AiPlayerbot.QuestGrabDistance
+#     Description: How far (yards), from the bot's own current position (not
+#                  the group leader), the "grab" strategy will walk to accept/
+#                  turn in a quest or interact with a quest-relevant object it
+#                  can already see. Enable with: nc +grab
+#     Default:     30.0
+AiPlayerbot.QuestGrabDistance = 30.0
 AiPlayerbot.WhisperDistance = 6000.0
 AiPlayerbot.ContactDistance = 0.45
 AiPlayerbot.AoeRadius = 10

--- a/src/Ai/Base/ActionContext.h
+++ b/src/Ai/Base/ActionContext.h
@@ -278,6 +278,7 @@ public:
         creators["new rpg do quest"] = &ActionContext::new_rpg_do_quest;
         creators["new rpg travel flight"] = &ActionContext::new_rpg_travel_flight;
         creators["new rpg outdoor pvp"] = &ActionContext::new_rpg_outdoor_pvp;
+        creators["grab quest item"] = &ActionContext::grab_quest_item;
         creators["wait for attack keep safe distance"] = &ActionContext::wait_for_attack_keep_safe_distance;
     }
 
@@ -484,6 +485,7 @@ private:
     static Action* new_rpg_do_quest(PlayerbotAI* ai) { return new NewRpgDoQuestAction(ai); }
     static Action* new_rpg_travel_flight(PlayerbotAI* ai) { return new NewRpgTravelFlightAction(ai); }
     static Action* new_rpg_outdoor_pvp(PlayerbotAI* ai) { return new NewRpgOutdoorPvpAction(ai); }
+    static Action* grab_quest_item(PlayerbotAI* ai) { return new GrabQuestItemAction(ai); }
     static Action* wait_for_attack_keep_safe_distance(PlayerbotAI* ai) { return new WaitForAttackKeepSafeDistanceAction(ai); }
 };
 

--- a/src/Ai/Base/Actions/GoAction.cpp
+++ b/src/Ai/Base/Actions/GoAction.cpp
@@ -67,6 +67,19 @@ bool GoAction::Execute(Event event)
         }
     }
 
+    // Manual, on-demand equivalent of the "grab" strategy (QuestGrabStrategy) for players
+    // who don't want it running automatically every "timer" tick -- same one-shot pattern
+    // BossAuraActions/GuildCreateActions already use to invoke another action directly,
+    // bypassing relevance/strategy gating entirely.
+    if (param == "quest" || param == "grab")
+    {
+        if (botAI->DoSpecificAction("grab quest item", Event(), true))
+            return true;
+
+        botAI->TellError("Nothing quest-relevant to grab right now");
+        return false;
+    }
+
     GuidVector gos = ChatHelper::parseGameobjects(param);
     if (!gos.empty())
     {
@@ -222,6 +235,7 @@ bool GoAction::Execute(Event event)
         return MoveNear(bot->GetMapId(), pos.x, pos.y, pos.z + 0.5f, sPlayerbotAIConfig.followDistance);
     }
 
-    botAI->TellMaster("Whisper 'go x,y', 'go [game object]', 'go unit' or 'go position' and I will go there");
+    botAI->TellMaster(
+        "Whisper 'go x,y', 'go [game object]', 'go unit', 'go position' or 'go quest' and I will go there");
     return false;
 }

--- a/src/Ai/Base/Actions/UseItemAction.cpp
+++ b/src/Ai/Base/Actions/UseItemAction.cpp
@@ -61,6 +61,8 @@ bool UseItemAction::UseItemAuto(Item* item) { return UseItem(item, ObjectGuid::E
 
 bool UseItemAction::UseItemOnGameObject(Item* item, ObjectGuid go) { return UseItem(item, go, nullptr); }
 
+bool UseItemAction::UseItemOnUnit(Item* item, Unit* unitTarget) { return UseItem(item, ObjectGuid::Empty, nullptr, unitTarget); }
+
 bool UseItemAction::UseItemOnItem(Item* item, Item* itemTarget) { return UseItem(item, ObjectGuid::Empty, itemTarget); }
 
 bool UseItemAction::UseItem(Item* item, ObjectGuid goGuid, Item* itemTarget, Unit* unitTarget)

--- a/src/Ai/Base/Actions/UseItemAction.h
+++ b/src/Ai/Base/Actions/UseItemAction.h
@@ -31,9 +31,9 @@ public:
     // inheritable", so callers construct a UseItemAction and invoke these directly.
     bool UseItemOnGameObject(Item* item, ObjectGuid go);
     bool UseItemOnUnit(Item* item, Unit* unitTarget);
+    bool UseItemAuto(Item* item);
 
 protected:
-    bool UseItemAuto(Item* item);
     bool UseItemOnItem(Item* item, Item* itemTarget);
     bool UseItem(Item* item, ObjectGuid go, Item* itemTarget, Unit* unitTarget = nullptr);
     bool UseGameObject(ObjectGuid guid);

--- a/src/Ai/Base/Actions/UseItemAction.h
+++ b/src/Ai/Base/Actions/UseItemAction.h
@@ -25,9 +25,15 @@ public:
     bool Execute(Event event) override;
     bool isPossible() override;
 
+    // Public composition points for other actions (e.g. GrabQuestItemAction) that need to
+    // use a specific item on a specific target and are not themselves a UseItemAction --
+    // NewRpgBaseAction's own header calls for actions to be "composable instead of
+    // inheritable", so callers construct a UseItemAction and invoke these directly.
+    bool UseItemOnGameObject(Item* item, ObjectGuid go);
+    bool UseItemOnUnit(Item* item, Unit* unitTarget);
+
 protected:
     bool UseItemAuto(Item* item);
-    bool UseItemOnGameObject(Item* item, ObjectGuid go);
     bool UseItemOnItem(Item* item, Item* itemTarget);
     bool UseItem(Item* item, ObjectGuid go, Item* itemTarget, Unit* unitTarget = nullptr);
     bool UseGameObject(ObjectGuid guid);

--- a/src/Ai/Base/Strategy/LeashStrategy.cpp
+++ b/src/Ai/Base/Strategy/LeashStrategy.cpp
@@ -1,0 +1,19 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "LeashStrategy.h"
+
+void LeashStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+{
+    // 15.0f beats every independent-movement action in the codebase today
+    // (new rpg: 3.0-11.0; grind is lower still per NewRpgStrategy's own
+    // comment) without hardcoding a value tied to any one of them, so it
+    // stays correct if those get retuned later. "leash too far" only
+    // activates past AiPlayerbot.LeashDistance, so "follow" is not even
+    // proposed -- let alone competing with anything -- while the bot is
+    // within range.
+    triggers.push_back(new TriggerNode("leash too far", { NextAction("follow", 15.0f) }));
+}

--- a/src/Ai/Base/Strategy/LeashStrategy.h
+++ b/src/Ai/Base/Strategy/LeashStrategy.h
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_LEASHSTRATEGY_H
+#define PLAYERBOTS_LEASHSTRATEGY_H
+
+#include "Strategy.h"
+
+class PlayerbotAI;
+
+// Keeps a bot from wandering past AiPlayerbot.LeashDistance from the group
+// leader while an independent-movement strategy (new rpg, grind, ...) is also
+// active. Those strategies propose their own movement actions at relevance
+// 3.0-11.0 (see NewRpgStrategy::getDefaultActions, "the relevance should be
+// greater than grind"), well above FollowMasterStrategy's default "follow"
+// relevance of 1.0 -- so simply also enabling "follow" never wins and never
+// actually leashes anything.
+//
+// This only proposes "follow" once the bot has already exceeded the leash
+// distance (see "leash too far" in TriggerContext.h), at a relevance above
+// every independent-movement action, so it has zero effect the rest of the
+// time. It does not by itself stop new rpg from choosing a target beyond the
+// leash distance again immediately after being recalled -- that half is
+// handled separately, everywhere new rpg picks a destination: idle NPCs/GOs
+// via PossibleNewRpgTargetsValue::AcceptUnit and
+// PossibleNewRpgGameObjectsValue::Calculate (PossibleRpgTargetsValue.cpp),
+// and grind/camp/quest destinations via WithinLeashRange
+// (NewRpgBaseAction.cpp) -- so new rpg's own candidate search never proposes
+// something this strategy would just have to fight.
+class LeashStrategy : public Strategy
+{
+public:
+    LeashStrategy(PlayerbotAI* botAI) : Strategy(botAI) {}
+
+    uint32 GetType() const override { return STRATEGY_TYPE_NONCOMBAT; }
+    std::string const getName() override { return "leash"; }
+    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
+};
+
+#endif

--- a/src/Ai/Base/Strategy/QuestGrabStrategy.cpp
+++ b/src/Ai/Base/Strategy/QuestGrabStrategy.cpp
@@ -1,0 +1,18 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "QuestGrabStrategy.h"
+
+void QuestGrabStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+{
+    // Same periodic "timer" trigger GatherStrategy already uses for
+    // "add gathering loot" (LootNonCombatStrategy.cpp). Relevance matches
+    // where "new rpg status update" sits today, well above plain "follow"'s
+    // baseline (1.0), so this wins whenever something's actually grabbable
+    // and yields back to "follow" the instant GrabQuestItemAction::Execute
+    // returns false.
+    triggers.push_back(new TriggerNode("timer", { NextAction("grab quest item", 11.0f) }));
+}

--- a/src/Ai/Base/Strategy/QuestGrabStrategy.h
+++ b/src/Ai/Base/Strategy/QuestGrabStrategy.h
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_QUESTGRABSTRATEGY_H
+#define PLAYERBOTS_QUESTGRABSTRATEGY_H
+
+#include "Strategy.h"
+
+class PlayerbotAI;
+
+// Two rules, meant to replace relying on "leash" + "new rpg" for a bot that
+// should just stick close and pick up whatever quest-relevant thing is
+// already in reach: if something within AiPlayerbot.QuestGrabDistance
+// satisfies an incomplete quest right now, interact with it (GrabQuestItemAction);
+// otherwise do nothing here and let plain "follow" (relevance 1.0, already
+// on by default) keep the bot near the leader.
+//
+// Deliberately does not invent a destination the way "new rpg" does (no POI
+// guessing, no synthetic averaged positions, no Z-height guessing) -- it only
+// ever reacts to an object the bot can already see, at its real position, so
+// the whole class of bugs that came from guessing a destination in advance
+// doesn't apply here by construction.
+//
+// Opt-in via "nc +grab" rather than added to every bot's permanent baseline
+// (AiFactory.cpp:585, where "follow"/"loot"/"quest" already live) -- this is
+// new, unvalidated code; fold it into that baseline later once proven.
+class QuestGrabStrategy : public Strategy
+{
+public:
+    QuestGrabStrategy(PlayerbotAI* botAI) : Strategy(botAI) {}
+
+    uint32 GetType() const override { return STRATEGY_TYPE_NONCOMBAT; }
+    std::string const getName() override { return "grab"; }
+    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
+};
+
+#endif

--- a/src/Ai/Base/StrategyContext.h
+++ b/src/Ai/Base/StrategyContext.h
@@ -29,6 +29,7 @@
 #include "GuardStrategy.h"
 #include "GuildStrategy.h"
 #include "KiteStrategy.h"
+#include "LeashStrategy.h"
 #include "LfgStrategy.h"
 #include "LootNonCombatStrategy.h"
 #include "MaintenanceStrategy.h"
@@ -40,6 +41,7 @@
 #include "NonCombatStrategy.h"
 #include "PassiveStrategy.h"
 #include "PullStrategy.h"
+#include "QuestGrabStrategy.h"
 #include "QuestStrategies.h"
 #include "RTSCStrategy.h"
 #include "RacialsStrategy.h"
@@ -90,6 +92,8 @@ public:
         creators["custom"] = &StrategyContext::custom;
         creators["reveal"] = &StrategyContext::reveal;
         creators["collision"] = &StrategyContext::collision;
+        creators["leash"] = &StrategyContext::leash;
+        creators["grab"] = &StrategyContext::grab;
         creators["rpg"] = &StrategyContext::rpg;
         creators["new rpg"] = &StrategyContext::new_rpg;
         creators["travel"] = &StrategyContext::travel;
@@ -169,6 +173,8 @@ private:
     static Strategy* custom(PlayerbotAI* botAI) { return new CustomStrategy(botAI); }
     static Strategy* reveal(PlayerbotAI* botAI) { return new RevealStrategy(botAI); }
     static Strategy* collision(PlayerbotAI* botAI) { return new CollisionStrategy(botAI); }
+    static Strategy* leash(PlayerbotAI* botAI) { return new LeashStrategy(botAI); }
+    static Strategy* grab(PlayerbotAI* botAI) { return new QuestGrabStrategy(botAI); }
     static Strategy* rpg(PlayerbotAI* botAI) { return new RpgStrategy(botAI); }
     static Strategy* new_rpg(PlayerbotAI* botAI) { return new NewRpgStrategy(botAI); }
     static Strategy* travel(PlayerbotAI* botAI) { return new TravelStrategy(botAI); }

--- a/src/Ai/Base/TriggerContext.h
+++ b/src/Ai/Base/TriggerContext.h
@@ -152,6 +152,7 @@ public:
         creators["not behind target"] = &TriggerContext::not_behind_target;
         creators["not facing target"] = &TriggerContext::not_facing_target;
         creators["far from master"] = &TriggerContext::far_from_master;
+        creators["leash too far"] = &TriggerContext::leash_too_far;
         creators["far from loot target"] = &TriggerContext::far_from_loot_target;
         creators["can loot"] = &TriggerContext::can_loot;
         creators["swimming"] = &TriggerContext::swimming;
@@ -299,6 +300,14 @@ private:
     static Trigger* can_loot(PlayerbotAI* botAI) { return new CanLootTrigger(botAI); }
     static Trigger* far_from_loot_target(PlayerbotAI* botAI) { return new FarFromCurrentLootTrigger(botAI); }
     static Trigger* far_from_master(PlayerbotAI* botAI) { return new FarFromMasterTrigger(botAI); }
+    // Separate named instance (own distance/check-interval) from "far from
+    // master" above -- that one is tied to the compiled-in 12.0f default and
+    // other callers may depend on that; this one is configurable via
+    // AiPlayerbot.LeashDistance for LeashStrategy (see LeashStrategy.cpp).
+    static Trigger* leash_too_far(PlayerbotAI* botAI)
+    {
+        return new FarFromMasterTrigger(botAI, "leash too far", sPlayerbotAIConfig.leashDistance, 10);
+    }
     static Trigger* behind_target(PlayerbotAI* botAI) { return new IsBehindTargetTrigger(botAI); }
     static Trigger* not_behind_target(PlayerbotAI* botAI) { return new IsNotBehindTargetTrigger(botAI); }
     static Trigger* not_facing_target(PlayerbotAI* botAI) { return new IsNotFacingTargetTrigger(botAI); }

--- a/src/Ai/Base/Value/PossibleRpgTargetsValue.cpp
+++ b/src/Ai/Base/Value/PossibleRpgTargetsValue.cpp
@@ -164,6 +164,26 @@ bool PossibleNewRpgTargetsValue::AcceptUnit(Unit* unit)
     if (unit->IsHostileTo(bot) || unit->IsPlayer())
         return false;
 
+    // LeashStrategy (see LeashStrategy.cpp) only recalls the bot once it has
+    // already wandered past AiPlayerbot.LeashDistance -- without this, new
+    // rpg could still pick an idle-interaction target beyond that distance
+    // (this value's own range is AiPlayerbot.RpgDistance, measured from the
+    // bot itself, not the leader), walk toward it, get recalled by the leash,
+    // then immediately re-pick the same distant target again. Refusing any
+    // candidate outside the leash distance from the actual leader closes
+    // that loop at the source instead of only reacting to it. The other half
+    // of this -- new rpg's own quest/grind/camp destination selection -- is
+    // guarded separately by WithinLeashRange in NewRpgBaseAction.cpp, since
+    // that path doesn't go through this value class at all.
+    if (botAI->HasStrategy("leash", BOT_STATE_NON_COMBAT))
+    {
+        if (Player* master = botAI->GetMaster())
+        {
+            if (ServerFacade::instance().GetDistance2d(master, unit) > sPlayerbotAIConfig.leashDistance)
+                return false;
+        }
+    }
+
     if (unit->HasNpcFlag(UNIT_NPC_FLAG_SPIRITHEALER))
         return false;
 
@@ -185,6 +205,11 @@ GuidVector PossibleNewRpgGameObjectsValue::Calculate()
     Acore::GameObjectListSearcher<AnyGameObjectInObjectRangeCheck> searcher(bot, targets, u_check);
     Cell::VisitObjects(bot, searcher, range);
 
+    // See the matching comment in PossibleNewRpgTargetsValue::AcceptUnit above
+    // -- same leash reasoning, applied to gameobjects instead of units.
+    bool const leashed = botAI->HasStrategy("leash", BOT_STATE_NON_COMBAT);
+    Player* const master = leashed ? botAI->GetMaster() : nullptr;
+
     std::vector<std::pair<ObjectGuid, float>> guidDistancePairs;
     for (GameObject* go : targets)
     {
@@ -203,6 +228,9 @@ GuidVector PossibleNewRpgGameObjectsValue::Calculate()
         if (!ignoreLos && !bot->IsWithinLOSInMap(go))
             continue;
 
+        if (master && ServerFacade::instance().GetDistance2d(master, go) > sPlayerbotAIConfig.leashDistance)
+            continue;
+
         guidDistancePairs.push_back({go->GetGUID(), bot->GetExactDist(go)});
     }
     GuidVector results;
@@ -212,6 +240,62 @@ GuidVector PossibleNewRpgGameObjectsValue::Calculate()
         return a.second < b.second;
     });
 
+    for (auto const& pair : guidDistancePairs) {
+        results.push_back(pair.first);
+    }
+    return results;
+}
+
+GuidVector PossibleQuestGrabTargetsValue::Calculate()
+{
+    std::list<GameObject*> targets;
+    AnyGameObjectInObjectRangeCheck u_check(bot, range);
+    Acore::GameObjectListSearcher<AnyGameObjectInObjectRangeCheck> searcher(bot, targets, u_check);
+    Cell::VisitObjects(bot, searcher, range);
+
+    // Diagnostic only: log every nearby GO this search actually visits, and exactly which
+    // check rejected it, so "grab" failures can be root-caused from Playerbots.log alone
+    // (LOG_DEBUG so it stays silent unless Logger.playerbots is at debug level).
+    LOG_DEBUG("playerbots", "[Quest Grab Search] {} found {} gameobject(s) within {} yd", bot->GetName(),
+              targets.size(), range);
+
+    std::vector<std::pair<ObjectGuid, float>> guidDistancePairs;
+    for (GameObject* go : targets)
+    {
+        if (!go->isSpawned() || !go->IsInWorld())
+        {
+            LOG_DEBUG("playerbots", "[Quest Grab Search] {} skipping {} (entry {}, {} yd) -- not spawned/in world",
+                      bot->GetName(), go->GetGOInfo()->name, go->GetEntry(), bot->GetDistance(go));
+            continue;
+        }
+
+        // No LOS/vmap raycast requirement here: the real client->server interaction path
+        // (WorldSession::HandleGameObjectUseOpcode, SpellHandler.cpp) only checks
+        // obj->IsWithinDistInMap(player, obj->GetInteractionDistance()) -- distance, nothing
+        // else. A vmap LOS check was rejecting perfectly legitimate targets (e.g. furniture
+        // pushed into a wall/tent corner, like Tallonkai's Dresser) that a real player can
+        // click on fine, since the client alone decides whether to render the use-cursor.
+
+        if (!go->ActivateToQuest(bot))
+        {
+            LOG_DEBUG("playerbots",
+                      "[Quest Grab Search] {} skipping {} (entry {}, type {}, {} yd) -- ActivateToQuest false",
+                      bot->GetName(), go->GetGOInfo()->name, go->GetEntry(), go->GetGoType(), bot->GetDistance(go));
+            continue;
+        }
+
+        LOG_DEBUG("playerbots", "[Quest Grab Search] {} accepted {} (entry {}, type {}, {} yd)", bot->GetName(),
+                  go->GetGOInfo()->name, go->GetEntry(), go->GetGoType(), bot->GetDistance(go));
+
+        guidDistancePairs.push_back({go->GetGUID(), bot->GetExactDist(go)});
+    }
+
+    // Sort by distance
+    std::sort(guidDistancePairs.begin(), guidDistancePairs.end(), [](auto const& a, auto const& b) {
+        return a.second < b.second;
+    });
+
+    GuidVector results;
     for (auto const& pair : guidDistancePairs) {
         results.push_back(pair.first);
     }

--- a/src/Ai/Base/Value/PossibleRpgTargetsValue.h
+++ b/src/Ai/Base/Value/PossibleRpgTargetsValue.h
@@ -60,4 +60,26 @@ private:
     bool ignoreLos;
 };
 
+// GameObjects the "grab" strategy (QuestGrabStrategy) should walk over to and
+// use. Unlike PossibleNewRpgGameObjectsValue (which only ever accepts
+// GAMEOBJECT_TYPE_QUESTGIVER), this filters with GameObject::ActivateToQuest
+// -- the same core-provided check the client itself uses to decide whether an
+// object should sparkle for a player's quests, covering CHEST/GOOBER/GENERIC/
+// SPELL_FOCUS/QUESTGIVER. Range is measured from the bot's own current
+// position, not the leader -- see the comment on AiPlayerbot.QuestGrabDistance.
+class PossibleQuestGrabTargetsValue : public ObjectGuidListCalculatedValue
+{
+public:
+    PossibleQuestGrabTargetsValue(PlayerbotAI* botAI, float range = 0.0f)
+        : ObjectGuidListCalculatedValue(botAI, "possible quest grab targets"),
+          range(range ? range : sPlayerbotAIConfig.questGrabDistance)
+    {
+    }
+
+    GuidVector Calculate() override;
+
+private:
+    float range;
+};
+
 #endif

--- a/src/Ai/Base/ValueContext.h
+++ b/src/Ai/Base/ValueContext.h
@@ -128,6 +128,7 @@ public:
         creators["possible rpg targets"] = &ValueContext::possible_rpg_targets;
         creators["possible new rpg targets"] = &ValueContext::possible_new_rpg_targets;
         creators["possible new rpg game objects"] = &ValueContext::possible_new_rpg_game_objects;
+        creators["possible quest grab targets"] = &ValueContext::possible_quest_grab_targets;
         creators["nearest adds"] = &ValueContext::nearest_adds;
         creators["nearest corpses"] = &ValueContext::nearest_corpses;
         creators["log level"] = &ValueContext::log_level;
@@ -437,6 +438,7 @@ private:
     static UntypedValue* possible_rpg_targets(PlayerbotAI* botAI) { return new PossibleRpgTargetsValue(botAI); }
     static UntypedValue* possible_new_rpg_targets(PlayerbotAI* botAI) { return new PossibleNewRpgTargetsValue(botAI); }
     static UntypedValue* possible_new_rpg_game_objects(PlayerbotAI* botAI) { return new PossibleNewRpgGameObjectsValue(botAI); }
+    static UntypedValue* possible_quest_grab_targets(PlayerbotAI* botAI) { return new PossibleQuestGrabTargetsValue(botAI); }
     static UntypedValue* possible_targets(PlayerbotAI* botAI) { return new PossibleTargetsValue(botAI); }
     static UntypedValue* possible_triggers(PlayerbotAI* botAI) { return new PossibleTriggersValue(botAI); }
     static UntypedValue* possible_targets_no_los(PlayerbotAI* botAI)

--- a/src/Ai/World/Rpg/Action/NewRpgAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.cpp
@@ -11,6 +11,7 @@
 #include "DBCStores.h"
 #include "GossipDef.h"
 #include "IVMapMgr.h"
+#include "LootMgr.h"
 #include "MotionMaster.h"
 #include "MoveSpline.h"
 #include "NewRpgInfo.h"
@@ -24,11 +25,13 @@
 #include "Player.h"
 #include "PlayerbotAI.h"
 #include "PlayerbotTextMgr.h"
+#include "Playerbots.h"
 #include "QuestDef.h"
 #include "Random.h"
 #include "SharedDefines.h"
 #include "Timer.h"
 #include "TravelMgr.h"
+#include "UseItemAction.h"
 #include "WaypointMovementGenerator.h"
 #include "G3D/Vector2.h"
 #include <cmath>
@@ -485,6 +488,8 @@ bool NewRpgDoQuestAction::DoIncompleteQuest(NewRpgInfo::DoQuest& data)
         if (!GetQuestPOIPosAndObjectiveIdx(questId, poiInfo))
         {
             // can't find a poi pos to go, stop doing quest for now
+            LOG_DEBUG("playerbots", "[New RPG] {} no in-range POI for incomplete quest {}, going idle",
+                      bot->GetName(), questId);
             botAI->rpgInfo.ChangeToIdle();
             return true;
         }
@@ -494,8 +499,14 @@ bool NewRpgDoQuestAction::DoIncompleteQuest(NewRpgInfo::DoQuest& data)
 
         float dx = nearestPoi.x, dy = nearestPoi.y;
 
-        // z = MAX_HEIGHT as we do not know accurate z
-        float dz = std::max(bot->GetMap()->GetHeight(dx, dy, MAX_HEIGHT), bot->GetMap()->GetWaterLevel(dx, dy));
+        // We do not know the accurate z, but GetHeight's vmap probe only
+        // searches maxSearchDist (default 50yd) below the z it's given --
+        // starting from MAX_HEIGHT never lands near real geometry, so vmap
+        // always misses and this silently fell back to the flat
+        // single-value-per-column .map heightmap, which is wrong on any
+        // multi-level structure (e.g. Teldrassil's tiered tree). The bot's
+        // own Z is a much better search origin since POIs are always close by.
+        float dz = std::max(bot->GetMap()->GetHeight(dx, dy, bot->GetPositionZ()), bot->GetMap()->GetWaterLevel(dx, dy));
 
         // double check for GetQuestPOIPosAndObjectiveIdx
         if (dz == INVALID_HEIGHT || dz == VMAP_INVALID_HEIGHT_VALUE)
@@ -505,6 +516,8 @@ bool NewRpgDoQuestAction::DoIncompleteQuest(NewRpgInfo::DoQuest& data)
         data.lastReachPOI = 0;
         data.pos = pos;
         data.objectiveIdx = objectiveIdx;
+        LOG_DEBUG("playerbots", "[New RPG] {} picked quest {} objective {} at X:{} Y:{} ({} yd away)",
+                  bot->GetName(), questId, objectiveIdx, dx, dy, bot->GetDistance(pos));
     }
 
     if (bot->GetDistance(data.pos) > 10.0f && !data.lastReachPOI)
@@ -588,8 +601,9 @@ bool NewRpgDoQuestAction::DoCompletedQuest(NewRpgInfo::DoQuest& data)
         assert(poiInfo.size() > 0);
         // now we get the place to get rewarded
         float dx = poiInfo[0].pos.x, dy = poiInfo[0].pos.y;
-        // z = MAX_HEIGHT as we do not know accurate z
-        float dz = std::max(bot->GetMap()->GetHeight(dx, dy, MAX_HEIGHT), bot->GetMap()->GetWaterLevel(dx, dy));
+        // See DoIncompleteQuest above for why this starts from the bot's Z
+        // instead of MAX_HEIGHT.
+        float dz = std::max(bot->GetMap()->GetHeight(dx, dy, bot->GetPositionZ()), bot->GetMap()->GetWaterLevel(dx, dy));
 
         // double check for GetQuestPOIPosAndObjectiveIdx
         if (dz == INVALID_HEIGHT || dz == VMAP_INVALID_HEIGHT_VALUE)
@@ -715,4 +729,123 @@ void NewRpgTravelFlightAction::ContinueCrossMapTaxi()
     flight->SkipCurrentNode();
 
     bot->TeleportTo(nextNode->map_id, node->x, node->y, node->z, bot->GetOrientation(), TELE_TO_NOT_LEAVE_TAXI);
+}
+
+bool GrabQuestItemAction::Execute(Event /*event*/)
+{
+    if (SearchQuestGiverAndAcceptOrReward())
+        return true;
+
+    if (UseQuestItemOnRequiredTarget())
+        return true;
+
+    GuidVector candidates = AI_VALUE(GuidVector, "possible quest grab targets");
+    if (candidates.empty())
+        return false;
+
+    ObjectGuid guid = candidates.front();
+    GameObject* go = botAI->GetGameObject(guid);
+    if (!go)
+        return false;
+
+    if (!IsWithinInteractionDist(go))
+        return MoveWorldObjectTo(guid);
+
+    // ActivateToQuest() (the filter behind "possible quest grab targets") accepts
+    // CHEST/GENERIC/GOOBER/SPELL_FOCUS/QUESTGIVER alike, but only CHEST is opened as
+    // loot -- the others grant quest credit via GameObject::Use() (KillCreditGO()),
+    // same as a player right-clicking them. SendLoot() is a no-op for those types.
+    if (go->GetGoType() == GAMEOBJECT_TYPE_CHEST)
+    {
+        // SendLoot releases any loot the bot already has open before opening a
+        // new one (Player::SendLoot) -- skip re-issuing it for the same object
+        // so a loot window already in progress gets a chance to actually be
+        // stored (via the "loot response" -> "store loot" pipeline, already
+        // wired unconditionally for every bot in WorldPacketHandlerStrategy)
+        // instead of being released and reopened every tick.
+        if (bot->GetLootGUID() != guid)
+        {
+            LOG_DEBUG("playerbots", "[Quest Grab] {} looting quest chest {} ({} yd away)", bot->GetName(),
+                      go->GetGOInfo()->name, bot->GetDistance(go));
+            bot->SendLoot(guid, LOOT_SKINNING);
+        }
+    }
+    else
+    {
+        LOG_DEBUG("playerbots", "[Quest Grab] {} using quest object {} ({} yd away)", bot->GetName(),
+                  go->GetGOInfo()->name, bot->GetDistance(go));
+        go->Use(bot);
+    }
+    return true;
+}
+
+bool GrabQuestItemAction::UseQuestItemOnRequiredTarget()
+{
+    std::vector<Item*> questItems = AI_VALUE2(std::vector<Item*>, "inventory items", "quest");
+    if (questItems.empty())
+        return false;
+
+    for (Item* item : questItems)
+    {
+        ItemTemplate const* proto = item->GetTemplate();
+        // Items that start a quest are handled by the always-on "use random quest item"
+        // maintenance action -- this is only for items used mid-quest on a target.
+        if (proto->StartQuest)
+            continue;
+
+        for (auto const& [questId, status] : bot->getQuestStatusMap())
+        {
+            if (status.Status != QUEST_STATUS_INCOMPLETE)
+                continue;
+
+            Quest const* quest = sObjectMgr->GetQuestTemplate(questId);
+            if (!quest)
+                continue;
+
+            for (uint8 i = 0; i < QUEST_OBJECTIVES_COUNT; ++i)
+            {
+                int32 reqEntry = quest->RequiredNpcOrGo[i];
+                if (!reqEntry || status.CreatureOrGOCount[i] >= quest->RequiredNpcOrGoCount[i])
+                    continue;
+
+                Object* target = nullptr;
+                GameObject* go = nullptr;
+                Creature* creature = nullptr;
+                if (reqEntry < 0)
+                {
+                    go = bot->FindNearestGameObject(uint32(-reqEntry), sPlayerbotAIConfig.questGrabDistance, true);
+                    target = go;
+                }
+                else
+                {
+                    creature = bot->FindNearestCreature(uint32(reqEntry), sPlayerbotAIConfig.questGrabDistance);
+                    target = creature;
+                }
+                if (!target)
+                    continue;
+
+                if (!IsWithinInteractionDist(target))
+                    return MoveWorldObjectTo(target->GetGUID());
+
+                LOG_DEBUG("playerbots",
+                          "[Quest Item Use] {} trying {} on {} {} for quest {} objective {} ({}/{} done)",
+                          bot->GetName(), proto->Name1, go ? "gameobject" : "creature", reqEntry, questId, i,
+                          status.CreatureOrGOCount[i], quest->RequiredNpcOrGoCount[i]);
+
+                bool used;
+                UseItemAction useItemAction(botAI);
+                if (go)
+                    used = useItemAction.UseItemOnGameObject(item, go->GetGUID());
+                else
+                    used = useItemAction.UseItemOnUnit(item, creature);
+
+                LOG_DEBUG("playerbots", "[Quest Item Use] {} {} using {} on {}", bot->GetName(),
+                          used ? "succeeded" : "failed", proto->Name1, target->GetGUID().ToString().c_str());
+
+                if (used)
+                    return true;
+            }
+        }
+    }
+    return false;
 }

--- a/src/Ai/World/Rpg/Action/NewRpgAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.cpp
@@ -739,6 +739,9 @@ bool GrabQuestItemAction::Execute(Event /*event*/)
     if (UseQuestItemOnRequiredTarget())
         return true;
 
+    if (UseQuestItemToCreateRequiredItem())
+        return true;
+
     GuidVector candidates = AI_VALUE(GuidVector, "possible quest grab targets");
     if (candidates.empty())
         return false;
@@ -844,6 +847,77 @@ bool GrabQuestItemAction::UseQuestItemOnRequiredTarget()
 
                 if (used)
                     return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool GrabQuestItemAction::UseQuestItemToCreateRequiredItem()
+{
+    std::vector<Item*> questItems = AI_VALUE2(std::vector<Item*>, "inventory items", "quest");
+    if (questItems.empty())
+        return false;
+
+    for (Item* item : questItems)
+    {
+        ItemTemplate const* proto = item->GetTemplate();
+        if (proto->StartQuest)
+            continue;
+
+        for (uint8 spellIdx = 0; spellIdx < MAX_ITEM_PROTO_SPELLS; ++spellIdx)
+        {
+            uint32 spellId = proto->Spells[spellIdx].SpellId;
+            if (!spellId)
+                continue;
+
+            SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+            if (!spellInfo)
+                continue;
+
+            for (uint8 effectIdx = 0; effectIdx < MAX_SPELL_EFFECTS; ++effectIdx)
+            {
+                if (spellInfo->Effects[effectIdx].Effect != SPELL_EFFECT_CREATE_ITEM)
+                    continue;
+
+                uint32 createdItemId = spellInfo->Effects[effectIdx].ItemType;
+
+                for (auto const& [questId, status] : bot->getQuestStatusMap())
+                {
+                    if (status.Status != QUEST_STATUS_INCOMPLETE)
+                        continue;
+
+                    Quest const* quest = sObjectMgr->GetQuestTemplate(questId);
+                    if (!quest)
+                        continue;
+
+                    for (uint8 j = 0; j < QUEST_ITEM_OBJECTIVES_COUNT; ++j)
+                    {
+                        if (quest->RequiredItemId[j] != createdItemId ||
+                            status.ItemCount[j] >= quest->RequiredItemCount[j])
+                            continue;
+
+                        // No explicit target: items like this (e.g. "Jade Phial" filled into
+                        // "Filled Jade Phial") are gated by the spell's own range/spell-focus
+                        // requirement, not by anything the bot selects -- the bot only needs
+                        // to already be standing in the right spot, which "grab" doesn't move
+                        // it for. UseItemAuto() lets the server's own cast validation decide;
+                        // a bot outside the required area just gets a harmless failed cast.
+                        LOG_DEBUG("playerbots",
+                                  "[Quest Item Use] {} trying {} (creates {}) for quest {} objective {} ({}/{} done)",
+                                  bot->GetName(), proto->Name1, createdItemId, questId, j, status.ItemCount[j],
+                                  quest->RequiredItemCount[j]);
+
+                        UseItemAction useItemAction(botAI);
+                        bool used = useItemAction.UseItemAuto(item);
+
+                        LOG_DEBUG("playerbots", "[Quest Item Use] {} {} using {}", bot->GetName(),
+                                  used ? "succeeded" : "failed", proto->Name1);
+
+                        if (used)
+                            return true;
+                    }
+                }
             }
         }
     }

--- a/src/Ai/World/Rpg/Action/NewRpgAction.h
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.h
@@ -122,4 +122,31 @@ protected:
     void ContinueCrossMapTaxi();
 };
 
+// Used by the "grab" strategy (QuestGrabStrategy), independent of "new rpg" --
+// reuses NewRpgBaseAction purely for its movement/quest-interaction helpers.
+// Three rules, tried in order: accept/turn in at a nearby questgiver if one's
+// ready (existing, unmodified SearchQuestGiverAndAcceptOrReward); else use a
+// carried quest item on the specific creature/GO a current objective still
+// needs (UseQuestItemOnRequiredTarget); else walk to and use the nearest
+// quest-relevant GameObject already in sight.
+class GrabQuestItemAction : public NewRpgBaseAction
+{
+public:
+    GrabQuestItemAction(PlayerbotAI* botAI) : NewRpgBaseAction(botAI, "grab quest item") {}
+    bool Execute(Event event) override;
+
+protected:
+    // Quest data (Quest::RequiredNpcOrGo[]) tells us exactly which creature (>0) or
+    // gameobject (<0) entry each objective slot still needs -- the same array
+    // NewRpgDoQuestAction already reads via RequiredNpcOrGoCount. What quest data does
+    // NOT tell us is which carried item resolves that objective (this codebase has no
+    // TrinityCore-style RequiredSourceItemId; classic "use item on target" quests grant
+    // credit via per-item hardcoded SpellScripts, e.g. spell_item_branns_communicator).
+    // So this tries each non-StartQuest "quest" category item against a nearby target
+    // matching an outstanding objective and lets the server's own item/spell target
+    // validation decide -- identical to what the manual "use <item> <target>" chat
+    // command already relies on.
+    bool UseQuestItemOnRequiredTarget();
+};
+
 #endif

--- a/src/Ai/World/Rpg/Action/NewRpgAction.h
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.h
@@ -124,11 +124,13 @@ protected:
 
 // Used by the "grab" strategy (QuestGrabStrategy), independent of "new rpg" --
 // reuses NewRpgBaseAction purely for its movement/quest-interaction helpers.
-// Three rules, tried in order: accept/turn in at a nearby questgiver if one's
+// Four rules, tried in order: accept/turn in at a nearby questgiver if one's
 // ready (existing, unmodified SearchQuestGiverAndAcceptOrReward); else use a
 // carried quest item on the specific creature/GO a current objective still
-// needs (UseQuestItemOnRequiredTarget); else walk to and use the nearest
-// quest-relevant GameObject already in sight.
+// needs (UseQuestItemOnRequiredTarget); else try a carried quest item that
+// has no target at all -- a spell-focus-gated "fill this near the right
+// spot" item like Jade Phial (UseQuestItemToCreateRequiredItem); else walk
+// to and use the nearest quest-relevant GameObject already in sight.
 class GrabQuestItemAction : public NewRpgBaseAction
 {
 public:
@@ -147,6 +149,17 @@ protected:
     // validation decide -- identical to what the manual "use <item> <target>" chat
     // command already relies on.
     bool UseQuestItemOnRequiredTarget();
+
+    // Covers RequiredItemId-only objectives satisfied by a *different* item than the one
+    // in the bot's bag -- e.g. quest 929 needs "Filled Jade Phial" (5639), obtained by
+    // using the empty "Jade Phial" (5619) while standing near a spell-focus gameobject
+    // the quest data never names. No script/table anywhere links 5619 -> 5639 -> quest
+    // 929 directly; the only place that link exists is the tool item's own on-use spell
+    // effect (SPELL_EFFECT_CREATE_ITEM), which ItemUsageValue::IsItemUsefulForQuest
+    // already walks for a different purpose. Reuses that same walk to find candidate
+    // tool items, then just calls UseItemAuto() with no target and lets the server's own
+    // spell-focus/range check decide -- there is nothing to path to or aim at.
+    bool UseQuestItemToCreateRequiredItem();
 };
 
 #endif

--- a/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "NewRpgBaseAction.h"
+#include <algorithm>
 #include "BroadcastHelper.h"
 #include "ChatHelper.h"
 #include "Creature.h"
@@ -805,21 +806,60 @@ bool NewRpgBaseAction::HasQuestToAcceptOrReward(WorldObject* object)
     return false;
 }
 
-static std::vector<float> GenerateRandomWeights(int n)
+// True when either the "leash" strategy isn't active for this bot, the bot
+// has no real-player master, or (x, y) is within AiPlayerbot.LeashDistance of
+// that master. Gates every destination new rpg's own status-selection can
+// pick (grind/camp/quest POIs) so it never proposes something a "leash too
+// far" recall (LeashStrategy.cpp) would just walk the bot straight back out
+// of again -- picking a target, getting recalled, then immediately
+// re-picking the same target is the "pulling on a chain" behavior a plain
+// recall-only leash does not prevent.
+static bool WithinLeashRange(Player* bot, float x, float y)
 {
-    std::vector<float> weights(n);
-    float sum = 0.0;
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+    if (!botAI || !botAI->HasStrategy("leash", BOT_STATE_NON_COMBAT))
+        return true;
 
-    for (int i = 0; i < n; ++i)
+    Player* master = botAI->GetMaster();
+    if (!master)
+        return true;
+
+    return master->GetDistance2d(x, y) <= sPlayerbotAIConfig.leashDistance;
+}
+
+// Picks ONE real point from a QuestPOI's spawn/interaction points --
+// restricted to those individually within leash range (all of them, if not
+// leashed) -- instead of blending several into a synthetic average
+// coordinate the way this code originally did.
+//
+// Two independent problems with blending: (1) GenerateRandomWeights draws
+// fresh randomness on every single call, so a point cloud spanning both
+// inside and outside the leash can blend to an in-range result on one call
+// (making a quest look "available" during a status check) and an
+// out-of-range result on the very next call that actually commits to a
+// destination -- the exact case that sent a bot walking 380+ yards from its
+// leader despite the leash "working". (2) a mathematical average of two real
+// points is not itself guaranteed to be a real, walkable point -- it can
+// land inside a wall, off a ledge, etc., which is what was producing bots
+// clipping through terrain trying to reach these blended destinations.
+// Picking one of the game's own real points, as SelectRandomGrindPos/
+// SelectRandomCampPos already do for their own candidate lists, avoids both.
+static bool PickLeashLegalPoint(Player* bot, std::vector<QuestPOIPoint> const& points, float& outX, float& outY)
+{
+    std::vector<QuestPOIPoint const*> candidates;
+    candidates.reserve(points.size());
+    for (QuestPOIPoint const& point : points)
     {
-        weights[i] = rand_norm();
-        sum += weights[i];
+        if (WithinLeashRange(bot, point.x, point.y))
+            candidates.push_back(&point);
     }
-    for (int i = 0; i < n; ++i)
-    {
-        weights[i] /= sum;
-    }
-    return weights;
+    if (candidates.empty())
+        return false;
+
+    QuestPOIPoint const& chosen = *candidates[urand(0, static_cast<uint32>(candidates.size()) - 1)];
+    outX = chosen.x;
+    outY = chosen.y;
+    return true;
 }
 
 bool NewRpgBaseAction::GetQuestPOIPosAndObjectiveIdx(uint32 questId, std::vector<POIInfo>& poiInfo, bool toComplete)
@@ -851,18 +891,23 @@ bool NewRpgBaseAction::GetQuestPOIPosAndObjectiveIdx(uint32 questId, std::vector
                 continue;
 
             float dx = 0, dy = 0;
-            std::vector<float> weights = GenerateRandomWeights(qPoi.points.size());
-            for (size_t i = 0; i < qPoi.points.size(); i++)
-            {
-                QuestPOIPoint const& point = qPoi.points[i];
-                dx += point.x * weights[i];
-                dy += point.y * weights[i];
-            }
+            if (!PickLeashLegalPoint(bot, qPoi.points, dx, dy))
+                continue;
 
             if (bot->GetDistance2d(dx, dy) >= 1500.0f)
                 continue;
 
-            float dz = std::max(bot->GetMap()->GetHeight(dx, dy, MAX_HEIGHT), bot->GetMap()->GetWaterLevel(dx, dy));
+            // GetHeight's vmap probe only looks maxSearchDist (default 50yd)
+            // below the z it's given. Starting from MAX_HEIGHT (100000) never
+            // lands within 50yd of real geometry, so vmap always misses and
+            // this silently fell back to the flat, single-value-per-column
+            // .map heightmap -- wrong on any multi-level structure (e.g.
+            // Teldrassil's tiered tree), where it returns some other tier's
+            // height instead of the one this POI is actually on. Starting
+            // from the bot's own Z lets the probe find the real nearby
+            // surface, since RPG POIs are always fairly close to the bot
+            // (the 1500yd check above already ran).
+            float dz = std::max(bot->GetMap()->GetHeight(dx, dy, bot->GetPositionZ()), bot->GetMap()->GetWaterLevel(dx, dy));
 
             if (dz == INVALID_HEIGHT || dz == VMAP_INVALID_HEIGHT_VALUE)
                 continue;
@@ -923,18 +968,15 @@ bool NewRpgBaseAction::GetQuestPOIPosAndObjectiveIdx(uint32 questId, std::vector
         if (qPoi.points.size() == 0)
             continue;
         float dx = 0, dy = 0;
-        std::vector<float> weights = GenerateRandomWeights(qPoi.points.size());
-        for (size_t i = 0; i < qPoi.points.size(); i++)
-        {
-            QuestPOIPoint const& point = qPoi.points[i];
-            dx += point.x * weights[i];
-            dy += point.y * weights[i];
-        }
+        if (!PickLeashLegalPoint(bot, qPoi.points, dx, dy))
+            continue;
 
         if (bot->GetDistance2d(dx, dy) >= 1500.0f)
             continue;
 
-        float dz = std::max(bot->GetMap()->GetHeight(dx, dy, MAX_HEIGHT), bot->GetMap()->GetWaterLevel(dx, dy));
+        // See the toComplete branch above for why this starts from the
+        // bot's Z instead of MAX_HEIGHT.
+        float dz = std::max(bot->GetMap()->GetHeight(dx, dy, bot->GetPositionZ()), bot->GetMap()->GetWaterLevel(dx, dy));
 
         if (dz == INVALID_HEIGHT || dz == VMAP_INVALID_HEIGHT_VALUE)
             continue;
@@ -979,6 +1021,9 @@ WorldPosition NewRpgBaseAction::SelectRandomGrindPos(Player* bot)
             continue;
 
         if (bot->GetExactDist(loc) > 2500.0f)
+            continue;
+
+        if (!WithinLeashRange(bot, loc.GetPositionX(), loc.GetPositionY()))
             continue;
 
         if (!inCity && bot->GetMap()->GetZoneId(bot->GetPhaseMask(), loc.GetPositionX(), loc.GetPositionY(),
@@ -1037,6 +1082,9 @@ WorldPosition NewRpgBaseAction::SelectRandomCampPos(Player* bot)
         if (bot->GetExactDist(loc) < 50.0f)
             continue;
 
+        if (!WithinLeashRange(bot, loc.GetPositionX(), loc.GetPositionY()))
+            continue;
+
         if (!inCity && bot->GetMap()->GetZoneId(bot->GetPhaseMask(), loc.GetPositionX(), loc.GetPositionY(),
                                                 loc.GetPositionZ()) != bot->GetZoneId())
             continue;
@@ -1088,23 +1136,60 @@ bool NewRpgBaseAction::RandomChangeStatus(std::vector<NewRpgStatus> candidateSta
             probSum += sPlayerbotAIConfig.RpgStatusProbWeight[status];
         }
     }
-    // Safety check. Default to "rest" if all RPG weights = 0
-    if (availableStatus.empty() || probSum == 0)
+    // While leashed, prefer a genuine quest objective over the normal
+    // weighted roll against wander/grind/camp. CheckRpgStatusAvailable for
+    // RPG_DO_QUEST already ran every quest POI through WithinLeashRange, so
+    // it being available here means there's real, in-range quest content --
+    // without this, DoQuest (weight 60) is still only ~35-45% of the total
+    // roll whenever wander/grind/camp are also available, so a bot parked
+    // right next to a quest object could spend many cycles wandering before
+    // the dice happen to favor it. That variety is fine for a free-roaming
+    // bot with nowhere in particular to be, but not for one leashed to you
+    // specifically to get things done nearby.
+    bool const leashed = botAI->HasStrategy("leash", BOT_STATE_NON_COMBAT);
+    bool const preferQuest = leashed &&
+        std::find(availableStatus.begin(), availableStatus.end(), RPG_DO_QUEST) != availableStatus.end();
+
+    NewRpgStatus chosenStatus = RPG_STATUS_END;
+    if (preferQuest)
     {
-        botAI->rpgInfo.ChangeToRest();
-        bot->SetStandState(UNIT_STAND_STATE_SIT);
+        chosenStatus = RPG_DO_QUEST;
+    }
+    else if (leashed)
+    {
+        // Leashed with no in-range quest right now: stay close to the
+        // leader instead of wandering/grinding/camping the way a
+        // free-roaming bot would. NewRpgStrategy::getDefaultActions always
+        // proposes "new rpg status update" at relevance 11.0 whenever new
+        // rpg is active -- that beats FollowMasterStrategy's own baseline
+        // "follow" (relevance 1.0) unconditionally, so plain "follow" never
+        // gets a turn of its own while this strategy is running. This action
+        // has to explicitly follow itself instead of just doing nothing and
+        // hoping a lower-relevance action picks up the slack.
+        if (Player* master = botAI->GetMaster())
+            Follow(master);
+        botAI->rpgInfo.ChangeToIdle();
         return true;
     }
-    uint32 rand = urand(1, probSum);
-    uint32 accumulate = 0;
-    NewRpgStatus chosenStatus = RPG_STATUS_END;
-    for (NewRpgStatus status : availableStatus)
+    else
     {
-        accumulate += sPlayerbotAIConfig.RpgStatusProbWeight[status];
-        if (accumulate >= rand)
+        // Safety check. Default to "rest" if all RPG weights = 0
+        if (availableStatus.empty() || probSum == 0)
         {
-            chosenStatus = status;
-            break;
+            botAI->rpgInfo.ChangeToRest();
+            bot->SetStandState(UNIT_STAND_STATE_SIT);
+            return true;
+        }
+        uint32 rand = urand(1, probSum);
+        uint32 accumulate = 0;
+        for (NewRpgStatus status : availableStatus)
+        {
+            accumulate += sPlayerbotAIConfig.RpgStatusProbWeight[status];
+            if (accumulate >= rand)
+            {
+                chosenStatus = status;
+                break;
+            }
         }
     }
 
@@ -1161,6 +1246,9 @@ bool NewRpgBaseAction::RandomChangeStatus(std::vector<NewRpgStatus> candidateSta
                 Quest const* quest = sObjectMgr->GetQuestTemplate(questId);
                 if (quest)
                 {
+                    LOG_DEBUG("playerbots", "[New RPG] {} chose to do quest {} ({} in-range candidate(s), leash-preferred: {})",
+                              bot->GetName(), questId, availableQuests.size(),
+                              botAI->HasStrategy("leash", BOT_STATE_NON_COMBAT));
                     botAI->rpgInfo.ChangeToDoQuest(questId, quest);
                     return true;
                 }

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -116,6 +116,21 @@ bool PlayerbotAIConfig::Initialize()
     tooCloseDistance = sConfigMgr->GetOption<float>("AiPlayerbot.TooCloseDistance", 5.0f);
     meleeDistance = sConfigMgr->GetOption<float>("AiPlayerbot.MeleeDistance", 0.75f);
     followDistance = sConfigMgr->GetOption<float>("AiPlayerbot.FollowDistance", 1.5f);
+    // Used by the "leash" strategy (LeashStrategy.cpp) to recall a bot from an
+    // independent-movement strategy (new rpg, grind, ...) once it wanders this
+    // far from the group leader. Deliberately a separate, much larger value
+    // than FollowDistance -- that one governs the tight formation-following
+    // radius, this one is a loose leash meant to let a bot roam and act on its
+    // own nearby, not hug the leader.
+    leashDistance = sConfigMgr->GetOption<float>("AiPlayerbot.LeashDistance", 30.0f);
+    // Used by the "grab" strategy (QuestGrabStrategy.cpp) as the max distance,
+    // from the bot's own current position (not the leader), it will walk to
+    // interact with a quest-relevant object it can already see. Deliberately
+    // bounded and short: paired with "follow", the bot only ever leaves a
+    // short, one-shot excursion from wherever it already is (which "follow"
+    // keeps near the leader) rather than needing its own leader-distance
+    // check the way "leash" does.
+    questGrabDistance = sConfigMgr->GetOption<float>("AiPlayerbot.QuestGrabDistance", 30.0f);
     whisperDistance = sConfigMgr->GetOption<float>("AiPlayerbot.WhisperDistance", 6000.0f);
     contactDistance = sConfigMgr->GetOption<float>("AiPlayerbot.ContactDistance", 0.45f);
     aoeRadius = sConfigMgr->GetOption<float>("AiPlayerbot.AoeRadius", 10.0f);

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -112,7 +112,7 @@ public:
     bool dynamicReactDelay;
     float sightDistance, spellDistance, reactDistance, grindDistance, lootDistance, shootDistance, fleeDistance,
         tooCloseDistance, meleeDistance, followDistance, whisperDistance, contactDistance, aoeRadius, rpgDistance,
-        targetPosRecalcDistance, farDistance, healDistance, aggroDistance;
+        targetPosRecalcDistance, farDistance, healDistance, aggroDistance, leashDistance, questGrabDistance;
     uint32 criticalHealth, lowHealth, mediumHealth, almostFullHealth;
     uint32 lowMana, mediumMana, highMana;
     bool autoSaveMana;


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description

Adds two new independent-movement strategies for bots, both **opt-in** (not part of the default strategy baseline):

- **`leash`** — recalls a bot back toward the group leader once it wanders past `AiPlayerbot.LeashDistance` while doing independent movement (`new rpg`, `grind`).
- **`grab`** (`QuestGrabStrategy` → `GrabQuestItemAction`) — lets a bot, independent of `new rpg`, accept/turn in quests at a nearby questgiver and interact with any other quest-relevant object already in reach.

Fixes several related bugs in quest-object interaction found while building `grab` (see commit messages / diff for `GrabQuestItemAction`, `PossibleQuestGrabTargetsValue`, `UseItemAction`): `SendLoot()` was being called on GOOBER/GENERIC/SPELL_FOCUS objects that only grant credit via `GameObject::Use()`; an `IsWithinLOSInMap()` check was rejecting legitimate targets the server itself only range-gates; no path existed for "use a carried quest item on a specific required target" or "no-target quest tool item" (Jade Phial-style) objectives.

**Since the last review:**
- PR retargeted to `test-staging` (thank you for fixing this).
- Added a manual `go quest` / `go grab` whisper command (`GoAction.cpp`) that invokes the same `GrabQuestItemAction` on demand via `DoSpecificAction`, for anyone who'd rather trigger it once than run `grab` as a standing strategy.
- See "Notes for Reviewers" below for the `follow`/relevance question.

## Feature Evaluation

- **Minimum logic required:**
  - `leash`: a single `TriggerNode` reusing the existing `FarFromMasterTrigger` class (already used for the codebase's ordinary follow-distance trigger) with a second, larger, configurable radius, pushing `NextAction("follow", 15.0f)`. No new trigger *class*, no new per-tick engine work beyond one more distance comparison — the same shape as the existing `far_from_master` trigger.
  - `grab`: one `TriggerNode` reusing the existing generic `"timer"` trigger (already used by `GatherStrategy`/`LootNonCombatStrategy`) at relevance 11.0. `GrabQuestItemAction::Execute` short-circuits through 4 cheap checks (existing `SearchQuestGiverAndAcceptOrReward`, then inventory-scoped item/target matching, then a cached `"possible quest grab targets"` value) and returns `false` immediately (yielding to plain `follow`) the instant nothing is grabbable.
- **Processing cost across many bots:** zero for any bot that doesn't have `leash`/`grab` enabled — both strategies are opt-in (`nc +leash`, `nc +grab`), matching "expensive behavior must be opt-in." For bots that do opt in, the added cost is one extra distance check (`leash`) or one extra `"timer"`-cadence action attempt (`grab`), not a per-tick-per-bot scan of the world — `grab`'s own target search (`PossibleQuestGrabTargetsValue`) is a cached Value, same caching model as every other `"possible ... targets"` value already in the codebase.

## How to Test the Changes

1. Enable on a bot: `nc +leash,+new rpg` (or `+grind`) — let it wander, confirm it's pulled back toward the leader once it exceeds `AiPlayerbot.LeashDistance` (conf, default 30 yd), and that `new rpg`/`grind` stop proposing destinations beyond that radius in the first place (no back-and-forth fighting).
2. Enable on a bot: `nc +grab` (no `new rpg` needed) near a quest giver / quest object — confirm it turns in/accepts quests and interacts with nearby GOOBER/GENERIC/SPELL_FOCUS objects (not just chests) and gets quest credit.
3. Whisper `go quest` to any bot near a grabbable target — confirm it performs the same interaction once, without `grab` enabled.
4. Quest-item cases: a `RequiredNpcOrGo` objective satisfied by walking a carried item to the right target, and a no-target "tool" item case (Jade Phial → Filled Jade Phial via a spell-focus GO).

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [x] Minimal impact (**explain below**)

  Zero cost when `leash`/`grab` are not enabled (the overwhelming majority of bots by default). For bots that opt in: `leash` adds one more `FarFromMasterTrigger`-style distance check (same primitive as the existing default follow trigger); `grab` reuses the existing `"timer"` cadence already paid for by gathering, and its target search is a normal cached Value like every other candidate-target Value in the codebase.

- Does this change modify default bot behavior?
    - - [x] No

  Both strategies are opt-in and not added to the default strategy set in `PlayerbotFactory.cpp`/`AiFactory.cpp`. The `GrabQuestItemAction`/`PossibleQuestGrabTargetsValue`/`UseItemAction` bug fixes only change behavior for bots that already have `grab` (or, via the shared helpers, `new rpg`) enabled.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] Yes (**explain below**)

  Two new `Strategy` subclasses (~40 lines each, mostly comments) and one new `Action` (`GrabQuestItemAction`) with three fallback rules. Kept deliberately narrow: `grab` does not invent destinations (no POI guessing, no averaged positions) — it only reacts to something the bot can already see, so the class of bugs from destination-guessing doesn't apply here by construction. See "Notes for Reviewers" for the alternative designs considered and why they weren't used instead.

## AI Assistance

Was AI assistance used while working on this change?
- - [x] Yes (**explain below**)

Used for brainstorming the fallback ordering in `GrabQuestItemAction`, drafting/refining code comments, and code generation for the `LeashStrategy`/`QuestGrabStrategy` boilerplate. All logic was reviewed, tested in-game (~6 hours of play), and is understood by me; the quest-interaction bug analysis (`SendLoot` vs `GameObject::Use`, the `IsWithinLOSInMap` false rejection, the `RequiredNpcOrGo`/Jade-Phial cases) was verified against server behavior and existing sibling code (`NewRpgDoQuestAction`, `ItemUsageValue::IsItemUsefulForQuest`), not taken on faith.

## Code Provenance / Attribution

- - [x] No, all code in this PR is original

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [ ] Any new bot dialogue lines are translated. (see note below)
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [ ] New and modified files do not introduce new compiler warnings. (not independently rebuilt locally since the last review; relying on CI (`C++`, `ubuntu-22.04-*`, `windows-2022`, `macos-14`) to confirm — all were green before this update, and this update is a small, self-contained addition to `GoAction.cpp` following an existing call pattern)

## Notes for Reviewers

On translations: the new `go quest`/`go grab` strings in `GoAction.cpp` are plain hardcoded English, matching every other player-facing string already in that file (`"It is too far away"`, `"Moving to..."`, the existing `go` help text) — none of them go through `GetBotTextOrDefault`. I left the new lines consistent with the file's existing (untranslated) convention rather than converting just mine, but flagging it in case the file as a whole is due for a translation pass.

On the design question raised in review — extending `go` and/or folding this into `follow` instead of new strategies:

- **`go` command:** done — `go quest`/`go grab` now calls `GrabQuestItemAction` directly via `DoSpecificAction`, same one-shot pattern `BossAuraActions`/`GuildCreateActions` already use. The standing `grab` strategy stays too, since a lot of the value here (per the original 6-hour playtest) is bots doing this *without* being told each time, the same way `follow`/`loot`/`quest` already work unattended.
- **Folding `leash` into `follow`'s own distance check** (the fishing precedent): I looked at this closely and don't think it's a clean win. `FollowAction::isUseful()`'s "master fishing" branch works because *nothing else is competing for the "follow" action slot* while fishing — it just gates whether the existing baseline-relevance `follow` trigger is useful. `leash` has a harder job: it has to *outrank* `new rpg`/`grind`'s own movement actions, which already propose themselves at relevance 3.0–11.0 (see `NewRpgStrategy::getDefaultActions`). Relevance in this engine is a fixed value baked in at `TriggerNode` registration time, not computed dynamically per tick, so there's no way to say "make plain follow win, but only once it's this far away" without either (a) permanently raising follow's baseline relevance above 11 (which would make it fight `new rpg` constantly, not just past the leash radius), or (b) a second, separate high-relevance trigger — which is exactly what `leash too far` is. For what it's worth, `master fishing` itself uses the same shape of override elsewhere in the same file: `NonCombatStrategy.cpp` pushes a dedicated `NextAction("end master fishing", 12.0f)` off the generic `"random"` trigger to end fishing, rather than relying on `isUseful()` alone. So `leash` isn't a new mechanism — it's the same "cheap trigger, relevance-based override" pattern used elsewhere in this codebase for this exact class of problem (an independent-movement action needs to be overridden regardless of what's currently winning). Happy to be pointed at a cleaner way to do this if I'm missing one, but wanted to lay out why I didn't just inline it into `isUseful()`.

Let me know if you'd like `leash`/`grab` split into separate PRs, or if the quest-interaction bug fixes (`SendLoot`/`GameObject::Use`, LOS check, `RequiredNpcOrGo` item targeting) should be pulled out on their own since they're independently useful to `new rpg` even without `grab`.
