### PR TITLE
feat(pmon): track relevance multipliers

### DIFF
--- a/src/Bot/Debug/PerfMonitor.cpp
+++ b/src/Bot/Debug/PerfMonitor.cpp
@@ -15,10 +15,72 @@
 #include "PerfMonitor.h"
 #include "Playerbots.h"
 
+namespace
+{
+std::chrono::microseconds Now()
+{
+    return (std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now()))
+        .time_since_epoch();
+}
+
+void RecordSample(PerformanceData* data, uint64 elapsed)
+{
+    std::lock_guard<std::mutex> guard(data->lock);
+    if (elapsed > 0)
+    {
+        if (!data->minTime || data->minTime > elapsed)
+            data->minTime = elapsed;
+
+        if (!data->maxTime || data->maxTime < elapsed)
+            data->maxTime = elapsed;
+
+        data->totalTime += elapsed;
+    }
+
+    ++data->count;
+}
+}  // namespace
+
+bool PerfMonitor::IsEnabled() { return sPlayerbotAIConfig.perfMonEnabled; }
+
+PerformanceData* PerfMonitor::GetOrCreate(PerformanceMetric metric, std::string const& name)
+{
+    std::lock_guard<std::mutex> guard(lock);
+    PerformanceData*& pd = data[metric][name];
+    if (!pd)
+    {
+        pd = new PerformanceData();
+        pd->minTime = 0;
+        pd->maxTime = 0;
+        pd->totalTime = 0;
+        pd->count = 0;
+        pd->blocks = 0;
+    }
+
+    return pd;
+}
+
+PerformanceData* PerfMonitor::acquire(PerformanceMetric metric, std::string const& name)
+{
+    if (!IsEnabled())
+        return nullptr;
+
+    return GetOrCreate(metric, name);
+}
+
+void PerfMonitor::CountBlock(PerformanceData* data)
+{
+    if (!data)
+        return;
+
+    std::lock_guard<std::mutex> guard(data->lock);
+    ++data->blocks;
+}
+
 PerfMonitorOperation* PerfMonitor::start(PerformanceMetric metric, std::string const name,
                                                        PerformanceStack* stack)
 {
-    if (!sPlayerbotAIConfig.perfMonEnabled)
+    if (!IsEnabled())
         return nullptr;
 
     std::string stackName = name;
@@ -41,19 +103,7 @@ PerfMonitorOperation* PerfMonitor::start(PerformanceMetric metric, std::string c
         stack->push_back(name);
     }
 
-    std::lock_guard<std::mutex> guard(lock);
-    PerformanceData* pd = data[metric][stackName];
-    if (!pd)
-    {
-        pd = new PerformanceData();
-        pd->minTime = 0;
-        pd->maxTime = 0;
-        pd->totalTime = 0;
-        pd->count = 0;
-        data[metric][stackName] = pd;
-    }
-
-    return new PerfMonitorOperation(pd, name, stack);
+    return new PerfMonitorOperation(GetOrCreate(metric, stackName), name, stack);
 }
 
 void PerfMonitor::PrintStats(bool perTick, bool fullStack)
@@ -94,6 +144,9 @@ void PerfMonitor::PrintStats(bool perTick, bool fullStack)
                 case PERF_MON_ACTION:
                     key = "Action";
                     break;
+                case PERF_MON_MULTIPLIER:
+                    key = "Mult";
+                    break;
                 case PERF_MON_RNDBOT:
                     key = "RndBot";
                     break;
@@ -123,11 +176,13 @@ void PerfMonitor::PrintStats(bool perTick, bool fullStack)
             uint64 typeMinTime = 0xffffffffu;
             uint64 typeMaxTime = 0;
             uint32 typeCount = 0;
