### PR TITLE
fix(pmon): measure every calculated value, not just the target pickers

### DIFF
--- a/src/Bot/Debug/PerfMonitor.cpp
+++ b/src/Bot/Debug/PerfMonitor.cpp
@@ -15,10 +15,62 @@
 #include "PerfMonitor.h"
 #include "Playerbots.h"
 
+namespace
+{
+std::chrono::microseconds Now()
+{
+    return (std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now()))
+        .time_since_epoch();
+}
+
+void RecordSample(PerformanceData* data, uint64 elapsed)
+{
+    std::lock_guard<std::mutex> guard(data->lock);
+    if (elapsed > 0)
+    {
+        if (!data->minTime || data->minTime > elapsed)
+            data->minTime = elapsed;
+
+        if (!data->maxTime || data->maxTime < elapsed)
+            data->maxTime = elapsed;
+
+        data->totalTime += elapsed;
+    }
+
+    ++data->count;
+}
+}  // namespace
+
+bool PerfMonitor::IsEnabled() { return sPlayerbotAIConfig.perfMonEnabled; }
+
+PerformanceData* PerfMonitor::GetOrCreate(PerformanceMetric metric, std::string const& name)
+{
+    std::lock_guard<std::mutex> guard(lock);
+    PerformanceData*& pd = data[metric][name];
+    if (!pd)
+    {
+        pd = new PerformanceData();
+        pd->minTime = 0;
+        pd->maxTime = 0;
+        pd->totalTime = 0;
+        pd->count = 0;
+    }
+
+    return pd;
+}
+
+PerformanceData* PerfMonitor::acquire(PerformanceMetric metric, std::string const& name)
+{
+    if (!IsEnabled())
+        return nullptr;
+
+    return GetOrCreate(metric, name);
+}
+
 PerfMonitorOperation* PerfMonitor::start(PerformanceMetric metric, std::string const name,
                                                        PerformanceStack* stack)
 {
-    if (!sPlayerbotAIConfig.perfMonEnabled)
+    if (!IsEnabled())
         return nullptr;
 
     std::string stackName = name;
@@ -41,19 +93,7 @@ PerfMonitorOperation* PerfMonitor::start(PerformanceMetric metric, std::string c
         stack->push_back(name);
     }
 
-    std::lock_guard<std::mutex> guard(lock);
-    PerformanceData* pd = data[metric][stackName];
-    if (!pd)
-    {
-        pd = new PerformanceData();
-        pd->minTime = 0;
-        pd->maxTime = 0;
-        pd->totalTime = 0;
-        pd->count = 0;
-        data[metric][stackName] = pd;
-    }
-
-    return new PerfMonitorOperation(pd, name, stack);
+    return new PerfMonitorOperation(GetOrCreate(metric, stackName), name, stack);
 }
 
 void PerfMonitor::PrintStats(bool perTick, bool fullStack)
@@ -275,32 +315,13 @@ void PerfMonitor::Reset()
 
 PerfMonitorOperation::PerfMonitorOperation(PerformanceData* data, std::string const name,
                                                          PerformanceStack* stack)
-    : data(data), name(name), stack(stack)
+    : data(data), name(name), stack(stack), started(Now())
 {
-    started = (std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now()))
-                  .time_since_epoch();
 }
 
 void PerfMonitorOperation::finish()
 {
-    std::chrono::microseconds finished =
-        (std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now()))
-            .time_since_epoch();
-    uint64 elapsed = (finished - started).count();
-
-    std::lock_guard<std::mutex> guard(data->lock);
-    if (elapsed > 0)
-    {
-        if (!data->minTime || data->minTime > elapsed)
-            data->minTime = elapsed;
-
-        if (!data->maxTime || data->maxTime < elapsed)
-            data->maxTime = elapsed;
-
-        data->totalTime += elapsed;
-    }
-
-    ++data->count;
+    RecordSample(data, (Now() - started).count());
 
     if (stack)
     {
@@ -308,4 +329,20 @@ void PerfMonitorOperation::finish()
     }
 
     delete this;
