### PR TITLE
Create GenericRogueStrategy class & refresh poisons in combat

### DIFF
--- a/src/Ai/Class/Rogue/Action/RogueActions.cpp
+++ b/src/Ai/Class/Rogue/Action/RogueActions.cpp
@@ -81,118 +81,52 @@ bool CastTricksOfTheTradeOnMainTankAction::isUseful()
 
 bool UseDeadlyPoisonAction::Execute(Event /*event*/)
 {
-    std::vector<std::string> poison_suffixs = {" IX", " VIII", " VII", " VI", " V", " IV", " III", " II", ""};
-    std::vector<Item*> items;
-    std::string poison_name;
-    for (std::string& suffix : poison_suffixs)
+    std::vector<Item*> const items =
+        AI_VALUE2(std::vector<Item*>, "inventory items", "Deadly Poison");
+    for (Item* const item : items)
     {
-        poison_name = "Deadly Poison" + suffix;
-        items = AI_VALUE2(std::vector<Item*>, "inventory items", poison_name);
-        if (!items.empty())
-        {
-            break;
-        }
-    }
-    if (items.empty())
-    {
-        return false;
-    }
-    Item* const itemForSpell = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
-    return UseItem(*items.begin(), ObjectGuid::Empty, itemForSpell);
-    // return UseItemAuto(*items.begin());
-}
+        // This check is needed only if there is a name match. I think the only one is Handbook
+        // of Deadly Poison V, which might be restored by IP. Keeping this here just in case.
+        if (item->GetTemplate()->Class != ITEM_CLASS_CONSUMABLE)
+            continue;
 
-bool UseDeadlyPoisonAction::isPossible()
-{
-    std::vector<std::string> poison_suffixs = {" IX", " VIII", " VII", " VI", " V", " IV", " III", " II", ""};
-    std::vector<Item*> items;
-    std::string poison_name;
-    for (std::string& suffix : poison_suffixs)
-    {
-        poison_name = "Deadly Poison" + suffix;
-        items = AI_VALUE2(std::vector<Item*>, "inventory items", poison_name);
-        if (!items.empty())
-        {
-            break;
-        }
+        Item* const itemForSpell = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
+        return UseItem(item, ObjectGuid::Empty, itemForSpell);
     }
-    return !items.empty();
+
+    return false;
 }
 
 bool UseInstantPoisonAction::Execute(Event /*event*/)
 {
-    std::vector<std::string> poison_suffixs = {" IX", " VIII", " VII", " VI", " V", " IV", " III", " II", ""};
-    std::vector<Item*> items;
-    std::string poison_name;
-    for (std::string& suffix : poison_suffixs)
+    std::vector<Item*> const items =
+        AI_VALUE2(std::vector<Item*>, "inventory items", "Instant Poison");
+    for (Item* const item : items)
     {
-        poison_name = "Instant Poison" + suffix;
-        items = AI_VALUE2(std::vector<Item*>, "inventory items", poison_name);
-        if (!items.empty())
-        {
-            break;
-        }
-    }
-    if (items.empty())
-    {
-        return false;
-    }
-    Item* const itemForSpell = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
-    return UseItem(*items.begin(), ObjectGuid::Empty, itemForSpell);
-}
+        // Not necessary for instant but keeping for symmetry and to guide a potential refactor.
+        if (item->GetTemplate()->Class != ITEM_CLASS_CONSUMABLE)
+            continue;
 