+            uint32 typeBlocks = 0;
             for (auto& name : names)
             {
                 PerformanceData* pd = pdMap[name];
                 typeTotalTime += pd->totalTime;
                 typeCount += pd->count;
+                typeBlocks += pd->blocks;
                 if (typeMinTime > pd->minTime)
                     typeMinTime = pd->minTime;
                 if (typeMaxTime < pd->maxTime)
@@ -141,7 +196,16 @@ void PerfMonitor::PrintStats(bool perTick, bool fullStack)
                 if (!fullStack && disName.find("|") != std::string::npos)
                     disName = disName.substr(0, disName.find("|")) + "]";
 
-                if (perc >= 0.1f || avg >= 0.25f || pd->maxTime > 1000)
+                bool show = perc >= 0.1f || avg >= 0.25f || pd->maxTime > 1000;
+                if (i->first == PERF_MON_MULTIPLIER)
+                {
+                    if (pd->blocks)
+                        disName += " [blocked " + std::to_string(pd->blocks) + "]";
+
+                    show = show || pd->blocks > 0 || perc >= 0.01f;
+                }
+
+                if (show)
                 {
                     LOG_INFO("playerbots",
                              "{:7.3f}% {:10.3f}s | {:7.1f} .. {:7.1f} ({:10.3f} of {:10d}) - {:6}    : {}", perc, time,
@@ -153,8 +217,12 @@ void PerfMonitor::PrintStats(bool perTick, bool fullStack)
             float tMinTime = (float)typeMinTime / 1000.0f;
             float tMaxTime = (float)typeMaxTime / 1000.0f;
             float tAvg = (float)typeTotalTime / (float)typeCount / 1000.0f;
+            std::string totalName = "Total";
+            if (i->first == PERF_MON_MULTIPLIER && typeBlocks)
+                totalName += " [blocked " + std::to_string(typeBlocks) + "]";
+
             LOG_INFO("playerbots", "{:7.3f}% {:10.3f}s | {:7.1f} .. {:7.1f} ({:10.3f} of {:10d}) - {:6}    : {}", tPerc,
-                     tTime, tMinTime, tMaxTime, tAvg, typeCount, key.c_str(), "Total");
+                     tTime, tMinTime, tMaxTime, tAvg, typeCount, key.c_str(), totalName.c_str());
             LOG_INFO("playerbots", " ");
         }
     }
@@ -189,6 +257,9 @@ void PerfMonitor::PrintStats(bool perTick, bool fullStack)
                 case PERF_MON_ACTION:
                     key = "Action";
                     break;
+                case PERF_MON_MULTIPLIER:
+                    key = "Mult";
+                    break;
                 case PERF_MON_RNDBOT:
                     key = "RndBot";
                     break;
@@ -214,11 +285,13 @@ void PerfMonitor::PrintStats(bool perTick, bool fullStack)
             uint64 typeMinTime = 0xffffffffu;
             uint64 typeMaxTime = 0;
             uint32 typeCount = 0;
+            uint32 typeBlocks = 0;
             for (auto& name : names)
             {
                 PerformanceData* pd = pdMap[name];
                 typeTotalTime += pd->totalTime;
                 typeCount += pd->count;
+                typeBlocks += pd->blocks;
                 if (typeMinTime > pd->minTime)
                     typeMinTime = pd->minTime;
                 if (typeMaxTime < pd->maxTime)
@@ -232,7 +305,16 @@ void PerfMonitor::PrintStats(bool perTick, bool fullStack)
                 std::string disName = name;
                 if (!fullStack && disName.find("|") != std::string::npos)
                     disName = disName.substr(0, disName.find("|")) + "]";
-                if (perc >= 0.1f || avg >= 0.25f || pd->maxTime > 1000)
+                bool show = perc >= 0.1f || avg >= 0.25f || pd->maxTime > 1000;
+                if (i->first == PERF_MON_MULTIPLIER)
+                {
+                    if (pd->blocks)
+                        disName += " [blocked " + std::to_string(pd->blocks) + "]";
+
+                    show = show || pd->blocks > 0 || perc >= 0.01f;
+                }
+
+                if (show)
                 {
                     LOG_INFO("playerbots",
                              "{:7.3f}% {:9.3f}ms | {:7.1f} .. {:7.1f} ({:10.3f} of {:10.2f}) - {:6}    : {}", perc,
@@ -247,8 +329,12 @@ void PerfMonitor::PrintStats(bool perTick, bool fullStack)
                 float tMaxTime = (float)typeMaxTime / 1000.0f;
                 float tAvg = (float)typeTotalTime / (float)typeCount / 1000.0f;
                 float tAmount = (float)typeCount / fullTickCount;
+                std::string totalName = "Total";
+                if (i->first == PERF_MON_MULTIPLIER && typeBlocks)
+                    totalName += " [blocked " + std::to_string(typeBlocks) + "]";
+
                 LOG_INFO("playerbots", "{:7.3f}% {:9.3f}ms | {:7.1f} .. {:7.1f} ({:10.3f} of {:10.2f}) - {:6}    : {}",
-                         tPerc, tTime, tMinTime, tMaxTime, tAvg, tAmount, key.c_str(), "Total");
+                         tPerc, tTime, tMinTime, tMaxTime, tAvg, tAmount, key.c_str(), totalName.c_str());
             }
             LOG_INFO("playerbots", " ");
         }
