### PR TITLE
feat(pmon): dump the performance monitor to JSON alongside the table

### DIFF
--- a/src/Bot/Debug/PerfMonitor.cpp
+++ b/src/Bot/Debug/PerfMonitor.cpp
@@ -13,7 +13,101 @@
  */
 
 #include "PerfMonitor.h"
+#include "Config.h"
 #include "Playerbots.h"
+#include <cmath>
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+
+namespace
+{
+std::string MetricName(PerformanceMetric metric)
+{
+    switch (metric)
+    {
+        case PERF_MON_TRIGGER:
+            return "Trigger";
+        case PERF_MON_VALUE:
+            return "Value";
+        case PERF_MON_ACTION:
+            return "Action";
+        case PERF_MON_RNDBOT:
+            return "RndBot";
+        case PERF_MON_TOTAL:
+            return "Total";
+        default:
+            return "?";
+    }
+}
+
+std::string JsonEscape(std::string const& value)
+{
+    std::ostringstream out;
+    for (char c : value)
+    {
+        switch (c)
+        {
+            case '"':
+                out << "\\\"";
+                break;
+            case '\\':
+                out << "\\\\";
+                break;
+            case '\b':
+                out << "\\b";
+                break;
+            case '\f':
+                out << "\\f";
+                break;
+            case '\n':
+                out << "\\n";
+                break;
+            case '\r':
+                out << "\\r";
+                break;
+            case '\t':
+                out << "\\t";
+                break;
+            default:
+                if (static_cast<unsigned char>(c) < 0x20)
+                    out << "\\u" << std::hex << std::setw(4) << std::setfill('0') << static_cast<uint32>(c)
+                        << std::dec;
+                else
+                    out << c;
+                break;
+        }
+    }
+
+    return out.str();
+}
+
+std::string JsonNumber(double value)
+{
+    if (!std::isfinite(value))
+        value = 0.0;
+
+    std::ostringstream out;
+    out << std::fixed << std::setprecision(3) << value;
+
+    return out.str();
+}
+
+std::string JsonRatio(double value, double total)
+{
+    return JsonNumber(total > 0.0 ? value / total : 0.0);
+}
+
+std::string JsonPath(bool perTick)
+{
+    std::string dir = sConfigMgr->GetOption<std::string>("LogsDir", "", false);
+    if (!dir.empty() && dir.back() != '/' && dir.back() != '\\')
+        dir.push_back('/');
+
+    return dir + (perTick ? "pmon_tick.json" : "pmon_total.json");
+}
+}  // namespace
 
 PerfMonitorOperation* PerfMonitor::start(PerformanceMetric metric, std::string const name,
                                                        PerformanceStack* stack)
@@ -82,28 +176,7 @@ void PerfMonitor::PrintStats(bool perTick, bool fullStack)
         {
             std::map<std::string, PerformanceData*> pdMap = i->second;
 
-            std::string key;
-            switch (i->first)
-            {
-                case PERF_MON_TRIGGER:
-                    key = "Trigger";
-                    break;
-                case PERF_MON_VALUE:
-                    key = "Value";
-                    break;
-                case PERF_MON_ACTION:
-                    key = "Action";
-                    break;
-                case PERF_MON_RNDBOT:
-                    key = "RndBot";
-                    break;
-                case PERF_MON_TOTAL:
-                    key = "Total";
-                    break;
-                default:
-                    key = "?";
-                    break;
-            }
+            std::string const key = MetricName(i->first);
 
             std::vector<std::string> names;
 
@@ -177,27 +250,7 @@ void PerfMonitor::PrintStats(bool perTick, bool fullStack)
         {
             std::map<std::string, PerformanceData*> pdMap = i->second;
 
-            std::string key;
-            switch (i->first)
-            {
-                case PERF_MON_TRIGGER:
-                    key = "Trigger";
-                    break;
-                case PERF_MON_VALUE:
-                    key = "Value";
-                    break;
-                case PERF_MON_ACTION:
-                    key = "Action";
-                    break;
-                case PERF_MON_RNDBOT:
-                    key = "RndBot";
-                    break;
-                case PERF_MON_TOTAL:
-                    key = "Total";
-                    break;
-                default:
-                    key = "?";
-            }
+            std::string const key = MetricName(i->first);
 
             std::vector<std::string> names;
 
@@ -253,6 +306,164 @@ void PerfMonitor::PrintStats(bool perTick, bool fullStack)
             LOG_INFO("playerbots", " ");
         }
     }