-bool UseInstantPoisonAction::isPossible()
-{
-    std::vector<std::string> poison_suffixs = {" IX", " VIII", " VII", " VI", " V", " IV", " III", " II", ""};
-    std::vector<Item*> items;
-    std::string poison_name;
-    for (std::string& suffix : poison_suffixs)
-    {
-        poison_name = "Instant Poison" + suffix;
-        items = AI_VALUE2(std::vector<Item*>, "inventory items", poison_name);
-        if (!items.empty())
-        {
-            break;
-        }
+        Item* const itemForSpell = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+        return UseItem(item, ObjectGuid::Empty, itemForSpell);
     }
-    return !items.empty();
+
+    return false;
 }
 
 bool UseInstantPoisonOffHandAction::Execute(Event /*event*/)
 {
-    std::vector<std::string> poison_suffixs = {" IX", " VIII", " VII", " VI", " V", " IV", " III", " II", ""};
-    std::vector<Item*> items;
-    std::string poison_name;
-    for (std::string& suffix : poison_suffixs)
+    std::vector<Item*> const items =
+        AI_VALUE2(std::vector<Item*>, "inventory items", "Instant Poison");
+    for (Item* const item : items)
     {
-        poison_name = "Instant Poison" + suffix;
-        items = AI_VALUE2(std::vector<Item*>, "inventory items", poison_name);
-        if (!items.empty())
-        {
-            break;
-        }
-    }
-    if (items.empty())
-    {
-        return false;
-    }
-    Item* const itemForSpell = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
-    return UseItem(*items.begin(), ObjectGuid::Empty, itemForSpell);
-}
+        // Not necessary for instant but keeping for symmetry and to guide a potential refactor.
+        if (item->GetTemplate()->Class != ITEM_CLASS_CONSUMABLE)
+            continue;
 
-bool UseInstantPoisonOffHandAction::isPossible()
-{
-    std::vector<std::string> poison_suffixs = {" IX", " VIII", " VII", " VI", " V", " IV", " III", " II", ""};
-    std::vector<Item*> items;
-    std::string poison_name;
-    for (std::string& suffix : poison_suffixs)
-    {
-        poison_name = "Instant Poison" + suffix;
-        items = AI_VALUE2(std::vector<Item*>, "inventory items", poison_name);
-        if (!items.empty())
-        {
-            break;
-        }
+        Item* const itemForSpell = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
+        return UseItem(item, ObjectGuid::Empty, itemForSpell);
     }
-    return !items.empty();
+
+    return false;
 }

--- a/src/Ai/Class/Rogue/Action/RogueActions.h
+++ b/src/Ai/Class/Rogue/Action/RogueActions.h
@@ -155,28 +155,29 @@ public:
 class UseDeadlyPoisonAction : public UseItemAction
 {
 public:
-    UseDeadlyPoisonAction(PlayerbotAI* ai) : UseItemAction(ai, "Deadly Poison") {}
+    UseDeadlyPoisonAction(PlayerbotAI* botAI) : UseItemAction(botAI, "Deadly Poison") {}
 
     bool Execute(Event event) override;
-    bool isPossible() override;
+    bool isPossible() override { return true; }
 };
 
 class UseInstantPoisonAction : public UseItemAction
 {
 public:
-    UseInstantPoisonAction(PlayerbotAI* ai) : UseItemAction(ai, "Instant Poison") {}
+    UseInstantPoisonAction(PlayerbotAI* botAI) : UseItemAction(botAI, "Instant Poison") {}
 
     bool Execute(Event event) override;
-    bool isPossible() override;
+    bool isPossible() override { return true; }
 };
 
 class UseInstantPoisonOffHandAction : public UseItemAction
 {
 public:
-    UseInstantPoisonOffHandAction(PlayerbotAI* ai) : UseItemAction(ai, "Instant Poison Off Hand") {}
+    UseInstantPoisonOffHandAction(PlayerbotAI* botAI)
+        : UseItemAction(botAI, "Instant Poison Off Hand") {}
 
     bool Execute(Event event) override;
-    bool isPossible() override;
+    bool isPossible() override { return true; }
 };
 
 class FanOfKnivesAction : public CastMeleeSpellAction