@@ -269,38 +355,20 @@ void PerfMonitor::Reset()
             pd->maxTime = 0;
             pd->totalTime = 0;
             pd->count = 0;
+            pd->blocks = 0;
         }
     }
 }
 
 PerfMonitorOperation::PerfMonitorOperation(PerformanceData* data, std::string const name,
                                                          PerformanceStack* stack)
-    : data(data), name(name), stack(stack)
+    : data(data), name(name), stack(stack), started(Now())
 {
-    started = (std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now()))
-                  .time_since_epoch();
 }
 
 void PerfMonitorOperation::finish()
 {
-    std::chrono::microseconds finished =
-        (std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now()))
-            .time_since_epoch();
-    uint64 elapsed = (finished - started).count();
-
-    std::lock_guard<std::mutex> guard(data->lock);
-    if (elapsed > 0)
-    {
-        if (!data->minTime || data->minTime > elapsed)
-            data->minTime = elapsed;
-
-        if (!data->maxTime || data->maxTime < elapsed)
-            data->maxTime = elapsed;
-
-        data->totalTime += elapsed;
-    }
-
-    ++data->count;
+    RecordSample(data, (Now() - started).count());
 
     if (stack)
     {
@@ -308,4 +376,20 @@ void PerfMonitorOperation::finish()
     }
 
     delete this;
+}
+
+PerfMonitorScope::PerfMonitorScope(PerformanceData* data) : data(data)
+{
+    if (!data)
+        return;
+
+    started = Now();
+}
+
+PerfMonitorScope::~PerfMonitorScope()
+{
+    if (!data)
+        return;
+
+    RecordSample(data, (Now() - started).count());
 }

--- a/src/Bot/Debug/PerfMonitor.h
+++ b/src/Bot/Debug/PerfMonitor.h
@@ -30,6 +30,7 @@ struct PerformanceData
     uint64_t maxTime;
     uint64_t totalTime;
     uint32_t count;
+    uint32_t blocks;
     std::mutex lock;
 };
 
@@ -38,6 +39,7 @@ enum PerformanceMetric
     PERF_MON_TRIGGER,
     PERF_MON_VALUE,
     PERF_MON_ACTION,
+    PERF_MON_MULTIPLIER,
     PERF_MON_RNDBOT,
     PERF_MON_TOTAL
 };
@@ -55,6 +57,20 @@ private:
     std::chrono::microseconds started;
 };
 
+class PerfMonitorScope
+{
+public:
+    explicit PerfMonitorScope(PerformanceData* data);
+    ~PerfMonitorScope();
+
+    PerfMonitorScope(PerfMonitorScope const&) = delete;
+    PerfMonitorScope& operator=(PerfMonitorScope const&) = delete;
+
+private:
+    PerformanceData* data;
+    std::chrono::microseconds started;
+};
+
 class PerfMonitor
 {
 public:
@@ -65,8 +81,12 @@ public:
         return instance;
     }
 
+    static bool IsEnabled();
+
     PerfMonitorOperation* start(PerformanceMetric metric, std::string const name,
                                        PerformanceStack* stack = nullptr);
+    PerformanceData* acquire(PerformanceMetric metric, std::string const& name);
+    static void CountBlock(PerformanceData* data);
     void PrintStats(bool perTick = false, bool fullStack = false);
     void Reset();
 
@@ -79,6 +99,8 @@ private:
 
     PerfMonitor(PerfMonitor&&) = delete;
     PerfMonitor& operator=(PerfMonitor&&) = delete;
+
+    PerformanceData* GetOrCreate(PerformanceMetric metric, std::string const& name);
 
     std::map<PerformanceMetric, std::map<std::string, PerformanceData*> > data;
     std::mutex lock;