+}
+
+PerfMonitorScope::PerfMonitorScope(PerformanceData* data) : data(data)
+{
+    if (!data)
+        return;
+
+    started = Now();
+}
+
+PerfMonitorScope::~PerfMonitorScope()
+{
+    if (!data)
+        return;
+
+    RecordSample(data, (Now() - started).count());
 }

--- a/src/Bot/Debug/PerfMonitor.h
+++ b/src/Bot/Debug/PerfMonitor.h
@@ -20,6 +20,7 @@
 #include <ctime>
 #include <map>
 #include <mutex>
+#include <string>
 #include <vector>
 
 typedef std::vector<std::string> PerformanceStack;
@@ -55,6 +56,20 @@ private:
     std::chrono::microseconds started;
 };
 
+class PerfMonitorScope
+{
+public:
+    explicit PerfMonitorScope(PerformanceData* data);
+    ~PerfMonitorScope();
+
+    PerfMonitorScope(PerfMonitorScope const&) = delete;
+    PerfMonitorScope& operator=(PerfMonitorScope const&) = delete;
+
+private:
+    PerformanceData* data;
+    std::chrono::microseconds started{};
+};
+
 class PerfMonitor
 {
 public:
@@ -65,8 +80,11 @@ public:
         return instance;
     }
 
+    static bool IsEnabled();
+
     PerfMonitorOperation* start(PerformanceMetric metric, std::string const name,
                                        PerformanceStack* stack = nullptr);
+    PerformanceData* acquire(PerformanceMetric metric, std::string const& name);
     void PrintStats(bool perTick = false, bool fullStack = false);
     void Reset();
 
@@ -79,6 +97,8 @@ private:
 
     PerfMonitor(PerfMonitor&&) = delete;
     PerfMonitor& operator=(PerfMonitor&&) = delete;
+
+    PerformanceData* GetOrCreate(PerformanceMetric metric, std::string const& name);
 
     std::map<PerformanceMetric, std::map<std::string, PerformanceData*> > data;
     std::mutex lock;

--- a/src/Bot/Engine/Value/Value.h
+++ b/src/Bot/Engine/Value/Value.h
@@ -9,6 +9,7 @@
 
 #include "AiObject.h"
 #include "ObjectGuid.h"
+#include "PerfMonitor.h"
 #include "Timer.h"
 #include "Unit.h"
 #include <time.h>