--- a/src/Ai/Class/Rogue/RogueAiObjectContext.cpp
+++ b/src/Ai/Class/Rogue/RogueAiObjectContext.cpp
@@ -74,9 +74,12 @@ public:
         creators["no stealth"] = &RogueTriggerFactoryInternal::no_stealth;
         creators["stealth"] = &RogueTriggerFactoryInternal::stealth;
         creators["sprint"] = &RogueTriggerFactoryInternal::sprint;
-        creators["main hand weapon no enchant"] = &RogueTriggerFactoryInternal::main_hand_weapon_no_enchant;
-        creators["off hand weapon no enchant"] = &RogueTriggerFactoryInternal::off_hand_weapon_no_enchant;
-        creators["tricks of the trade on main tank"] = &RogueTriggerFactoryInternal::tricks_of_the_trade_on_main_tank;
+        creators["main hand weapon no enchant"] =
+            &RogueTriggerFactoryInternal::main_hand_weapon_no_enchant;
+        creators["off hand weapon no enchant"] =
+            &RogueTriggerFactoryInternal::off_hand_weapon_no_enchant;
+        creators["tricks of the trade on main tank"] =
+            &RogueTriggerFactoryInternal::tricks_of_the_trade_on_main_tank;
         creators["adrenaline rush"] = &RogueTriggerFactoryInternal::adrenaline_rush;
         creators["blade flurry"] = &RogueTriggerFactoryInternal::blade_flurry;
     }
@@ -88,18 +91,27 @@ private:
     static Trigger* slice_and_dice(PlayerbotAI* botAI) { return new SliceAndDiceTrigger(botAI); }
     static Trigger* hunger_for_blood(PlayerbotAI* botAI) { return new HungerForBloodTrigger(botAI); }
     static Trigger* expose_armor(PlayerbotAI* botAI) { return new ExposeArmorTrigger(botAI); }
-    static Trigger* kick_on_enemy_healer(PlayerbotAI* botAI) { return new KickInterruptEnemyHealerSpellTrigger(botAI); }
+    static Trigger* kick_on_enemy_healer(PlayerbotAI* botAI)
+    {
+        return new KickInterruptEnemyHealerSpellTrigger(botAI);
+    }
     static Trigger* unstealth(PlayerbotAI* botAI) { return new UnstealthTrigger(botAI); }
     static Trigger* sap(PlayerbotAI* botAI) { return new SapTrigger(botAI); }
     static Trigger* in_stealth(PlayerbotAI* botAI) { return new InStealthTrigger(botAI); }
     static Trigger* no_stealth(PlayerbotAI* botAI) { return new NoStealthTrigger(botAI); }
     static Trigger* stealth(PlayerbotAI* botAI) { return new StealthTrigger(botAI); }
     static Trigger* sprint(PlayerbotAI* botAI) { return new SprintTrigger(botAI); }
-    static Trigger* main_hand_weapon_no_enchant(PlayerbotAI* ai) { return new MainHandWeaponNoEnchantTrigger(ai); }
-    static Trigger* off_hand_weapon_no_enchant(PlayerbotAI* ai) { return new OffHandWeaponNoEnchantTrigger(ai); }
-    static Trigger* tricks_of_the_trade_on_main_tank(PlayerbotAI* ai)
+    static Trigger* main_hand_weapon_no_enchant(PlayerbotAI* botAI)
     {
-        return new TricksOfTheTradeOnMainTankTrigger(ai);
+        return new MainHandWeaponNoEnchantTrigger(botAI);
+    }
+    static Trigger* off_hand_weapon_no_enchant(PlayerbotAI* botAI)
+    {
+        return new OffHandWeaponNoEnchantTrigger(botAI);
+    }
+    static Trigger* tricks_of_the_trade_on_main_tank(PlayerbotAI* botAI)
+    {
+        return new TricksOfTheTradeOnMainTankTrigger(botAI);
     }
     static Trigger* adrenaline_rush(PlayerbotAI* botAI) { return new AdrenalineRushTrigger(botAI); }
     static Trigger* blade_flurry(PlayerbotAI* botAI) { return new BladeFlurryTrigger(botAI); }
