### PR TITLE
Priests cast Fear Ward on the MT

### DIFF
--- a/src/Ai/Class/Priest/PriestActions.h
+++ b/src/Ai/Class/Priest/PriestActions.h
@@ -153,8 +153,6 @@ BUFF_ACTION(CastTouchOfWeaknessAction, "touch of weakness");
 DEBUFF_ACTION(CastHexOfWeaknessAction, "hex of weakness");
 BUFF_ACTION(CastShadowguardAction, "shadowguard");
 HEAL_ACTION(CastDesperatePrayerAction, "desperate prayer");
-BUFF_ACTION(CastFearWardAction, "fear ward");
-BUFF_PARTY_ACTION(CastFearWardOnPartyAction, "fear ward");
 SPELL_ACTION_U(CastStarshardsAction, "starshards",
                (AI_VALUE2(uint8, "mana", "self target") > 50 && AI_VALUE(Unit*, "current target") &&
                 AI_VALUE2(float, "distance", "current target") > 15.0f));
@@ -184,7 +182,8 @@ public:
 class CastPenanceOnPartyAction : public HealPartyMemberAction
 {
 public:
-    CastPenanceOnPartyAction(PlayerbotAI* ai) : HealPartyMemberAction(ai, "penance", 25.0f, HealingManaEfficiency::HIGH)
+    CastPenanceOnPartyAction(PlayerbotAI* ai)
+        : HealPartyMemberAction(ai, "penance", 25.0f, HealingManaEfficiency::HIGH)
     {
     }
 };
@@ -235,6 +234,12 @@ public:
 
     bool isUseful() override;
     Unit* GetTarget() override;
+};
+
+class CastFearWardOnMainTankAction : public BuffOnMainTankAction
+{
+public:
+    CastFearWardOnMainTankAction(PlayerbotAI* botAI) : BuffOnMainTankAction(botAI, "fear ward") {}
 };
 
 class CastMindSearAction : public CastSpellAction

--- a/src/Ai/Class/Priest/PriestAiObjectContext.cpp
+++ b/src/Ai/Class/Priest/PriestAiObjectContext.cpp
@@ -96,7 +96,7 @@ public:
         creators["touch of weakness"] = &PriestTriggerFactoryInternal::touch_of_weakness;
         creators["hex of weakness"] = &PriestTriggerFactoryInternal::hex_of_weakness;
         creators["shadowguard"] = &PriestTriggerFactoryInternal::shadowguard;
-        creators["fear ward"] = &PriestTriggerFactoryInternal::fear_ward;
+        creators["fear ward on main tank"] = &PriestTriggerFactoryInternal::fear_ward_on_main_tank;
         creators["feedback"] = &PriestTriggerFactoryInternal::feedback;
         creators["binding heal"] = &PriestTriggerFactoryInternal::binding_heal;
         creators["chastise"] = &PriestTriggerFactoryInternal::chastise;
@@ -135,7 +135,7 @@ private:
     static Trigger* shadow_protection(PlayerbotAI* botAI) { return new ShadowProtectionTrigger(botAI); }
     static Trigger* shackle_undead(PlayerbotAI* botAI) { return new ShackleUndeadTrigger(botAI); }
     static Trigger* feedback(PlayerbotAI* botAI) { return new FeedbackTrigger(botAI); }
-    static Trigger* fear_ward(PlayerbotAI* botAI) { return new FearWardTrigger(botAI); }
+    static Trigger* fear_ward_on_main_tank(PlayerbotAI* botAI) { return new FearWardOnMainTankTrigger(botAI); }
     static Trigger* shadowguard(PlayerbotAI* botAI) { return new ShadowguardTrigger(botAI); }
     static Trigger* hex_of_weakness(PlayerbotAI* botAI) { return new HexOfWeaknessTrigger(botAI); }
     static Trigger* touch_of_weakness(PlayerbotAI* botAI) { return new TouchOfWeaknessTrigger(botAI); }