@@ -71,13 +72,17 @@ public:
     T Get() override
     {
         if (checkInterval < 2)
+        {
+            PerfMonitorScope scope(GetPerfData());
             value = Calculate();
+        }
         else
         {
             time_t now = getMSTime();
             if (!lastCheckTime || now - lastCheckTime >= checkInterval)
             {
                 lastCheckTime = now;
+                PerfMonitorScope scope(GetPerfData());
                 value = Calculate();
             }
         }
@@ -94,13 +99,17 @@ public:
     T& RefGet() override
     {
         if (checkInterval < 2)
+        {
+            PerfMonitorScope scope(GetPerfData());
             value = Calculate();
+        }
         else
         {
             time_t now = getMSTime();
             if (!lastCheckTime || now - lastCheckTime >= checkInterval)
             {
                 lastCheckTime = now;
+                PerfMonitorScope scope(GetPerfData());
                 value = Calculate();
             }
         }
@@ -113,9 +122,21 @@ public:
 protected:
     virtual T Calculate() = 0;
 
+    PerformanceData* GetPerfData()
+    {
+        if (!PerfMonitor::IsEnabled())
+            return nullptr;
+
+        if (!perfData)
+            perfData = sPerfMonitor.acquire(PERF_MON_VALUE, getName());
+
+        return perfData;
+    }
+
     uint32 checkInterval;
     uint32 lastCheckTime;
     T value;
+    PerformanceData* perfData = nullptr;
 };
 
 template <class T>
@@ -133,6 +154,7 @@ public:
         if (!this->lastCheckTime)
         {
             this->lastCheckTime = now;
+            PerfMonitorScope scope(this->GetPerfData());
             this->value = this->Calculate();
         }
 


### PR DESCRIPTION
## Pull Request Description

pmon's Value block is missing most of what it should report. PERF_MON_VALUE is
only recorded in `UnitCalculatedValue::Get()`, which covers 35 of the 208 values
registered in ValueContext, all of them target pickers. `AttackersValue`, the
`NearestUnitsValue` classes and every bool and counter value are not measured.

`CalculatedValue` had the same instrumentation commented out and
`SingleCalculatedValue` had it live. #2576 removed both when it dropped the
`PerfMonitor.h` include from Value.h.

Calling `sPerfMonitor.start()` from `CalculatedValue::Get()` is too expensive to
put back. `start()` returns early when the monitor is off, but it takes `name` by
value and `getName()` also returns by value, so a std::string is built and
destroyed on every value read before `start()` can decline.

`CalculatedValue` now looks up its `PerformanceData` once, caches the pointer and
times `Calculate()` with an RAII scope. The enabled check is re-read on every
call, so turning the monitor on arms values that already exist. With the monitor
off it is one bool check. `UnitCalculatedValue::Get()` still uses `start()`
because it is the only value that pushes onto the performance stack.

Also included:

- `PerfMonitorOperation` and the new scope share one clock read and one record
  helper instead of duplicating the min/max/total accumulation.
- `PerfMonitor.h` includes `<string>`, which its own signatures use.

## Feature Evaluation

Minimum logic: with the monitor off, one bool read per value evaluation. With it
on, one map lookup per value per bot for the lifetime of that value object, then
two clock reads and a locked accumulate per evaluation. That is the same cost the
target pickers already pay.

Processing cost across many bots: the monitor-off path adds a call to
`PerfMonitor::IsEnabled()` and a branch in `CalculatedValue::Get()` and
`RefGet()`. No allocation and no string construction. The measuring path is
opt-in behind `AiPlayerbot.PerfMonEnabled`.

## How to Test the Changes

1. Set `BotActiveAlone = 100` and `botActiveAloneSmartScale = 0`. Leave
   `AiPlayerbot.PerfMonEnabled` at 0.
2. Start the server and wait for the bots to log in.
3. Run `playerbot pmon toggle`.
4. Five minutes later, run `playerbot pmon stack`.

The Value block should list values other than target pickers, `attackers` and the
`nearest ...` values in particular. Its `Value : Total` line reads much higher
than before because it sums the whole metric instead of a sixth of it. The last
`Total` line does not change, it is still driven by
`PlayerbotAI::UpdateAIInternal`.

Values nest, so a value that reads another value inside `Calculate()` has the
inner time counted in both rows. That was already true of the target pickers.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly
  with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

One bool check per value read while the monitor is off.

- Does this change modify default bot behavior?
    - - [x] No
    - - [ ] Yes (**explain why**)

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)

No new bot decision logic. The one added branch is the monitor's own enabled
check, covered above.

## AI Assistance

Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)

Used for the timing helper refactor and for drafting this description. Reviewed
and understood, including the decision to cache the `PerformanceData` pointer
rather than restore `start()` on the base template.

## Code Provenance / Attribution

Was any code in this PR copied or adapted from a sister / upstream project?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)

PerfMonitor.cpp and PerfMonitor.h are ported from CMaNGOS playerbots and carry
that attribution in their file headers. Those headers are untouched.

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated. (none added)
- - [x] New source files use the GPLv2 header. (no new files)
- - [x] Documentation updated if needed.
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers

Three files: PerfMonitor.h, PerfMonitor.cpp, Value.h.

`CalculatedValue::GetPerfData()` caches a `PerformanceData*` for the lifetime of
the value object. That is safe because `PerfMonitor::Reset()` zeroes the counters
in place and never erases the map or frees entries, and std::map pointers are
stable. If Reset() ever starts deleting, the cache has to go too.