@@ -139,35 +151,54 @@ public:
         creators["sap"] = &RogueAiObjectContextInternal::sap;
         creators["check stealth"] = &RogueAiObjectContextInternal::check_stealth;
         creators["envenom"] = &RogueAiObjectContextInternal::envenom;
-        creators["tricks of the trade on main tank"] = &RogueAiObjectContextInternal::tricks_of_the_trade_on_main_tank;
-        creators["use instant poison on main hand"] = &RogueAiObjectContextInternal::use_instant_poison;
-        creators["use deadly poison on off hand"] = &RogueAiObjectContextInternal::use_deadly_poison;
-        creators["use instant poison on off hand"] = &RogueAiObjectContextInternal::use_instant_poison_off_hand;
+        creators["tricks of the trade on main tank"] =
+            &RogueAiObjectContextInternal::tricks_of_the_trade_on_main_tank;
+        creators["use instant poison on main hand"] =
+            &RogueAiObjectContextInternal::use_instant_poison;
+        creators["use deadly poison on off hand"] =
+            &RogueAiObjectContextInternal::use_deadly_poison;
+        creators["use instant poison on off hand"] =
+            &RogueAiObjectContextInternal::use_instant_poison_off_hand;
         creators["fan of knives"] = &RogueAiObjectContextInternal::fan_of_knives;
         creators["killing spree"] = &RogueAiObjectContextInternal::killing_spree;
         creators["cold blood"] = &RogueAiObjectContextInternal::cold_blood;
     }
 
 private:
-    static Action* adrenaline_rush(PlayerbotAI* botAI) { return new CastAdrenalineRushAction(botAI); }
+    static Action* adrenaline_rush(PlayerbotAI* botAI)
+    {
+        return new CastAdrenalineRushAction(botAI);
+    }
     static Action* blade_flurry(PlayerbotAI* botAI) { return new CastBladeFlurryAction(botAI); }
     static Action* riposte(PlayerbotAI* botAI) { return new CastRiposteAction(botAI); }
     static Action* mutilate(PlayerbotAI* botAI) { return new CastMutilateAction(botAI); }
-    static Action* sinister_strike(PlayerbotAI* botAI) { return new CastSinisterStrikeAction(botAI); }
+    static Action* sinister_strike(PlayerbotAI* botAI)
+    {
+        return new CastSinisterStrikeAction(botAI);
+    }
     static Action* gouge(PlayerbotAI* botAI) { return new CastGougeAction(botAI); }
     static Action* kidney_shot(PlayerbotAI* botAI) { return new CastKidneyShotAction(botAI); }
     static Action* rupture(PlayerbotAI* botAI) { return new CastRuptureAction(botAI); }
     static Action* slice_and_dice(PlayerbotAI* botAI) { return new CastSliceAndDiceAction(botAI); }
-    static Action* hunger_for_blood(PlayerbotAI* botAI) { return new CastHungerForBloodAction(botAI); }
+    static Action* hunger_for_blood(PlayerbotAI* botAI)
+    {
+        return new CastHungerForBloodAction(botAI);
+    }
     static Action* eviscerate(PlayerbotAI* botAI) { return new CastEviscerateAction(botAI); }
     static Action* vanish(PlayerbotAI* botAI) { return new CastVanishAction(botAI); }
     static Action* evasion(PlayerbotAI* botAI) { return new CastEvasionAction(botAI); }
-    static Action* cloak_of_shadows(PlayerbotAI* botAI) { return new CastCloakOfShadowsAction(botAI); }
+    static Action* cloak_of_shadows(PlayerbotAI* botAI)
+    {
+        return new CastCloakOfShadowsAction(botAI);
+    }
     static Action* kick(PlayerbotAI* botAI) { return new CastKickAction(botAI); }
     static Action* feint(PlayerbotAI* botAI) { return new CastFeintAction(botAI); }
     static Action* backstab(PlayerbotAI* botAI) { return new CastBackstabAction(botAI); }
     static Action* expose_armor(PlayerbotAI* botAI) { return new CastExposeArmorAction(botAI); }