@@ -215,8 +215,7 @@ public:
         creators["hex of weakness"] = &PriestAiObjectContextInternal::hex_of_weakness;
         creators["shadowguard"] = &PriestAiObjectContextInternal::shadowguard;
         creators["desperate prayer"] = &PriestAiObjectContextInternal::desperate_prayer;
-        creators["fear ward"] = &PriestAiObjectContextInternal::fear_ward;
-        creators["fear ward on party"] = &PriestAiObjectContextInternal::fear_ward_on_party;
+        creators["fear ward on main tank"] = &PriestAiObjectContextInternal::fear_ward_on_main_tank;
         creators["starshards"] = &PriestAiObjectContextInternal::starshards;
         creators["elune's grace"] = &PriestAiObjectContextInternal::elunes_grace;
         creators["feedback"] = &PriestAiObjectContextInternal::feedback;
@@ -308,8 +307,7 @@ private:
     static Action* feedback(PlayerbotAI* botAI) { return new CastFeedbackAction(botAI); }
     static Action* elunes_grace(PlayerbotAI* botAI) { return new CastElunesGraceAction(botAI); }
     static Action* starshards(PlayerbotAI* botAI) { return new CastStarshardsAction(botAI); }
-    static Action* fear_ward_on_party(PlayerbotAI* botAI) { return new CastFearWardOnPartyAction(botAI); }
-    static Action* fear_ward(PlayerbotAI* botAI) { return new CastFearWardAction(botAI); }
+    static Action* fear_ward_on_main_tank(PlayerbotAI* botAI) { return new CastFearWardOnMainTankAction(botAI); }
     static Action* desperate_prayer(PlayerbotAI* botAI) { return new CastDesperatePrayerAction(botAI); }
     static Action* shadowguard(PlayerbotAI* botAI) { return new CastShadowguardAction(botAI); }
     static Action* hex_of_weakness(PlayerbotAI* botAI) { return new CastHexOfWeaknessAction(botAI); }

--- a/src/Ai/Class/Priest/PriestTriggers.cpp
+++ b/src/Ai/Class/Priest/PriestTriggers.cpp
@@ -32,6 +32,15 @@ bool InnerFireTrigger::IsActive()
     return SpellTrigger::IsActive() && !botAI->HasAura(spell, target);
 }
 
+bool FearWardOnMainTankTrigger::IsActive()
+{
+    uint32 const spellId = AI_VALUE2(uint32, "spell id", spell);
+    if (!spellId || bot->HasSpellCooldown(spellId))
+        return false;
+
+    return BuffOnMainTankTrigger::IsActive();
+}
+
 bool ShadowformTrigger::IsActive() { return !botAI->HasAura("shadowform", bot); }
 
 bool ShadowfiendTrigger::IsActive() { return BoostTrigger::IsActive() && !bot->HasSpellCooldown(34433); }

--- a/src/Ai/Class/Priest/PriestTriggers.h
+++ b/src/Ai/Class/Priest/PriestTriggers.h
@@ -31,16 +31,12 @@ BUFF_TRIGGER(InnerFocusTrigger, "inner focus");
 CC_TRIGGER(ShackleUndeadTrigger, "shackle undead");
 INTERRUPT_TRIGGER(SilenceTrigger, "silence");
 INTERRUPT_HEALER_TRIGGER(SilenceEnemyHealerTrigger, "silence");
-
-// racials
 DEBUFF_CHECKISOWNER_TRIGGER(DevouringPlagueTrigger, "devouring plague");
 BUFF_TRIGGER(TouchOfWeaknessTrigger, "touch of weakness");
 DEBUFF_TRIGGER(HexOfWeaknessTrigger, "hex of weakness");
 BUFF_TRIGGER(ShadowguardTrigger, "shadowguard");
-BUFF_TRIGGER(FearWardTrigger, "fear ward");
 DEFLECT_TRIGGER(FeedbackTrigger, "feedback");
 SNARE_TRIGGER(ChastiseTrigger, "chastise");