+}
+
+void PerfMonitor::DumpJson(bool perTick)
+{
+    std::map<PerformanceMetric, std::map<std::string, PerformanceData*>> snapshot;
+    {
+        std::lock_guard<std::mutex> guard(lock);
+        snapshot = data;
+    }
+
+    if (snapshot.empty())
+        return;
+
+    struct Sample
+    {
+        std::string name;
+        uint64 totalTime;
+        uint64 minTime;
+        uint64 maxTime;
+        uint32 count;
+    };
+
+    std::map<PerformanceMetric, std::vector<Sample>> samples;
+    for (auto const& metric : snapshot)
+    {
+        std::vector<Sample>& rows = samples[metric.first];
+        for (auto const& entry : metric.second)
+        {
+            PerformanceData* pd = entry.second;
+            if (!pd)
+                continue;
+
+            std::lock_guard<std::mutex> guard(pd->lock);
+            rows.push_back({entry.first, pd->totalTime, pd->minTime, pd->maxTime, pd->count});
+        }
+
+        std::sort(rows.begin(), rows.end(),
+                  [](Sample const& i, Sample const& j) { return i.totalTime > j.totalTime; });
+    }
+
+    double updateAiTotalTime = 0.0;
+    double fullTickTotalTime = 0.0;
+    double fullTickCount = 0.0;
+    auto const totals = samples.find(PERF_MON_TOTAL);
+    if (totals != samples.end())
+    {
+        for (Sample const& row : totals->second)
+        {
+            if (row.name.find("PlayerbotAI::UpdateAIInternal") != std::string::npos)
+                updateAiTotalTime += static_cast<double>(row.totalTime);
+
+            if (row.name == "PlayerbotAIBase::FullTick")
+            {
+                fullTickTotalTime = static_cast<double>(row.totalTime);
+                fullTickCount = static_cast<double>(row.count);
+            }
+        }
+    }
+
+    double const denominator = perTick ? fullTickTotalTime : updateAiTotalTime;
+
+    char stamp[32] = "";
+    std::time_t const now = std::time(nullptr);
+    if (std::tm const* utc = std::gmtime(&now))
+        std::strftime(stamp, sizeof(stamp), "%Y-%m-%dT%H:%M:%SZ", utc);
+
+    std::ostringstream out;
+    out << "{\n";
+    out << "  \"generatedAt\": " << static_cast<uint64>(now) << ",\n";
+    out << "  \"generatedAtUtc\": \"" << stamp << "\",\n";
+    out << "  \"mode\": \"" << (perTick ? "tick" : "total") << "\",\n";
+    out << "  \"enabled\": " << (sPlayerbotAIConfig.perfMonEnabled ? "true" : "false") << ",\n";
+    out << "  \"timeUnit\": \"microseconds\",\n";
+    out << "  \"fullTickCount\": " << static_cast<uint64>(fullTickCount) << ",\n";
+    out << "  \"fullTickTotalTime\": " << static_cast<uint64>(fullTickTotalTime) << ",\n";
+    out << "  \"updateAiTotalTime\": " << static_cast<uint64>(updateAiTotalTime) << ",\n";
+    out << "  \"metrics\": [\n";
+
+    bool firstMetric = true;
+    for (auto const& metric : samples)
+    {
+        if (!firstMetric)
+            out << ",\n";
+        firstMetric = false;
+
+        out << "    {\n";
+        out << "      \"type\": \"" << MetricName(metric.first) << "\",\n";
+
+        if (metric.first != PERF_MON_TOTAL)
+        {
+            uint64 typeTotalTime = 0;
+            uint64 typeMinTime = 0;
+            uint64 typeMaxTime = 0;
+            uint64 typeCount = 0;
+            for (Sample const& row : metric.second)
+            {
+                typeTotalTime += row.totalTime;
+                typeCount += row.count;
+                if (!typeMinTime || (row.minTime && typeMinTime > row.minTime))
+                    typeMinTime = row.minTime;
+                if (typeMaxTime < row.maxTime)
+                    typeMaxTime = row.maxTime;
+            }
+
+            out << "      \"totalTime\": " << typeTotalTime << ",\n";
+            out << "      \"count\": " << typeCount << ",\n";
+            out << "      \"minTime\": " << typeMinTime << ",\n";
+            out << "      \"maxTime\": " << typeMaxTime << ",\n";
+            out << "      \"avgTime\": "
+                << JsonRatio(static_cast<double>(typeTotalTime), static_cast<double>(typeCount)) << ",\n";
+            out << "      \"percent\": "
+                << JsonNumber(denominator > 0.0 ? static_cast<double>(typeTotalTime) / denominator * 100.0 : 0.0)
+                << ",\n";
+            out << "      \"timePerTick\": " << JsonRatio(static_cast<double>(typeTotalTime), fullTickCount) << ",\n";
+            out << "      \"callsPerTick\": " << JsonRatio(static_cast<double>(typeCount), fullTickCount) << ",\n";
+        }
+
+        out << "      \"rows\": [\n";
+
+        bool firstRow = true;
+        for (Sample const& row : metric.second)
+        {
+            if (!firstRow)
+                out << ",\n";
+            firstRow = false;
+
+            out << "        {\"name\": \"" << JsonEscape(row.name) << "\"";
+            out << ", \"totalTime\": " << row.totalTime;
+            out << ", \"count\": " << row.count;
+            out << ", \"minTime\": " << row.minTime;
+            out << ", \"maxTime\": " << row.maxTime;
+            out << ", \"avgTime\": " << JsonRatio(static_cast<double>(row.totalTime), static_cast<double>(row.count));
+            out << ", \"percent\": "
+                << JsonNumber(denominator > 0.0 ? static_cast<double>(row.totalTime) / denominator * 100.0 : 0.0);
+            out << ", \"timePerTick\": " << JsonRatio(static_cast<double>(row.totalTime), fullTickCount);
+            out << ", \"callsPerTick\": " << JsonRatio(static_cast<double>(row.count), fullTickCount);
+            out << "}";
+        }
+
+        out << (firstRow ? "" : "\n") << "      ]\n";
+        out << "    }";
+    }
+
+    out << (firstMetric ? "" : "\n") << "  ]\n";
+    out << "}\n";
+
+    std::string const path = JsonPath(perTick);
+    std::ofstream file(path.c_str(), std::ios::out | std::ios::trunc);
+    if (!file)
+    {
+        LOG_ERROR("playerbots", "Performance monitor could not write {}", path);
+        return;
+    }
+
+    file << out.str();
+    file.close();
+
+    LOG_INFO("playerbots", "Performance monitor dump written to {}", path);
 }
 
 void PerfMonitor::Reset()