-    static Action* kick_on_enemy_healer(PlayerbotAI* botAI) { return new CastKickOnEnemyHealerAction(botAI); }
+    static Action* kick_on_enemy_healer(PlayerbotAI* botAI)
+    {
+        return new CastKickOnEnemyHealerAction(botAI);
+    }
     static Action* ambush(PlayerbotAI* botAI) { return new CastAmbushAction(botAI); }
     static Action* stealth(PlayerbotAI* botAI) { return new CastStealthAction(botAI); }
     static Action* sprint(PlayerbotAI* botAI) { return new CastSprintAction(botAI); }
@@ -177,17 +208,26 @@ private:
     static Action* check_stealth(PlayerbotAI* botAI) { return new CheckStealthAction(botAI); }
     static Action* sap(PlayerbotAI* botAI) { return new CastSapAction(botAI); }
     static Action* unstealth(PlayerbotAI* botAI) { return new UnstealthAction(botAI); }
-    static Action* envenom(PlayerbotAI* ai) { return new CastEnvenomAction(ai); }
-    static Action* tricks_of_the_trade_on_main_tank(PlayerbotAI* ai)
+    static Action* envenom(PlayerbotAI* botAI) { return new CastEnvenomAction(botAI); }
+    static Action* tricks_of_the_trade_on_main_tank(PlayerbotAI* botAI)
     {
-        return new CastTricksOfTheTradeOnMainTankAction(ai);
+        return new CastTricksOfTheTradeOnMainTankAction(botAI);
     }
-    static Action* use_instant_poison(PlayerbotAI* ai) { return new UseInstantPoisonAction(ai); }
-    static Action* use_deadly_poison(PlayerbotAI* ai) { return new UseDeadlyPoisonAction(ai); }
-    static Action* use_instant_poison_off_hand(PlayerbotAI* ai) { return new UseInstantPoisonOffHandAction(ai); }
-    static Action* fan_of_knives(PlayerbotAI* ai) { return new FanOfKnivesAction(ai); }
-    static Action* killing_spree(PlayerbotAI* ai) { return new CastKillingSpreeAction(ai); }
-    static Action* cold_blood(PlayerbotAI* ai) { return new CastColdBloodAction(ai); }
+    static Action* use_instant_poison(PlayerbotAI* botAI)
+    {
+        return new UseInstantPoisonAction(botAI);
+    }
+    static Action* use_deadly_poison(PlayerbotAI* botAI)
+    {
+        return new UseDeadlyPoisonAction(botAI);
+    }
+    static Action* use_instant_poison_off_hand(PlayerbotAI* botAI)
+    {
+        return new UseInstantPoisonOffHandAction(botAI);
+    }
+    static Action* fan_of_knives(PlayerbotAI* botAI) { return new FanOfKnivesAction(botAI); }
+    static Action* killing_spree(PlayerbotAI* botAI) { return new CastKillingSpreeAction(botAI); }
+    static Action* cold_blood(PlayerbotAI* botAI) { return new CastColdBloodAction(botAI); }
 };
 
 SharedNamedObjectContextList<Strategy> RogueAiObjectContext::sharedStrategyContexts;
@@ -209,26 +249,30 @@ void RogueAiObjectContext::BuildSharedContexts()
     BuildSharedValueContexts(sharedValueContexts);
 }
 
-void RogueAiObjectContext::BuildSharedStrategyContexts(SharedNamedObjectContextList<Strategy>& strategyContexts)
+void RogueAiObjectContext::BuildSharedStrategyContexts(
+    SharedNamedObjectContextList<Strategy>& strategyContexts)
 {
     AiObjectContext::BuildSharedStrategyContexts(strategyContexts);
     strategyContexts.Add(new RogueStrategyFactoryInternal());
     strategyContexts.Add(new RogueCombatStrategyFactoryInternal());
 }
 