-
 BOOST_TRIGGER_A(ShadowfiendTrigger, "shadowfiend");
 
 class ShadowProtectionTrigger : public BuffTrigger
@@ -87,6 +83,15 @@ class DivineSpiritTrigger : public BuffTrigger
 public:
     DivineSpiritTrigger(PlayerbotAI* botAI)
         : BuffTrigger(botAI, "divine spirit", 4 * 2000) {}
+
+    bool IsActive() override;
+};
+
+class FearWardOnMainTankTrigger : public BuffOnMainTankTrigger
+{
+public:
+    FearWardOnMainTankTrigger(PlayerbotAI* botAI)
+        : BuffOnMainTankTrigger(botAI, "fear ward", false, 2000) {}
 
     bool IsActive() override;
 };

--- a/src/Ai/Class/Priest/Strategy/GenericPriestStrategy.cpp
+++ b/src/Ai/Class/Priest/Strategy/GenericPriestStrategy.cpp
@@ -23,19 +23,17 @@ void GenericPriestStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
         ACTION_HIGH + 5) }));
     triggers.push_back(new TriggerNode(
         "critical health", { NextAction("power word: shield", ACTION_NORMAL) }));
-
+    triggers.push_back(new TriggerNode("fear ward on main tank",
+        { NextAction("fear ward on main tank", ACTION_HIGH + 3) }));
     triggers.push_back(
         new TriggerNode("low health", { NextAction("power word: shield", ACTION_HIGH) }));
-
     triggers.push_back(
         new TriggerNode("medium mana",
             {
                 NextAction("shadowfiend", ACTION_HIGH + 2),
                 NextAction("inner focus", ACTION_HIGH + 1) }));
-
     triggers.push_back(
         new TriggerNode("low mana", { NextAction("hymn of hope", ACTION_HIGH) }));
-
     triggers.push_back(new TriggerNode("enemy too close for spell",
                                        { NextAction("flee", ACTION_MOVE + 9) }));
     triggers.push_back(new TriggerNode("often", { NextAction("apply oil", 1.0f) }));


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

Priests don't currently use Fear Ward. There are triggers and actions for "fear ward" and "fear ward on party," but they are not included in any strategy. I decided to delete the existing triggers and actions and do a separate "fear ward on main tank" because that is the best usage of it imo, and it's easy to implement since there are already existing classes for buffing the main tank specifically (used for other abilities like Misdirection and Tricks of the Trade).

Oh and I broke CastPenanceOnPartyAction into two lines because it was nearby and about 1,000,000,000,000 characters long.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

Add actions and triggers for casting Fear Ward on the main tank and include it in GenericPriestStrategy. The trigger inherits from BuffOnMainTankTrigger but overrides IsActive() to first check for the cooldown. I figured this was a good way to limit cost because Fear Ward has a 3-minute cooldown. I also added a 2s throttle to the trigger.

The action inherits from BuffOnMainTankAction and does nothing but pass the spell name.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

Make a group with a Priest and a tank. Enter combat, and the Priest should immediately cast Fear Ward on the tank (it's relatively high priority, and when combat just begins, it's unlikely there's going to be a higher-priority trigger that is true). If you have multiple tanks, give one the MT flag, and Fear Ward should be cast on the MT.

## Impact Assessment
<!--
As a generic test, pmon checks before and after your edits are helpful. To standardize the measurement, set the configs
BotActiveAlone = 100 & botActiveAloneSmartScale = 0. After server boot, enable the monitor `playerbot pmon toggle`
right after the bots finished logging-in, and run the stack command `playerbot pmon stack` 5 minutes after that.
The last "Total" line is the main result to look for.
-->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

It's a new action and trigger, but it's throttled and first gated by cooldown so should be cheaper than other members of BuffOnMainTankTrigger.

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

Shut up.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [x] No
- - [ ] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->



## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/Ai/Base/Actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated.
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