--- a/src/Bot/Engine/Engine.cpp
+++ b/src/Bot/Engine/Engine.cpp
@@ -186,11 +186,20 @@ bool Engine::DoNextAction(Unit* /*unit*/, uint32 /*depth*/, bool minimal)
             // Apply multipliers early to avoid unnecessary iterations
             for (Multiplier* multiplier : multipliers)
             {
-                relevance *= multiplier->GetValue(action);
+                float value;
+                {
+                    PerfMonitorScope scope(multiplier->GetPerfData());
+                    value = multiplier->GetValue(action);
+                }
+
+                relevance *= value;
                 action->setRelevance(relevance);
 
                 if (relevance <= 0)
                 {
+                    if (value <= 0)
+                        multiplier->NoteBlock();
+
                     LogAction("Multiplier %s made action %s useless", multiplier->getName().c_str(), action->getName().c_str());
                     break;
                 }

--- a/src/Bot/Engine/Multiplier.cpp
+++ b/src/Bot/Engine/Multiplier.cpp
@@ -1,0 +1,21 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "Multiplier.h"
+#include "PerfMonitor.h"
+
+PerformanceData* Multiplier::GetPerfData()
+{
+    if (!PerfMonitor::IsEnabled())
+        return nullptr;
+
+    if (!perfData)
+        perfData = sPerfMonitor.acquire(PERF_MON_MULTIPLIER, getName());
+
+    return perfData;
+}
+
+void Multiplier::NoteBlock() { PerfMonitor::CountBlock(GetPerfData()); }

--- a/src/Bot/Engine/Multiplier.h
+++ b/src/Bot/Engine/Multiplier.h
@@ -11,6 +11,7 @@
 
 class Action;
 class PlayerbotAI;
+struct PerformanceData;
 
 class Multiplier : public AiNamedObject
 {
@@ -19,6 +20,12 @@ public:
     virtual ~Multiplier() {}
 
     virtual float GetValue([[maybe_unused]] Action* action) { return 1.0f; }
+
+    PerformanceData* GetPerfData();
+    void NoteBlock();
+
+private:
+    PerformanceData* perfData = nullptr;
 };
 
 #endif


### PR DESCRIPTION
## Pull Request Description

pmon measures triggers, values and actions, but not multipliers. Multipliers are
the stage that can zero an action's relevance, so when a bot won't do something
obvious a multiplier is often the reason, and pmon can't say which one. Finding
out today means rebuilding with `LogAction` on.

This adds a `Mult` metric, plus a veto count on each row: how many times that
multiplier drove an action's relevance to zero.

```
  0.412%      1.204s |     0.0 ..     1.8 (     0.001 of    1184320) - Mult      : wait for attack [vetoed 218447]
  0.301%      0.879s |     0.0 ..     1.1 (     0.001 of     974106) - Mult      : cast time [vetoed 41822]
  0.144%      0.421s |     0.0 ..     0.9 (     0.000 of     974106) - Mult      : threat
  0.098%      0.287s |     0.0 ..     0.7 (     0.000 of     612840) - Mult      : focus [vetoed 9013]
  0.955%      2.791s |     0.0 ..     1.8 (     0.001 of    3745372) - Mult      : Total [vetoed 269282]
```

Numbers are illustrative. The first row says `wait for attack` ran 1.18M times
and killed an action on about one in five of them.

Rows for the existing metrics are unchanged.

## Feature Evaluation

- **Describe the minimum logic required to achieve the intended behavior.**

  Two additions to the multiplier loop in `Engine::DoNextAction`: a timer around
  `multiplier->GetValue(action)`, and an increment on the existing break path when
  the multiplier returned `<= 0`.

  The timer is a new `PerfMonitorScope`, a stack object holding one pointer. It
  timestamps in the constructor and folds the sample into a counter in the
  destructor. The counter is looked up once per multiplier instance and cached on
  the multiplier.

  `PerfMonitor::start()` doesn't work here. It returns early when the monitor is
  off, but the caller has already paid, because `getName()` returns `std::string`
  by value: every call builds and destroys a string, and that is a heap allocation
  for names past the small-string buffer. With the monitor on it also takes the
  global lock, copies the string again, does a string-keyed map lookup and
  heap-allocates an operation. That's fine a few times per bot tick. The
  multiplier loop runs once per multiplier per action popped.

- **Describe the processing cost when this logic executes across many bots.**

  With pmon off, which is the default, the cost is one branch per multiplier
  evaluation. `GetPerfData()` reads `perfMonEnabled` and returns `nullptr`, the
  scope constructor returns without reading the clock, and the destructor returns
  without taking a lock. No string, no allocation.

  With pmon on, each evaluation costs two clock reads and one short lock section,
  the same shape as the existing pmon metrics.

## How to Test the Changes

1. Boot with bots on a default config.
2. `.playerbots pmon toggle`, then let it run a few minutes.
3. `.playerbots pmon`. A `Mult` block appears between `Action` and `RndBot`.
4. `.playerbots pmon stack` and `.playerbots pmon tick`. Same block, same layout
   as the other metrics.
5. `.playerbots pmon reset`. Veto counts zero along with the timings.
6. `.playerbots pmon toggle` again. The `Mult` counters stop advancing.

Also capture a `pmon stack` report before and after the patch. Every non-`Mult`
line should be identical.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly
  with thousands of bots?
  - [x] Minimal impact

  With pmon off, one branch per multiplier evaluation, no allocation and no lock.
  With pmon on the cost is opt-in, and it is the cheapest per-call shape
  available, which is why it doesn't reuse `PerfMonitor::start()`.

- Does this change modify default bot behavior?
  - [x] No

  `relevance` is computed from the same values in the same order. The only new
  statement on the hot path reads a config bool. The veto increment sits inside
  the existing `relevance <= 0` break, which already emitted a `LogAction`.

- Does this change add new decision branches or increase maintenance complexity?
  - [x] Yes

  One enum value, one class (`PerfMonitorScope`, about 20 lines), two methods on
  `Multiplier`, and a new `Multiplier.cpp`. The class was header-only until now;
  `PassiveMultiplier.cpp` is the precedent for a `.cpp` in that directory.

  It also removes some. The timing block needed by both
  `PerfMonitorOperation::finish()` and the new scope is now shared through two
  file-local helpers instead of written twice.

## AI Assistance

- [x] Yes

  Used for code generation and for working out where the per-call cost lands.
  Reviewed and owned by me.

## Code Provenance / Attribution

- [x] No, all code in this PR is original

  `PerfMonitor.cpp` already carries a CMaNGOS attribution header crediting ike3
  and Sebastiaan Keek. It is untouched.

## Final Checklist

- [x] Changes are understood and tested for server stability and performance impact.
- [x] Any new bot dialogue lines are translated. (N/A, no dialogue added.)
- [x] New source files use the GPLv2 header. (`Multiplier.cpp`.)
- [x] Documentation updated if needed. (N/A, no new config or commands.)
- [x] New and modified files do not introduce new compiler warnings. (Checked with
      `-fsyntax-only` using the project's own compile flags; cppcheck clean.)

## Notes for Reviewers

- How much lock contention this adds depends on `MapUpdate.Threads`. pmon counters
  are shared server-wide by name, so every bot evaluating `cast time` writes to
  the same counter behind the same mutex. Multipliers are evaluated far more often
  than anything else pmon measures and they concentrate on a few shared names, so
  while pmon is armed those locks take much more traffic than any existing metric.
  At the default of one map thread there is no contention. On a multi-threaded map
  update the busiest `Mult` rows will include some lock wait in their timings, so
  trust the veto counts over the microseconds. Happy to rework it as an atomic or
  per-thread accumulator if that's preferred; it would apply to the existing
  metrics too.

- A multiplier is credited with a veto only when its own `GetValue()` returned
  `<= 0`, not just when relevance was `<= 0` after the multiply. Otherwise a
  basket arriving with no relevance left would blame whichever multiplier ran
  first.

- `PERF_MON_MULTIPLIER` goes before `PERF_MON_TOTAL`, which has to stay last:
  `data` is a `std::map` keyed by the enum and both branches of `PrintStats`
  special-case the final block. This shifts the values of `PERF_MON_RNDBOT` and
  `PERF_MON_TOTAL`. Nothing persists them.

- The `Mult` block uses a lower noise floor, and any veto earns a row. Most
  `GetValue()` bodies are a branch or two, so the shared filter
  (`perc >= 0.1 || avg >= 0.25 || max > 1000`) would hide the whole block. The row
  exists to show which actions a multiplier is suppressing, so hiding it for being
  fast defeats the point.

- Caching the counter pointer is safe. A `Multiplier` is `new`'d by one
  engine, deleted by that engine, bound to one bot's `botAI`, and only touched by
  that bot's AI update. Counters are never freed. `GetPerfData()` re-reads
  `perfMonEnabled` on every call rather than trusting the cache, so `pmon toggle`
  works in both directions at runtime.

- `PerfMonitorOperation::finish()` changes shape but not behaviour. It now
  calls the shared `RecordSample()` helper: same min/max/total/count, same lock,
  same `elapsed > 0` guard.