-void RogueAiObjectContext::BuildSharedActionContexts(SharedNamedObjectContextList<Action>& actionContexts)
+void RogueAiObjectContext::BuildSharedActionContexts(
+    SharedNamedObjectContextList<Action>& actionContexts)
 {
     AiObjectContext::BuildSharedActionContexts(actionContexts);
     actionContexts.Add(new RogueAiObjectContextInternal());
 }
 
-void RogueAiObjectContext::BuildSharedTriggerContexts(SharedNamedObjectContextList<Trigger>& triggerContexts)
+void RogueAiObjectContext::BuildSharedTriggerContexts(
+    SharedNamedObjectContextList<Trigger>& triggerContexts)
 {
     AiObjectContext::BuildSharedTriggerContexts(triggerContexts);
     triggerContexts.Add(new RogueTriggerFactoryInternal());
 }
 
-void RogueAiObjectContext::BuildSharedValueContexts(SharedNamedObjectContextList<UntypedValue>& valueContexts)
+void RogueAiObjectContext::BuildSharedValueContexts(
+    SharedNamedObjectContextList<UntypedValue>& valueContexts)
 {
     AiObjectContext::BuildSharedValueContexts(valueContexts);
 }

--- a/src/Ai/Class/Rogue/Strategy/AssassinationRogueStrategy.cpp
+++ b/src/Ai/Class/Rogue/Strategy/AssassinationRogueStrategy.cpp
@@ -57,7 +57,8 @@ private:
     }
 };
 
-AssassinationRogueStrategy::AssassinationRogueStrategy(PlayerbotAI* ai) : MeleeCombatStrategy(ai)
+AssassinationRogueStrategy::AssassinationRogueStrategy(PlayerbotAI* botAI)
+    : GenericRogueStrategy(botAI)
 {
     actionNodeFactories.Add(new AssassinationRogueStrategyActionNodeFactory());
 }
@@ -71,7 +72,7 @@ std::vector<NextAction> AssassinationRogueStrategy::getDefaultActions()
 
 void AssassinationRogueStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
-    MeleeCombatStrategy::InitTriggers(triggers);
+    GenericRogueStrategy::InitTriggers(triggers);
 
     triggers.push_back(
         new TriggerNode(

--- a/src/Ai/Class/Rogue/Strategy/AssassinationRogueStrategy.h
+++ b/src/Ai/Class/Rogue/Strategy/AssassinationRogueStrategy.h
@@ -7,18 +7,17 @@
 #ifndef PLAYERBOTS_ASSASSINATIONROGUESTRATEGY_H
 #define PLAYERBOTS_ASSASSINATIONROGUESTRATEGY_H
 
-#include "MeleeCombatStrategy.h"
+#include "GenericRogueStrategy.h"
 
-class AssassinationRogueStrategy : public MeleeCombatStrategy
+class AssassinationRogueStrategy : public GenericRogueStrategy
 {
 public:
-    AssassinationRogueStrategy(PlayerbotAI* ai);
+    AssassinationRogueStrategy(PlayerbotAI* botAI);
 
 public:
     virtual void InitTriggers(std::vector<TriggerNode*>& triggers) override;
     virtual std::string const getName() override { return "melee"; }
     virtual std::vector<NextAction> getDefaultActions() override;
-    uint32 GetType() const override { return MeleeCombatStrategy::GetType() | STRATEGY_TYPE_DPS; }
 };
 
 #endif

--- a/src/Ai/Class/Rogue/Strategy/DpsRogueStrategy.cpp
+++ b/src/Ai/Class/Rogue/Strategy/DpsRogueStrategy.cpp
@@ -61,7 +61,7 @@ private:
     }
 };
 