--- a/src/Bot/Debug/PerfMonitor.cpp
+++ b/src/Bot/Debug/PerfMonitor.cpp
@@ -17,9 +17,11 @@
 #include "Playerbots.h"
 #include <cmath>
 #include <ctime>
+#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <sstream>
+#include <system_error>
 
 namespace
 {
@@ -400,14 +402,16 @@ void PerfMonitor::DumpJson(bool perTick)
             uint64 typeMinTime = 0;
             uint64 typeMaxTime = 0;
             uint64 typeCount = 0;
+            bool firstSample = true;
             for (Sample const& row : metric.second)
             {
                 typeTotalTime += row.totalTime;
                 typeCount += row.count;
-                if (!typeMinTime || (row.minTime && typeMinTime > row.minTime))
+                if (firstSample || typeMinTime > row.minTime)
                     typeMinTime = row.minTime;
                 if (typeMaxTime < row.maxTime)
                     typeMaxTime = row.maxTime;
+                firstSample = false;
             }
 
             out << "      \"totalTime\": " << typeTotalTime << ",\n";
@@ -453,15 +457,37 @@ void PerfMonitor::DumpJson(bool perTick)
     out << "}\n";
 
     std::string const path = JsonPath(perTick);
-    std::ofstream file(path.c_str(), std::ios::out | std::ios::trunc);
+    std::string const tempPath = path + ".tmp";
+
+    std::ofstream file(tempPath.c_str(), std::ios::out | std::ios::trunc);
     if (!file)
     {
-        LOG_ERROR("playerbots", "Performance monitor could not write {}", path);
+        LOG_ERROR("playerbots", "Performance monitor could not write {}", tempPath);
         return;
     }
 
     file << out.str();
     file.close();
+
+    if (!file)
+    {
+        LOG_ERROR("playerbots", "Performance monitor failed to write {}", tempPath);
+
+        std::error_code removeError;
+        std::filesystem::remove(tempPath, removeError);
+        return;
+    }
+
+    std::error_code renameError;
+    std::filesystem::rename(tempPath, path, renameError);
+    if (renameError)
+    {
+        LOG_ERROR("playerbots", "Performance monitor could not replace {}: {}", path, renameError.message());
+
+        std::error_code removeError;
+        std::filesystem::remove(tempPath, removeError);
+        return;
+    }
 
     LOG_INFO("playerbots", "Performance monitor dump written to {}", path);
 }

