### PR TITLE
fix(lfg): count a selfbot as a player in an all bot LFG check

### DIFF
--- a/src/Script/Playerbots.cpp
+++ b/src/Script/Playerbots.cpp
@@ -386,7 +386,7 @@ public:
         {
             Player* player = ObjectAccessor::FindPlayer(guid);
 
-            if (guid.IsGroup() || (player && !PlayerbotsMgr::instance().GetPlayerbotAI(player)))
+            if (guid.IsGroup() || IsRealPlayer(player) || IsSelfBot(player))
             {
                 nonBotFound = true;
                 break;


### PR DESCRIPTION
## Pull Request Description

`PlayerbotsScript::OnPlayerbotCheckLFGQueue` refuses an LFG proposal whose members are all
bots, so a pool of autonomous bots can never form a "ghost" dungeon group with no human in
it. It decided "is a bot" on the presence of a `PlayerbotAI` alone — which is also true of a
**selfbot**, a character with a real person driving it from a game client.

The consequence: a selfbot who queues **solo** in the Dungeon Finder can never be matched.
`LFGMgr::JoinLfg` enqueues a soloist under their own player guid, so every member of any
proposal containing them tested as a bot, `OnPlayerbotCheckLFGQueue` reported "all bots", and
`LFGQueue::CheckCompatibility` threw the proposal out as `LFG_INCOMPATIBLES_HAS_IGNORES` —
silently, forever. Queueing as part of a group hid the bug, because a group is enqueued under
its **group** guid and `guid.IsGroup()` already counts as a player.

Fix: test with the `IsRealPlayer` / `IsSelfBot` pair from #2592, which is how the rest of the
codebase spells "a real person is at the client" (e.g. `TradeStatusAction.cpp:32`). A
genuinely all-bot proposal is still refused — an ordinary bot's master is never itself.

```cpp
- if (guid.IsGroup() || (player && !PlayerbotsMgr::instance().GetPlayerbotAI(player)))
+ if (guid.IsGroup() || IsRealPlayer(player) || IsSelfBot(player))
```

The separate `player &&` guard is dropped because both helpers are null-safe:
`PlayerbotsMgr::GetPlayerbotAI` returns `nullptr` for a null player, so `IsRealPlayer(nullptr)`
and `IsSelfBot(nullptr)` are both `false` — exactly what the old guard produced.

## Feature Evaluation

- **Minimum logic required:** one additional `IsSelfBot()` test on the guids of a candidate
  proposal, reusing the existing helper rather than re-deriving "has a human client".
- **Processing cost:** at most one extra `_playerbotsAIMap` lookup per queued member (5 max),
  and only for proposals that already reached `LFGQueue::CheckCompatibility`. Nothing runs per
  bot or per tick.

## How to Test the Changes

1. Set `AiPlayerbot.RandomBotJoinLfg = 1` (default) so random bots populate the Dungeon Finder
   queue, and `AiPlayerbot.SelfBotLevel = 1` or `2` (default `1`, which requires GM).
2. Log in a character and toggle it into a selfbot with `.playerbots bot self`
   ("Enable player botAI").
3. Queue **solo** for a random dungeon with a role the bot pool can complete.
4. **Before:** the queue never produces a proposal — `LFGQueue::CheckCompatibility` keeps
   returning `LFG_INCOMPATIBLES_HAS_IGNORES` (visible with `lfg` debug logging on).
   **After:** a proposal forms and the group is created as it would be for an unbotted player.
5. Regression check: with **no** selfbot and no real player queued, a set of five random bots
   must still fail to form a proposal — the all-bot guard is unchanged for them.
6. Regression check: a selfbot queueing as part of a group behaves exactly as before (that
   path went through `guid.IsGroup()` and is untouched).

## Impact Assessment

- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
  - [x] No, not at all
- Does this change modify default bot behavior?
  - [x] No — bot-vs-bot proposals are still rejected. Only a selfbot, which is a human-driven
    character, is now counted as the player it is.
- Does this change add new decision branches or increase maintenance complexity?
  - [x] No — it replaces an open-coded `GetPlayerbotAI()` test with the two existing helpers,
    so this site now tracks the same definition of "selfbot" as the other ~40 call sites.

## AI Assistance

- [x] Yes

Used to trace the failure through `LFGQueue::CheckCompatibility` → `ScriptMgr::OnPlayerbotCheckLFGQueue`
→ `IsValidBoolScript` and confirm the return-value polarity, and to draft this description.
The change itself is two lines and was reviewed and verified by hand.

## Code Provenance / Attribution

- [x] No, all code in this PR is original

## Final Checklist

- [x] Stability is not compromised.
- [x] Performance impact is understood, tested, and acceptable.
- [x] Added logic complexity is justified and explained.
- [x] Any new bot dialogue lines are translated. (n/a — no new dialogue)
- [x] Any code ported/adapted from another project is attributed. (n/a)
- [x] New source files use the GPLv2 header. (n/a — no new files)
- [x] Documentation updated if needed. (n/a — no config or command changes)
- [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers

Two adjacent observations found while tracing this, both **pre-existing and deliberately left
out of scope**:

1. `guid.IsGroup()` short-circuits the whole check, so the all-bot guard only ever fires for a
   set of solo-queued individuals. A group of pure bots led by a bot is already admitted. That
   is upstream behaviour and unchanged here.
2. `WorldPacketHandlerStrategy` (`getName() == "default"`, added to every bot at
   `AiFactory.cpp:288`) wires `lfg proposal` → `lfg accept`. A selfbot therefore auto-accepts
   its own LFG proposal via `CMSG_LFG_PROPOSAL_RESULT` rather than the person clicking Accept.
   Harmless, but worth knowing when testing — it is the observable behaviour once proposals
   start forming. Gating `LfgAcceptAction` on `IsSelfBot` would be a separate change.