-DpsRogueStrategy::DpsRogueStrategy(PlayerbotAI* botAI) : MeleeCombatStrategy(botAI)
+DpsRogueStrategy::DpsRogueStrategy(PlayerbotAI* botAI) : GenericRogueStrategy(botAI)
 {
     actionNodeFactories.Add(new DpsRogueStrategyActionNodeFactory());
 }
@@ -76,7 +76,7 @@ std::vector<NextAction> DpsRogueStrategy::getDefaultActions()
 
 void DpsRogueStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
-    MeleeCombatStrategy::InitTriggers(triggers);
+    GenericRogueStrategy::InitTriggers(triggers);
 
     triggers.push_back(
         new TriggerNode(

--- a/src/Ai/Class/Rogue/Strategy/DpsRogueStrategy.h
+++ b/src/Ai/Class/Rogue/Strategy/DpsRogueStrategy.h
@@ -7,12 +7,11 @@
 #ifndef PLAYERBOTS_DPSROGUESTRATEGY_H
 #define PLAYERBOTS_DPSROGUESTRATEGY_H
 
-#include "CombatStrategy.h"
-#include "MeleeCombatStrategy.h"
+#include "GenericRogueStrategy.h"
 
 class PlayerbotAI;
 
-class DpsRogueStrategy : public MeleeCombatStrategy
+class DpsRogueStrategy : public GenericRogueStrategy
 {
 public:
     DpsRogueStrategy(PlayerbotAI* botAI);
@@ -20,7 +19,6 @@ public:
     void InitTriggers(std::vector<TriggerNode*>& triggers) override;
     std::string const getName() override { return "dps"; }
     std::vector<NextAction> getDefaultActions() override;
-    uint32 GetType() const override { return MeleeCombatStrategy::GetType() | STRATEGY_TYPE_DPS; }
 };
 
 class StealthedRogueStrategy : public Strategy

--- a/src/Ai/Class/Rogue/Strategy/GenericRogueStrategy.cpp
+++ b/src/Ai/Class/Rogue/Strategy/GenericRogueStrategy.cpp
@@ -1,0 +1,55 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "GenericRogueStrategy.h"
+
+class GenericRogueStrategyActionNodeFactory : public NamedObjectFactory<ActionNode>
+{
+public:
+    GenericRogueStrategyActionNodeFactory()
+    {
+        creators["use deadly poison on off hand"] = &use_deadly_poison_on_off_hand;
+    }
+
+private:
+    static ActionNode* use_deadly_poison_on_off_hand([[maybe_unused]] PlayerbotAI* botAI)
+    {
+        return new ActionNode("use deadly poison on off hand",
+                            /*P*/ {},
+                            /*A*/ { NextAction("use instant poison on off hand") },
+                            /*C*/ {});
+    }
+};
+
+GenericRogueStrategy::GenericRogueStrategy(PlayerbotAI* botAI) : CombatStrategy(botAI)
+{
+    actionNodeFactories.Add(new GenericRogueStrategyActionNodeFactory());
+}
+
+void GenericRogueStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+{
+    CombatStrategy::InitTriggers(triggers);
+
+    // The right priority for poisons is probably above any attack but below any survival ability.
+    // Everything about Rogues needs to be redone, but right now 26 is just below Cloak of Shadows
+    // and Evasion and just above Slice and Dice.
+    triggers.push_back(
+        new TriggerNode(
+            "main hand weapon no enchant",
+            {
+                NextAction("use instant poison on main hand", 26.0f)
+            }
+        )
+    );
+    triggers.push_back(
+        new TriggerNode(
+            "off hand weapon no enchant",
+            {
+                NextAction("use deadly poison on off hand", 25.5f)
+            }
+        )
+    );
+}

--- a/src/Ai/Class/Rogue/Strategy/GenericRogueStrategy.h
+++ b/src/Ai/Class/Rogue/Strategy/GenericRogueStrategy.h
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_GENERICROGUESTRATEGY_H
+#define PLAYERBOTS_GENERICROGUESTRATEGY_H
+
+#include "CombatStrategy.h"
+
+class PlayerbotAI;
+
+class GenericRogueStrategy : public CombatStrategy
+{
+public:
+    GenericRogueStrategy(PlayerbotAI* botAI);
+
+    std::string const getName() override { return "rogue"; }
+    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
+    uint32 GetType() const override
+    {
+        return CombatStrategy::GetType() | STRATEGY_TYPE_DPS | STRATEGY_TYPE_MELEE;
+    }
+};
+
+#endif


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->

I mainly just wanted to get Rogues to refresh poisons in combat because it kills their DPS to lose them mid-encounter, but there wasn't a good place to put the strategies because Rogues, unlike every other class in the mod, don't have a generic combat strategy. So I went ahead and added one to put the combat poison strategies in. This file/strategy also is the better place to house many of the strategies that are currently in the spec-based files (like Evasion, Cloak of Shadows, Sprint, etc.), but I'm not dealing with that right now and probably not ever.

I set the priority for applying poisons to higher than any offensive ability (including Slice and Dice) but below defensive ones. I think this is justified since poisons constitute (at level 70 anyway) 20-25% of Combat's dps and 35-40% of Assassination's dps (and also enables Assassination's finisher, so basically if poisons drop off mid-combat for an Assassination Rogue, they're getting outdps'd by the Prot Warrior).

I have no desire to refactor the class, but after this is merged, I'll do a pass to rename the specs from "dps" and "melee" in a separate PR.

## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.

  - New GenericRogueStrategy.cpp and GenericRogueStrategy.h files
  - New GenericRogueStrategy class that inherits from CombatStrategy
  - DpsRogueStrategy (i.e., Combat spec) and AssassinationRogueStrategy now inherit from GenericRogueStrategy
  - One ActionNode and two TriggerNodes in GenericRogueStrategy to apply MH instant and OH deadly poisons in combat (fallback to OH instant if no deadly is available, not because I think this is a good idea but because this matches the non-combat strategy)
  - Some formatting/naming cleanups

Edit: Forgot, I also changed the conf to take the chance of an rndbot being sub to 0 since the spec isn't implemented. I tuned to raise Combat a bit and lower Assassination a bit since Assassination is not viable before level 62 (or 63?), and Combat is the better leveling/questing spec always. I made it 60/40; probably it should be even higher in favor of Combat, but I didn't want to rock the boat too much.

## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->

Easiest way is to log into a Rogue character, remove poisons on weapons, attack a mob, and turn on selfbot. They should put their poisons back on and otherwise keep fighting like normal.

## Impact Assessment
<!--
As a generic test, pmon checks before and after your edits are helpful. To standardize the measurement, set the configs
BotActiveAlone = 100 & botActiveAloneSmartScale = 0. After server boot, enable the monitor `playerbot pmon toggle`
right after the bots finished logging-in, and run the stack command `playerbot pmon stack` 5 minutes after that.
The last "Total" line is the main result to look for.
-->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [x] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)

The trigger wasn't previously evaluated in combat, but this is not going to make any difference.

- Does this change modify default bot behavior?
    - - [ ] No
    - - [x] Yes (**explain why**)

Man I just told you.

- Does this change add new decision branches or increase maintenance complexity?
    - - [x] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [x] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->

I had AI take a pass after I finished and was told I unnecessarily included GenericRogueStrategy.h in RogueAiObjectContext.cpp so thanks for that value add

## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [x] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/Ai/Base/Actions/FishingAction.cpp
-->

## Final Checklist

- - [x] Changes are understood and tested for server stability and performance impact.
- - [x] Any new bot dialogue lines are translated.
- - [x] New source files use the GPLv2 header.
- - [x] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [x] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