--- a/src/Bot/Debug/PerfMonitor.h
+++ b/src/Bot/Debug/PerfMonitor.h
@@ -20,6 +20,7 @@
 #include <ctime>
 #include <map>
 #include <mutex>
+#include <string>
 #include <vector>
 
 typedef std::vector<std::string> PerformanceStack;
@@ -68,6 +69,7 @@ public:
     PerfMonitorOperation* start(PerformanceMetric metric, std::string const name,
                                        PerformanceStack* stack = nullptr);
     void PrintStats(bool perTick = false, bool fullStack = false);
+    void DumpJson(bool perTick = false);
     void Reset();
 
 private:

--- a/src/Script/PlayerbotCommandScript.cpp
+++ b/src/Script/PlayerbotCommandScript.cpp
@@ -74,12 +74,14 @@ public:
         if (!strcmp(args, "tick"))
         {
             sPerfMonitor.PrintStats(true, false);
+            sPerfMonitor.DumpJson(true);
             return true;
         }
 
         if (!strcmp(args, "stack"))
         {
             sPerfMonitor.PrintStats(false, true);
+            sPerfMonitor.DumpJson(false);
             return true;
         }
 
@@ -94,6 +96,7 @@ public:
         }
 
         sPerfMonitor.PrintStats();
+        sPerfMonitor.DumpJson(false);
         return true;
     }
 


### PR DESCRIPTION
## Pull Request Description

`.playerbots pmon`, `pmon tick` and `pmon stack` now also write the same data to
a JSON file next to the server logs, and log the path they wrote to. The printed
table in the console is unchanged.

The reason is that the table in the console is a summary, not a dump. It only prints a row when
it is over 0.1% of total, averages 0.25ms or more, or has had a single call over
1ms; on the total view it also drops every `Total` row that isn't
`UpdateAIInternal`. That is the right filter for reading in a console, but it
means anything cheap-but-very-frequent never shows up, and without the full stack
flag the stack names get truncated at the first `|`. Comparing two profiling runs
means eyeballing two walls of text, and anything that wants to chart or diff pmon
output has to scrape the log format.

The JSON has every row, unfiltered, with untruncated names: raw microsecond
totals, call counts, min/max, average, percentage, per-tick time and calls per
tick, sorted most expensive first, plus the denominators the percentages are
derived from (`fullTickCount`, `fullTickTotalTime`, `updateAiTotalTime`) so the
numbers can be recomputed or rescaled. Per-metric aggregates are included for
Trigger/Value/Action/RndBot. The `Total` metric gets its rows but no aggregate —
its scopes nest inside each other, so summing them double-counts.

Files are `<LogsDir>/pmon_total.json` for `pmon`/`pmon stack` and
`<LogsDir>/pmon_tick.json` for `pmon tick`, overwritten each time.

The metric-name switch (`PERF_MON_VALUE` -> `"Value"` etc.) was already
duplicated across both `PrintStats` branches and the dump needed it a third time,
so it moved into a single `MetricName` helper. No behavior change there.

Written by hand with `std::ostringstream` rather than a library: AzerothCore has
no JSON dependency, and its Boost floor (1.74) predates `boost::json` (1.75).
The output is a handful of scalar types and one string field, which is escaped.

## Feature Evaluation

- **Minimum logic:** the dump snapshots the existing `PerfMonitor` data map under
  the same lock `PrintStats` uses, copies each row's counters under that row's
  own lock, sorts, formats and writes one file. It reads state that is already
  being collected; it adds no new measurement points and stores nothing extra.
- **Processing cost across many bots:** none. The code only runs when an
  administrator types a `pmon` command, and it runs once on the calling thread,
  not per bot and not per tick. The work is proportional to the number of
  distinct measured names (the same set `PrintStats` already walks), not to the
  bot count.

## How to Test the Changes

1. Boot a server with bots and enable the monitor: `.playerbots pmon toggle`.
2. Let it run a few minutes so there is something to see.
3. Run `.playerbots pmon stack`. The console table prints as before, followed by
   a line like `Performance monitor dump written to
   /path/to/logs/pmon_total.json`.
4. Open that file and confirm it is valid JSON (`python3 -m json.tool
   pmon_total.json`, or `jq . pmon_total.json`).
5. Spot-check a few rows against the table: `percent`, `avgTime` (microseconds,
   so the table's ms column x1000) and `count` should match the printed values,
   and rows that the table filtered out should be present in the file.
6. Run `.playerbots pmon tick` and confirm `pmon_tick.json` appears with
   `"mode": "tick"`.
7. `.playerbots pmon reset` then `.playerbots pmon` — the file is rewritten from
   the cleared counters.

Some things worth checking deliberately:

- With the monitor toggled off and no data collected, the command writes nothing
  and returns cleanly rather than emitting a truncated file.
- If `LogsDir` is unset the file lands in the server's working directory; if it
  is not writable the command logs `Performance monitor could not write <path>`
  as an error and carries on.

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly
  with thousands of bots?
    - - [x] No, not at all

  Nothing runs on the bot update path. The only code that executes outside a
  `pmon` command is the extracted `MetricName` helper, which is called from the
  same two places the inline switch was called from — both inside `PrintStats`.

- Does this change modify default bot behavior?
    - - [x] No

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] Yes

  One new method, `PerfMonitor::DumpJson`, plus small file-local helpers for JSON
  escaping and number formatting. The maintenance cost worth naming is that the
  JSON is now a second output format to keep in step with the counters: if a new
  field is added to `PerformanceData`, it should be added here too. The printed
  format is deliberately untouched, since it is parsed by external tooling.

## AI Assistance

Was AI assistance used while working on this change?
- - [x] Yes

AI was used for the JSON writer and the helper extraction, and to draft this
description. I reviewed all of it: the locking follows the existing `PrintStats`
pattern, the escaping and the division-by-zero guards were checked by hand, and
the output was validated as parseable JSON and checked against the printed table.
The commit carries a `Co-Authored-By` trailer.

## Code Provenance / Attribution

Was any code in this PR copied or adapted from a sister / upstream project?
- - [x] No, all code in this PR is original

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated. (None added.)
- - [x] New source files use the GPLv2 header. (No new files.)
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers

The printed table format is intentionally byte-for-byte unchanged — external
tooling parses it, so any reformatting there would be a breaking change.

The `Total` metric having rows but no aggregate is deliberate, not an oversight.
Its scopes are nested (`FullTick` contains `UpdateAIInternal`, and so on), so an
aggregate line would be a meaningless sum. Note that the existing total-view
table does print one; the JSON omits it rather than reproducing a number a
consumer could easily misread.

`avgTime`, `minTime`, `maxTime` and `timePerTick` are all microseconds, matching
the monitor's internal unit. The table converts to ms/s for display; the JSON
does not convert anything, so consumers can scale as they like. `timeUnit` in
the header states this.
