### PR TITLE
Test staging

### DIFF
--- a/.github/workflows/core_build.yml
+++ b/.github/workflows/core_build.yml
@@ -18,22 +18,24 @@ jobs:
       matrix:
         # the result of the matrix will be the combination of all attributes, so we get os*compiler builds
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             c_compiler: clang
             cpp_compiler: clang++
-            build_type: Release
-          - os: ubuntu-22.04
-            c_compiler: gcc
-            cpp_compiler: g++
             build_type: Release
           - os: ubuntu-24.04
             c_compiler: gcc
             cpp_compiler: g++
             build_type: Release
-            
+          - os: ubuntu-26.04
+            c_compiler: gcc
+            cpp_compiler: g++
+            build_type: Release
+
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }}-${{ matrix.cpp_compiler }}
 
+    env:
+      CXXFLAGS: "-Wall -Wextra -Winit-self -Woverloaded-virtual -Werror -Wno-error=deprecated-declarations -Wno-error=array-bounds"
     steps:
       - name: Checkout AzerothCore
         uses: actions/checkout@v3
@@ -46,13 +48,12 @@ jobs:
         shell: bash
         run: |
           echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
-          
+
       - name: Checkout Playerbot Module
         uses: actions/checkout@v3
         with:
-          repository: 'mod-playerbots/mod-playerbots'
           path: 'modules/mod-playerbots'
-      
+
       - name: Cache
         uses: actions/cache@v4
         with:
@@ -75,4 +76,4 @@ jobs:
           -S ${{ github.workspace }}
 
       - name: Build
-        run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+        run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }} -- -k

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -18,16 +18,20 @@ jobs:
           - macos-14
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }}
+
+    env:
+      CXXFLAGS: "-Wall -Wextra -Winit-self -Woverloaded-virtual -Werror -Wno-error=deprecated-declarations"
+      MAKEFLAGS: "-k"
     steps:
       - name: Checkout AzerothCore
         uses: actions/checkout@v4
         with:
           repository: 'mod-playerbots/azerothcore-wotlk'
           ref: ${{ (github.base_ref || github.ref_name) == 'test-staging' && 'test-staging' || 'Playerbot' }}
+
       - name: Checkout Playerbot Module
         uses: actions/checkout@v4
         with:
-          repository: 'mod-playerbots/mod-playerbots'
           path: 'modules/mod-playerbots'
       - name: Cache
         uses: actions/cache@v4

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -24,6 +24,7 @@ jobs:
       BOOST_ROOT: C:\local\boost_1_87_0
       CMAKE_GENERATOR: Ninja
       CTOOLS_BUILD: all
+      CXXFLAGS: "-WX -wd4996 -wd4244 -wd4267 -wd4305"
 
     steps:
       - name: Checkout AzerothCore
@@ -36,7 +37,6 @@ jobs:
       - name: Checkout Playerbot Module
         uses: actions/checkout@v4
         with:
-          repository: 'mod-playerbots/mod-playerbots'
           path: a/modules/mod-playerbots
 
       - name: Move source tree to short path

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -172,7 +172,9 @@ AiPlayerbot.RandomBotGuildCount = 20
 # Maximum number of members in randombot guilds (minimum is hardcoded to 10)
 AiPlayerbot.RandomBotGuildSizeMax = 15
 
-# Delete all randombot guilds if set to 1
+# Delete all randombot (and any addclass bot) guilds on startup. While enabled,
+# no new randombot guilds are created or joined. Set back to 0 and restart the
+# server to resume normal random bot guild assignment.
 AiPlayerbot.DeleteRandomBotGuilds = 0
 
 # Randombots will invite players to groups/raids/guilds
@@ -1687,9 +1689,9 @@ AiPlayerbot.RandomBotArenaTeam5v5Count = 5
 AiPlayerbot.RandomBotArenaTeamMaxRating = 2000
 AiPlayerbot.RandomBotArenaTeamMinRating = 1000
 
-# Delete all random bot arena teams on startup. While enabled, no new random bot
-# arena teams are created or joined. Set back to 0 and restart the server to
-# resume normal random bot arena team assignment.
+# Delete all randombot (and any addclass bot) arena teams on startup. While enabled,
+# no new randombot arena teams are created or joined. Set back to 0 and restart the
+# server to resume normal randombot arena team assignment.
 AiPlayerbot.DeleteRandomBotArenaTeams = 0
 
 # PvP Restricted Zones (bots will not initiate PvP or defend themselves if attacked)

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -736,6 +736,12 @@ AiPlayerbot.RandomBotMaxLevel = 80
 # Default: 0 (disabled)
 AiPlayerbot.SyncLevelWithPlayers = 0
 
+# Concentrate randombots teleporting into level-appropriate open-world zones that hold a real
+# (non-GM) player. Falls back to normal teleporting behaviour when no player's zone matches.
+# Best paired with AiPlayerbot.SyncLevelWithPlayers.
+# Default: 0 (disabled)
+AiPlayerbot.RandomBotConcentrateInPlayerZone = 0
+
 # Mark many quests ≤ bot level as complete (slows down bot creation)
 # Default: 0 (disabled)
 AiPlayerbot.PreQuests = 0

--- a/src/Ai/Base/Actions/AcceptInvitationAction.cpp
+++ b/src/Ai/Base/Actions/AcceptInvitationAction.cpp
@@ -36,7 +36,7 @@ bool AcceptInvitationAction::Execute(Event event)
         return false;
     }
 
-    if (bot->isAFK())
+    if (bot->isAFK() && !IsSelfBot(bot))
         bot->ToggleAFK();
 
     WorldPacket p;

--- a/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
+++ b/src/Ai/Base/Actions/BattleGroundJoinAction.cpp
@@ -742,8 +742,8 @@ bool BGStatusAction::Execute(Event event)
 {
     uint32 QueueSlot;
     uint32 instanceId;
-    uint32 mapId;
-    uint32 statusid;
+    uint32 mapId = 0;
+    uint32 statusid = 0;
     uint32 Time1 = 0;
     uint32 Time2 = 0;
     std::string _bgType;
@@ -797,12 +797,13 @@ bool BGStatusAction::Execute(Event event)
     if (!queueTypeId)
         return false;
 
-    BattlegroundBracketId bracketId = BG_BRACKET_ID_FIRST;
     Battleground* bg = sBattlegroundMgr->GetBattlegroundTemplate(_bgTypeId);
     mapId = bg->GetMapId();
     PvPDifficultyEntry const* pvpDiff = GetBattlegroundBracketByLevel(mapId, bot->GetLevel());
-    if (pvpDiff)
-        bracketId = pvpDiff->GetBracketId();
+    if (!pvpDiff)
+        return false;
+
+    BattlegroundBracketId bracketId = pvpDiff->GetBracketId();
 
     bool isArena = false;
     uint8 type = false;  // arenatype if arena

--- a/src/Ai/Base/Actions/LootAction.cpp
+++ b/src/Ai/Base/Actions/LootAction.cpp
@@ -107,9 +107,16 @@ bool OpenLootAction::DoLoot(LootObject& lootObject)
         return true;
     }
 
+    // Everything below this point casts, and every opening or gathering spell has a cast
+    // time -- PlayerbotAI::CastSpell refuses outright while isMoving(). StopMoving() only
+    // asks the spline to end, so casting in the same tick burns the attempt and the bot
+    // walks off and comes back: measured at seven refused casts in one second, all with
+    // isMoving() still true. Stop, then retry on a later tick, standing still.
     if (bot->isMoving())
     {
         bot->StopMoving();
+        botAI->SetNextCheckDelay(sPlayerbotAIConfig.lootDelay);
+        return false;
     }
 
     if (creature)

--- a/src/Ai/Base/Actions/PassLeadershipToMasterAction.cpp
+++ b/src/Ai/Base/Actions/PassLeadershipToMasterAction.cpp
@@ -39,5 +39,6 @@ bool PassLeadershipToMasterAction::isUseful()
 
 bool GiveLeaderAction::isUseful()
 {
-    return IsRealPlayer(botAI->GetMaster()) && bot->GetGroup() && bot->GetGroup()->IsLeader(bot->GetGUID());
+    return (IsRealPlayer(botAI->GetMaster()) || IsSelfBot(botAI->GetMaster())) && bot->GetGroup() &&
+           bot->GetGroup()->IsLeader(bot->GetGUID());
 }

--- a/src/Ai/Base/Actions/SellAction.cpp
+++ b/src/Ai/Base/Actions/SellAction.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "SellAction.h"
+#include "ChatHelper.h"
 #include "Event.h"
 #include "ItemPackets.h"
 #include "ItemUsageValue.h"
@@ -26,18 +27,48 @@ private:
     SellAction* action;
 };
 
-class SellGrayItemsVisitor : public SellItemsVisitor
+class SellQualityItemsVisitor : public SellItemsVisitor
 {
 public:
-    SellGrayItemsVisitor(SellAction* action) : SellItemsVisitor(action) {}
+    SellQualityItemsVisitor(SellAction* action, uint32 maxQuality, bool allClasses)
+        : SellItemsVisitor(action), maxQuality(maxQuality), allClasses(allClasses)
+    {
+    }
 
     bool Visit(Item* item) override
     {
-        if (item->GetTemplate()->Quality != ITEM_QUALITY_POOR)
+        ItemTemplate const* proto = item->GetTemplate();
+        if (proto->Quality > maxQuality)
+            return true;
+
+        if (IsProfessionTool(proto))
+            return true;
+
+        if (!allClasses && proto->Quality > ITEM_QUALITY_POOR && !IsEquipment(proto))
             return true;
 
         return SellItemsVisitor::Visit(item);
     }
+
+private:
+    static bool IsEquipment(ItemTemplate const* proto)
+    {
+        return proto->Class == ITEM_CLASS_ARMOR || proto->Class == ITEM_CLASS_WEAPON;
+    }
+
+    static bool IsProfessionTool(ItemTemplate const* proto)
+    {
+        if (proto->Class != ITEM_CLASS_WEAPON)
+            return false;
+
+        if (proto->SubClass == ITEM_SUBCLASS_WEAPON_MISC || proto->SubClass == ITEM_SUBCLASS_WEAPON_FISHING_POLE)
+            return true;
+
+        return proto->TotemCategory != 0;
+    }
+
+    uint32 maxQuality;
+    bool allClasses;
 };
 
 class SellVendorItemsVisitor : public SellItemsVisitor
@@ -62,7 +93,7 @@ bool SellAction::Execute(Event event)
     std::string const text = event.getParam();
     if (text == "gray" || text == "*")
     {
-        SellGrayItemsVisitor visitor(this);
+        SellQualityItemsVisitor visitor(this, ITEM_QUALITY_POOR, false);
         IterateItems(&visitor);
         return true;
     }
@@ -70,6 +101,24 @@ bool SellAction::Execute(Event event)
     if (text == "vendor")
     {
         SellVendorItemsVisitor visitor(this, context);
+        IterateItems(&visitor);
+        return true;
+    }
+
+    std::string quality = text;
+    bool allClasses = false;
+
+    size_t const split = quality.rfind(' ');
+    if (split != std::string::npos && quality.substr(split + 1) == "all")
+    {
+        quality.erase(split);
+        allClasses = true;
+    }
+
+    uint32 const maxQuality = ChatHelper::parseItemQuality(quality);
+    if (maxQuality != MAX_ITEM_QUALITY)
+    {
+        SellQualityItemsVisitor visitor(this, maxQuality, allClasses);
         IterateItems(&visitor);
         return true;
     }
@@ -84,7 +133,7 @@ bool SellAction::Execute(Event event)
         return true;
     }
 
-    botAI->TellError("Usage: s gray/*/vendor/[item link]");
+    botAI->TellError("Usage: s gray/*/vendor/<quality> [all]/[item link]");
     return false;
 }
 

--- a/src/Ai/Base/Actions/TrainerAction.cpp
+++ b/src/Ai/Base/Actions/TrainerAction.cpp
@@ -67,10 +67,20 @@ bool TrainerAction::isPossible()
     if (!trainer->IsTrainerValidForPlayer(bot))
         return false;
 
-    if (trainer->GetSpells().empty())
-        return false;
+    for (Trainer::Spell const& spell : trainer->GetSpells())
+    {
+        Trainer::Spell const* trainerSpell = trainer->GetSpell(spell.SpellId);
+        if (!trainerSpell)
+            continue;
 
-    return true;
+        if (!PlayerbotFactory::IsTrainerSpellAllowedForBot(bot, trainer, trainerSpell))
+            continue;
+
+        if (trainer->CanTeachSpell(bot, trainerSpell))
+            return true;
+    }
+
+    return false;
 }
 
 Unit* TrainerAction::GetTarget()
@@ -107,6 +117,9 @@ void TrainerAction::Iterate(Creature* creature, bool learnSpells, uint32 spellId
 
         Trainer::Spell const* trainerSpell = trainer->GetSpell(spell.SpellId);
         if (!trainerSpell)
+            continue;
+
+        if (!PlayerbotFactory::IsTrainerSpellAllowedForBot(bot, trainer, trainerSpell))
             continue;
 
         if (!trainer->CanTeachSpell(bot, trainerSpell))

--- a/src/Ai/Base/Actions/WipeAction.cpp
+++ b/src/Ai/Base/Actions/WipeAction.cpp
@@ -15,7 +15,9 @@ bool WipeAction::Execute(Event event)
     if (owner != nullptr && master != nullptr && master->GetGUID() != owner->GetGUID())
         return false;
 
-    bot->Kill(bot, bot);
+    if (!bot->IsAlive())
+        return false;
 
+    bot->Kill(bot, bot);
     return true;
 }

--- a/src/Ai/Base/Actions/WipeAction.h
+++ b/src/Ai/Base/Actions/WipeAction.h
@@ -17,9 +17,6 @@ public:
     WipeAction(PlayerbotAI* botAI) : Action(botAI, "wipe") {}
 
     bool Execute(Event event) override;
-
-private:
-    std::string bossName;
 };
 
 #endif

--- a/src/Ai/Base/Value/AttackersValue.cpp
+++ b/src/Ai/Base/Value/AttackersValue.cpp
@@ -212,25 +212,32 @@ bool AttackersValue::IsPossibleTarget(Unit* attacker, Player* bot, float /*range
         if (bot->GetGroup() && botAI->GetMaster())
             leaderHasThreat = attacker->GetThreatMgr().GetThreat(botAI->GetMaster());
 
-        bool isMemberBotGroup = false;
-        if (bot->GetGroup() && botAI->GetMaster())
+        // A player claims a creature by damaging it or landing a hostile spell on it, which is what
+        // sets its loot recipient. The below code covers anti-kill-stealing mechanics.
+        //
+        // (1) Whatever the claim, the bot may attack if it (a) is in a raid/group and has a master
+        //     holding nonzero threat on the creature, (b) has, or has a raid/group member that has,
+        //     already tapped it, or (c) is already in combat with the creature.
+        if (leaderHasThreat || c->isTappedBy(bot) || c->IsInCombatWith(bot))
+            return true;
+
+        // (2) Nobody has claimed the creature, so ask who it is attacking. If it is not attacking
+        //     anything, or if it is attacking (a) something with no player behind it (e.g., a
+        //     critter), (b) the bot, (c) the bot's master, or (d) a member of the bot's raid/group,
+        //     then the victim is considered to belong to the bot and may be attacked. Clauses (b)
+        //     through (d) also include a player's pets, guardians, totems, and charms.
+        if (!c->hasLootRecipient())
         {
-            PlayerbotAI* masterBotAI = GET_PLAYERBOT_AI(botAI->GetMaster());
-            if (masterBotAI && !IsSelfBot(botAI->GetMaster()))
-                isMemberBotGroup = true;
+            Unit* victim = c->GetVictim();
+            Player* victimOwner = victim ? victim->GetCharmerOrOwnerPlayerOrPlayerItself() : nullptr;
+            if (!victim || !victimOwner || victimOwner == bot || victimOwner == botAI->GetMaster() ||
+                (bot->GetGroup() && bot->GetGroup() == victimOwner->GetGroup()))
+                return true;
         }
 
-        bool canAttack = (!isMemberBotGroup && botAI->HasStrategy("attack tagged", BOT_STATE_NON_COMBAT)) ||
-            leaderHasThreat ||
-            (!c->hasLootRecipient() &&
-                (!c->GetVictim() ||
-                    (c->GetVictim() &&
-                        ((!c->GetVictim()->IsPlayer() || bot->IsInSameGroupWith(c->GetVictim()->ToPlayer())) ||
-                            (botAI->GetMaster() && c->GetVictim() == botAI->GetMaster()))))) ||
-            c->isTappedBy(bot);
-
-        if (!canAttack)
-            return false;
+        // (3) Last because it is applied automatically only in battlegrounds and arenas: the
+        //     "attack tagged" strategy always allows for attacking of creatures.
+        return botAI->HasStrategy("attack tagged", BOT_STATE_NON_COMBAT);
     }
 
     return true;

--- a/src/Ai/Base/Value/PossibleRpgTargetsValue.cpp
+++ b/src/Ai/Base/Value/PossibleRpgTargetsValue.cpp
@@ -15,35 +15,33 @@
 #include "SharedDefines.h"
 #include <unordered_set>
 
-std::vector<uint32> PossibleRpgTargetsValue::allowedNpcFlags;
+const std::vector<uint32> PossibleRpgTargetsValue::allowedNpcFlags = {
+    UNIT_NPC_FLAG_INNKEEPER,
+    UNIT_NPC_FLAG_GOSSIP,
+    UNIT_NPC_FLAG_QUESTGIVER,
+    UNIT_NPC_FLAG_FLIGHTMASTER,
+    UNIT_NPC_FLAG_BANKER,
+    UNIT_NPC_FLAG_GUILD_BANKER,
+    UNIT_NPC_FLAG_TRAINER_CLASS,
+    UNIT_NPC_FLAG_TRAINER_PROFESSION,
+    UNIT_NPC_FLAG_VENDOR_AMMO,
+    UNIT_NPC_FLAG_VENDOR_FOOD,
+    UNIT_NPC_FLAG_VENDOR_POISON,
+    UNIT_NPC_FLAG_VENDOR_REAGENT,
+    UNIT_NPC_FLAG_AUCTIONEER,
+    UNIT_NPC_FLAG_STABLEMASTER,
+    UNIT_NPC_FLAG_PETITIONER,
+    UNIT_NPC_FLAG_TABARDDESIGNER,
+    UNIT_NPC_FLAG_BATTLEMASTER,
+
+    UNIT_NPC_FLAG_TRAINER,
+    UNIT_NPC_FLAG_VENDOR,
+    UNIT_NPC_FLAG_REPAIR,
+};
 
 PossibleRpgTargetsValue::PossibleRpgTargetsValue(PlayerbotAI* botAI, float range)
     : NearestUnitsValue(botAI, "possible rpg targets", range, true)
 {
-    if (allowedNpcFlags.empty())
-    {
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_INNKEEPER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_GOSSIP);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_QUESTGIVER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_FLIGHTMASTER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_BANKER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_GUILD_BANKER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_TRAINER_CLASS);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_TRAINER_PROFESSION);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR_AMMO);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR_FOOD);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR_POISON);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR_REAGENT);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_AUCTIONEER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_STABLEMASTER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_PETITIONER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_TABARDDESIGNER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_BATTLEMASTER);
-
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_TRAINER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_REPAIR);
-    }
 }
 
 void PossibleRpgTargetsValue::FindUnits(std::list<Unit*>& targets)
@@ -87,7 +85,29 @@ bool PossibleRpgTargetsValue::AcceptUnit(Unit* unit)
     return false;
 }
 
-std::vector<uint32> PossibleNewRpgTargetsValue::allowedNpcFlags;
+const std::vector<uint32> PossibleNewRpgTargetsValue::allowedNpcFlags = {
+    UNIT_NPC_FLAG_INNKEEPER,
+    UNIT_NPC_FLAG_GOSSIP,
+    UNIT_NPC_FLAG_QUESTGIVER,
+    UNIT_NPC_FLAG_FLIGHTMASTER,
+    UNIT_NPC_FLAG_BANKER,
+    UNIT_NPC_FLAG_GUILD_BANKER,
+    UNIT_NPC_FLAG_TRAINER_CLASS,
+    UNIT_NPC_FLAG_TRAINER_PROFESSION,
+    UNIT_NPC_FLAG_VENDOR_AMMO,
+    UNIT_NPC_FLAG_VENDOR_FOOD,
+    UNIT_NPC_FLAG_VENDOR_POISON,
+    UNIT_NPC_FLAG_VENDOR_REAGENT,
+    UNIT_NPC_FLAG_AUCTIONEER,
+    UNIT_NPC_FLAG_STABLEMASTER,
+    UNIT_NPC_FLAG_PETITIONER,
+    UNIT_NPC_FLAG_TABARDDESIGNER,
+    UNIT_NPC_FLAG_BATTLEMASTER,
+
+    UNIT_NPC_FLAG_TRAINER,
+    UNIT_NPC_FLAG_VENDOR,
+    UNIT_NPC_FLAG_REPAIR,
+};
 
 // Sparse starting zones where the default scan range is insufficient for WANDER_NPC (requires >= 3 NPCs)
 static const std::unordered_set<uint32> rpgRangeOverrideAreaIds = { 3526 /* Ammen Vale */, 2117 /* Deathknell */ };
@@ -95,30 +115,6 @@ static const std::unordered_set<uint32> rpgRangeOverrideAreaIds = { 3526 /* Amme
 PossibleNewRpgTargetsValue::PossibleNewRpgTargetsValue(PlayerbotAI* botAI, float range)
     : NearestUnitsValue(botAI, "possible new rpg targets", range, true), defaultRange(range)
 {
-    if (allowedNpcFlags.empty())
-    {
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_INNKEEPER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_GOSSIP);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_QUESTGIVER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_FLIGHTMASTER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_BANKER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_GUILD_BANKER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_TRAINER_CLASS);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_TRAINER_PROFESSION);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR_AMMO);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR_FOOD);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR_POISON);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR_REAGENT);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_AUCTIONEER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_STABLEMASTER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_PETITIONER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_TABARDDESIGNER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_BATTLEMASTER);
-
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_TRAINER);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_VENDOR);
-        allowedNpcFlags.push_back(UNIT_NPC_FLAG_REPAIR);
-    }
 }
 
 GuidVector PossibleNewRpgTargetsValue::Calculate()
@@ -176,7 +172,9 @@ bool PossibleNewRpgTargetsValue::AcceptUnit(Unit* unit)
     return false;
 }
 
-std::vector<GameobjectTypes> PossibleNewRpgGameObjectsValue::allowedGOFlags;
+const std::vector<GameobjectTypes> PossibleNewRpgGameObjectsValue::allowedGOFlags = {
+    GAMEOBJECT_TYPE_QUESTGIVER,
+};
 
 GuidVector PossibleNewRpgGameObjectsValue::Calculate()
 {

--- a/src/Ai/Base/Value/PossibleRpgTargetsValue.h
+++ b/src/Ai/Base/Value/PossibleRpgTargetsValue.h
@@ -19,7 +19,7 @@ class PossibleRpgTargetsValue : public NearestUnitsValue
 public:
     PossibleRpgTargetsValue(PlayerbotAI* botAI, float range = 70.0f);
 
-    static std::vector<uint32> allowedNpcFlags;
+    static const std::vector<uint32> allowedNpcFlags;
 
 protected:
     void FindUnits(std::list<Unit*>& targets) override;
@@ -31,7 +31,7 @@ class PossibleNewRpgTargetsValue : public NearestUnitsValue
 public:
     PossibleNewRpgTargetsValue(PlayerbotAI* botAI, float range = 150.0f);
 
-    static std::vector<uint32> allowedNpcFlags;
+    static const std::vector<uint32> allowedNpcFlags;
     GuidVector Calculate() override;
 protected:
     void FindUnits(std::list<Unit*>& targets) override;
@@ -46,13 +46,9 @@ public:
     PossibleNewRpgGameObjectsValue(PlayerbotAI* botAI, float range = 150.0f, bool ignoreLos = true)
         : ObjectGuidListCalculatedValue(botAI, "possible new rpg game objects"), range(range), ignoreLos(ignoreLos)
     {
-        if (allowedGOFlags.empty())
-        {
-            allowedGOFlags.push_back(GAMEOBJECT_TYPE_QUESTGIVER);
-        }
     }
 
-    static std::vector<GameobjectTypes> allowedGOFlags;
+    static const std::vector<GameobjectTypes> allowedGOFlags;
     GuidVector Calculate() override;
 
 private:

--- a/src/Ai/Class/Priest/PriestActions.h
+++ b/src/Ai/Class/Priest/PriestActions.h
@@ -153,8 +153,6 @@ BUFF_ACTION(CastTouchOfWeaknessAction, "touch of weakness");
 DEBUFF_ACTION(CastHexOfWeaknessAction, "hex of weakness");
 BUFF_ACTION(CastShadowguardAction, "shadowguard");
 HEAL_ACTION(CastDesperatePrayerAction, "desperate prayer");
-BUFF_ACTION(CastFearWardAction, "fear ward");
-BUFF_PARTY_ACTION(CastFearWardOnPartyAction, "fear ward");
 SPELL_ACTION_U(CastStarshardsAction, "starshards",
                (AI_VALUE2(uint8, "mana", "self target") > 50 && AI_VALUE(Unit*, "current target") &&
                 AI_VALUE2(float, "distance", "current target") > 15.0f));
@@ -184,7 +182,8 @@ public:
 class CastPenanceOnPartyAction : public HealPartyMemberAction
 {
 public:
-    CastPenanceOnPartyAction(PlayerbotAI* ai) : HealPartyMemberAction(ai, "penance", 25.0f, HealingManaEfficiency::HIGH)
+    CastPenanceOnPartyAction(PlayerbotAI* ai)
+        : HealPartyMemberAction(ai, "penance", 25.0f, HealingManaEfficiency::HIGH)
     {
     }
 };
@@ -235,6 +234,12 @@ public:
 
     bool isUseful() override;
     Unit* GetTarget() override;
+};
+
+class CastFearWardOnMainTankAction : public BuffOnMainTankAction
+{
+public:
+    CastFearWardOnMainTankAction(PlayerbotAI* botAI) : BuffOnMainTankAction(botAI, "fear ward") {}
 };
 
 class CastMindSearAction : public CastSpellAction

--- a/src/Ai/Class/Priest/PriestAiObjectContext.cpp
+++ b/src/Ai/Class/Priest/PriestAiObjectContext.cpp
@@ -96,7 +96,7 @@ public:
         creators["touch of weakness"] = &PriestTriggerFactoryInternal::touch_of_weakness;
         creators["hex of weakness"] = &PriestTriggerFactoryInternal::hex_of_weakness;
         creators["shadowguard"] = &PriestTriggerFactoryInternal::shadowguard;
-        creators["fear ward"] = &PriestTriggerFactoryInternal::fear_ward;
+        creators["fear ward on main tank"] = &PriestTriggerFactoryInternal::fear_ward_on_main_tank;
         creators["feedback"] = &PriestTriggerFactoryInternal::feedback;
         creators["binding heal"] = &PriestTriggerFactoryInternal::binding_heal;
         creators["chastise"] = &PriestTriggerFactoryInternal::chastise;
@@ -135,7 +135,7 @@ private:
     static Trigger* shadow_protection(PlayerbotAI* botAI) { return new ShadowProtectionTrigger(botAI); }
     static Trigger* shackle_undead(PlayerbotAI* botAI) { return new ShackleUndeadTrigger(botAI); }
     static Trigger* feedback(PlayerbotAI* botAI) { return new FeedbackTrigger(botAI); }
-    static Trigger* fear_ward(PlayerbotAI* botAI) { return new FearWardTrigger(botAI); }
+    static Trigger* fear_ward_on_main_tank(PlayerbotAI* botAI) { return new FearWardOnMainTankTrigger(botAI); }
     static Trigger* shadowguard(PlayerbotAI* botAI) { return new ShadowguardTrigger(botAI); }
     static Trigger* hex_of_weakness(PlayerbotAI* botAI) { return new HexOfWeaknessTrigger(botAI); }
     static Trigger* touch_of_weakness(PlayerbotAI* botAI) { return new TouchOfWeaknessTrigger(botAI); }
@@ -215,8 +215,7 @@ public:
         creators["hex of weakness"] = &PriestAiObjectContextInternal::hex_of_weakness;
         creators["shadowguard"] = &PriestAiObjectContextInternal::shadowguard;
         creators["desperate prayer"] = &PriestAiObjectContextInternal::desperate_prayer;
-        creators["fear ward"] = &PriestAiObjectContextInternal::fear_ward;
-        creators["fear ward on party"] = &PriestAiObjectContextInternal::fear_ward_on_party;
+        creators["fear ward on main tank"] = &PriestAiObjectContextInternal::fear_ward_on_main_tank;
         creators["starshards"] = &PriestAiObjectContextInternal::starshards;
         creators["elune's grace"] = &PriestAiObjectContextInternal::elunes_grace;
         creators["feedback"] = &PriestAiObjectContextInternal::feedback;
@@ -308,8 +307,7 @@ private:
     static Action* feedback(PlayerbotAI* botAI) { return new CastFeedbackAction(botAI); }
     static Action* elunes_grace(PlayerbotAI* botAI) { return new CastElunesGraceAction(botAI); }
     static Action* starshards(PlayerbotAI* botAI) { return new CastStarshardsAction(botAI); }
-    static Action* fear_ward_on_party(PlayerbotAI* botAI) { return new CastFearWardOnPartyAction(botAI); }
-    static Action* fear_ward(PlayerbotAI* botAI) { return new CastFearWardAction(botAI); }
+    static Action* fear_ward_on_main_tank(PlayerbotAI* botAI) { return new CastFearWardOnMainTankAction(botAI); }
     static Action* desperate_prayer(PlayerbotAI* botAI) { return new CastDesperatePrayerAction(botAI); }
     static Action* shadowguard(PlayerbotAI* botAI) { return new CastShadowguardAction(botAI); }
     static Action* hex_of_weakness(PlayerbotAI* botAI) { return new CastHexOfWeaknessAction(botAI); }

--- a/src/Ai/Class/Priest/PriestTriggers.cpp
+++ b/src/Ai/Class/Priest/PriestTriggers.cpp
@@ -32,6 +32,15 @@ bool InnerFireTrigger::IsActive()
     return SpellTrigger::IsActive() && !botAI->HasAura(spell, target);
 }
 
+bool FearWardOnMainTankTrigger::IsActive()
+{
+    uint32 const spellId = AI_VALUE2(uint32, "spell id", spell);
+    if (!spellId || bot->HasSpellCooldown(spellId))
+        return false;
+
+    return BuffOnMainTankTrigger::IsActive();
+}
+
 bool ShadowformTrigger::IsActive() { return !botAI->HasAura("shadowform", bot); }
 
 bool ShadowfiendTrigger::IsActive() { return BoostTrigger::IsActive() && !bot->HasSpellCooldown(34433); }

--- a/src/Ai/Class/Priest/PriestTriggers.h
+++ b/src/Ai/Class/Priest/PriestTriggers.h
@@ -31,16 +31,12 @@ BUFF_TRIGGER(InnerFocusTrigger, "inner focus");
 CC_TRIGGER(ShackleUndeadTrigger, "shackle undead");
 INTERRUPT_TRIGGER(SilenceTrigger, "silence");
 INTERRUPT_HEALER_TRIGGER(SilenceEnemyHealerTrigger, "silence");
-
-// racials
 DEBUFF_CHECKISOWNER_TRIGGER(DevouringPlagueTrigger, "devouring plague");
 BUFF_TRIGGER(TouchOfWeaknessTrigger, "touch of weakness");
 DEBUFF_TRIGGER(HexOfWeaknessTrigger, "hex of weakness");
 BUFF_TRIGGER(ShadowguardTrigger, "shadowguard");
-BUFF_TRIGGER(FearWardTrigger, "fear ward");
 DEFLECT_TRIGGER(FeedbackTrigger, "feedback");
 SNARE_TRIGGER(ChastiseTrigger, "chastise");
-
 BOOST_TRIGGER_A(ShadowfiendTrigger, "shadowfiend");
 
 class ShadowProtectionTrigger : public BuffTrigger
@@ -87,6 +83,15 @@ class DivineSpiritTrigger : public BuffTrigger
 public:
     DivineSpiritTrigger(PlayerbotAI* botAI)
         : BuffTrigger(botAI, "divine spirit", 4 * 2000) {}
+
+    bool IsActive() override;
+};
+
+class FearWardOnMainTankTrigger : public BuffOnMainTankTrigger
+{
+public:
+    FearWardOnMainTankTrigger(PlayerbotAI* botAI)
+        : BuffOnMainTankTrigger(botAI, "fear ward", false, 2000) {}
 
     bool IsActive() override;
 };

--- a/src/Ai/Class/Priest/Strategy/GenericPriestStrategy.cpp
+++ b/src/Ai/Class/Priest/Strategy/GenericPriestStrategy.cpp
@@ -23,19 +23,17 @@ void GenericPriestStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
         ACTION_HIGH + 5) }));
     triggers.push_back(new TriggerNode(
         "critical health", { NextAction("power word: shield", ACTION_NORMAL) }));
-
+    triggers.push_back(new TriggerNode("fear ward on main tank",
+        { NextAction("fear ward on main tank", ACTION_HIGH + 3) }));
     triggers.push_back(
         new TriggerNode("low health", { NextAction("power word: shield", ACTION_HIGH) }));
-
     triggers.push_back(
         new TriggerNode("medium mana",
             {
                 NextAction("shadowfiend", ACTION_HIGH + 2),
                 NextAction("inner focus", ACTION_HIGH + 1) }));
-
     triggers.push_back(
         new TriggerNode("low mana", { NextAction("hymn of hope", ACTION_HIGH) }));
-
     triggers.push_back(new TriggerNode("enemy too close for spell",
                                        { NextAction("flee", ACTION_MOVE + 9) }));
     triggers.push_back(new TriggerNode("often", { NextAction("apply oil", 1.0f) }));

--- a/src/Ai/Class/Rogue/Action/RogueActions.cpp
+++ b/src/Ai/Class/Rogue/Action/RogueActions.cpp
@@ -81,118 +81,52 @@ bool CastTricksOfTheTradeOnMainTankAction::isUseful()
 
 bool UseDeadlyPoisonAction::Execute(Event /*event*/)
 {
-    std::vector<std::string> poison_suffixs = {" IX", " VIII", " VII", " VI", " V", " IV", " III", " II", ""};
-    std::vector<Item*> items;
-    std::string poison_name;
-    for (std::string& suffix : poison_suffixs)
+    std::vector<Item*> const items =
+        AI_VALUE2(std::vector<Item*>, "inventory items", "Deadly Poison");
+    for (Item* const item : items)
     {
-        poison_name = "Deadly Poison" + suffix;
-        items = AI_VALUE2(std::vector<Item*>, "inventory items", poison_name);
-        if (!items.empty())
-        {
-            break;
-        }
-    }
-    if (items.empty())
-    {
-        return false;
-    }
-    Item* const itemForSpell = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
-    return UseItem(*items.begin(), ObjectGuid::Empty, itemForSpell);
-    // return UseItemAuto(*items.begin());
-}
+        // This check is needed only if there is a name match. I think the only one is Handbook
+        // of Deadly Poison V, which might be restored by IP. Keeping this here just in case.
+        if (item->GetTemplate()->Class != ITEM_CLASS_CONSUMABLE)
+            continue;
 
-bool UseDeadlyPoisonAction::isPossible()
-{
-    std::vector<std::string> poison_suffixs = {" IX", " VIII", " VII", " VI", " V", " IV", " III", " II", ""};
-    std::vector<Item*> items;
-    std::string poison_name;
-    for (std::string& suffix : poison_suffixs)
-    {
-        poison_name = "Deadly Poison" + suffix;
-        items = AI_VALUE2(std::vector<Item*>, "inventory items", poison_name);
-        if (!items.empty())
-        {
-            break;
-        }
+        Item* const itemForSpell = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
+        return UseItem(item, ObjectGuid::Empty, itemForSpell);
     }
-    return !items.empty();
+
+    return false;
 }
 
 bool UseInstantPoisonAction::Execute(Event /*event*/)
 {
-    std::vector<std::string> poison_suffixs = {" IX", " VIII", " VII", " VI", " V", " IV", " III", " II", ""};
-    std::vector<Item*> items;
-    std::string poison_name;
-    for (std::string& suffix : poison_suffixs)
+    std::vector<Item*> const items =
+        AI_VALUE2(std::vector<Item*>, "inventory items", "Instant Poison");
+    for (Item* const item : items)
     {
-        poison_name = "Instant Poison" + suffix;
-        items = AI_VALUE2(std::vector<Item*>, "inventory items", poison_name);
-        if (!items.empty())
-        {
-            break;
-        }
-    }
-    if (items.empty())
-    {
-        return false;
-    }
-    Item* const itemForSpell = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
-    return UseItem(*items.begin(), ObjectGuid::Empty, itemForSpell);
-}
+        // Not necessary for instant but keeping for symmetry and to guide a potential refactor.
+        if (item->GetTemplate()->Class != ITEM_CLASS_CONSUMABLE)
+            continue;
 
-bool UseInstantPoisonAction::isPossible()
-{
-    std::vector<std::string> poison_suffixs = {" IX", " VIII", " VII", " VI", " V", " IV", " III", " II", ""};
-    std::vector<Item*> items;
-    std::string poison_name;
-    for (std::string& suffix : poison_suffixs)
-    {
-        poison_name = "Instant Poison" + suffix;
-        items = AI_VALUE2(std::vector<Item*>, "inventory items", poison_name);
-        if (!items.empty())
-        {
-            break;
-        }
+        Item* const itemForSpell = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_MAINHAND);
+        return UseItem(item, ObjectGuid::Empty, itemForSpell);
     }
-    return !items.empty();
+
+    return false;
 }
 
 bool UseInstantPoisonOffHandAction::Execute(Event /*event*/)
 {
-    std::vector<std::string> poison_suffixs = {" IX", " VIII", " VII", " VI", " V", " IV", " III", " II", ""};
-    std::vector<Item*> items;
-    std::string poison_name;
-    for (std::string& suffix : poison_suffixs)
+    std::vector<Item*> const items =
+        AI_VALUE2(std::vector<Item*>, "inventory items", "Instant Poison");
+    for (Item* const item : items)
     {
-        poison_name = "Instant Poison" + suffix;
-        items = AI_VALUE2(std::vector<Item*>, "inventory items", poison_name);
-        if (!items.empty())
-        {
-            break;
-        }
-    }
-    if (items.empty())
-    {
-        return false;
-    }
-    Item* const itemForSpell = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
-    return UseItem(*items.begin(), ObjectGuid::Empty, itemForSpell);
-}
+        // Not necessary for instant but keeping for symmetry and to guide a potential refactor.
+        if (item->GetTemplate()->Class != ITEM_CLASS_CONSUMABLE)
+            continue;
 
-bool UseInstantPoisonOffHandAction::isPossible()
-{
-    std::vector<std::string> poison_suffixs = {" IX", " VIII", " VII", " VI", " V", " IV", " III", " II", ""};
-    std::vector<Item*> items;
-    std::string poison_name;
-    for (std::string& suffix : poison_suffixs)
-    {
-        poison_name = "Instant Poison" + suffix;
-        items = AI_VALUE2(std::vector<Item*>, "inventory items", poison_name);
-        if (!items.empty())
-        {
-            break;
-        }
+        Item* const itemForSpell = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_OFFHAND);
+        return UseItem(item, ObjectGuid::Empty, itemForSpell);
     }
-    return !items.empty();
+
+    return false;
 }

--- a/src/Ai/Class/Rogue/Action/RogueActions.h
+++ b/src/Ai/Class/Rogue/Action/RogueActions.h
@@ -155,28 +155,29 @@ public:
 class UseDeadlyPoisonAction : public UseItemAction
 {
 public:
-    UseDeadlyPoisonAction(PlayerbotAI* ai) : UseItemAction(ai, "Deadly Poison") {}
+    UseDeadlyPoisonAction(PlayerbotAI* botAI) : UseItemAction(botAI, "Deadly Poison") {}
 
     bool Execute(Event event) override;
-    bool isPossible() override;
+    bool isPossible() override { return true; }
 };
 
 class UseInstantPoisonAction : public UseItemAction
 {
 public:
-    UseInstantPoisonAction(PlayerbotAI* ai) : UseItemAction(ai, "Instant Poison") {}
+    UseInstantPoisonAction(PlayerbotAI* botAI) : UseItemAction(botAI, "Instant Poison") {}
 
     bool Execute(Event event) override;
-    bool isPossible() override;
+    bool isPossible() override { return true; }
 };
 
 class UseInstantPoisonOffHandAction : public UseItemAction
 {
 public:
-    UseInstantPoisonOffHandAction(PlayerbotAI* ai) : UseItemAction(ai, "Instant Poison Off Hand") {}
+    UseInstantPoisonOffHandAction(PlayerbotAI* botAI)
+        : UseItemAction(botAI, "Instant Poison Off Hand") {}
 
     bool Execute(Event event) override;
-    bool isPossible() override;
+    bool isPossible() override { return true; }
 };
 
 class FanOfKnivesAction : public CastMeleeSpellAction

--- a/src/Ai/Class/Rogue/RogueAiObjectContext.cpp
+++ b/src/Ai/Class/Rogue/RogueAiObjectContext.cpp
@@ -74,9 +74,12 @@ public:
         creators["no stealth"] = &RogueTriggerFactoryInternal::no_stealth;
         creators["stealth"] = &RogueTriggerFactoryInternal::stealth;
         creators["sprint"] = &RogueTriggerFactoryInternal::sprint;
-        creators["main hand weapon no enchant"] = &RogueTriggerFactoryInternal::main_hand_weapon_no_enchant;
-        creators["off hand weapon no enchant"] = &RogueTriggerFactoryInternal::off_hand_weapon_no_enchant;
-        creators["tricks of the trade on main tank"] = &RogueTriggerFactoryInternal::tricks_of_the_trade_on_main_tank;
+        creators["main hand weapon no enchant"] =
+            &RogueTriggerFactoryInternal::main_hand_weapon_no_enchant;
+        creators["off hand weapon no enchant"] =
+            &RogueTriggerFactoryInternal::off_hand_weapon_no_enchant;
+        creators["tricks of the trade on main tank"] =
+            &RogueTriggerFactoryInternal::tricks_of_the_trade_on_main_tank;
         creators["adrenaline rush"] = &RogueTriggerFactoryInternal::adrenaline_rush;
         creators["blade flurry"] = &RogueTriggerFactoryInternal::blade_flurry;
     }
@@ -88,18 +91,27 @@ private:
     static Trigger* slice_and_dice(PlayerbotAI* botAI) { return new SliceAndDiceTrigger(botAI); }
     static Trigger* hunger_for_blood(PlayerbotAI* botAI) { return new HungerForBloodTrigger(botAI); }
     static Trigger* expose_armor(PlayerbotAI* botAI) { return new ExposeArmorTrigger(botAI); }
-    static Trigger* kick_on_enemy_healer(PlayerbotAI* botAI) { return new KickInterruptEnemyHealerSpellTrigger(botAI); }
+    static Trigger* kick_on_enemy_healer(PlayerbotAI* botAI)
+    {
+        return new KickInterruptEnemyHealerSpellTrigger(botAI);
+    }
     static Trigger* unstealth(PlayerbotAI* botAI) { return new UnstealthTrigger(botAI); }
     static Trigger* sap(PlayerbotAI* botAI) { return new SapTrigger(botAI); }
     static Trigger* in_stealth(PlayerbotAI* botAI) { return new InStealthTrigger(botAI); }
     static Trigger* no_stealth(PlayerbotAI* botAI) { return new NoStealthTrigger(botAI); }
     static Trigger* stealth(PlayerbotAI* botAI) { return new StealthTrigger(botAI); }
     static Trigger* sprint(PlayerbotAI* botAI) { return new SprintTrigger(botAI); }
-    static Trigger* main_hand_weapon_no_enchant(PlayerbotAI* ai) { return new MainHandWeaponNoEnchantTrigger(ai); }
-    static Trigger* off_hand_weapon_no_enchant(PlayerbotAI* ai) { return new OffHandWeaponNoEnchantTrigger(ai); }
-    static Trigger* tricks_of_the_trade_on_main_tank(PlayerbotAI* ai)
+    static Trigger* main_hand_weapon_no_enchant(PlayerbotAI* botAI)
     {
-        return new TricksOfTheTradeOnMainTankTrigger(ai);
+        return new MainHandWeaponNoEnchantTrigger(botAI);
+    }
+    static Trigger* off_hand_weapon_no_enchant(PlayerbotAI* botAI)
+    {
+        return new OffHandWeaponNoEnchantTrigger(botAI);
+    }
+    static Trigger* tricks_of_the_trade_on_main_tank(PlayerbotAI* botAI)
+    {
+        return new TricksOfTheTradeOnMainTankTrigger(botAI);
     }
     static Trigger* adrenaline_rush(PlayerbotAI* botAI) { return new AdrenalineRushTrigger(botAI); }
     static Trigger* blade_flurry(PlayerbotAI* botAI) { return new BladeFlurryTrigger(botAI); }
@@ -139,35 +151,54 @@ public:
         creators["sap"] = &RogueAiObjectContextInternal::sap;
         creators["check stealth"] = &RogueAiObjectContextInternal::check_stealth;
         creators["envenom"] = &RogueAiObjectContextInternal::envenom;
-        creators["tricks of the trade on main tank"] = &RogueAiObjectContextInternal::tricks_of_the_trade_on_main_tank;
-        creators["use instant poison on main hand"] = &RogueAiObjectContextInternal::use_instant_poison;
-        creators["use deadly poison on off hand"] = &RogueAiObjectContextInternal::use_deadly_poison;
-        creators["use instant poison on off hand"] = &RogueAiObjectContextInternal::use_instant_poison_off_hand;
+        creators["tricks of the trade on main tank"] =
+            &RogueAiObjectContextInternal::tricks_of_the_trade_on_main_tank;
+        creators["use instant poison on main hand"] =
+            &RogueAiObjectContextInternal::use_instant_poison;
+        creators["use deadly poison on off hand"] =
+            &RogueAiObjectContextInternal::use_deadly_poison;
+        creators["use instant poison on off hand"] =
+            &RogueAiObjectContextInternal::use_instant_poison_off_hand;
         creators["fan of knives"] = &RogueAiObjectContextInternal::fan_of_knives;
         creators["killing spree"] = &RogueAiObjectContextInternal::killing_spree;
         creators["cold blood"] = &RogueAiObjectContextInternal::cold_blood;
     }
 
 private:
-    static Action* adrenaline_rush(PlayerbotAI* botAI) { return new CastAdrenalineRushAction(botAI); }
+    static Action* adrenaline_rush(PlayerbotAI* botAI)
+    {
+        return new CastAdrenalineRushAction(botAI);
+    }
     static Action* blade_flurry(PlayerbotAI* botAI) { return new CastBladeFlurryAction(botAI); }
     static Action* riposte(PlayerbotAI* botAI) { return new CastRiposteAction(botAI); }
     static Action* mutilate(PlayerbotAI* botAI) { return new CastMutilateAction(botAI); }
-    static Action* sinister_strike(PlayerbotAI* botAI) { return new CastSinisterStrikeAction(botAI); }
+    static Action* sinister_strike(PlayerbotAI* botAI)
+    {
+        return new CastSinisterStrikeAction(botAI);
+    }
     static Action* gouge(PlayerbotAI* botAI) { return new CastGougeAction(botAI); }
     static Action* kidney_shot(PlayerbotAI* botAI) { return new CastKidneyShotAction(botAI); }
     static Action* rupture(PlayerbotAI* botAI) { return new CastRuptureAction(botAI); }
     static Action* slice_and_dice(PlayerbotAI* botAI) { return new CastSliceAndDiceAction(botAI); }
-    static Action* hunger_for_blood(PlayerbotAI* botAI) { return new CastHungerForBloodAction(botAI); }
+    static Action* hunger_for_blood(PlayerbotAI* botAI)
+    {
+        return new CastHungerForBloodAction(botAI);
+    }
     static Action* eviscerate(PlayerbotAI* botAI) { return new CastEviscerateAction(botAI); }
     static Action* vanish(PlayerbotAI* botAI) { return new CastVanishAction(botAI); }
     static Action* evasion(PlayerbotAI* botAI) { return new CastEvasionAction(botAI); }
-    static Action* cloak_of_shadows(PlayerbotAI* botAI) { return new CastCloakOfShadowsAction(botAI); }
+    static Action* cloak_of_shadows(PlayerbotAI* botAI)
+    {
+        return new CastCloakOfShadowsAction(botAI);
+    }
     static Action* kick(PlayerbotAI* botAI) { return new CastKickAction(botAI); }
     static Action* feint(PlayerbotAI* botAI) { return new CastFeintAction(botAI); }
     static Action* backstab(PlayerbotAI* botAI) { return new CastBackstabAction(botAI); }
     static Action* expose_armor(PlayerbotAI* botAI) { return new CastExposeArmorAction(botAI); }
-    static Action* kick_on_enemy_healer(PlayerbotAI* botAI) { return new CastKickOnEnemyHealerAction(botAI); }
+    static Action* kick_on_enemy_healer(PlayerbotAI* botAI)
+    {
+        return new CastKickOnEnemyHealerAction(botAI);
+    }
     static Action* ambush(PlayerbotAI* botAI) { return new CastAmbushAction(botAI); }
     static Action* stealth(PlayerbotAI* botAI) { return new CastStealthAction(botAI); }
     static Action* sprint(PlayerbotAI* botAI) { return new CastSprintAction(botAI); }
@@ -177,17 +208,26 @@ private:
     static Action* check_stealth(PlayerbotAI* botAI) { return new CheckStealthAction(botAI); }
     static Action* sap(PlayerbotAI* botAI) { return new CastSapAction(botAI); }
     static Action* unstealth(PlayerbotAI* botAI) { return new UnstealthAction(botAI); }
-    static Action* envenom(PlayerbotAI* ai) { return new CastEnvenomAction(ai); }
-    static Action* tricks_of_the_trade_on_main_tank(PlayerbotAI* ai)
+    static Action* envenom(PlayerbotAI* botAI) { return new CastEnvenomAction(botAI); }
+    static Action* tricks_of_the_trade_on_main_tank(PlayerbotAI* botAI)
     {
-        return new CastTricksOfTheTradeOnMainTankAction(ai);
+        return new CastTricksOfTheTradeOnMainTankAction(botAI);
     }
-    static Action* use_instant_poison(PlayerbotAI* ai) { return new UseInstantPoisonAction(ai); }
-    static Action* use_deadly_poison(PlayerbotAI* ai) { return new UseDeadlyPoisonAction(ai); }
-    static Action* use_instant_poison_off_hand(PlayerbotAI* ai) { return new UseInstantPoisonOffHandAction(ai); }
-    static Action* fan_of_knives(PlayerbotAI* ai) { return new FanOfKnivesAction(ai); }
-    static Action* killing_spree(PlayerbotAI* ai) { return new CastKillingSpreeAction(ai); }
-    static Action* cold_blood(PlayerbotAI* ai) { return new CastColdBloodAction(ai); }
+    static Action* use_instant_poison(PlayerbotAI* botAI)
+    {
+        return new UseInstantPoisonAction(botAI);
+    }
+    static Action* use_deadly_poison(PlayerbotAI* botAI)
+    {
+        return new UseDeadlyPoisonAction(botAI);
+    }
+    static Action* use_instant_poison_off_hand(PlayerbotAI* botAI)
+    {
+        return new UseInstantPoisonOffHandAction(botAI);
+    }
+    static Action* fan_of_knives(PlayerbotAI* botAI) { return new FanOfKnivesAction(botAI); }
+    static Action* killing_spree(PlayerbotAI* botAI) { return new CastKillingSpreeAction(botAI); }
+    static Action* cold_blood(PlayerbotAI* botAI) { return new CastColdBloodAction(botAI); }
 };
 
 SharedNamedObjectContextList<Strategy> RogueAiObjectContext::sharedStrategyContexts;
@@ -209,26 +249,30 @@ void RogueAiObjectContext::BuildSharedContexts()
     BuildSharedValueContexts(sharedValueContexts);
 }
 
-void RogueAiObjectContext::BuildSharedStrategyContexts(SharedNamedObjectContextList<Strategy>& strategyContexts)
+void RogueAiObjectContext::BuildSharedStrategyContexts(
+    SharedNamedObjectContextList<Strategy>& strategyContexts)
 {
     AiObjectContext::BuildSharedStrategyContexts(strategyContexts);
     strategyContexts.Add(new RogueStrategyFactoryInternal());
     strategyContexts.Add(new RogueCombatStrategyFactoryInternal());
 }
 
-void RogueAiObjectContext::BuildSharedActionContexts(SharedNamedObjectContextList<Action>& actionContexts)
+void RogueAiObjectContext::BuildSharedActionContexts(
+    SharedNamedObjectContextList<Action>& actionContexts)
 {
     AiObjectContext::BuildSharedActionContexts(actionContexts);
     actionContexts.Add(new RogueAiObjectContextInternal());
 }
 
-void RogueAiObjectContext::BuildSharedTriggerContexts(SharedNamedObjectContextList<Trigger>& triggerContexts)
+void RogueAiObjectContext::BuildSharedTriggerContexts(
+    SharedNamedObjectContextList<Trigger>& triggerContexts)
 {
     AiObjectContext::BuildSharedTriggerContexts(triggerContexts);
     triggerContexts.Add(new RogueTriggerFactoryInternal());
 }
 
-void RogueAiObjectContext::BuildSharedValueContexts(SharedNamedObjectContextList<UntypedValue>& valueContexts)
+void RogueAiObjectContext::BuildSharedValueContexts(
+    SharedNamedObjectContextList<UntypedValue>& valueContexts)
 {
     AiObjectContext::BuildSharedValueContexts(valueContexts);
 }

--- a/src/Ai/Class/Rogue/Strategy/AssassinationRogueStrategy.cpp
+++ b/src/Ai/Class/Rogue/Strategy/AssassinationRogueStrategy.cpp
@@ -57,7 +57,8 @@ private:
     }
 };
 
-AssassinationRogueStrategy::AssassinationRogueStrategy(PlayerbotAI* ai) : MeleeCombatStrategy(ai)
+AssassinationRogueStrategy::AssassinationRogueStrategy(PlayerbotAI* botAI)
+    : GenericRogueStrategy(botAI)
 {
     actionNodeFactories.Add(new AssassinationRogueStrategyActionNodeFactory());
 }
@@ -71,7 +72,7 @@ std::vector<NextAction> AssassinationRogueStrategy::getDefaultActions()
 
 void AssassinationRogueStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
-    MeleeCombatStrategy::InitTriggers(triggers);
+    GenericRogueStrategy::InitTriggers(triggers);
 
     triggers.push_back(
         new TriggerNode(

--- a/src/Ai/Class/Rogue/Strategy/AssassinationRogueStrategy.h
+++ b/src/Ai/Class/Rogue/Strategy/AssassinationRogueStrategy.h
@@ -7,18 +7,17 @@
 #ifndef PLAYERBOTS_ASSASSINATIONROGUESTRATEGY_H
 #define PLAYERBOTS_ASSASSINATIONROGUESTRATEGY_H
 
-#include "MeleeCombatStrategy.h"
+#include "GenericRogueStrategy.h"
 
-class AssassinationRogueStrategy : public MeleeCombatStrategy
+class AssassinationRogueStrategy : public GenericRogueStrategy
 {
 public:
-    AssassinationRogueStrategy(PlayerbotAI* ai);
+    AssassinationRogueStrategy(PlayerbotAI* botAI);
 
 public:
     virtual void InitTriggers(std::vector<TriggerNode*>& triggers) override;
     virtual std::string const getName() override { return "melee"; }
     virtual std::vector<NextAction> getDefaultActions() override;
-    uint32 GetType() const override { return MeleeCombatStrategy::GetType() | STRATEGY_TYPE_DPS; }
 };
 
 #endif

--- a/src/Ai/Class/Rogue/Strategy/DpsRogueStrategy.cpp
+++ b/src/Ai/Class/Rogue/Strategy/DpsRogueStrategy.cpp
@@ -61,7 +61,7 @@ private:
     }
 };
 
-DpsRogueStrategy::DpsRogueStrategy(PlayerbotAI* botAI) : MeleeCombatStrategy(botAI)
+DpsRogueStrategy::DpsRogueStrategy(PlayerbotAI* botAI) : GenericRogueStrategy(botAI)
 {
     actionNodeFactories.Add(new DpsRogueStrategyActionNodeFactory());
 }
@@ -76,7 +76,7 @@ std::vector<NextAction> DpsRogueStrategy::getDefaultActions()
 
 void DpsRogueStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
-    MeleeCombatStrategy::InitTriggers(triggers);
+    GenericRogueStrategy::InitTriggers(triggers);
 
     triggers.push_back(
         new TriggerNode(

--- a/src/Ai/Class/Rogue/Strategy/DpsRogueStrategy.h
+++ b/src/Ai/Class/Rogue/Strategy/DpsRogueStrategy.h
@@ -7,12 +7,11 @@
 #ifndef PLAYERBOTS_DPSROGUESTRATEGY_H
 #define PLAYERBOTS_DPSROGUESTRATEGY_H
 
-#include "CombatStrategy.h"
-#include "MeleeCombatStrategy.h"
+#include "GenericRogueStrategy.h"
 
 class PlayerbotAI;
 
-class DpsRogueStrategy : public MeleeCombatStrategy
+class DpsRogueStrategy : public GenericRogueStrategy
 {
 public:
     DpsRogueStrategy(PlayerbotAI* botAI);
@@ -20,7 +19,6 @@ public:
     void InitTriggers(std::vector<TriggerNode*>& triggers) override;
     std::string const getName() override { return "dps"; }
     std::vector<NextAction> getDefaultActions() override;
-    uint32 GetType() const override { return MeleeCombatStrategy::GetType() | STRATEGY_TYPE_DPS; }
 };
 
 class StealthedRogueStrategy : public Strategy

--- a/src/Ai/Class/Rogue/Strategy/GenericRogueStrategy.cpp
+++ b/src/Ai/Class/Rogue/Strategy/GenericRogueStrategy.cpp
@@ -1,0 +1,55 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "GenericRogueStrategy.h"
+
+class GenericRogueStrategyActionNodeFactory : public NamedObjectFactory<ActionNode>
+{
+public:
+    GenericRogueStrategyActionNodeFactory()
+    {
+        creators["use deadly poison on off hand"] = &use_deadly_poison_on_off_hand;
+    }
+
+private:
+    static ActionNode* use_deadly_poison_on_off_hand([[maybe_unused]] PlayerbotAI* botAI)
+    {
+        return new ActionNode("use deadly poison on off hand",
+                            /*P*/ {},
+                            /*A*/ { NextAction("use instant poison on off hand") },
+                            /*C*/ {});
+    }
+};
+
+GenericRogueStrategy::GenericRogueStrategy(PlayerbotAI* botAI) : CombatStrategy(botAI)
+{
+    actionNodeFactories.Add(new GenericRogueStrategyActionNodeFactory());
+}
+
+void GenericRogueStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+{
+    CombatStrategy::InitTriggers(triggers);
+
+    // The right priority for poisons is probably above any attack but below any survival ability.
+    // Everything about Rogues needs to be redone, but right now 26 is just below Cloak of Shadows
+    // and Evasion and just above Slice and Dice.
+    triggers.push_back(
+        new TriggerNode(
+            "main hand weapon no enchant",
+            {
+                NextAction("use instant poison on main hand", 26.0f)
+            }
+        )
+    );
+    triggers.push_back(
+        new TriggerNode(
+            "off hand weapon no enchant",
+            {
+                NextAction("use deadly poison on off hand", 25.5f)
+            }
+        )
+    );
+}

--- a/src/Ai/Class/Rogue/Strategy/GenericRogueStrategy.h
+++ b/src/Ai/Class/Rogue/Strategy/GenericRogueStrategy.h
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_GENERICROGUESTRATEGY_H
+#define PLAYERBOTS_GENERICROGUESTRATEGY_H
+
+#include "CombatStrategy.h"
+
+class PlayerbotAI;
+
+class GenericRogueStrategy : public CombatStrategy
+{
+public:
+    GenericRogueStrategy(PlayerbotAI* botAI);
+
+    std::string const getName() override { return "rogue"; }
+    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
+    uint32 GetType() const override
+    {
+        return CombatStrategy::GetType() | STRATEGY_TYPE_DPS | STRATEGY_TYPE_MELEE;
+    }
+};
+
+#endif

--- a/src/Ai/Class/Warrior/Strategy/GenericWarriorStrategy.cpp
+++ b/src/Ai/Class/Warrior/Strategy/GenericWarriorStrategy.cpp
@@ -38,10 +38,10 @@ void GenericWarriorStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
         "fear sleep sap", { NextAction("berserker rage", ACTION_EMERGENCY + 1) }));
 }
 
-class WarrirorAoeStrategyActionNodeFactory : public NamedObjectFactory<ActionNode>
+class WarriorAoeStrategyActionNodeFactory : public NamedObjectFactory<ActionNode>
 {
 public:
-    WarrirorAoeStrategyActionNodeFactory()
+    WarriorAoeStrategyActionNodeFactory()
     {
 
     }
@@ -50,12 +50,12 @@ private:
 
 };
 
-WarrirorAoeStrategy::WarrirorAoeStrategy(PlayerbotAI* botAI) : CombatStrategy(botAI)
+WarriorAoeStrategy::WarriorAoeStrategy(PlayerbotAI* botAI) : CombatStrategy(botAI)
 {
-    actionNodeFactories.Add(new WarrirorAoeStrategyActionNodeFactory());
+    actionNodeFactories.Add(new WarriorAoeStrategyActionNodeFactory());
 }
 
-void WarrirorAoeStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+void WarriorAoeStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
     triggers.push_back(new TriggerNode(
         "light aoe", { NextAction("sweeping strikes", ACTION_HIGH + 7),

--- a/src/Ai/Class/Warrior/Strategy/GenericWarriorStrategy.h
+++ b/src/Ai/Class/Warrior/Strategy/GenericWarriorStrategy.h
@@ -226,10 +226,10 @@ public:
     std::string const getName() override { return "warrior"; }
 };
 
-class WarrirorAoeStrategy : public CombatStrategy
+class WarriorAoeStrategy : public CombatStrategy
 {
 public:
-    WarrirorAoeStrategy(PlayerbotAI* botAI);
+    WarriorAoeStrategy(PlayerbotAI* botAI);
 
     void InitTriggers(std::vector<TriggerNode*>& triggers) override;
     std::string const getName() override { return "aoe"; }

--- a/src/Ai/Class/Warrior/WarriorAiObjectContext.cpp
+++ b/src/Ai/Class/Warrior/WarriorAiObjectContext.cpp
@@ -27,7 +27,7 @@ public:
 
 private:
     static Strategy* nc(PlayerbotAI* botAI) { return new GenericWarriorNonCombatStrategy(botAI); }
-    static Strategy* warrior_aoe(PlayerbotAI* botAI) { return new WarrirorAoeStrategy(botAI); }
+    static Strategy* warrior_aoe(PlayerbotAI* botAI) { return new WarriorAoeStrategy(botAI); }
     static Strategy* pull(PlayerbotAI* botAI) { return new WarriorPullStrategy(botAI); }
 };
 

--- a/src/Ai/Dungeon/AC/ACActionContext.h
+++ b/src/Ai/Dungeon/AC/ACActionContext.h
@@ -8,13 +8,12 @@
 #define PLAYERBOTS_ACACTIONCONTEXT_H
 
 #include "ACActions.h"
-#include "Action.h"
 #include "NamedObjectContext.h"
 
 class TbcDungeonAuchenaiCryptsActionContext : public NamedObjectContext<Action>
 {
 public:
-    TbcDungeonAuchenaiCryptsActionContext() : NamedObjectContext<Action>(false, true)
+    TbcDungeonAuchenaiCryptsActionContext()
     {
         creators["shirrak tank position boss"] =
             &TbcDungeonAuchenaiCryptsActionContext::shirrak_tank_position_boss;
@@ -26,7 +25,6 @@ public:
             &TbcDungeonAuchenaiCryptsActionContext::shirrak_ranged_keep_distance;
     }
 private:
-
     static Action* shirrak_tank_position_boss(
         PlayerbotAI* botAI) { return new ShirrakTankPositionBossAction(botAI); }
 

--- a/src/Ai/Dungeon/AC/ACActions.cpp
+++ b/src/Ai/Dungeon/AC/ACActions.cpp
@@ -6,16 +6,16 @@
 
 #include "ACActions.h"
 #include "ACTriggers.h"
-#include "AiFactory.h"
+#include "EncounterHelpers.h"
+#include "PlayerbotAIConfig.h"
 #include "Playerbots.h"
+#include <algorithm>
+#include <iterator>
+#include <vector>
 
-// Shirrak the Dead Watcher
+using namespace EncounterHelpers;
 
-static const Position SHIRRAK_RANGED_POSITION = { -21.777f, -162.700f, 26.062f };
-static const Position SHIRRAK_TANK_POSITION = { -65.171f, -162.920f, 26.504f };
-
-// Tank will position Shirrak at the specified coordinates, further down the corridor past the stairs
-
+// Tank will position Shirrak at the specified coordinates, up the stairs
 bool ShirrakTankPositionBossAction::Execute(Event /*event*/)
 {
     Unit* shirrak = AI_VALUE2(Unit*, "find target", "shirrak the dead watcher");
@@ -25,70 +25,63 @@ bool ShirrakTankPositionBossAction::Execute(Event /*event*/)
     if (bot->GetVictim() != shirrak)
         return Attack(shirrak);
 
-    if (shirrak->GetVictim() == bot && bot->IsWithinMeleeRange(shirrak) &&
-        bot->GetHealthPct()>30.0f)
+    if (shirrak->GetVictim() != bot || !bot->IsWithinMeleeRange(shirrak) ||
+        bot->GetHealthPct() < 30.0f)
     {
-        Position const& position = SHIRRAK_TANK_POSITION;
-        float distToPosition = bot->GetExactDist2d(position.GetPositionX(),
-                                                   position.GetPositionY());
-        if (distToPosition > 6.0f)
-        {
-            float dX = position.GetPositionX() - bot->GetPositionX();
-            float dY = position.GetPositionY() - bot->GetPositionY();
-            float moveDist = std::min(2.0f, distToPosition);
-            float moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
-            float moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
-
-            return MoveTo(bot->GetMapId(), moveX, moveY, bot->GetPositionZ(), false, false,
-                   false, false, MovementPriority::MOVEMENT_COMBAT, true, true);
-        }
+        return false;
     }
 
-    return false;
-}
+    constexpr float arrivalDist = 3.0f;
+    float moveX;
+    float moveY;
+    bool backwards;
+    if (!GetStepToPosition(
+            bot, SHIRRAK_TANK_POSITION, arrivalDist, shirrak, moveX, moveY, backwards))
+    {
+        return false;
+    }
 
-//  Flee from Shirrak's Focus Fire
+    return MoveTo(
+        bot->GetMapId(), moveX, moveY, bot->GetPositionZ(), false, false, false, false,
+        MovementPriority::MOVEMENT_COMBAT, true, backwards);
+}
 
 bool ShirrakFleeFocusFireAction::Execute(Event /*event*/)
 {
-    std::list<Creature*> creatureList;
-        bot->GetCreatureListWithEntryInGrid(creatureList, static_cast<uint32>(AuchenaiCryptsIDs::NPC_FOCUS_FIRE), 20.0f);
+    Creature* flare = bot->FindNearestCreature(NPC_FOCUS_FIRE, FLARE_SEARCH_RADIUS);
+    if (!flare)
+        return false;
 
-    for (Creature* flare : creatureList)
-    {
-        if (flare && flare->IsAlive())
-        {
-            float currentDistance = bot->GetDistance2d(flare);
-            constexpr float safeDistance = 12.0f;
-            constexpr float buffer = 5.0f;
+    float currentDistance = bot->GetExactDist2d(flare);
+    constexpr float safeDistance = 12.0f;
+    if (currentDistance >= safeDistance)
+        return false;
 
-            if (currentDistance < safeDistance)
-            {
-                bot->AttackStop();
-
-                float distanceToMove = safeDistance - currentDistance + buffer;
-
-                return MoveAway(flare, distanceToMove);
-            }
-        }
-    }
-    return false;
+    bot->CastStop();
+    float distanceToMove = safeDistance - currentDistance;
+    return MoveAway(flare, distanceToMove);
 }
 
 // Ranged should keep distance from Shirrak, staying at the edge of the stairs
-
 bool ShirrakRangedKeepDistanceAction::Execute(Event /*event*/)
 {
+    Unit* shirrak = AI_VALUE2(Unit*, "find target", "shirrak the dead watcher");
+    if (!shirrak)
+        return false;
+
+    if (bot->GetExactDist(shirrak) - shirrak->GetCombatReach() > sPlayerbotAIConfig.spellDistance)
+        return false;
+
+    Group* group = bot->GetGroup();
+    if (!group)
+        return false;
 
     std::vector<Player*> rangedBots;
-    if (Group* group = bot->GetGroup())
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
-        for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
-        {
-            Player* member = ref->GetSource();
-            if (member && botAI->IsRanged(member))
-                rangedBots.push_back(member);
-        }
+        Player* member = ref->GetSource();
+        if (member && PlayerbotAI::IsRanged(member))
+            rangedBots.push_back(member);
     }
 
     auto findIt = std::find(rangedBots.begin(), rangedBots.end(), bot);
@@ -98,26 +91,25 @@ bool ShirrakRangedKeepDistanceAction::Execute(Event /*event*/)
     constexpr float arcSpan = M_PI / 2.0f;
     float arcCenter = M_PI;
     float arcStart = arcCenter - (arcSpan / 2.0f);
+    float angle = (count <= 1)
+        ? arcCenter : (arcStart + (arcSpan * (float)botIndex / (float)(count - 1)));
 
-    float angle = (count <= 1) ? arcCenter : (arcStart + (arcSpan * (float)botIndex / (float)(count - 1)));
-
+    Position const& position = SHIRRAK_RANGED_POSITION;
     constexpr float spreadRadius = 3.0f;
-    float targetX = SHIRRAK_RANGED_POSITION.GetPositionX() + cos(angle) * spreadRadius;
-    float targetY = SHIRRAK_RANGED_POSITION.GetPositionY() + sin(angle) * spreadRadius;
+    float targetX = position.GetPositionX() + cos(angle) * spreadRadius;
+    float targetY = position.GetPositionY() + sin(angle) * spreadRadius;
 
     float distToSpot = bot->GetExactDist2d(targetX, targetY);
+    if (distToSpot <= 4.0f)
+        return false;
 
-    if (distToSpot > 4.0f)
-    {
-        float dX = targetX - bot->GetPositionX();
-        float dY = targetY - bot->GetPositionY();
+    float dX = targetX - bot->GetPositionX();
+    float dY = targetY - bot->GetPositionY();
+    float moveDist = std::min(2.0f, distToSpot);
+    float moveX = bot->GetPositionX() + (dX / distToSpot) * moveDist;
+    float moveY = bot->GetPositionY() + (dY / distToSpot) * moveDist;
 
-        float moveDist = std::min(2.0f, distToSpot);
-        float moveX = bot->GetPositionX() + (dX / distToSpot) * moveDist;
-        float moveY = bot->GetPositionY() + (dY / distToSpot) * moveDist;
-
-        return MoveTo(bot->GetMapId(), moveX, moveY, bot->GetPositionZ(), false, false,
-                      false, false, MovementPriority::MOVEMENT_COMBAT, true, false);
-    }
-    return false;
+    return MoveTo(
+        bot->GetMapId(), moveX, moveY, bot->GetPositionZ(), false, false, false, false,
+        MovementPriority::MOVEMENT_COMBAT, true, false);
 }

--- a/src/Ai/Dungeon/AC/ACActions.h
+++ b/src/Ai/Dungeon/AC/ACActions.h
@@ -16,21 +16,24 @@
 class ShirrakTankPositionBossAction : public AttackAction
 {
 public:
-    ShirrakTankPositionBossAction(PlayerbotAI* botAI) : AttackAction(botAI, "shirrak tank position boss") {}
+    ShirrakTankPositionBossAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "shirrak tank position boss") {}
     bool Execute(Event event) override;
 };
 
 class ShirrakFleeFocusFireAction : public MovementAction
 {
 public:
-    ShirrakFleeFocusFireAction(PlayerbotAI* botAI) : MovementAction(botAI, "shirrak flee focus fire") {}
+    ShirrakFleeFocusFireAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "shirrak flee focus fire") {}
     bool Execute(Event event) override;
 };
 
 class ShirrakRangedKeepDistanceAction : public MovementAction
 {
 public:
-    ShirrakRangedKeepDistanceAction(PlayerbotAI* botAI) : MovementAction(botAI, "shirrak ranged keep distance") {}
+    ShirrakRangedKeepDistanceAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "shirrak ranged keep distance") {}
     bool Execute(Event event) override;
 };
 

--- a/src/Ai/Dungeon/AC/ACMultipliers.cpp
+++ b/src/Ai/Dungeon/AC/ACMultipliers.cpp
@@ -7,8 +7,8 @@
 #include "ACMultipliers.h"
 #include "ACActions.h"
 #include "ACTriggers.h"
-#include "AiObjectContext.h"
-#include "FollowActions.h"
+#include "HunterActions.h"
+#include "MageActions.h"
 #include "MovementActions.h"
 #include "Playerbots.h"
 #include "ReachTargetActions.h"
@@ -18,34 +18,30 @@
 // Flee from Focus Fire and dont run back in
 float ShirrakFleeFocusFireMultiplier::GetValue(Action* action)
 {
+    if (dynamic_cast<AttackAction*>(action))
+        return 1.0f;
+
+    bool const isMovementSpell = dynamic_cast<CastReachTargetSpellAction*>(action) ||
+        dynamic_cast<CastBlinkBackAction*>(action) || dynamic_cast<CastDisengageAction*>(action);
+
+    if (!isMovementSpell && !dynamic_cast<MovementAction*>(action))
+        return 1.0f;
+
     if (!AI_VALUE2(Unit*, "find target", "shirrak the dead watcher"))
         return 1.0f;
 
-    std::list<Creature*> creatureList;
-    bot->GetCreatureListWithEntryInGrid(creatureList, static_cast<uint32>(AuchenaiCryptsIDs::NPC_FOCUS_FIRE), 20.0f);
+    if (dynamic_cast<ShirrakFleeFocusFireAction*>(action))
+        return 1.0f;
 
-    for (Creature* flare : creatureList)
-    {
-        if (flare && flare->IsAlive())
-        {
-            if (dynamic_cast<CastReachTargetSpellAction*>(action))
-                return 0.0f;
+    Creature* flare = bot->FindNearestCreature(NPC_FOCUS_FIRE, FLARE_SEARCH_RADIUS);
+    if (!flare)
+        return 1.0f;
 
-            float currentDistance = bot->GetDistance2d(flare);
-            constexpr float safeDistance = 12.0f;
-            constexpr float buffer = 5.0f;
+    if (isMovementSpell)
+        return 0.0f;
 
-            if (currentDistance < safeDistance + buffer && (
-                dynamic_cast<CombatFormationMoveAction*>(action) ||
-                dynamic_cast<ShirrakRangedKeepDistanceAction*>(action) ||
-                dynamic_cast<FleeAction*>(action) ||
-                dynamic_cast<FollowAction*>(action) ||
-                dynamic_cast<ReachTargetAction*>(action) ||
-                dynamic_cast<AvoidAoeAction*>(action)))
-            {
-                return 0.0f;
-            }
-        }
-    }
-    return 1.0f;
+    float currentDistance = bot->GetExactDist2d(flare);
+    constexpr float safeDistance = 12.0f;
+    constexpr float buffer = 2.0f;
+    return currentDistance < safeDistance + buffer ? 0.0f : 1.0f;
 }

--- a/src/Ai/Dungeon/AC/ACMultipliers.h
+++ b/src/Ai/Dungeon/AC/ACMultipliers.h
@@ -12,7 +12,8 @@
 class ShirrakFleeFocusFireMultiplier : public Multiplier
 {
 public:
-    ShirrakFleeFocusFireMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "shirrak flee focus fire") {}
+    ShirrakFleeFocusFireMultiplier(PlayerbotAI* botAI)
+        : Multiplier(botAI, "shirrak flee focus fire") {}
     float GetValue(Action* action) override;
 };
 

--- a/src/Ai/Dungeon/AC/ACStrategy.cpp
+++ b/src/Ai/Dungeon/AC/ACStrategy.cpp
@@ -12,13 +12,13 @@ void TbcDungeonAuchenaiCryptsStrategy::InitTriggers(std::vector<TriggerNode*>& t
 {
     // Shirrak The Dead Watcher
     triggers.push_back(new TriggerNode("shirrak tank position boss", {
-        NextAction("shirrak tank position boss", ACTION_RAID + 1) }));
+        NextAction("shirrak tank position boss", ACTION_RAID) }));
 
     triggers.push_back(new TriggerNode("shirrak flee focus fire", {
         NextAction("shirrak flee focus fire", ACTION_EMERGENCY + 10) }));
 
     triggers.push_back(new TriggerNode("shirrak ranged keep distance", {
-        NextAction("shirrak ranged keep distance", ACTION_RAID + 1) }));
+        NextAction("shirrak ranged keep distance", ACTION_RAID) }));
 }
 
 void TbcDungeonAuchenaiCryptsStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)

--- a/src/Ai/Dungeon/AC/ACStrategy.h
+++ b/src/Ai/Dungeon/AC/ACStrategy.h
@@ -9,12 +9,13 @@
 
 #include "Multiplier.h"
 #include "Strategy.h"
+#include <string>
+#include <vector>
 
 class TbcDungeonAuchenaiCryptsStrategy : public Strategy
 {
 public:
     TbcDungeonAuchenaiCryptsStrategy(PlayerbotAI* botAI) : Strategy(botAI) {}
-
     virtual std::string const getName() override { return "tbc-ac"; }
 
     virtual void InitTriggers(std::vector<TriggerNode*> &triggers) override;

--- a/src/Ai/Dungeon/AC/ACTriggerContext.h
+++ b/src/Ai/Dungeon/AC/ACTriggerContext.h
@@ -9,7 +9,6 @@
 
 #include "ACTriggers.h"
 #include "NamedObjectContext.h"
-#include "TriggerContext.h"
 
 class TbcDungeonAuchenaiCryptsTriggerContext : public NamedObjectContext<Trigger>
 {

--- a/src/Ai/Dungeon/AC/ACTriggers.cpp
+++ b/src/Ai/Dungeon/AC/ACTriggers.cpp
@@ -5,16 +5,14 @@
  */
 
 #include "ACTriggers.h"
-#include "AiObject.h"
-#include "AiObjectContext.h"
 #include "Playerbots.h"
 
 // Shirrak the Dead Watcher
 
 bool ShirrakTankPositionBossTrigger::IsActive()
 {
-    return botAI->IsTank(bot) &&
-           AI_VALUE2(Unit*, "find target", "shirrak the dead watcher");
+    return PlayerbotAI::IsTank(bot) &&
+        AI_VALUE2(Unit*, "find target", "shirrak the dead watcher");
 }
 
 bool ShirrakFleeFocusFireTrigger::IsActive()
@@ -22,19 +20,11 @@ bool ShirrakFleeFocusFireTrigger::IsActive()
     if (!AI_VALUE2(Unit*, "find target", "shirrak the dead watcher"))
         return false;
 
-    std::list<Creature*> creatureList;
-    bot->GetCreatureListWithEntryInGrid(creatureList, static_cast<uint32>(AuchenaiCryptsIDs::NPC_FOCUS_FIRE), 20.0f);
-
-    for (Creature* flare : creatureList)
-    {
-        if (flare && flare->IsAlive())
-            return true;
-    }
-    return false;
+    return bot->FindNearestCreature(NPC_FOCUS_FIRE, FLARE_SEARCH_RADIUS);
 }
 
 bool ShirrakRangedKeepDistanceTrigger::IsActive()
 {
-    return botAI->IsRanged(bot) &&
-           AI_VALUE2(Unit*, "find target", "shirrak the dead watcher");
+    return PlayerbotAI::IsRanged(bot) &&
+        AI_VALUE2(Unit*, "find target", "shirrak the dead watcher");
 }

--- a/src/Ai/Dungeon/AC/ACTriggers.h
+++ b/src/Ai/Dungeon/AC/ACTriggers.h
@@ -7,37 +7,37 @@
 #ifndef PLAYERBOTS_ACTRIGGERS_H
 #define PLAYERBOTS_ACTRIGGERS_H
 
-#include "DungeonStrategyUtils.h"
-#include "GenericTriggers.h"
+#include "Common.h"
 #include "Trigger.h"
 
-enum class AuchenaiCryptsIDs : uint32
-{
-    // Shirrak The Dead Watcher
-    NPC_FOCUS_FIRE                  = 18374,
-};
+struct Position;
+
+inline constexpr uint32 NPC_FOCUS_FIRE = 18374;
+inline constexpr float FLARE_SEARCH_RADIUS = 20.0f;
+inline Position const SHIRRAK_RANGED_POSITION = { -21.777f, -162.700f, 26.062f };
+inline Position const SHIRRAK_TANK_POSITION =   { -65.171f, -162.920f, 26.504f };
 
 class ShirrakTankPositionBossTrigger : public Trigger
 {
 public:
-    ShirrakTankPositionBossTrigger(PlayerbotAI* botAI) : Trigger(botAI, "shirrak tank position boss") {}
-
+    ShirrakTankPositionBossTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "shirrak tank position boss") {}
     bool IsActive() override;
 };
 
 class ShirrakFleeFocusFireTrigger : public Trigger
 {
 public:
-    ShirrakFleeFocusFireTrigger(PlayerbotAI* botAI) : Trigger(botAI, "shirrak flee focus fire") {}
-
+    ShirrakFleeFocusFireTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "shirrak flee focus fire") {}
     bool IsActive() override;
 };
 
 class ShirrakRangedKeepDistanceTrigger : public Trigger
 {
 public:
-    ShirrakRangedKeepDistanceTrigger(PlayerbotAI* botAI) : Trigger(botAI, "shirrak ranged keep distance") {}
-
+    ShirrakRangedKeepDistanceTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "shirrak ranged keep distance") {}
     bool IsActive() override;
 };
 

--- a/src/Ai/Dungeon/DungeonStrategyContext.h
+++ b/src/Ai/Dungeon/DungeonStrategyContext.h
@@ -17,6 +17,7 @@
 #include "HoLStrategy.h"
 #include "HoSStrategy.h"
 #include "MechStrategy.h"
+#include "MgTStrategy.h"
 #include "NexStrategy.h"
 #include "OCStrategy.h"
 #include "PoSStrategy.h"
@@ -41,6 +42,7 @@ class DungeonStrategyContext : public NamedObjectContext<Strategy>
             creators["tbc-seth"] = &DungeonStrategyContext::tbc_seth;       // Auchindoun: Sethekk Halls
             creators["tbc-mech"] = &DungeonStrategyContext::tbc_mech;       // Tempest Keep: The Mechanar
             creators["tbc-ub"] = &DungeonStrategyContext::tbc_ub;           // Coilfang Reservoir: The Underbog
+            creators["tbc-mgt"] = &DungeonStrategyContext::tbc_mgt;         // Magisters' Terrace
 
             // Wrath of the Lich King
             creators["wotlk-uk"] = &DungeonStrategyContext::wotlk_uk;       // Utgarde Keep
@@ -64,6 +66,7 @@ class DungeonStrategyContext : public NamedObjectContext<Strategy>
         static Strategy* tbc_seth(PlayerbotAI* botAI) { return new TbcDungeonSethekkHallsStrategy(botAI); }
         static Strategy* tbc_mech(PlayerbotAI* botAI) { return new TbcDungeonMechanarStrategy(botAI); }
         static Strategy* tbc_ub(PlayerbotAI* botAI) { return new TbcDungeonUnderbogStrategy(botAI); }
+        static Strategy* tbc_mgt(PlayerbotAI* botAI) { return new TbcDungeonMagistersTerraceStrategy(botAI); }
         static Strategy* wotlk_uk(PlayerbotAI* botAI) { return new WotlkDungeonUKStrategy(botAI); }
         static Strategy* wotlk_nex(PlayerbotAI* botAI) { return new WotlkDungeonNexStrategy(botAI); }
         static Strategy* wotlk_an(PlayerbotAI* botAI) { return new WotlkDungeonANStrategy(botAI); }

--- a/src/Ai/Dungeon/GD/GDActionContext.h
+++ b/src/Ai/Dungeon/GD/GDActionContext.h
@@ -17,11 +17,15 @@ class WotlkDungeonGDActionContext : public NamedObjectContext<Action>
         WotlkDungeonGDActionContext() {
             creators["avoid poison nova"] = &WotlkDungeonGDActionContext::avoid_poison_nova;
             creators["attack snake wrap"] = &WotlkDungeonGDActionContext::attack_snake_wrap;
+            creators["slad'ran stack on tank"] = &WotlkDungeonGDActionContext::sladran_stack_on_tank;
+            creators["slad'ran tank hold"] = &WotlkDungeonGDActionContext::sladran_tank_hold;
             creators["avoid whirling slash"] = &WotlkDungeonGDActionContext::avoid_whirling_slash;
         }
     private:
         static Action* avoid_poison_nova(PlayerbotAI* ai) { return new AvoidPoisonNovaAction(ai); }
         static Action* attack_snake_wrap(PlayerbotAI* ai) { return new AttackSnakeWrapAction(ai); }
+        static Action* sladran_stack_on_tank(PlayerbotAI* ai) { return new SladranStackOnTankAction(ai); }
+        static Action* sladran_tank_hold(PlayerbotAI* ai) { return new SladranTankHoldAction(ai); }
         static Action* avoid_whirling_slash(PlayerbotAI* ai) { return new AvoidWhirlingSlashAction(ai); }
 };
 

--- a/src/Ai/Dungeon/GD/GDActions.cpp
+++ b/src/Ai/Dungeon/GD/GDActions.cpp
@@ -26,27 +26,28 @@ bool AvoidPoisonNovaAction::Execute(Event /*event*/)
 
 bool AttackSnakeWrapAction::Execute(Event /*event*/)
 {
-    Unit* boss = AI_VALUE2(Unit*, "find target", "slad'ran");
+    Unit* snakeWrap = GundrakSladran::GetAssignedSnakeWrap(botAI);
+    if (!snakeWrap) { return false; }
+
+    if (AI_VALUE(Unit*, "current target") == snakeWrap) { return false; }
+
+    return Attack(snakeWrap);
+}
+
+bool SladranStackOnTankAction::Execute(Event /*event*/)
+{
+    Player* tank = GundrakSladran::GetStackTank(botAI);
+    if (!tank) { return false; }
+
+    return MoveTo(tank, GundrakSladran::STACK_CLOSE_TO_YD, MovementPriority::MOVEMENT_COMBAT);
+}
+
+bool SladranTankHoldAction::Execute(Event /*event*/)
+{
+    Unit* boss = GundrakSladran::GetTankHoldTarget(botAI);
     if (!boss) { return false; }
 
-    // Target is not findable from threat table using AI_VALUE2(),
-    // therefore need to search manually for the unit name
-    GuidVector targets = AI_VALUE(GuidVector, "possible targets no los");
-
-    for (auto& target : targets)
-    {
-        Unit* unit = botAI->GetUnit(target);
-        if (unit && unit->GetEntry() == NPC_SNAKE_WRAP)
-        {
-            Unit* currentTarget = AI_VALUE(Unit*, "current target");
-            if (!currentTarget || currentTarget->GetEntry() != NPC_SNAKE_WRAP)
-            {
-            return Attack(unit);
-            }
-        }
-    }
-
-    return false;
+    return Attack(boss);
 }
 
 bool AvoidWhirlingSlashAction::Execute(Event /*event*/)

--- a/src/Ai/Dungeon/GD/GDActions.h
+++ b/src/Ai/Dungeon/GD/GDActions.h
@@ -27,6 +27,20 @@ public:
     bool Execute(Event event) override;
 };
 
+class SladranStackOnTankAction : public MovementAction
+{
+public:
+    SladranStackOnTankAction(PlayerbotAI* ai) : MovementAction(ai, "slad'ran stack on tank") {}
+    bool Execute(Event event) override;
+};
+
+class SladranTankHoldAction : public AttackAction
+{
+public:
+    SladranTankHoldAction(PlayerbotAI* ai) : AttackAction(ai, "slad'ran tank hold") {}
+    bool Execute(Event event) override;
+};
+
 class AvoidWhirlingSlashAction : public MovementAction
 {
 public:

--- a/src/Ai/Dungeon/GD/GDMultipliers.cpp
+++ b/src/Ai/Dungeon/GD/GDMultipliers.cpp
@@ -11,6 +11,8 @@
 #include "GDTriggers.h"
 #include "GenericSpellActions.h"
 #include "MovementActions.h"
+#include "Playerbots.h"
+#include "ReachTargetActions.h"
 
 float SladranMultiplier::GetValue(Action* action)
 {
@@ -19,32 +21,54 @@ float SladranMultiplier::GetValue(Action* action)
 
     if (boss->FindCurrentSpellBySpellId(SPELL_POISON_NOVA))
     {
-        if (dynamic_cast<MovementAction*>(action) && !dynamic_cast<AvoidPoisonNovaAction*>(action))
+        if (dynamic_cast<AvoidPoisonNovaAction*>(action)) { return 1.0f; }
+
+        if (dynamic_cast<MovementAction*>(action))
         {
             return 0.0f;
         }
     }
 
-    if (!botAI->IsDps(bot)) { return 1.0f; }
-
-    if (action->getThreatType() == Action::ActionThreatType::Aoe)
+    if (dynamic_cast<FleeAction*>(action) ||
+        dynamic_cast<RunAwayAction*>(action) ||
+        dynamic_cast<MoveRandomAction*>(action) ||
+        dynamic_cast<MoveFromGroupAction*>(action))
     {
         return 0.0f;
     }
 
-    Unit* snakeWrap = nullptr;
-    GuidVector targets = AI_VALUE(GuidVector, "possible targets no los");
-    for (auto& target : targets)
+    if (PlayerbotAI::IsTank(bot))
     {
-        Unit* unit = botAI->GetUnit(target);
-        if (unit && unit->GetEntry() == NPC_SNAKE_WRAP)
+        if (dynamic_cast<TankAssistAction*>(action))
         {
-            snakeWrap = unit;
-            break;
+            Unit* tankTarget = AI_VALUE(Unit*, "tank target");
+            if (tankTarget && GundrakSladran::IsAdd(tankTarget) &&
+                bot->GetExactDist2d(tankTarget) > GundrakSladran::TANK_PICKUP_YD)
+            {
+                return 0.0f;
+            }
         }
+
+        if (dynamic_cast<ReachTargetAction*>(action))
+        {
+            Unit* currentTarget = AI_VALUE(Unit*, "current target");
+            if (currentTarget && GundrakSladran::IsAdd(currentTarget) &&
+                bot->GetExactDist2d(currentTarget) > GundrakSladran::TANK_PICKUP_YD)
+            {
+                return 0.0f;
+            }
+        }
+
+        return 1.0f;
     }
-    // Prevent auto-target acquisition during snake wraps
-    if (snakeWrap && dynamic_cast<DpsAssistAction*>(action))
+
+    if (dynamic_cast<CombatFormationMoveAction*>(action) &&
+        !dynamic_cast<SetBehindTargetAction*>(action))
+    {
+        return 0.0f;
+    }
+
+    if (dynamic_cast<DpsAssistAction*>(action) && GundrakSladran::GetAssignedSnakeWrap(botAI))
     {
         return 0.0f;
     }

--- a/src/Ai/Dungeon/GD/GDStrategy.cpp
+++ b/src/Ai/Dungeon/GD/GDStrategy.cpp
@@ -20,6 +20,10 @@ void WotlkDungeonGDStrategy::InitTriggers(std::vector<TriggerNode*> &triggers)
         { NextAction("avoid poison nova", ACTION_RAID + 5) }));
     triggers.push_back(new TriggerNode("snake wrap",
         { NextAction("attack snake wrap", ACTION_RAID + 4) }));
+    triggers.push_back(new TriggerNode("slad'ran stack on tank",
+        { NextAction("slad'ran stack on tank", ACTION_RAID + 1) }));
+    triggers.push_back(new TriggerNode("slad'ran tank hold",
+        { NextAction("slad'ran tank hold", ACTION_RAID + 1) }));
 
     // Gal'darah
     triggers.push_back(new TriggerNode("whirling slash",

--- a/src/Ai/Dungeon/GD/GDTriggerContext.h
+++ b/src/Ai/Dungeon/GD/GDTriggerContext.h
@@ -17,11 +17,15 @@ class WotlkDungeonGDTriggerContext : public NamedObjectContext<Trigger>
         {
             creators["poison nova"] = &WotlkDungeonGDTriggerContext::poison_nova;
             creators["snake wrap"] = &WotlkDungeonGDTriggerContext::snake_wrap;
+            creators["slad'ran stack on tank"] = &WotlkDungeonGDTriggerContext::sladran_stack_on_tank;
+            creators["slad'ran tank hold"] = &WotlkDungeonGDTriggerContext::sladran_tank_hold;
             creators["whirling slash"] = &WotlkDungeonGDTriggerContext::whirling_slash;
         }
     private:
         static Trigger* poison_nova(PlayerbotAI* ai) { return new SladranPoisonNovaTrigger(ai); }
         static Trigger* snake_wrap(PlayerbotAI* ai) { return new SladranSnakeWrapTrigger(ai); }
+        static Trigger* sladran_stack_on_tank(PlayerbotAI* ai) { return new SladranStackOnTankTrigger(ai); }
+        static Trigger* sladran_tank_hold(PlayerbotAI* ai) { return new SladranTankHoldTrigger(ai); }
         static Trigger* whirling_slash(PlayerbotAI* ai) { return new GaldarahWhirlingSlashTrigger(ai); }
 };
 

--- a/src/Ai/Dungeon/GD/GDTriggers.cpp
+++ b/src/Ai/Dungeon/GD/GDTriggers.cpp
@@ -6,7 +6,184 @@
 
 #include "GDTriggers.h"
 #include "AiObjectContext.h"
+#include "AttackersValue.h"
+#include "Creature.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
+#include <algorithm>
+#include <list>
+#include <utility>
+#include <vector>
+
+using namespace EncounterHelpers;
+
+namespace GundrakSladran
+{
+
+static bool IsClosestSnakeWrapFreer(Player* bot, Unit* snakeWrap, float distance)
+{
+    Group* group = bot->GetGroup();
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member || member == bot || !member->IsAlive() || !member->IsInCombat() ||
+            !GET_PLAYERBOT_AI(member) || member->GetMap() != bot->GetMap() ||
+            !PlayerbotAI::IsDps(member) || member->HasAura(SPELL_SNAKE_WRAP))
+        {
+            continue;
+        }
+
+        float memberDistance = member->GetExactDist2d(snakeWrap);
+        if (memberDistance > distance ||
+            (memberDistance == distance && bot->GetGUID() < member->GetGUID()))
+        {
+            continue;
+        }
+
+        if (!member->IsWithinLOSInMap(snakeWrap))
+        {
+            continue;
+        }
+
+        return false;
+    }
+
+    return true;
+}
+
+bool IsAdd(Unit* unit)
+{
+    if (!unit) { return false; }
+
+    uint32 entry = unit->GetEntry();
+    return entry == NPC_SLADRAN_VIPER || entry == NPC_SLADRAN_CONSTRICTOR;
+}
+
+ObjectGuid CalculateAssignedSnakeWrap(PlayerbotAI* botAI)
+{
+    Player* bot = botAI->GetBot();
+    if (!bot->IsAlive() || !bot->IsInCombat() || !PlayerbotAI::IsDps(bot) ||
+        bot->HasAura(SPELL_SNAKE_WRAP) || !bot->GetGroup())
+    {
+        return ObjectGuid::Empty;
+    }
+
+    std::list<Creature*> wraps;
+    bot->GetCreatureListWithEntryInGrid(wraps, NPC_SNAKE_WRAP, sPlayerbotAIConfig.sightDistance);
+
+    std::vector<std::pair<float, Creature*>> candidates;
+    candidates.reserve(wraps.size());
+    for (Creature* snakeWrap : wraps)
+    {
+        if (!snakeWrap->IsAlive() || !AttackersValue::IsPossibleTarget(snakeWrap, bot)) { continue; }
+
+        candidates.emplace_back(bot->GetExactDist2d(snakeWrap), snakeWrap);
+    }
+
+    std::sort(candidates.begin(), candidates.end(),
+              [](std::pair<float, Creature*> const& lhs, std::pair<float, Creature*> const& rhs)
+              { return lhs.first < rhs.first; });
+
+    for (auto const& candidate : candidates)
+    {
+        if (!bot->IsWithinLOSInMap(candidate.second)) { continue; }
+
+        if (IsClosestSnakeWrapFreer(bot, candidate.second, candidate.first))
+        {
+            return candidate.second->GetGUID();
+        }
+    }
+
+    return ObjectGuid::Empty;
+}
+
+Unit* GetAssignedSnakeWrap(PlayerbotAI* botAI)
+{
+    ObjectGuid guid =
+        botAI->GetAiObjectContext()->GetValue<ObjectGuid>("slad'ran snake wrap target")->Get();
+    if (guid.IsEmpty()) { return nullptr; }
+
+    Unit* snakeWrap = botAI->GetUnit(guid);
+    if (!snakeWrap || !snakeWrap->IsAlive() || snakeWrap->GetEntry() != NPC_SNAKE_WRAP)
+    {
+        return nullptr;
+    }
+
+    return snakeWrap;
+}
+
+Player* GetStackTank(PlayerbotAI* botAI)
+{
+    Player* bot = botAI->GetBot();
+    if (!bot->IsAlive() || PlayerbotAI::IsTank(bot))
+    {
+        return nullptr;
+    }
+
+    AiObjectContext* context = botAI->GetAiObjectContext();
+    if (!context->GetValue<Unit*>("find target", "slad'ran")->Get())
+    {
+        return nullptr;
+    }
+
+    if (GetAssignedSnakeWrap(botAI))
+    {
+        return nullptr;
+    }
+
+    Unit* currentTarget = context->GetValue<Unit*>("current target")->Get();
+    if (currentTarget && currentTarget->IsAlive() && currentTarget->GetEntry() == NPC_SNAKE_WRAP)
+    {
+        return nullptr;
+    }
+
+    Player* tank = GetGroupMainTank(bot);
+    if (!tank || tank == bot || tank->GetMap() != bot->GetMap())
+    {
+        return nullptr;
+    }
+
+    if (bot->GetExactDist2d(tank) <= STACK_LEASH_YD)
+    {
+        return nullptr;
+    }
+
+    return tank;
+}
+
+Unit* GetTankHoldTarget(PlayerbotAI* botAI)
+{
+    Player* bot = botAI->GetBot();
+    if (!bot->IsAlive() || !PlayerbotAI::IsTank(bot))
+    {
+        return nullptr;
+    }
+
+    AiObjectContext* context = botAI->GetAiObjectContext();
+    Unit* boss = context->GetValue<Unit*>("find target", "slad'ran")->Get();
+    if (!boss || !boss->IsAlive())
+    {
+        return nullptr;
+    }
+
+    Unit* currentTarget = context->GetValue<Unit*>("current target")->Get();
+    if (currentTarget && currentTarget->IsAlive())
+    {
+        if (currentTarget == boss)
+        {
+            return nullptr;
+        }
+
+        if (IsAdd(currentTarget) && bot->GetExactDist2d(currentTarget) <= TANK_PICKUP_YD)
+        {
+            return nullptr;
+        }
+    }
+
+    return boss;
+}
+
+}
 
 bool SladranPoisonNovaTrigger::IsActive()
 {
@@ -18,21 +195,17 @@ bool SladranPoisonNovaTrigger::IsActive()
 
 bool SladranSnakeWrapTrigger::IsActive()
 {
-    if (!botAI->IsDps(bot)) { return false; }
+    return GundrakSladran::GetAssignedSnakeWrap(botAI) != nullptr;
+}
 
-    // Target is not findable from threat table using AI_VALUE2(),
-    // therefore need to search manually for the unit name
-    GuidVector targets = AI_VALUE(GuidVector, "possible targets");
+bool SladranStackOnTankTrigger::IsActive()
+{
+    return GundrakSladran::GetStackTank(botAI) != nullptr;
+}
 
-    for (auto& target : targets)
-    {
-        Unit* unit = botAI->GetUnit(target);
-        if (unit && unit->GetEntry() == NPC_SNAKE_WRAP)
-        {
-            return true;
-        }
-    }
-    return false;
+bool SladranTankHoldTrigger::IsActive()
+{
+    return GundrakSladran::GetTankHoldTarget(botAI) != nullptr;
 }
 
 bool GaldarahWhirlingSlashTrigger::IsActive()

--- a/src/Ai/Dungeon/GD/GDTriggers.h
+++ b/src/Ai/Dungeon/GD/GDTriggers.h
@@ -9,6 +9,7 @@
 
 #include "DungeonStrategyUtils.h"
 #include "GenericTriggers.h"
+#include "ObjectGuid.h"
 #include "PlayerbotAIConfig.h"
 #include "Trigger.h"
 
@@ -17,7 +18,10 @@ enum GundrakIDs
     // Slad'ran
     SPELL_POISON_NOVA_N             = 55081,
     SPELL_POISON_NOVA_H             = 59842,
+    SPELL_SNAKE_WRAP                = 55126,
     NPC_SNAKE_WRAP                  = 29742,
+    NPC_SLADRAN_VIPER               = 29680,
+    NPC_SLADRAN_CONSTRICTOR         = 29713,
 
     // Gal'darah
     SPELL_WHIRLING_SLASH_N          = 55250,
@@ -26,6 +30,20 @@ enum GundrakIDs
 
 #define SPELL_POISON_NOVA           DUNGEON_MODE(bot, SPELL_POISON_NOVA_N, SPELL_POISON_NOVA_H)
 #define SPELL_WHIRLING_SLASH        DUNGEON_MODE(bot, SPELL_WHIRLING_SLASH_N, SPELL_WHIRLING_SLASH_H)
+
+namespace GundrakSladran
+{
+constexpr float STACK_LEASH_YD = 10.0f;
+constexpr float STACK_CLOSE_TO_YD = 5.0f;
+constexpr float TANK_PICKUP_YD = 12.0f;
+constexpr uint32 SNAKE_WRAP_SCAN_INTERVAL = 200;
+
+bool IsAdd(Unit* unit);
+ObjectGuid CalculateAssignedSnakeWrap(PlayerbotAI* botAI);
+Unit* GetAssignedSnakeWrap(PlayerbotAI* botAI);
+Player* GetStackTank(PlayerbotAI* botAI);
+Unit* GetTankHoldTarget(PlayerbotAI* botAI);
+}
 
 class SladranPoisonNovaTrigger : public Trigger
 {
@@ -38,6 +56,20 @@ class SladranSnakeWrapTrigger : public Trigger
 {
 public:
     SladranSnakeWrapTrigger(PlayerbotAI* ai) : Trigger(ai, "slad'ran snake wrap") {}
+    bool IsActive() override;
+};
+
+class SladranStackOnTankTrigger : public Trigger
+{
+public:
+    SladranStackOnTankTrigger(PlayerbotAI* ai) : Trigger(ai, "slad'ran stack on tank") {}
+    bool IsActive() override;
+};
+
+class SladranTankHoldTrigger : public Trigger
+{
+public:
+    SladranTankHoldTrigger(PlayerbotAI* ai) : Trigger(ai, "slad'ran tank hold") {}
     bool IsActive() override;
 };
 

--- a/src/Ai/Dungeon/GD/GDValueContext.h
+++ b/src/Ai/Dungeon/GD/GDValueContext.h
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_GDVALUECONTEXT_H
+#define PLAYERBOTS_GDVALUECONTEXT_H
+
+#include "GDTriggers.h"
+#include "NamedObjectContext.h"
+#include "ObjectGuid.h"
+#include "Value.h"
+
+class SladranAssignedSnakeWrapValue : public CalculatedValue<ObjectGuid>
+{
+public:
+    SladranAssignedSnakeWrapValue(PlayerbotAI* botAI)
+        : CalculatedValue<ObjectGuid>(botAI, "slad'ran snake wrap target", GundrakSladran::SNAKE_WRAP_SCAN_INTERVAL)
+    {
+    }
+
+protected:
+    ObjectGuid Calculate() override { return GundrakSladran::CalculateAssignedSnakeWrap(botAI); }
+};
+
+class WotlkDungeonGDValueContext : public NamedObjectContext<UntypedValue>
+{
+public:
+    WotlkDungeonGDValueContext()
+    {
+        creators["slad'ran snake wrap target"] = &WotlkDungeonGDValueContext::sladran_snake_wrap_target;
+    }
+
+private:
+    static UntypedValue* sladran_snake_wrap_target(PlayerbotAI* botAI)
+    {
+        return new SladranAssignedSnakeWrapValue(botAI);
+    }
+};
+
+#endif

--- a/src/Ai/Dungeon/MgT/MgTActionContext.h
+++ b/src/Ai/Dungeon/MgT/MgTActionContext.h
@@ -1,0 +1,65 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_MGTACTIONCONTEXT_H
+#define PLAYERBOTS_MGTACTIONCONTEXT_H
+
+#include "Action.h"
+#include "AiObjectContext.h"
+#include "MgTActions.h"
+
+class TbcDungeonMagistersTerraceActionContext : public NamedObjectContext<Action>
+{
+public:
+    TbcDungeonMagistersTerraceActionContext()
+    {
+        creators["mgt kill crystal"] = &TbcDungeonMagistersTerraceActionContext::mgt_kill_crystal;
+        creators["mgt return to room"] = &TbcDungeonMagistersTerraceActionContext::mgt_return_to_room;
+        creators["mgt leave dampening field"] = &TbcDungeonMagistersTerraceActionContext::mgt_leave_dampening_field;
+        creators["mgt close on mage guard"] = &TbcDungeonMagistersTerraceActionContext::mgt_close_on_mage_guard;
+        creators["mgt clear arcane nova"] = &TbcDungeonMagistersTerraceActionContext::mgt_clear_arcane_nova;
+        creators["mgt priority interrupt"] = &TbcDungeonMagistersTerraceActionContext::mgt_priority_interrupt;
+        creators["mgt focus target"] = &TbcDungeonMagistersTerraceActionContext::mgt_focus_target;
+        creators["mgt taunt enraged wretched"] = &TbcDungeonMagistersTerraceActionContext::mgt_taunt_enraged_wretched;
+        creators["mgt delrissa interrupt"] = &TbcDungeonMagistersTerraceActionContext::mgt_delrissa_interrupt;
+        creators["mgt delrissa focus target"] = &TbcDungeonMagistersTerraceActionContext::mgt_delrissa_focus_target;
+        creators["mgt delrissa tremor totem"] = &TbcDungeonMagistersTerraceActionContext::mgt_delrissa_tremor_totem;
+        creators["mgt leave flame strike"] = &TbcDungeonMagistersTerraceActionContext::mgt_leave_flame_strike;
+        creators["mgt leave phoenix burn"] = &TbcDungeonMagistersTerraceActionContext::mgt_leave_phoenix_burn;
+        creators["mgt kael focus target"] = &TbcDungeonMagistersTerraceActionContext::mgt_kael_focus_target;
+        creators["mgt kael interrupt"] = &TbcDungeonMagistersTerraceActionContext::mgt_kael_interrupt;
+        creators["mgt take lapse spot"] = &TbcDungeonMagistersTerraceActionContext::mgt_take_lapse_spot;
+    }
+
+private:
+    static Action* mgt_kill_crystal(PlayerbotAI* botAI) { return new MgTKillCrystalAction(botAI); }
+    static Action* mgt_return_to_room(PlayerbotAI* botAI) { return new MgTReturnToRoomAction(botAI); }
+    static Action* mgt_leave_dampening_field(PlayerbotAI* botAI) { return new MgTLeaveDampeningFieldAction(botAI); }
+    static Action* mgt_close_on_mage_guard(PlayerbotAI* botAI) { return new MgTCloseOnMageGuardAction(botAI); }
+    static Action* mgt_clear_arcane_nova(PlayerbotAI* botAI) { return new MgTClearArcaneNovaAction(botAI); }
+    static Action* mgt_priority_interrupt(PlayerbotAI* botAI) { return new MgTPriorityInterruptAction(botAI); }
+    static Action* mgt_focus_target(PlayerbotAI* botAI) { return new MgTFocusTargetAction(botAI); }
+    static Action* mgt_taunt_enraged_wretched(PlayerbotAI* botAI)
+    {
+        return new MgTTauntEnragedWretchedAction(botAI);
+    }
+    static Action* mgt_delrissa_interrupt(PlayerbotAI* botAI) { return new MgTDelrissaInterruptAction(botAI); }
+    static Action* mgt_delrissa_focus_target(PlayerbotAI* botAI)
+    {
+        return new MgTDelrissaFocusTargetAction(botAI);
+    }
+    static Action* mgt_delrissa_tremor_totem(PlayerbotAI* botAI)
+    {
+        return new MgTDelrissaTremorTotemAction(botAI);
+    }
+    static Action* mgt_leave_flame_strike(PlayerbotAI* botAI) { return new MgTLeaveFlameStrikeAction(botAI); }
+    static Action* mgt_leave_phoenix_burn(PlayerbotAI* botAI) { return new MgTLeavePhoenixBurnAction(botAI); }
+    static Action* mgt_kael_focus_target(PlayerbotAI* botAI) { return new MgTKaelFocusTargetAction(botAI); }
+    static Action* mgt_kael_interrupt(PlayerbotAI* botAI) { return new MgTKaelInterruptAction(botAI); }
+    static Action* mgt_take_lapse_spot(PlayerbotAI* botAI) { return new MgTTakeLapseSpotAction(botAI); }
+};
+
+#endif

--- a/src/Ai/Dungeon/MgT/MgTActions.cpp
+++ b/src/Ai/Dungeon/MgT/MgTActions.cpp
@@ -1,0 +1,191 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "MgTActions.h"
+#include "AiObjectContext.h"
+#include "EncounterHelpers.h"
+#include "MgTShared.h"
+#include "Playerbots.h"
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <vector>
+
+using namespace EncounterHelpers;
+
+bool MgTEscapeAction::Execute(Event)
+{
+    if (IsWaitingForLastMove(MovementPriority::MOVEMENT_COMBAT))
+        return false;
+
+    auto const& spots = AI_VALUE_REF(MagistersTerrace::EscapeSpots, _value);
+    for (MagistersTerrace::EscapeSpot const& spot : spots)
+    {
+        if (MoveTo(bot->GetMapId(), spot.x, spot.y, spot.z, false, false, false, false,
+                   MovementPriority::MOVEMENT_COMBAT, true, false))
+            return true;
+    }
+
+    return false;
+}
+
+bool MgTFocusAction::Execute(Event)
+{
+    Unit* target = botAI->GetUnit(AI_VALUE(ObjectGuid, _value));
+    if (!target)
+        return false;
+
+    if (IsMechanicTrackerBot(bot, MagistersTerrace::MAP_MAGISTERS_TERRACE))
+        MarkTargetWithSkull(bot, target);
+
+    if (AI_VALUE(Unit*, "current target") == target)
+        return false;
+
+    return Attack(target);
+}
+
+bool MgTKillCrystalAction::Execute(Event)
+{
+    Unit* crystal = botAI->GetUnit(AI_VALUE(ObjectGuid, "mgt crystal target"));
+    if (!crystal || AI_VALUE(Unit*, "current target") == crystal)
+        return false;
+
+    return Attack(crystal);
+}
+
+bool MgTReturnToRoomAction::Execute(Event)
+{
+    float x = MagistersTerrace::SELIN_REGROUP_X;
+    float y = bot->GetPositionY();
+    MagistersTerrace::ClampIntoRoom(x, y);
+
+    float const bx = bot->GetPositionX();
+    float const by = bot->GetPositionY();
+    float const bz = bot->GetPositionZ();
+
+    float const dist = bot->GetExactDist2d(x, y);
+    if (dist < 1.0f)
+        return false;
+
+    float const step = std::min(8.0f, dist);
+    float const moveX = bx + ((x - bx) / dist) * step;
+    float const moveY = by + ((y - by) / dist) * step;
+
+    float moveZ = bot->GetMapHeight(moveX, moveY, bz + MagistersTerrace::GROUND_SEARCH_UP, true,
+                                    MagistersTerrace::GROUND_SEARCH_DOWN);
+    if (std::fabs(moveZ - bz) > MagistersTerrace::GROUND_TIER_STEP)
+        moveZ = bz;
+
+    return MoveTo(bot->GetMapId(), moveX, moveY, moveZ, false, false, false, false,
+                  MovementPriority::MOVEMENT_COMBAT, true, false);
+}
+
+bool MgTCloseOnMageGuardAction::Execute(Event)
+{
+    Unit* guard = botAI->GetUnit(AI_VALUE(ObjectGuid, "mgt mage guard target"));
+    if (!guard)
+        return false;
+
+    return ReachCombatTo(guard, 0.0f);
+}
+
+bool MgTPriorityInterruptAction::Execute(Event)
+{
+    Unit* target = botAI->GetUnit(AI_VALUE(ObjectGuid, "mgt interrupt target"));
+    if (!target)
+        return false;
+
+    uint8 const urgency = MagistersTerrace::GetInterruptUrgency(target);
+    if (!urgency)
+        return false;
+
+    return !MagistersTerrace::CastInterrupt(botAI, target, urgency).empty();
+}
+
+bool MgTTauntEnragedWretchedAction::Execute(Event)
+{
+    Unit* wretched = botAI->GetUnit(AI_VALUE(ObjectGuid, "mgt enraged wretched"));
+    if (!wretched)
+        return false;
+
+    for (std::string const& spell : MagistersTerrace::TauntSpellNames())
+    {
+        if (botAI->CanCastSpell(spell, wretched) && botAI->CastSpell(spell, wretched))
+            return true;
+    }
+
+    return false;
+}
+
+bool MgTDelrissaInterruptAction::Execute(Event)
+{
+    auto const& order = AI_VALUE_REF(GuidVector, "mgt delrissa interrupt order");
+    for (ObjectGuid const guid : order)
+    {
+        Unit* target = botAI->GetUnit(guid);
+        if (!target)
+            continue;
+
+        uint8 const urgency = MagistersTerrace::GetRetinueInterruptUrgency(target);
+        if (!urgency)
+            continue;
+
+        if (!MagistersTerrace::CastInterrupt(botAI, target, urgency).empty())
+            return true;
+    }
+
+    return false;
+}
+
+bool MgTDelrissaTremorTotemAction::Execute(Event)
+{
+    return botAI->CanCastSpell("tremor totem", bot) && botAI->CastSpell("tremor totem", bot);
+}
+
+bool MgTKaelInterruptAction::Execute(Event)
+{
+    Unit* target = MagistersTerrace::GetKaelInterruptTarget(bot);
+    if (!target)
+        return false;
+
+    return !MagistersTerrace::CastInterrupt(botAI, target, MagistersTerrace::CONTROL_INTERRUPT_URGENCY).empty();
+}
+
+bool MgTTakeLapseSpotAction::Execute(Event)
+{
+    if (IsWaitingForLastMove(MovementPriority::MOVEMENT_COMBAT))
+        return false;
+
+    MagistersTerrace::LapseWorld world;
+    MagistersTerrace::CollectLapseWorld(bot, world);
+
+    MagistersTerrace::LapseSpot spot = { bot->GetPositionX(), bot->GetPositionY() };
+    MagistersTerrace::LapseSpot station = spot;
+    Unit* kael = MagistersTerrace::GetKaelthas(bot);
+    bool move = false;
+
+    if (MagistersTerrace::GetGravityLapseKite(bot, world, spot, _kite) ||
+        MagistersTerrace::GetGravityLapseDodge(bot, world, spot))
+    {
+        move = true;
+    }
+    else if (MagistersTerrace::GetGravityLapseSpot(bot, world, station) &&
+             !MagistersTerrace::OnLapseStation(bot, kael, station))
+    {
+        move = MagistersTerrace::GetLapseApproach(bot, world, station,
+                                                  MagistersTerrace::LapseThreatened(bot, world), spot);
+    }
+
+    if (!move)
+        return false;
+
+    float z = bot->GetPositionZ();
+    if (kael && MagistersTerrace::IsLapseMeleeSlot(bot))
+        z = kael->GetPositionZ();
+
+    return MoveTo(bot->GetMapId(), spot.x, spot.y, z, false, false, false, false,
+                  MovementPriority::MOVEMENT_COMBAT, true, false);
+}

--- a/src/Ai/Dungeon/MgT/MgTActions.h
+++ b/src/Ai/Dungeon/MgT/MgTActions.h
@@ -1,0 +1,168 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_MGTACTIONS_H
+#define PLAYERBOTS_MGTACTIONS_H
+
+#include "AttackAction.h"
+#include "MgTShared.h"
+#include "MovementActions.h"
+
+class MgTEscapeAction : public MovementAction
+{
+public:
+    MgTEscapeAction(PlayerbotAI* botAI, std::string const name, std::string const value)
+        : MovementAction(botAI, name), _value(value)
+    {
+    }
+
+    bool Execute(Event event) override;
+
+private:
+    std::string const _value;
+};
+
+class MgTLeaveDampeningFieldAction : public MgTEscapeAction
+{
+public:
+    MgTLeaveDampeningFieldAction(PlayerbotAI* botAI)
+        : MgTEscapeAction(botAI, "mgt leave dampening field", "mgt dampening escape")
+    {
+    }
+};
+
+class MgTClearArcaneNovaAction : public MgTEscapeAction
+{
+public:
+    MgTClearArcaneNovaAction(PlayerbotAI* botAI)
+        : MgTEscapeAction(botAI, "mgt clear arcane nova", "mgt nova escape")
+    {
+    }
+};
+
+class MgTLeaveFlameStrikeAction : public MgTEscapeAction
+{
+public:
+    MgTLeaveFlameStrikeAction(PlayerbotAI* botAI)
+        : MgTEscapeAction(botAI, "mgt leave flame strike", "mgt flame strike escape")
+    {
+    }
+};
+
+class MgTLeavePhoenixBurnAction : public MgTEscapeAction
+{
+public:
+    MgTLeavePhoenixBurnAction(PlayerbotAI* botAI)
+        : MgTEscapeAction(botAI, "mgt leave phoenix burn", "mgt phoenix escape")
+    {
+    }
+};
+
+class MgTFocusAction : public AttackAction
+{
+public:
+    MgTFocusAction(PlayerbotAI* botAI, std::string const name, std::string const value)
+        : AttackAction(botAI, name), _value(value)
+    {
+    }
+
+    bool Execute(Event event) override;
+
+private:
+    std::string const _value;
+};
+
+class MgTFocusTargetAction : public MgTFocusAction
+{
+public:
+    MgTFocusTargetAction(PlayerbotAI* botAI) : MgTFocusAction(botAI, "mgt focus target", "mgt focus target") {}
+};
+
+class MgTDelrissaFocusTargetAction : public MgTFocusAction
+{
+public:
+    MgTDelrissaFocusTargetAction(PlayerbotAI* botAI)
+        : MgTFocusAction(botAI, "mgt delrissa focus target", "mgt delrissa focus target")
+    {
+    }
+};
+
+class MgTKaelFocusTargetAction : public MgTFocusAction
+{
+public:
+    MgTKaelFocusTargetAction(PlayerbotAI* botAI)
+        : MgTFocusAction(botAI, "mgt kael focus target", "mgt kael focus target")
+    {
+    }
+};
+
+class MgTKillCrystalAction : public AttackAction
+{
+public:
+    MgTKillCrystalAction(PlayerbotAI* botAI) : AttackAction(botAI, "mgt kill crystal") {}
+    bool Execute(Event event) override;
+};
+
+class MgTReturnToRoomAction : public MovementAction
+{
+public:
+    MgTReturnToRoomAction(PlayerbotAI* botAI) : MovementAction(botAI, "mgt return to room") {}
+    bool Execute(Event event) override;
+};
+
+class MgTCloseOnMageGuardAction : public MovementAction
+{
+public:
+    MgTCloseOnMageGuardAction(PlayerbotAI* botAI) : MovementAction(botAI, "mgt close on mage guard") {}
+    bool Execute(Event event) override;
+};
+
+class MgTPriorityInterruptAction : public Action
+{
+public:
+    MgTPriorityInterruptAction(PlayerbotAI* botAI) : Action(botAI, "mgt priority interrupt") {}
+    bool Execute(Event event) override;
+};
+
+class MgTTauntEnragedWretchedAction : public Action
+{
+public:
+    MgTTauntEnragedWretchedAction(PlayerbotAI* botAI) : Action(botAI, "mgt taunt enraged wretched") {}
+    bool Execute(Event event) override;
+};
+
+class MgTDelrissaInterruptAction : public Action
+{
+public:
+    MgTDelrissaInterruptAction(PlayerbotAI* botAI) : Action(botAI, "mgt delrissa interrupt") {}
+    bool Execute(Event event) override;
+};
+
+class MgTDelrissaTremorTotemAction : public Action
+{
+public:
+    MgTDelrissaTremorTotemAction(PlayerbotAI* botAI) : Action(botAI, "mgt delrissa tremor totem") {}
+    bool Execute(Event event) override;
+};
+
+class MgTKaelInterruptAction : public Action
+{
+public:
+    MgTKaelInterruptAction(PlayerbotAI* botAI) : Action(botAI, "mgt kael interrupt") {}
+    bool Execute(Event event) override;
+};
+
+class MgTTakeLapseSpotAction : public MovementAction
+{
+public:
+    MgTTakeLapseSpotAction(PlayerbotAI* botAI) : MovementAction(botAI, "mgt take lapse spot") {}
+    bool Execute(Event event) override;
+
+private:
+    MagistersTerrace::KiteState _kite;
+};
+
+#endif

--- a/src/Ai/Dungeon/MgT/MgTMultipliers.cpp
+++ b/src/Ai/Dungeon/MgT/MgTMultipliers.cpp
@@ -1,0 +1,233 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "MgTMultipliers.h"
+#include "AiObjectContext.h"
+#include "AttackersValue.h"
+#include "ChooseTargetActions.h"
+#include "FollowActions.h"
+#include "GenericSpellActions.h"
+#include "MgTActions.h"
+#include "MgTShared.h"
+#include "MovementActions.h"
+#include "Playerbots.h"
+#include "ReachTargetActions.h"
+#include "ShamanActions.h"
+
+float MgTCrystalFocusMultiplier::GetValue(Action* action)
+{
+    if (dynamic_cast<MgTKillCrystalAction*>(action))
+        return 1.0f;
+
+    bool const suppressed =
+        dynamic_cast<DpsAssistAction*>(action) ||
+        dynamic_cast<TankAssistAction*>(action) ||
+        dynamic_cast<CastDebuffSpellOnAttackerAction*>(action) ||
+        (action->getThreatType() == Action::ActionThreatType::Aoe && PlayerbotAI::IsDps(bot) &&
+         !dynamic_cast<CastHealingSpellAction*>(action));
+
+    if (!suppressed)
+        return 1.0f;
+
+    if (PlayerbotAI::IsHeal(bot))
+        return 1.0f;
+
+    if (AI_VALUE(ObjectGuid, "mgt crystal target").IsEmpty())
+        return 1.0f;
+
+    return 0.0f;
+}
+
+float MgTFocusOrderMultiplier::GetValue(Action* action)
+{
+    bool const picker =
+        dynamic_cast<DpsAssistAction*>(action) ||
+        dynamic_cast<DpsAoeAction*>(action) ||
+        dynamic_cast<TankAssistAction*>(action);
+
+    bool const drop = !picker && dynamic_cast<DropTargetAction*>(action) != nullptr;
+
+    if (!picker && !drop)
+        return 1.0f;
+
+    if (!bot->IsInCombat())
+        return 1.0f;
+
+    if (PlayerbotAI::IsHeal(bot) || PlayerbotAI::IsTank(bot) || !PlayerbotAI::IsDps(bot))
+        return 1.0f;
+
+    if (!AI_VALUE(ObjectGuid, "mgt crystal target").IsEmpty())
+        return 1.0f;
+
+    ObjectGuid const order = MagistersTerrace::ResolveFocusOrder(botAI);
+    if (order.IsEmpty())
+        return 1.0f;
+
+    if (!drop)
+        return 0.0f;
+
+    Unit* current = AI_VALUE(Unit*, "current target");
+    if (!current || current->GetGUID() != order)
+        return 1.0f;
+    if (!current->IsAlive() || !AttackersValue::IsValidTarget(current, bot))
+        return 1.0f;
+
+    return 0.0f;
+}
+
+float MgTFocusBurstMultiplier::GetValue(Action* action)
+{
+    if (action->getThreatType() != Action::ActionThreatType::Aoe)
+        return 1.0f;
+
+    if (dynamic_cast<CastHealingSpellAction*>(action))
+        return 1.0f;
+
+    if (PlayerbotAI::IsHeal(bot) || !PlayerbotAI::IsDps(bot))
+        return 1.0f;
+
+    switch (MagistersTerrace::ResolveFocusOrderOwner(botAI))
+    {
+        case MagistersTerrace::FocusOrder::Kael:
+        case MagistersTerrace::FocusOrder::Delrissa:
+            return 0.0f;
+        default:
+            return 1.0f;
+    }
+}
+
+float MgTRoomLeashMultiplier::GetValue(Action* action)
+{
+    bool const isFlight =
+        dynamic_cast<FleeAction*>(action) ||
+        dynamic_cast<FleeWithPetAction*>(action) ||
+        dynamic_cast<RunAwayAction*>(action);
+
+    if (!isFlight)
+        return 1.0f;
+
+    if (bot->GetPositionX() > MagistersTerrace::SELIN_SAFE_X + MagistersTerrace::SELIN_FLEE_SLACK)
+        return 1.0f;
+
+    if (!MagistersTerrace::GetSelin(bot))
+        return 1.0f;
+
+    return 0.0f;
+}
+
+float MgTDampeningFieldMultiplier::GetValue(Action* action)
+{
+    bool const isCompeting =
+        dynamic_cast<CombatFormationMoveAction*>(action) ||
+        dynamic_cast<FollowAction*>(action) ||
+        dynamic_cast<AvoidAoeAction*>(action);
+
+    if (!isCompeting)
+        return 1.0f;
+
+    auto const& spots = AI_VALUE_REF(MagistersTerrace::EscapeSpots, "mgt dampening escape");
+    if (spots.empty())
+        return 1.0f;
+
+    return 0.0f;
+}
+
+float MgTDelrissaTremorTotemMultiplier::GetValue(Action* action)
+{
+    bool const isCompeting =
+        dynamic_cast<CastStrengthOfEarthTotemAction*>(action) ||
+        dynamic_cast<CastStoneskinTotemAction*>(action) ||
+        dynamic_cast<CastEarthbindTotemAction*>(action);
+
+    if (!isCompeting)
+        return 1.0f;
+
+    if (!AI_VALUE(bool, "mgt delrissa tremor totem"))
+        return 1.0f;
+
+    return 0.0f;
+}
+
+float MgTFlameStrikeMultiplier::GetValue(Action* action)
+{
+    bool const isCompeting =
+        dynamic_cast<CombatFormationMoveAction*>(action) ||
+        dynamic_cast<FollowAction*>(action) ||
+        dynamic_cast<AvoidAoeAction*>(action);
+
+    if (!isCompeting)
+        return 1.0f;
+
+    auto const& spots = AI_VALUE_REF(MagistersTerrace::EscapeSpots, "mgt flame strike escape");
+    if (spots.empty())
+        return 1.0f;
+
+    return 0.0f;
+}
+
+float MgTGravityLapseMultiplier::GetValue(Action* action)
+{
+    bool const isCompeting =
+        dynamic_cast<CombatFormationMoveAction*>(action) ||
+        dynamic_cast<FollowAction*>(action) ||
+        dynamic_cast<ReachTargetAction*>(action) ||
+        dynamic_cast<CastReachTargetSpellAction*>(action);
+
+    if (!isCompeting)
+        return 1.0f;
+
+    if (!AI_VALUE(bool, "mgt gravity lapse"))
+        return 1.0f;
+
+    return 0.0f;
+}
+
+float MgTKaelUnattackableMultiplier::GetValue(Action* action)
+{
+    bool const suppressed =
+        dynamic_cast<DpsAssistAction*>(action) ||
+        dynamic_cast<TankAssistAction*>(action) ||
+        dynamic_cast<CastDebuffSpellOnAttackerAction*>(action) ||
+        (action->getThreatType() == Action::ActionThreatType::Aoe && PlayerbotAI::IsDps(bot) &&
+         !dynamic_cast<CastHealingSpellAction*>(action));
+
+    if (!suppressed)
+        return 1.0f;
+
+    if (PlayerbotAI::IsHeal(bot))
+        return 1.0f;
+
+    if (!AI_VALUE(bool, "mgt kael unattackable"))
+        return 1.0f;
+
+    return 0.0f;
+}
+
+float MgTPhoenixBurnMultiplier::GetValue(Action* action)
+{
+    bool const isCompeting =
+        dynamic_cast<CombatFormationMoveAction*>(action) ||
+        dynamic_cast<FollowAction*>(action) ||
+        dynamic_cast<AvoidAoeAction*>(action) ||
+        dynamic_cast<ReachTargetAction*>(action) ||
+        dynamic_cast<CastReachTargetSpellAction*>(action);
+
+    if (!isCompeting)
+        return 1.0f;
+
+    MagistersTerrace::PhoenixRing const ring = AI_VALUE(MagistersTerrace::PhoenixRing, "mgt phoenix ring");
+    if (ring != MagistersTerrace::PhoenixRing::None && dynamic_cast<SetBehindTargetAction*>(action))
+        return 0.0f;
+
+    auto const& spots = AI_VALUE_REF(MagistersTerrace::EscapeSpots, "mgt phoenix escape");
+    if (!spots.empty())
+        return 0.0f;
+
+    if (ring == MagistersTerrace::PhoenixRing::Covers)
+        return 0.0f;
+
+    return 1.0f;
+}

--- a/src/Ai/Dungeon/MgT/MgTMultipliers.h
+++ b/src/Ai/Dungeon/MgT/MgTMultipliers.h
@@ -1,0 +1,82 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_MGTMULTIPLIERS_H
+#define PLAYERBOTS_MGTMULTIPLIERS_H
+
+#include "Multiplier.h"
+
+class MgTCrystalFocusMultiplier : public Multiplier
+{
+public:
+    MgTCrystalFocusMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "mgt crystal focus") {}
+    float GetValue(Action* action) override;
+};
+
+class MgTFocusOrderMultiplier : public Multiplier
+{
+public:
+    MgTFocusOrderMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "mgt focus order") {}
+    float GetValue(Action* action) override;
+};
+
+class MgTFocusBurstMultiplier : public Multiplier
+{
+public:
+    MgTFocusBurstMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "mgt focus burst") {}
+    float GetValue(Action* action) override;
+};
+
+class MgTRoomLeashMultiplier : public Multiplier
+{
+public:
+    MgTRoomLeashMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "mgt room leash") {}
+    float GetValue(Action* action) override;
+};
+
+class MgTDampeningFieldMultiplier : public Multiplier
+{
+public:
+    MgTDampeningFieldMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "mgt dampening field") {}
+    float GetValue(Action* action) override;
+};
+
+class MgTDelrissaTremorTotemMultiplier : public Multiplier
+{
+public:
+    MgTDelrissaTremorTotemMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "mgt delrissa tremor totem") {}
+    float GetValue(Action* action) override;
+};
+
+class MgTFlameStrikeMultiplier : public Multiplier
+{
+public:
+    MgTFlameStrikeMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "mgt flame strike") {}
+    float GetValue(Action* action) override;
+};
+
+class MgTPhoenixBurnMultiplier : public Multiplier
+{
+public:
+    MgTPhoenixBurnMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "mgt phoenix burn") {}
+    float GetValue(Action* action) override;
+};
+
+class MgTKaelUnattackableMultiplier : public Multiplier
+{
+public:
+    MgTKaelUnattackableMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "mgt kael unattackable") {}
+    float GetValue(Action* action) override;
+};
+
+class MgTGravityLapseMultiplier : public Multiplier
+{
+public:
+    MgTGravityLapseMultiplier(PlayerbotAI* botAI) : Multiplier(botAI, "mgt gravity lapse") {}
+    float GetValue(Action* action) override;
+};
+
+#endif

--- a/src/Ai/Dungeon/MgT/MgTShared.cpp
+++ b/src/Ai/Dungeon/MgT/MgTShared.cpp
@@ -1,0 +1,1927 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "MgTShared.h"
+#include "AiObjectContext.h"
+#include "AttackersValue.h"
+#include "Creature.h"
+#include "EncounterHelpers.h"
+#include "Group.h"
+#include "PlayerbotAIConfig.h"
+#include "Playerbots.h"
+#include "Spell.h"
+#include "SpellInfo.h"
+#include "SpellMgr.h"
+#include "Timer.h"
+#include <algorithm>
+#include <cmath>
+#include <iterator>
+#include <limits>
+#include <list>
+#include <string>
+#include <utility>
+
+using namespace EncounterHelpers;
+
+namespace MagistersTerrace
+{
+namespace
+{
+enum MgTNpcs : uint32
+{
+    NPC_SELIN_FIREHEART         = 24723,
+    NPC_FEL_CRYSTAL             = 24722,
+
+    NPC_SUNBLADE_MAGE_GUARD     = 24683,
+    NPC_SUNBLADE_BLOOD_KNIGHT   = 24684,
+    NPC_SUNBLADE_MAGISTER       = 24685,
+    NPC_SUNBLADE_WARLOCK        = 24686,
+    NPC_SUNBLADE_PHYSICIAN      = 24687,
+    NPC_SUNBLADE_IMP            = 24815,
+
+    NPC_WRETCHED_SKULKER        = 24688,
+    NPC_WRETCHED_BRUISER        = 24689,
+    NPC_WRETCHED_HUSK           = 24690,
+
+    NPC_COILSKAR_WITCH          = 24696,
+    NPC_SISTER_OF_TORMENT       = 24697,
+    NPC_ETHEREUM_SMUGGLER       = 24698,
+};
+
+enum MgTSpells : uint32
+{
+    SPELL_MAGIC_DAMPENING_FIELD = 44475,
+
+    SPELL_HOLY_LIGHT            = 44479,
+    SPELL_HOLY_LIGHT_H          = 46029,
+
+    SPELL_ARCANE_NOVA           = 44644,
+    SPELL_ARCANE_NOVA_H         = 46036,
+
+    SPELL_INCINERATE            = 44519,
+    SPELL_INCINERATE_H          = 46043,
+    SPELL_FROSTBOLT             = 44606,
+    SPELL_FROSTBOLT_H           = 46035,
+
+    SPELL_WRETCHED_FIREBALL     = 44503,
+    SPELL_WRETCHED_FROSTBOLT    = 44504,
+
+    SPELL_DEADLY_EMBRACE        = 44547,
+
+    SPELL_FORKED_LIGHTNING      = 20299,
+    SPELL_FORKED_LIGHTNING_H    = 46150,
+
+    SPELL_DRINK_FEL_INFUSION    = 44505,
+};
+
+enum MgTDelrissaNpcs : uint32
+{
+    NPC_DELRISSA                = 24560,
+
+    NPC_APOKO                   = 24553,
+    NPC_ELLRYS_DUSKHALLOW       = 24558,
+    NPC_YAZZAI                  = 24561,
+    NPC_ZELFAN                  = 24556,
+    NPC_GARAXXAS                = 24555,
+    NPC_KAGANI_NIGHTSTRIKE      = 24557,
+    NPC_WARLORD_SALARIS         = 24559,
+    NPC_ERAMAS_BRIGHTBLAZE      = 24554,
+
+    NPC_HIGH_EXPLOSIVE_SHEEP    = 24715,
+
+    NPC_FIZZLE                  = 24656,
+    NPC_SLIVER                  = 24552,
+};
+
+enum MgTDelrissaSpells : uint32
+{
+    SPELL_FLASH_HEAL            = 17843,
+    SPELL_LESSER_HEALING_WAVE   = 44256,
+    SPELL_SUMMON_IMP            = 44163,
+    SPELL_DELRISSA_FEAR         = 38595,
+    SPELL_POLYMORPH             = 13323,
+
+    SPELL_TREMOR_TOTEM          = 8143,
+};
+
+enum MgTKaelNpcs : uint32
+{
+    NPC_KAEL_THAS               = 24664,
+    NPC_FLAMESTRIKE_TRIGGER     = 24666,
+    NPC_PHOENIX                 = 24674,
+    NPC_PHOENIX_EGG             = 24675,
+    NPC_ARCANE_SPHERE           = 24708,
+};
+
+enum MgTKaelSpells : uint32
+{
+    SPELL_FLAME_STRIKE          = 44190,
+    SPELL_FLAME_STRIKE_H        = 46163,
+
+    SPELL_PHOENIX_BURN          = 44197,
+
+    SPELL_SHOCK_BARRIER         = 46165,
+    SPELL_PYROBLAST             = 36819,
+
+    SPELL_KAEL_FIREBALL         = 44189,
+
+    SPELL_GRAVITY_LAPSE_INITIAL = 44224,
+    SPELL_GRAVITY_LAPSE_DOT     = 44226,
+    SPELL_GRAVITY_LAPSE_FLY     = 44227,
+    SPELL_POWER_FEEDBACK        = 44233,
+};
+
+constexpr char const* SELIN_NAME = "selin fireheart";
+constexpr char const* KAEL_NAME  = "kael'thas sunstrider";
+
+constexpr float ROOM_X_MIN = 218.0f;
+constexpr float ROOM_X_MAX = 260.0f;
+constexpr float ROOM_Y_MIN = -40.0f;
+constexpr float ROOM_Y_MAX = 40.0f;
+
+constexpr float CRYSTAL_SCAN_RANGE = 60.0f;
+
+constexpr float DAMPENING_RADIUS = 5.0f;
+constexpr float DAMPENING_STAND  = DAMPENING_RADIUS + 1.5f;
+constexpr float DAMPENING_CLEAR  = DAMPENING_RADIUS + 4.0f;
+constexpr float DAMPENING_SCAN   = 30.0f;
+
+constexpr float TANK_REJOIN_GAP = 5.0f;
+
+constexpr float GLAIVE_MIN_RANGE = 12.0f;
+constexpr float GLAIVE_MAX_RANGE = 60.0f;
+
+constexpr float NOVA_CLEAR = 16.0f;
+
+constexpr float INTERRUPT_SCAN = 30.0f;
+constexpr float WRETCHED_SCAN  = 40.0f;
+constexpr float FOCUS_SCAN     = 40.0f;
+
+constexpr float ESCAPE_LOS_HEIGHT = 2.0f;
+
+constexpr float PARTY_CENTROID_RANGE = 60.0f;
+
+constexpr float ESCAPE_RADII[] = { 7.0f, 10.0f, 13.0f, 16.0f };
+constexpr uint8 ESCAPE_BEARINGS = 12;
+constexpr float ESCAPE_TRAVEL_WEIGHT = 0.25f;
+constexpr uint8 ESCAPE_KEEP = 5;
+
+constexpr float FLAMESTRIKE_STAND = 7.5f;
+constexpr float FLAMESTRIKE_CLEAR = 10.0f;
+constexpr float FLAMESTRIKE_SCAN  = 40.0f;
+
+constexpr float BURN_DAMAGE  = 8.0f;
+constexpr float BURN_STAND   = 9.0f;
+constexpr float BURN_CLEAR   = 12.0f;
+constexpr float PHOENIX_SCAN = 40.0f;
+
+constexpr float BURN_MELEE_STAND = BURN_DAMAGE + 0.5f;
+constexpr float BURN_MELEE_CLEAR = BURN_DAMAGE + 2.5f;
+constexpr float BURN_MELEE_RADII[] = { 3.0f, 5.0f, 7.0f, 9.0f, 12.0f };
+constexpr uint8 BURN_MELEE_BEARINGS = 16;
+
+constexpr float KAEL_MELEE_RING = 5.0f;
+
+constexpr LapseSpot KAEL_P2      = { 148.54f, 181.13f };
+
+constexpr LapseSpot LAPSE_TANK   = { 148.54f, 177.53f };
+constexpr LapseSpot LAPSE_MELEE[] = {
+    { 151.30f, 178.82f },
+    { 145.78f, 178.82f },
+};
+
+constexpr LapseSpot LAPSE_HEALER = { 148.54f, 167.13f };
+constexpr LapseSpot LAPSE_RANGED[] = {
+    { 137.07f, 164.75f },
+    { 148.54f, 155.13f },
+    { 164.92f, 169.66f },
+};
+
+constexpr float SPHERE_DAMAGE    = 5.0f;
+constexpr float SPHERE_CLEAR     = 8.0f;
+constexpr float SPHERE_SCAN      = 40.0f;
+
+constexpr float LAPSE_PUSH_MAX   = 8.0f;
+
+constexpr float SPHERE_SPEED     = 3.0f;
+constexpr float SPHERE_LEAD      = 2.5f;
+
+constexpr float SPHERE_ALERT     = 9.0f;
+constexpr float SPHERE_TRANSIT   = 6.0f;
+constexpr float SPHERE_ROUTE_SLACK = 0.5f;
+
+constexpr float SPHERE_DODGE_NEAR_RADIUS = 4.0f;
+constexpr float SPHERE_DODGE_RADII[]     = { SPHERE_DODGE_NEAR_RADIUS, 7.0f, 11.0f, 15.0f };
+constexpr uint8 SPHERE_DODGE_BEARINGS    = 16;
+constexpr float SPHERE_DODGE_TRAVEL_COST = 0.25f;
+constexpr float SPHERE_DODGE_MARGIN_CAP    = 6.0f;
+constexpr float SPHERE_DODGE_MARGIN_WEIGHT = 0.5f;
+constexpr float SPHERE_DODGE_MIN_GAIN      = 2.0f;
+
+constexpr float KITE_LEG          = 12.0f;
+constexpr float KITE_TURN_MAGNITUDES[] = { 0.0f, 25.0f, 50.0f, 75.0f,
+                                           100.0f, 125.0f, 150.0f, 175.0f };
+
+constexpr float KITE_PROBE_STEP   = 2.0f;
+constexpr float KITE_PROBE_MAX    = 24.0f;
+
+constexpr float KITE_PASS_CLEAR   = SPHERE_DAMAGE;
+constexpr float KITE_RUNWAY_TIEBREAK = 0.5f;
+constexpr float KITE_COMMIT_BONUS = 3.0f;
+constexpr float KITE_COMMIT_STRAIGHT = 10.0f;
+
+constexpr uint32 KITE_COMMIT_BREAK_MS = 1500;
+
+constexpr float KITE_NORTH_MIN    = 340.0f;
+constexpr float KITE_NORTH_MAX    = 20.0f;
+constexpr float KITE_BOWL_MIN     = 100.0f;
+constexpr float KITE_BOWL_MAX     = 260.0f;
+constexpr float KITE_BOWL_RADIUS  = 22.0f;
+constexpr float KITE_SIDE_RADIUS  = 13.0f;
+
+constexpr float LAPSE_TOLERANCE  = 3.0f;
+
+constexpr float LAPSE_BURN_COST = 6.0f;
+
+constexpr float LAPSE_LEG          = 10.0f;
+constexpr float LAPSE_PROGRESS_MIN = 1.0f;
+constexpr float LAPSE_DETOUR_TURNS[] = { 0.0f, 20.0f, 40.0f, 60.0f, 80.0f, 100.0f };
+
+struct Hazard
+{
+    float x;
+    float y;
+    float stand;
+    float clear;
+};
+
+struct ScoredSpot
+{
+    float score;
+    float x;
+    float y;
+};
+
+void CollectCreaturesByEntry(Player* bot, std::vector<uint32> const& entries, float radius,
+                             std::vector<Unit*>& out)
+{
+    std::list<Creature*> found;
+    bot->GetCreatureListWithEntryInGrid(found, entries, radius);
+
+    out.reserve(out.size() + found.size());
+    for (Creature* creature : found)
+    {
+        if (creature->IsAlive())
+            out.push_back(creature);
+    }
+}
+
+void CollectAttackersByEntry(Player* bot, std::vector<uint32> const& entries, float radius,
+                             std::vector<Unit*>& out)
+{
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+
+    auto const& attackers = botAI->GetAiObjectContext()->GetValue<GuidVector>("attackers")->Get();
+    for (ObjectGuid const guid : attackers)
+    {
+        Unit* attacker = botAI->GetUnit(guid);
+        if (!attacker)
+            continue;
+
+        if (std::find(entries.begin(), entries.end(), attacker->GetEntry()) == entries.end())
+            continue;
+
+        if (bot->GetExactDist2d(attacker) > radius)
+            continue;
+
+        out.push_back(attacker);
+    }
+}
+
+bool PartyCentroid(Player* bot, float& cx, float& cy)
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+        return false;
+
+    float sx = 0.0f, sy = 0.0f;
+    int n = 0;
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member || member == bot || !member->IsAlive() || member->GetMapId() != bot->GetMapId())
+            continue;
+        if (bot->GetExactDist2d(member) > PARTY_CENTROID_RANGE)
+            continue;
+
+        sx += member->GetPositionX();
+        sy += member->GetPositionY();
+        ++n;
+    }
+
+    if (n == 0)
+        return false;
+
+    cx = sx / n;
+    cy = sy / n;
+    return true;
+}
+
+bool SpotClearsHazards(std::vector<Hazard> const& hazards, float x, float y)
+{
+    for (Hazard const& hazard : hazards)
+    {
+        float const dx = x - hazard.x;
+        float const dy = y - hazard.y;
+        if (dx * dx + dy * dy < hazard.clear * hazard.clear)
+            return false;
+    }
+
+    return true;
+}
+
+bool InsideAnyHazard(std::vector<Hazard> const& hazards, float x, float y)
+{
+    for (Hazard const& hazard : hazards)
+    {
+        float const dx = x - hazard.x;
+        float const dy = y - hazard.y;
+        if (dx * dx + dy * dy < hazard.stand * hazard.stand)
+            return true;
+    }
+
+    return false;
+}
+
+void KeepBestReachable(Player* bot, std::vector<ScoredSpot>& scored, EscapeSpots& out)
+{
+    std::stable_sort(scored.begin(), scored.end(),
+                     [](ScoredSpot const& a, ScoredSpot const& b) { return a.score < b.score; });
+
+    float const bz = bot->GetPositionZ();
+
+    uint8 kept = 0;
+    for (ScoredSpot const& spot : scored)
+    {
+        float const z = bot->GetMapHeight(spot.x, spot.y, bz + GROUND_SEARCH_UP, true, GROUND_SEARCH_DOWN);
+        if (!(std::fabs(z - bz) <= GROUND_TIER_STEP))
+            continue;
+
+        if (!bot->IsWithinLOS(spot.x, spot.y, z + ESCAPE_LOS_HEIGHT))
+            continue;
+
+        out.push_back({ spot.x, spot.y, z });
+
+        if (++kept >= ESCAPE_KEEP)
+            break;
+    }
+}
+
+void CollectHazardEscapes(Player* bot, std::vector<Hazard> const& hazards, float anchorGap,
+                          EscapeSpots& out)
+{
+    if (hazards.empty())
+        return;
+
+    float const bx = bot->GetPositionX();
+    float const by = bot->GetPositionY();
+
+    if (!InsideAnyHazard(hazards, bx, by))
+        return;
+
+    float cx = 0.0f, cy = 0.0f;
+    bool const haveParty = PartyCentroid(bot, cx, cy);
+
+    std::vector<ScoredSpot> scored;
+    for (float radius : ESCAPE_RADII)
+    {
+        for (int i = 0; i < ESCAPE_BEARINGS; ++i)
+        {
+            float const angle = (2.0f * static_cast<float>(M_PI) * i) / ESCAPE_BEARINGS;
+            float const x = bx + std::cos(angle) * radius;
+            float const y = by + std::sin(angle) * radius;
+            if (!SpotClearsHazards(hazards, x, y))
+                continue;
+
+            float score = radius * ESCAPE_TRAVEL_WEIGHT;
+            if (haveParty)
+                score += std::fabs(std::hypot(x - cx, y - cy) - anchorGap);
+
+            scored.push_back({ score, x, y });
+        }
+    }
+
+    KeepBestReachable(bot, scored, out);
+}
+
+void CollectRingEscapes(Player* bot, Unit* anchor, std::vector<Hazard> const& hazards, EscapeSpots& out)
+{
+    if (hazards.empty())
+        return;
+
+    float const bx = bot->GetPositionX();
+    float const by = bot->GetPositionY();
+
+    if (!InsideAnyHazard(hazards, bx, by))
+        return;
+
+    float const ax = anchor->GetPositionX();
+    float const ay = anchor->GetPositionY();
+
+    std::vector<ScoredSpot> scored;
+    for (float radius : BURN_MELEE_RADII)
+    {
+        for (int i = 0; i < BURN_MELEE_BEARINGS; ++i)
+        {
+            float const angle = (2.0f * static_cast<float>(M_PI) * i) / BURN_MELEE_BEARINGS;
+            float const x = bx + std::cos(angle) * radius;
+            float const y = by + std::sin(angle) * radius;
+            if (!SpotClearsHazards(hazards, x, y))
+                continue;
+
+            float const score = std::hypot(x - ax, y - ay) + radius * ESCAPE_TRAVEL_WEIGHT;
+            scored.push_back({ score, x, y });
+        }
+    }
+
+    KeepBestReachable(bot, scored, out);
+}
+
+uint8 InterruptPriority(uint32 spellId)
+{
+    switch (spellId)
+    {
+        case SPELL_DEADLY_EMBRACE:
+            return 1;
+        case SPELL_HOLY_LIGHT:
+        case SPELL_HOLY_LIGHT_H:
+            return 2;
+        case SPELL_ARCANE_NOVA:
+        case SPELL_ARCANE_NOVA_H:
+            return 3;
+        case SPELL_FORKED_LIGHTNING:
+        case SPELL_FORKED_LIGHTNING_H:
+            return 4;
+        case SPELL_INCINERATE:
+        case SPELL_INCINERATE_H:
+            return 5;
+        case SPELL_FROSTBOLT:
+        case SPELL_FROSTBOLT_H:
+            return 6;
+        case SPELL_WRETCHED_FIREBALL:
+        case SPELL_WRETCHED_FROSTBOLT:
+            return 7;
+        default:
+            return 0;
+    }
+}
+
+uint8 CurrentCastPriority(Unit* caster)
+{
+    uint8 best = 0;
+    for (CurrentSpellTypes slot : { CURRENT_GENERIC_SPELL, CURRENT_CHANNELED_SPELL })
+    {
+        Spell* spell = caster->GetCurrentSpell(slot);
+        if (!spell || !spell->m_spellInfo)
+            continue;
+
+        uint8 const prio = InterruptPriority(spell->m_spellInfo->Id);
+        if (prio && (!best || prio < best))
+            best = prio;
+    }
+
+    return best;
+}
+
+bool StopsACast(uint32 spellId)
+{
+    SpellInfo const* info = sSpellMgr->GetSpellInfo(spellId);
+    if (!info)
+        return false;
+
+    if ((info->InterruptFlags & SPELL_INTERRUPT_FLAG_INTERRUPT) &&
+        info->PreventionType == SPELL_PREVENTION_TYPE_SILENCE)
+        return true;
+
+    for (uint8 i = EFFECT_0; i <= EFFECT_2; ++i)
+    {
+        if (info->Effects[i].Effect == SPELL_EFFECT_INTERRUPT_CAST)
+            return true;
+
+        if (info->Effects[i].Effect != SPELL_EFFECT_APPLY_AURA)
+            continue;
+
+        if (info->Effects[i].ApplyAuraName == SPELL_AURA_MOD_SILENCE ||
+            info->Effects[i].ApplyAuraName == SPELL_AURA_MOD_STUN)
+            return true;
+    }
+
+    return false;
+}
+
+enum class InterruptKind
+{
+    Dedicated,
+    Control,
+};
+
+struct InterruptSpell
+{
+    char const* name;
+    InterruptKind kind;
+};
+
+std::vector<InterruptSpell> const& InterruptSpells()
+{
+    static std::vector<InterruptSpell> const spells = {
+        { "kick", InterruptKind::Dedicated },
+        { "pummel", InterruptKind::Dedicated },
+        { "shield bash", InterruptKind::Dedicated },
+        { "wind shear", InterruptKind::Dedicated },
+        { "mind freeze", InterruptKind::Dedicated },
+        { "counterspell", InterruptKind::Dedicated },
+        { "spell lock", InterruptKind::Dedicated },
+        { "silencing shot", InterruptKind::Dedicated },
+        { "shockwave", InterruptKind::Control },
+        { "shadowfury", InterruptKind::Control },
+        { "concussion blow", InterruptKind::Control },
+        { "hammer of justice", InterruptKind::Control },
+        { "maim", InterruptKind::Control },
+        { "kidney shot", InterruptKind::Control },
+        { "silence", InterruptKind::Control },
+        { "bash", InterruptKind::Control },
+        { "strangulate", InterruptKind::Control },
+        { "arcane torrent", InterruptKind::Control },
+    };
+
+    return spells;
+}
+
+uint8 TrashFocusRank(uint32 entry)
+{
+    switch (entry)
+    {
+        case NPC_SUNBLADE_PHYSICIAN:
+            return 1;
+        case NPC_SUNBLADE_BLOOD_KNIGHT:
+            return 2;
+        case NPC_SISTER_OF_TORMENT:
+            return 3;
+        case NPC_SUNBLADE_WARLOCK:
+            return 4;
+        case NPC_SUNBLADE_MAGISTER:
+            return 5;
+        case NPC_ETHEREUM_SMUGGLER:
+            return 6;
+        case NPC_COILSKAR_WITCH:
+            return 7;
+        case NPC_SUNBLADE_IMP:
+            return 8;
+        case NPC_SUNBLADE_MAGE_GUARD:
+            return 9;
+        default:
+            return 0;
+    }
+}
+
+uint8 RetinueFocusRank(uint32 entry)
+{
+    switch (entry)
+    {
+        case NPC_HIGH_EXPLOSIVE_SHEEP:
+            return 1;
+        case NPC_APOKO:
+            return 2;
+        case NPC_ELLRYS_DUSKHALLOW:
+            return 3;
+        case NPC_YAZZAI:
+            return 4;
+        case NPC_ZELFAN:
+            return 5;
+        case NPC_WARLORD_SALARIS:
+            return 6;
+        case NPC_GARAXXAS:
+            return 7;
+        case NPC_KAGANI_NIGHTSTRIKE:
+            return 8;
+        case NPC_ERAMAS_BRIGHTBLAZE:
+            return 9;
+        case NPC_DELRISSA:
+            return 10;
+        default:
+            return 0;
+    }
+}
+
+Unit* PickRankedFocus(Player* bot, uint8 (*rank)(uint32), std::vector<Unit*> const& extra,
+                      ObjectGuid& latched)
+{
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+
+    Unit* held = nullptr;
+    uint8 heldRank = 0;
+    Unit* best = nullptr;
+    uint8 bestRank = 0;
+    float bestDist = 0.0f;
+
+    auto consider = [&](Unit* candidate)
+    {
+        uint8 const candidateRank = rank(candidate->GetEntry());
+        if (!candidateRank)
+            return;
+
+        float const dist = bot->GetExactDist2d(candidate);
+        if (dist > FOCUS_SCAN)
+            return;
+
+        if (!latched.IsEmpty() && candidate->GetGUID() == latched)
+        {
+            held = candidate;
+            heldRank = candidateRank;
+        }
+
+        if (!best || candidateRank < bestRank || (candidateRank == bestRank && dist < bestDist))
+        {
+            best = candidate;
+            bestRank = candidateRank;
+            bestDist = dist;
+        }
+    };
+
+    auto const& attackers = botAI->GetAiObjectContext()->GetValue<GuidVector>("attackers")->Get();
+    for (ObjectGuid const guid : attackers)
+    {
+        if (Unit* attacker = botAI->GetUnit(guid))
+            consider(attacker);
+    }
+
+    for (Unit* candidate : extra)
+        consider(candidate);
+
+    if (held && heldRank <= bestRank)
+        return held;
+
+    latched = best ? best->GetGUID() : ObjectGuid::Empty;
+    return best;
+}
+
+bool RetinueEngaged(Player* bot)
+{
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+
+    auto const& attackers = botAI->GetAiObjectContext()->GetValue<GuidVector>("attackers")->Get();
+    for (ObjectGuid const guid : attackers)
+    {
+        Unit* attacker = botAI->GetUnit(guid);
+        if (attacker && RetinueFocusRank(attacker->GetEntry()))
+            return true;
+    }
+
+    return false;
+}
+
+uint8 RetinueInterruptPriority(uint32 spellId)
+{
+    switch (spellId)
+    {
+        case SPELL_DELRISSA_FEAR:
+        case SPELL_POLYMORPH:
+            return 1;
+        case SPELL_FLASH_HEAL:
+        case SPELL_LESSER_HEALING_WAVE:
+            return 2;
+        case SPELL_SUMMON_IMP:
+            return 3;
+        default:
+            return 0;
+    }
+}
+
+uint8 CurrentRetinueCastPriority(Unit* caster)
+{
+    uint8 best = 0;
+    for (CurrentSpellTypes slot : { CURRENT_GENERIC_SPELL, CURRENT_CHANNELED_SPELL })
+    {
+        Spell* spell = caster->GetCurrentSpell(slot);
+        if (!spell || !spell->m_spellInfo)
+            continue;
+
+        uint8 const prio = RetinueInterruptPriority(spell->m_spellInfo->Id);
+        if (prio && (!best || prio < best))
+            best = prio;
+    }
+
+    return best;
+}
+
+int InterruptSlot(Player* bot)
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+        return 0;
+
+    int slot = 0;
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member || member == bot || !member->IsAlive() || member->GetMapId() != bot->GetMapId())
+            continue;
+
+        if (!GET_PLAYERBOT_AI(member))
+            continue;
+
+        if (member->GetGUID() < bot->GetGUID())
+            ++slot;
+    }
+
+    return slot;
+}
+
+constexpr FocusOrder FOCUS_ORDER_OWNERS[] = { FocusOrder::Kael, FocusOrder::Delrissa, FocusOrder::Trash };
+constexpr char const* FOCUS_ORDER_KEYS[] = { "mgt kael focus target", "mgt delrissa focus target",
+                                             "mgt focus target" };
+
+bool LapseActive(Player* bot, Unit* kael)
+{
+    if (!kael || kael->HasAura(SPELL_POWER_FEEDBACK))
+        return false;
+
+    if (bot->HasAura(SPELL_GRAVITY_LAPSE_DOT) || bot->HasAura(SPELL_GRAVITY_LAPSE_FLY))
+        return true;
+
+    for (CurrentSpellTypes slot : { CURRENT_GENERIC_SPELL, CURRENT_CHANNELED_SPELL })
+    {
+        Spell* spell = kael->GetCurrentSpell(slot);
+        if (spell && spell->m_spellInfo && spell->m_spellInfo->Id == SPELL_GRAVITY_LAPSE_INITIAL)
+            return true;
+    }
+
+    return false;
+}
+
+uint8 KaelInterruptPriority(uint32 spellId)
+{
+    switch (spellId)
+    {
+        case SPELL_PYROBLAST:
+            return 1;
+        case SPELL_KAEL_FIREBALL:
+            return 2;
+        default:
+            return 0;
+    }
+}
+
+uint8 CurrentKaelCastPriority(Unit* kael)
+{
+    uint8 best = 0;
+    for (CurrentSpellTypes slot : { CURRENT_GENERIC_SPELL, CURRENT_CHANNELED_SPELL })
+    {
+        Spell* spell = kael->GetCurrentSpell(slot);
+        if (!spell || !spell->m_spellInfo)
+            continue;
+
+        uint8 const prio = KaelInterruptPriority(spell->m_spellInfo->Id);
+        if (prio && (!best || prio < best))
+            best = prio;
+    }
+
+    return best;
+}
+
+enum class LapseRole
+{
+    Tank,
+    Healer,
+    Melee,
+    Ranged
+};
+
+LapseRole ClassifyLapseRole(Player* member)
+{
+    if (PlayerbotAI::IsTank(member))
+        return LapseRole::Tank;
+
+    if (PlayerbotAI::IsHeal(member))
+        return LapseRole::Healer;
+
+    if (PlayerbotAI::IsMelee(member))
+        return LapseRole::Melee;
+
+    return LapseRole::Ranged;
+}
+
+int LapseSlot(Player* bot, LapseRole role)
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+        return 0;
+
+    int slot = 0;
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member || member == bot || !member->IsAlive() || member->GetMapId() != bot->GetMapId())
+            continue;
+
+        if (!GET_PLAYERBOT_AI(member) || ClassifyLapseRole(member) != role)
+            continue;
+
+        if (member->GetGUID() < bot->GetGUID())
+            ++slot;
+    }
+
+    return slot;
+}
+
+bool LapseAnchor(Player* bot, LapseSpot& out)
+{
+    LapseRole const role = ClassifyLapseRole(bot);
+    size_t const slot = static_cast<size_t>(LapseSlot(bot, role));
+
+    switch (role)
+    {
+        case LapseRole::Tank:
+            out = LAPSE_TANK;
+            break;
+        case LapseRole::Healer:
+            out = LAPSE_HEALER;
+            break;
+        case LapseRole::Melee:
+            out = LAPSE_MELEE[slot % std::size(LAPSE_MELEE)];
+            break;
+        default:
+            out = LAPSE_RANGED[slot % std::size(LAPSE_RANGED)];
+            break;
+    }
+
+    return true;
+}
+
+float BearingFromKael(float x, float y)
+{
+    float degrees = std::atan2(x - KAEL_P2.x, y - KAEL_P2.y) * 180.0f / static_cast<float>(M_PI);
+    if (degrees < 0.0f)
+        degrees += 360.0f;
+
+    return degrees;
+}
+
+bool SphereHeading(Unit* sphere, float& hx, float& hy)
+{
+    if (Unit* victim = sphere->GetVictim())
+    {
+        float const dx = victim->GetPositionX() - sphere->GetPositionX();
+        float const dy = victim->GetPositionY() - sphere->GetPositionY();
+        float const len = std::hypot(dx, dy);
+        if (len < 0.1f)
+            return false;
+
+        hx = dx / len;
+        hy = dy / len;
+        return true;
+    }
+
+    hx = std::cos(sphere->GetOrientation());
+    hy = std::sin(sphere->GetOrientation());
+    return true;
+}
+
+float DistanceToSphereSweep(Unit* sphere, float x, float y)
+{
+    float const sx = sphere->GetPositionX();
+    float const sy = sphere->GetPositionY();
+
+    float hx = 0.0f, hy = 0.0f;
+    if (!SphereHeading(sphere, hx, hy))
+        return std::hypot(x - sx, y - sy);
+
+    float const reach = SPHERE_SPEED * SPHERE_LEAD;
+    float t = (x - sx) * hx + (y - sy) * hy;
+    t = std::clamp(t, 0.0f, reach);
+
+    return std::hypot(x - (sx + hx * t), y - (sy + hy * t));
+}
+
+float PointToSegment(float px, float py, float ax, float ay, float bx, float by)
+{
+    float const dx = bx - ax;
+    float const dy = by - ay;
+    float const len2 = dx * dx + dy * dy;
+    if (len2 < 0.0001f)
+        return std::hypot(px - ax, py - ay);
+
+    float t = ((px - ax) * dx + (py - ay) * dy) / len2;
+    t = std::clamp(t, 0.0f, 1.0f);
+
+    return std::hypot(px - (ax + dx * t), py - (ay + dy * t));
+}
+
+float SegmentToSegment(float ax, float ay, float bx, float by, float cx, float cy, float dx, float dy)
+{
+    auto side = [](float ox, float oy, float px, float py, float qx, float qy)
+    { return (px - ox) * (qy - oy) - (py - oy) * (qx - ox); };
+
+    float const d1 = side(cx, cy, dx, dy, ax, ay);
+    float const d2 = side(cx, cy, dx, dy, bx, by);
+    float const d3 = side(ax, ay, bx, by, cx, cy);
+    float const d4 = side(ax, ay, bx, by, dx, dy);
+
+    if (((d1 > 0.0f) != (d2 > 0.0f)) && ((d3 > 0.0f) != (d4 > 0.0f)))
+        return 0.0f;
+
+    return std::min({ PointToSegment(ax, ay, cx, cy, dx, dy), PointToSegment(bx, by, cx, cy, dx, dy),
+                      PointToSegment(cx, cy, ax, ay, bx, by), PointToSegment(dx, dy, ax, ay, bx, by) });
+}
+
+float WalkClearanceOfSphere(Unit* sphere, float fx, float fy, float tx, float ty)
+{
+    float const sx = sphere->GetPositionX();
+    float const sy = sphere->GetPositionY();
+
+    float hx = 0.0f, hy = 0.0f;
+    if (!SphereHeading(sphere, hx, hy))
+        return PointToSegment(sx, sy, fx, fy, tx, ty);
+
+    float const reach = SPHERE_SPEED * SPHERE_LEAD;
+
+    return SegmentToSegment(fx, fy, tx, ty, sx, sy, sx + hx * reach, sy + hy * reach);
+}
+
+bool InsideKiteArena(float x, float y, bool healer)
+{
+    float const bearing = BearingFromKael(x, y);
+
+    if (bearing >= KITE_NORTH_MIN || bearing <= KITE_NORTH_MAX)
+        return false;
+
+    bool const bowl = bearing >= KITE_BOWL_MIN && bearing <= KITE_BOWL_MAX;
+    if (healer && !bowl)
+        return false;
+
+    float const limit = bowl ? KITE_BOWL_RADIUS : KITE_SIDE_RADIUS;
+
+    return std::hypot(x - KAEL_P2.x, y - KAEL_P2.y) <= limit;
+}
+
+float KiteRunway(float fx, float fy, float hx, float hy, bool healer, bool outside)
+{
+    int const steps = static_cast<int>(KITE_PROBE_MAX / KITE_PROBE_STEP);
+
+    bool started = !outside;
+    float runway = 0.0f;
+    for (int i = 1; i <= steps; ++i)
+    {
+        float const step = KITE_PROBE_STEP * i;
+        bool const clear = InsideKiteArena(fx + hx * step, fy + hy * step, healer);
+
+        if (!started)
+        {
+            if (clear)
+            {
+                started = true;
+                runway = step;
+            }
+
+            continue;
+        }
+
+        if (!clear)
+            break;
+
+        runway = step;
+    }
+
+    return started ? runway : 0.0f;
+}
+
+bool IsLapseHealer(Player* bot)
+{
+    return PlayerbotAI::IsHeal(bot) && !PlayerbotAI::IsTank(bot);
+}
+
+bool InsideAnyBurn(std::vector<LapseSpot> const& burns, float x, float y)
+{
+    for (LapseSpot const& burn : burns)
+    {
+        if (std::hypot(x - burn.x, y - burn.y) < BURN_DAMAGE)
+            return true;
+    }
+
+    return false;
+}
+
+Unit* GetChasingSphere(Player* bot, LapseWorld const& world)
+{
+    for (Unit* sphere : world.spheres)
+    {
+        if (sphere->GetVictim() == bot)
+            return sphere;
+    }
+
+    return nullptr;
+}
+
+float BurningPhoenixKaelGap(Player* bot, Unit* kael)
+{
+    std::vector<Unit*> phoenixes;
+    CollectCreaturesByEntry(bot, { NPC_PHOENIX }, PHOENIX_SCAN, phoenixes);
+
+    float gap = std::numeric_limits<float>::max();
+    for (Unit* phoenix : phoenixes)
+    {
+        if (phoenix->HasAura(SPELL_PHOENIX_BURN))
+            gap = std::min(gap, phoenix->GetExactDist2d(kael));
+    }
+
+    return gap;
+}
+}
+
+Unit* GetSelin(Player* bot)
+{
+    return GET_PLAYERBOT_AI(bot)->GetAiObjectContext()->GetValue<Unit*>("find target", SELIN_NAME)->Get();
+}
+
+Unit* GetKaelthas(Player* bot)
+{
+    return GET_PLAYERBOT_AI(bot)->GetAiObjectContext()->GetValue<Unit*>("find target", KAEL_NAME)->Get();
+}
+
+Unit* GetActiveFelCrystal(Player* bot)
+{
+    if (!GetSelin(bot))
+        return nullptr;
+
+    std::vector<Unit*> crystals;
+    CollectCreaturesByEntry(bot, { NPC_FEL_CRYSTAL }, CRYSTAL_SCAN_RANGE, crystals);
+
+    Unit* best = nullptr;
+    float bestDist = CRYSTAL_SCAN_RANGE;
+    for (Unit* crystal : crystals)
+    {
+        if (!AttackersValue::IsValidTarget(crystal, bot))
+            continue;
+
+        float const dist = bot->GetExactDist2d(crystal);
+        if (dist < bestDist)
+        {
+            bestDist = dist;
+            best = crystal;
+        }
+    }
+
+    return best;
+}
+
+void CollectDampeningEscapes(Player* bot, EscapeSpots& out)
+{
+    if (!bot->IsInCombat())
+        return;
+
+    std::vector<Hazard> fields;
+    for (Position const& pos : GetDynamicObjectPositions(bot, DAMPENING_SCAN, SPELL_MAGIC_DAMPENING_FIELD))
+        fields.push_back({ pos.GetPositionX(), pos.GetPositionY(), DAMPENING_STAND, DAMPENING_CLEAR });
+
+    CollectHazardEscapes(bot, fields, PlayerbotAI::IsTank(bot) ? TANK_REJOIN_GAP : 0.0f, out);
+}
+
+Unit* GetGlaiveThrowingMageGuard(Player* bot)
+{
+    std::vector<Unit*> guards;
+    CollectAttackersByEntry(bot, { NPC_SUNBLADE_MAGE_GUARD }, GLAIVE_MAX_RANGE, guards);
+
+    for (Unit* guard : guards)
+    {
+        if (guard->GetVictim() != bot)
+            continue;
+
+        if (bot->GetExactDist2d(guard) > GLAIVE_MIN_RANGE)
+            return guard;
+    }
+
+    return nullptr;
+}
+
+void CollectNovaEscapes(Player* bot, EscapeSpots& out)
+{
+    if (PlayerbotAI::IsMelee(bot))
+        return;
+
+    std::vector<Unit*> magisters;
+    CollectAttackersByEntry(bot, { NPC_SUNBLADE_MAGISTER }, NOVA_CLEAR, magisters);
+
+    std::vector<Hazard> hazards;
+    hazards.reserve(magisters.size());
+    for (Unit* magister : magisters)
+    {
+        hazards.push_back({ magister->GetPositionX(), magister->GetPositionY(), NOVA_CLEAR,
+                            NOVA_CLEAR + 2.0f });
+    }
+
+    CollectHazardEscapes(bot, hazards, 0.0f, out);
+}
+
+uint8 GetInterruptUrgency(Unit* caster)
+{
+    return caster ? CurrentCastPriority(caster) : 0;
+}
+
+Unit* GetInterruptTarget(Player* bot)
+{
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+
+    Unit* best = nullptr;
+    uint8 bestPrio = 0;
+    float bestDist = 0.0f;
+    auto const& attackers = botAI->GetAiObjectContext()->GetValue<GuidVector>("attackers")->Get();
+    for (ObjectGuid const guid : attackers)
+    {
+        Unit* caster = botAI->GetUnit(guid);
+        if (!caster)
+            continue;
+
+        float const dist = bot->GetExactDist2d(caster);
+        if (dist > INTERRUPT_SCAN)
+            continue;
+
+        uint8 const prio = CurrentCastPriority(caster);
+        if (!prio)
+            continue;
+
+        if (!best || prio < bestPrio || (prio == bestPrio && dist < bestDist))
+        {
+            best = caster;
+            bestPrio = prio;
+            bestDist = dist;
+        }
+    }
+
+    return best;
+}
+
+std::string CastInterrupt(PlayerbotAI* botAI, Unit* target, uint8 urgency)
+{
+    if (!target->IsNonMeleeSpellCast(true))
+        return {};
+
+    bool const allowControl = urgency && urgency <= CONTROL_INTERRUPT_URGENCY;
+
+    for (InterruptSpell const& entry : InterruptSpells())
+    {
+        if (entry.kind == InterruptKind::Control && !allowControl)
+            continue;
+
+        std::string const name = entry.name;
+
+        uint32 const spellId = botAI->GetAiObjectContext()->GetValue<uint32>("spell id", name)->Get();
+        if (!spellId || !StopsACast(spellId))
+            continue;
+
+        if (!botAI->CanCastSpell(name, target))
+            continue;
+
+        if (botAI->CastSpell(name, target))
+            return name;
+    }
+
+    return {};
+}
+
+uint8 GetRetinueInterruptUrgency(Unit* caster)
+{
+    return caster ? CurrentRetinueCastPriority(caster) : 0;
+}
+
+Unit* GetFocusTarget(Player* bot, ObjectGuid& latched)
+{
+    return PickRankedFocus(bot, &TrashFocusRank, {}, latched);
+}
+
+ObjectGuid ResolveFocusOrder(PlayerbotAI* botAI)
+{
+    AiObjectContext* context = botAI->GetAiObjectContext();
+
+    for (char const* key : FOCUS_ORDER_KEYS)
+    {
+        ObjectGuid const order = context->GetValue<ObjectGuid>(key)->Get();
+        if (!order.IsEmpty())
+            return order;
+    }
+
+    return ObjectGuid::Empty;
+}
+
+FocusOrder ResolveFocusOrderOwner(PlayerbotAI* botAI)
+{
+    AiObjectContext* context = botAI->GetAiObjectContext();
+
+    for (size_t i = 0; i < std::size(FOCUS_ORDER_KEYS); ++i)
+    {
+        if (!context->GetValue<ObjectGuid>(FOCUS_ORDER_KEYS[i])->Get().IsEmpty())
+            return FOCUS_ORDER_OWNERS[i];
+    }
+
+    return FocusOrder::None;
+}
+
+void CollectFocusExclusions(Player* bot, std::vector<ObjectGuid>& out)
+{
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+
+    ObjectGuid const order = ResolveFocusOrder(botAI);
+    if (order.IsEmpty())
+        return;
+
+    Unit* focus = botAI->GetUnit(order);
+    bool const transient = !focus || focus->GetEntry() == NPC_HIGH_EXPLOSIVE_SHEEP ||
+                           focus->GetEntry() == NPC_PHOENIX_EGG;
+
+    auto const& attackers = botAI->GetAiObjectContext()->GetValue<GuidVector>("attackers")->Get();
+    out.reserve(out.size() + attackers.size() + 1);
+    for (ObjectGuid const guid : attackers)
+    {
+        if (guid != order)
+            out.push_back(guid);
+    }
+
+    if (transient)
+        out.push_back(order);
+}
+
+Unit* GetEnragedWretched(Player* bot)
+{
+    std::vector<Unit*> wretched;
+    CollectAttackersByEntry(bot, { NPC_WRETCHED_SKULKER, NPC_WRETCHED_BRUISER, NPC_WRETCHED_HUSK },
+                            WRETCHED_SCAN, wretched);
+
+    Unit* best = nullptr;
+    float bestDist = WRETCHED_SCAN;
+    for (Unit* mob : wretched)
+    {
+        if (!mob->HasAura(SPELL_DRINK_FEL_INFUSION))
+            continue;
+
+        Unit* victim = mob->GetVictim();
+        if (!victim || victim == bot)
+            continue;
+
+        float const dist = bot->GetExactDist2d(mob);
+        if (dist < bestDist)
+        {
+            bestDist = dist;
+            best = mob;
+        }
+    }
+
+    return best;
+}
+
+std::vector<std::string> const& TauntSpellNames()
+{
+    static std::vector<std::string> const names = { "taunt", "growl", "dark command", "hand of reckoning" };
+
+    return names;
+}
+
+void ClampIntoRoom(float& x, float& y)
+{
+    x = std::clamp(x, ROOM_X_MIN, ROOM_X_MAX);
+    y = std::clamp(y, ROOM_Y_MIN, ROOM_Y_MAX);
+}
+
+bool ShouldHoldTremorTotem(Player* bot)
+{
+    if (bot->getClass() != CLASS_SHAMAN || !bot->HasSpell(SPELL_TREMOR_TOTEM))
+        return false;
+
+    return RetinueEngaged(bot);
+}
+
+Unit* GetDelrissaFocusTarget(Player* bot, ObjectGuid& latched)
+{
+    std::vector<Unit*> sheep;
+    if (RetinueEngaged(bot))
+    {
+        std::vector<Unit*> found;
+        CollectCreaturesByEntry(bot, { NPC_HIGH_EXPLOSIVE_SHEEP }, FOCUS_SCAN, found);
+
+        for (Unit* mob : found)
+        {
+            if (AttackersValue::IsValidTarget(mob, bot))
+                sheep.push_back(mob);
+        }
+    }
+
+    return PickRankedFocus(bot, &RetinueFocusRank, sheep, latched);
+}
+
+void CollectDelrissaInterruptPreference(Player* bot, std::vector<Unit*>& out)
+{
+    PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot);
+
+    std::vector<std::pair<uint8, Unit*>> ranked;
+    auto const& attackers = botAI->GetAiObjectContext()->GetValue<GuidVector>("attackers")->Get();
+    for (ObjectGuid const guid : attackers)
+    {
+        Unit* caster = botAI->GetUnit(guid);
+        if (!caster || bot->GetExactDist2d(caster) > INTERRUPT_SCAN)
+            continue;
+
+        if (!RetinueFocusRank(caster->GetEntry()))
+            continue;
+
+        if (uint8 const prio = CurrentRetinueCastPriority(caster))
+            ranked.push_back({ prio, caster });
+    }
+
+    if (ranked.empty())
+        return;
+
+    std::sort(ranked.begin(), ranked.end(), [](auto const& a, auto const& b) {
+        if (a.first != b.first)
+            return a.first < b.first;
+
+        return a.second->GetGUID() < b.second->GetGUID();
+    });
+
+    size_t const slot = static_cast<size_t>(InterruptSlot(bot));
+    size_t const index = slot < ranked.size() ? slot : 0;
+
+    out.reserve(out.size() + ranked.size());
+    out.push_back(ranked[index].second);
+
+    for (size_t i = 0; i < ranked.size(); ++i)
+    {
+        if (i != index)
+            out.push_back(ranked[i].second);
+    }
+}
+
+void CollectDelrissaPets(Player* bot, std::vector<ObjectGuid>& out)
+{
+    std::vector<Unit*> pets;
+    CollectAttackersByEntry(bot, { NPC_FIZZLE, NPC_SLIVER }, FOCUS_SCAN, pets);
+
+    out.reserve(out.size() + pets.size());
+    for (Unit* pet : pets)
+        out.push_back(pet->GetGUID());
+}
+
+Unit* GetKaelInterruptTarget(Player* bot)
+{
+    Unit* kael = GetKaelthas(bot);
+    if (!kael || kael->HasAura(SPELL_SHOCK_BARRIER))
+        return nullptr;
+
+    return CurrentKaelCastPriority(kael) ? kael : nullptr;
+}
+
+bool IsKaelUnattackable(Player* bot)
+{
+    Unit* kael = GetKaelthas(bot);
+
+    return kael && kael->HasUnitFlag(UNIT_FLAG_IMMUNE_TO_PC);
+}
+
+void CollectFlameStrikeEscapes(Player* bot, EscapeSpots& out)
+{
+    if (!GetKaelthas(bot))
+        return;
+
+    std::vector<Hazard> hazards;
+
+    std::vector<Unit*> triggers;
+    CollectCreaturesByEntry(bot, { NPC_FLAMESTRIKE_TRIGGER }, FLAMESTRIKE_SCAN, triggers);
+    for (Unit* trigger : triggers)
+    {
+        hazards.push_back({ trigger->GetPositionX(), trigger->GetPositionY(), FLAMESTRIKE_STAND,
+                            FLAMESTRIKE_CLEAR });
+    }
+
+    for (uint32 spellId : { SPELL_FLAME_STRIKE, SPELL_FLAME_STRIKE_H })
+    {
+        for (Position const& pos : GetDynamicObjectPositions(bot, FLAMESTRIKE_SCAN, spellId))
+        {
+            hazards.push_back({ pos.GetPositionX(), pos.GetPositionY(), FLAMESTRIKE_STAND,
+                                FLAMESTRIKE_CLEAR });
+        }
+    }
+
+    CollectHazardEscapes(bot, hazards, 0.0f, out);
+}
+
+void CollectPhoenixEscapes(Player* bot, EscapeSpots& out)
+{
+    Unit* kael = GetKaelthas(bot);
+    if (!kael || LapseActive(bot, kael))
+        return;
+
+    bool const melee = PlayerbotAI::IsMelee(bot);
+    float const stand = melee ? BURN_MELEE_STAND : BURN_STAND;
+    float const clear = melee ? BURN_MELEE_CLEAR : BURN_CLEAR;
+
+    std::vector<Unit*> phoenixes;
+    CollectCreaturesByEntry(bot, { NPC_PHOENIX }, PHOENIX_SCAN, phoenixes);
+
+    std::vector<Hazard> hazards;
+    for (Unit* phoenix : phoenixes)
+    {
+        if (!phoenix->HasAura(SPELL_PHOENIX_BURN))
+            continue;
+
+        hazards.push_back({ phoenix->GetPositionX(), phoenix->GetPositionY(), stand, clear });
+    }
+
+    if (melee)
+        CollectRingEscapes(bot, kael, hazards, out);
+    else
+        CollectHazardEscapes(bot, hazards, 0.0f, out);
+}
+
+PhoenixRing GetPhoenixRing(Player* bot)
+{
+    if (!PlayerbotAI::IsMelee(bot))
+        return PhoenixRing::None;
+
+    Unit* kael = GetKaelthas(bot);
+    if (!kael || LapseActive(bot, kael))
+        return PhoenixRing::None;
+
+    float const gap = BurningPhoenixKaelGap(bot, kael);
+    if (gap >= KAEL_MELEE_RING + BURN_MELEE_CLEAR)
+        return PhoenixRing::None;
+
+    if (gap < BURN_MELEE_CLEAR - KAEL_MELEE_RING &&
+        bot->GetExactDist2d(kael) <= KAEL_MELEE_RING + BURN_MELEE_CLEAR)
+        return PhoenixRing::Covers;
+
+    return PhoenixRing::Threatens;
+}
+
+Unit* GetKaelFocusTarget(Player* bot)
+{
+    Unit* kael = GetKaelthas(bot);
+    if (!kael)
+        return nullptr;
+
+    if (kael->HasAura(SPELL_SHOCK_BARRIER) && AttackersValue::IsValidTarget(kael, bot))
+        return kael;
+
+    std::vector<Unit*> kin;
+    CollectCreaturesByEntry(bot, { NPC_PHOENIX_EGG, NPC_PHOENIX }, PHOENIX_SCAN, kin);
+
+    Unit* best = nullptr;
+    float bestDist = PHOENIX_SCAN;
+    for (Unit* egg : kin)
+    {
+        if (egg->GetEntry() != NPC_PHOENIX_EGG || !AttackersValue::IsValidTarget(egg, bot))
+            continue;
+
+        float const dist = bot->GetExactDist2d(egg);
+        if (dist < bestDist)
+        {
+            bestDist = dist;
+            best = egg;
+        }
+    }
+
+    if (best)
+        return best;
+
+    if (PlayerbotAI::IsMelee(bot))
+        return nullptr;
+
+    bestDist = PHOENIX_SCAN;
+    for (Unit* phoenix : kin)
+    {
+        if (phoenix->GetEntry() != NPC_PHOENIX || !phoenix->IsInCombat() ||
+            !AttackersValue::IsValidTarget(phoenix, bot))
+            continue;
+
+        float const dist = bot->GetExactDist2d(phoenix);
+        if (dist < bestDist)
+        {
+            bestDist = dist;
+            best = phoenix;
+        }
+    }
+
+    return best;
+}
+
+bool IsGravityLapseActive(Player* bot)
+{
+    return LapseActive(bot, GetKaelthas(bot));
+}
+
+void CollectLapseWorld(Player* bot, LapseWorld& out)
+{
+    std::vector<Unit*> units;
+    CollectCreaturesByEntry(bot, { NPC_ARCANE_SPHERE, NPC_PHOENIX }, std::max(SPHERE_SCAN, PHOENIX_SCAN), units);
+
+    for (Unit* unit : units)
+    {
+        if (unit->GetEntry() == NPC_ARCANE_SPHERE && bot->GetExactDist2d(unit) <= SPHERE_SCAN)
+            out.spheres.push_back(unit);
+        else if (unit->GetEntry() == NPC_PHOENIX && unit->HasAura(SPELL_PHOENIX_BURN) &&
+                 bot->GetExactDist2d(unit) <= PHOENIX_SCAN)
+            out.burns.push_back({ unit->GetPositionX(), unit->GetPositionY() });
+    }
+}
+
+bool GetGravityLapseKite(Player* bot, LapseWorld const& world, LapseSpot& out, KiteState& state)
+{
+    Unit* chaser = GetChasingSphere(bot, world);
+    if (!chaser)
+    {
+        state = KiteState{};
+        return false;
+    }
+
+    if (state.lastMs && GetMSTimeDiffToNow(state.lastMs) > KITE_COMMIT_BREAK_MS)
+        state = KiteState{};
+
+    float const bx = bot->GetPositionX();
+    float const by = bot->GetPositionY();
+
+    float ax = bx - chaser->GetPositionX();
+    float ay = by - chaser->GetPositionY();
+    float away = std::hypot(ax, ay);
+
+    if (away < 0.1f)
+    {
+        ax = bx - KAEL_P2.x;
+        ay = by - KAEL_P2.y;
+        away = std::hypot(ax, ay);
+        if (away < 0.1f)
+            return false;
+    }
+
+    ax /= away;
+    ay /= away;
+
+    bool const healer = IsLapseHealer(bot);
+    bool const outside = !InsideKiteArena(bx, by, healer);
+
+    float here = std::numeric_limits<float>::max();
+    for (Unit* other : world.spheres)
+        here = std::min(here, DistanceToSphereSweep(other, bx, by));
+
+    float const passBar = std::min(KITE_PASS_CLEAR, here - SPHERE_ROUTE_SLACK);
+
+    bool haveFallback = false;
+    float fallbackClear = -1.0f;
+    float fallbackTurn = 0.0f;
+    LapseSpot fallback = { bx, by };
+
+    for (int pass = 0; pass < 2; ++pass)
+    {
+        bool const requireFullLeg = pass == 0;
+
+        for (float magnitude : KITE_TURN_MAGNITUDES)
+        {
+            bool found = false;
+            float bestPreference = 0.0f;
+            float bestTurn = 0.0f;
+            LapseSpot best = { bx, by };
+
+            for (int side = 0; side < 2; ++side)
+            {
+                float const turn = side ? -magnitude : magnitude;
+                if (side && magnitude <= 0.0f)
+                    continue;
+
+                float const angle = turn * static_cast<float>(M_PI) / 180.0f;
+                float const cosT = std::cos(angle);
+                float const sinT = std::sin(angle);
+
+                float const hx = ax * cosT - ay * sinT;
+                float const hy = ax * sinT + ay * cosT;
+
+                float const x = bx + hx * KITE_LEG;
+                float const y = by + hy * KITE_LEG;
+
+                float const runway = KiteRunway(bx, by, hx, hy, healer, outside);
+
+                if (requireFullLeg ? runway < KITE_LEG : !InsideKiteArena(x, y, healer))
+                    continue;
+
+                float clearance = std::numeric_limits<float>::max();
+                for (Unit* other : world.spheres)
+                    clearance = std::min(clearance, WalkClearanceOfSphere(other, bx, by, x, y));
+
+                if (clearance < passBar)
+                {
+                    if (clearance > fallbackClear)
+                    {
+                        haveFallback = true;
+                        fallbackClear = clearance;
+                        fallbackTurn = turn;
+                        fallback = { x, y };
+                    }
+
+                    continue;
+                }
+
+                float preference = clearance + runway * KITE_RUNWAY_TIEBREAK;
+
+                if (std::fabs(turn) > KITE_COMMIT_STRAIGHT && std::fabs(state.turn) > KITE_COMMIT_STRAIGHT &&
+                    (turn > 0.0f) == (state.turn > 0.0f))
+                    preference += KITE_COMMIT_BONUS;
+
+                if (InsideAnyBurn(world.burns, x, y))
+                    preference -= LAPSE_BURN_COST;
+
+                if (!found || preference > bestPreference)
+                {
+                    found = true;
+                    bestPreference = preference;
+                    bestTurn = turn;
+                    best = { x, y };
+                }
+            }
+
+            if (found)
+            {
+                out = best;
+                state.turn = bestTurn;
+                state.lastMs = getMSTime();
+
+                return true;
+            }
+        }
+    }
+
+    if (!haveFallback)
+        return false;
+
+    out = fallback;
+    state.turn = fallbackTurn;
+    state.lastMs = getMSTime();
+
+    return true;
+}
+
+bool IsLapseMeleeSlot(Player* bot)
+{
+    LapseRole const role = ClassifyLapseRole(bot);
+
+    return role == LapseRole::Tank || role == LapseRole::Melee;
+}
+
+bool GetGravityLapseDodge(Player* bot, LapseWorld const& world, LapseSpot& out)
+{
+    if (world.spheres.empty())
+        return false;
+
+    float const bx = bot->GetPositionX();
+    float const by = bot->GetPositionY();
+
+    float here = std::numeric_limits<float>::max();
+    for (Unit* sphere : world.spheres)
+        here = std::min(here, DistanceToSphereSweep(sphere, bx, by));
+
+    if (here >= SPHERE_ALERT)
+        return false;
+
+    LapseSpot anchor = { bx, by };
+    LapseAnchor(bot, anchor);
+
+    bool const healer = IsLapseHealer(bot);
+
+    float const routeBar = std::min(SPHERE_TRANSIT, here - SPHERE_ROUTE_SLACK);
+
+    bool found = false;
+    float best = 0.0f;
+
+    bool haveFallback = false;
+    float fallbackClearance = 0.0f;
+    LapseSpot fallback = { bx, by };
+
+    for (float radius : SPHERE_DODGE_RADII)
+    {
+        for (int i = 0; i < SPHERE_DODGE_BEARINGS; ++i)
+        {
+            float const angle = (2.0f * static_cast<float>(M_PI) * i) / SPHERE_DODGE_BEARINGS;
+            float const x = bx + std::cos(angle) * radius;
+            float const y = by + std::sin(angle) * radius;
+
+            if (!InsideKiteArena(x, y, healer))
+                continue;
+
+            float clearance = std::numeric_limits<float>::max();
+            float route = std::numeric_limits<float>::max();
+            for (Unit* sphere : world.spheres)
+            {
+                clearance = std::min(clearance, DistanceToSphereSweep(sphere, x, y));
+                route = std::min(route, WalkClearanceOfSphere(sphere, bx, by, x, y));
+            }
+
+            if (route < routeBar)
+                continue;
+
+            if (clearance < SPHERE_CLEAR)
+            {
+                if (clearance > here + SPHERE_DODGE_MIN_GAIN && clearance > fallbackClearance)
+                {
+                    haveFallback = true;
+                    fallbackClearance = clearance;
+                    fallback = { x, y };
+                }
+
+                continue;
+            }
+
+            float const margin = std::min(clearance - SPHERE_CLEAR, SPHERE_DODGE_MARGIN_CAP);
+            float const score = std::hypot(x - anchor.x, y - anchor.y) +
+                                radius * SPHERE_DODGE_TRAVEL_COST - margin * SPHERE_DODGE_MARGIN_WEIGHT +
+                                (InsideAnyBurn(world.burns, x, y) ? LAPSE_BURN_COST : 0.0f);
+
+            if (!found || score < best)
+            {
+                best = score;
+                out = { x, y };
+                found = true;
+            }
+        }
+    }
+
+    if (found)
+        return true;
+
+    if (haveFallback)
+    {
+        out = fallback;
+        return true;
+    }
+
+    return false;
+}
+
+bool GetGravityLapseSpot(Player* bot, LapseWorld const& world, LapseSpot& out)
+{
+    if (!LapseAnchor(bot, out))
+        return false;
+
+    LapseSpot const anchor = out;
+
+    for (Unit* sphere : world.spheres)
+    {
+        float dx = out.x - sphere->GetPositionX();
+        float dy = out.y - sphere->GetPositionY();
+        float dist = std::hypot(dx, dy);
+        if (dist >= SPHERE_CLEAR)
+            continue;
+
+        if (dist < 0.1f)
+        {
+            dx = out.x - KAEL_P2.x;
+            dy = out.y - KAEL_P2.y;
+            dist = std::hypot(dx, dy);
+            if (dist < 0.1f)
+                break;
+        }
+
+        out.x = sphere->GetPositionX() + (dx / dist) * SPHERE_CLEAR;
+        out.y = sphere->GetPositionY() + (dy / dist) * SPHERE_CLEAR;
+    }
+
+    float const pushX = out.x - anchor.x;
+    float const pushY = out.y - anchor.y;
+    float const push = std::hypot(pushX, pushY);
+    if (push > LAPSE_PUSH_MAX)
+    {
+        out.x = anchor.x + (pushX / push) * LAPSE_PUSH_MAX;
+        out.y = anchor.y + (pushY / push) * LAPSE_PUSH_MAX;
+    }
+
+    bool const healer = IsLapseHealer(bot);
+    if (InsideKiteArena(anchor.x, anchor.y, healer) && !InsideKiteArena(out.x, out.y, healer))
+        out = anchor;
+
+    return true;
+}
+
+bool OnLapseStation(Player* bot, Unit* kael, LapseSpot const& spot)
+{
+    if (!IsLapseMeleeSlot(bot) || !kael)
+        return bot->GetExactDist2d(spot.x, spot.y) <= LAPSE_TOLERANCE;
+
+    return bot->IsWithinCombatRange(kael, sPlayerbotAIConfig.meleeDistance + CONTACT_DISTANCE);
+}
+
+bool LapseThreatened(Player* bot, LapseWorld const& world)
+{
+    float const bx = bot->GetPositionX();
+    float const by = bot->GetPositionY();
+
+    for (Unit* sphere : world.spheres)
+    {
+        if (DistanceToSphereSweep(sphere, bx, by) < SPHERE_ALERT)
+            return true;
+    }
+
+    return false;
+}
+
+bool GetLapseApproach(Player* bot, LapseWorld const& world, LapseSpot const& station, bool allowBlocked,
+                      LapseSpot& out)
+{
+    float const bx = bot->GetPositionX();
+    float const by = bot->GetPositionY();
+
+    float const gap = std::hypot(station.x - bx, station.y - by);
+    if (gap < 0.1f)
+        return false;
+
+    float const leg = std::min(LAPSE_LEG, gap);
+    float const progressBar = std::min(LAPSE_PROGRESS_MIN, leg * 0.5f);
+    float const dx = (station.x - bx) / gap;
+    float const dy = (station.y - by) / gap;
+
+    float here = std::numeric_limits<float>::max();
+    for (Unit* sphere : world.spheres)
+        here = std::min(here, DistanceToSphereSweep(sphere, bx, by));
+
+    float const routeBar = std::min(SPHERE_TRANSIT, here - SPHERE_ROUTE_SLACK);
+
+    bool haveFallback = false;
+    float fallbackRoute = -1.0f;
+    LapseSpot fallback = { bx, by };
+
+    for (float magnitude : LAPSE_DETOUR_TURNS)
+    {
+        bool found = false;
+        float bestRoute = 0.0f;
+        LapseSpot best = { bx, by };
+
+        for (int side = 0; side < 2; ++side)
+        {
+            if (side && magnitude <= 0.0f)
+                continue;
+
+            float const angle = (side ? -magnitude : magnitude) * static_cast<float>(M_PI) / 180.0f;
+            float const cosT = std::cos(angle);
+            float const sinT = std::sin(angle);
+
+            float const x = bx + (dx * cosT - dy * sinT) * leg;
+            float const y = by + (dx * sinT + dy * cosT) * leg;
+
+            if (gap - std::hypot(station.x - x, station.y - y) < progressBar)
+                continue;
+
+            float route = std::numeric_limits<float>::max();
+            for (Unit* sphere : world.spheres)
+                route = std::min(route, WalkClearanceOfSphere(sphere, bx, by, x, y));
+
+            if (route < routeBar)
+            {
+                if (route > fallbackRoute)
+                {
+                    haveFallback = true;
+                    fallbackRoute = route;
+                    fallback = { x, y };
+                }
+
+                continue;
+            }
+
+            if (!found || route > bestRoute)
+            {
+                found = true;
+                bestRoute = route;
+                best = { x, y };
+            }
+        }
+
+        if (found)
+        {
+            out = best;
+            return true;
+        }
+    }
+
+    if (!allowBlocked || !haveFallback)
+        return false;
+
+    out = fallback;
+
+    return true;
+}
+
+void CollectMeleePhoenixExclusions(Player* bot, std::vector<ObjectGuid>& out)
+{
+    if (!PlayerbotAI::IsMelee(bot) || !GetKaelthas(bot))
+        return;
+
+    std::vector<Unit*> phoenixes;
+    CollectCreaturesByEntry(bot, { NPC_PHOENIX }, PHOENIX_SCAN, phoenixes);
+
+    for (Unit* phoenix : phoenixes)
+        out.push_back(phoenix->GetGUID());
+}
+}

--- a/src/Ai/Dungeon/MgT/MgTShared.h
+++ b/src/Ai/Dungeon/MgT/MgTShared.h
@@ -1,0 +1,150 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_MGTSHARED_H
+#define PLAYERBOTS_MGTSHARED_H
+
+#include "Define.h"
+#include "ObjectGuid.h"
+#include <string>
+#include <vector>
+
+class Player;
+class PlayerbotAI;
+class Unit;
+
+namespace MagistersTerrace
+{
+constexpr uint32 MAP_MAGISTERS_TERRACE = 585;
+
+constexpr float SELIN_LEASH_X   = 216.0f;
+constexpr float SELIN_SAFE_X    = SELIN_LEASH_X + 4.0f;
+constexpr float SELIN_REGROUP_X = 232.0f;
+constexpr float SELIN_FLEE_SLACK = 6.0f;
+
+constexpr float GROUND_TIER_STEP   = 3.0f;
+constexpr float GROUND_SEARCH_UP   = 5.0f;
+constexpr float GROUND_SEARCH_DOWN = 12.0f;
+
+constexpr uint8 CONTROL_INTERRUPT_URGENCY = 2;
+
+struct EscapeSpot
+{
+    float x;
+    float y;
+    float z;
+};
+
+using EscapeSpots = std::vector<EscapeSpot>;
+
+struct LapseSpot
+{
+    float x;
+    float y;
+};
+
+struct LapseWorld
+{
+    std::vector<Unit*> spheres;
+    std::vector<LapseSpot> burns;
+};
+
+struct KiteState
+{
+    float turn = 0.0f;
+    uint32 lastMs = 0;
+};
+
+enum class PhoenixRing : uint8
+{
+    None,
+    Threatens,
+    Covers
+};
+
+enum class FocusOrder
+{
+    None,
+    Kael,
+    Delrissa,
+    Trash
+};
+
+Unit* GetSelin(Player* bot);
+Unit* GetKaelthas(Player* bot);
+
+Unit* GetActiveFelCrystal(Player* bot);
+
+void CollectDampeningEscapes(Player* bot, EscapeSpots& out);
+
+Unit* GetGlaiveThrowingMageGuard(Player* bot);
+
+void CollectNovaEscapes(Player* bot, EscapeSpots& out);
+
+std::string CastInterrupt(PlayerbotAI* botAI, Unit* target, uint8 urgency);
+
+Unit* GetInterruptTarget(Player* bot);
+
+uint8 GetInterruptUrgency(Unit* caster);
+uint8 GetRetinueInterruptUrgency(Unit* caster);
+
+Unit* GetFocusTarget(Player* bot, ObjectGuid& latched);
+
+ObjectGuid ResolveFocusOrder(PlayerbotAI* botAI);
+
+FocusOrder ResolveFocusOrderOwner(PlayerbotAI* botAI);
+
+void CollectFocusExclusions(Player* bot, std::vector<ObjectGuid>& out);
+
+Unit* GetEnragedWretched(Player* bot);
+
+std::vector<std::string> const& TauntSpellNames();
+
+void ClampIntoRoom(float& x, float& y);
+
+bool ShouldHoldTremorTotem(Player* bot);
+
+Unit* GetDelrissaFocusTarget(Player* bot, ObjectGuid& latched);
+
+void CollectDelrissaInterruptPreference(Player* bot, std::vector<Unit*>& out);
+
+void CollectDelrissaPets(Player* bot, std::vector<ObjectGuid>& out);
+
+void CollectFlameStrikeEscapes(Player* bot, EscapeSpots& out);
+
+void CollectPhoenixEscapes(Player* bot, EscapeSpots& out);
+
+PhoenixRing GetPhoenixRing(Player* bot);
+
+Unit* GetKaelInterruptTarget(Player* bot);
+
+bool IsKaelUnattackable(Player* bot);
+
+Unit* GetKaelFocusTarget(Player* bot);
+
+bool IsGravityLapseActive(Player* bot);
+
+void CollectLapseWorld(Player* bot, LapseWorld& out);
+
+bool GetGravityLapseKite(Player* bot, LapseWorld const& world, LapseSpot& out, KiteState& state);
+
+bool GetGravityLapseSpot(Player* bot, LapseWorld const& world, LapseSpot& out);
+
+bool GetGravityLapseDodge(Player* bot, LapseWorld const& world, LapseSpot& out);
+
+bool IsLapseMeleeSlot(Player* bot);
+
+bool OnLapseStation(Player* bot, Unit* kael, LapseSpot const& spot);
+
+bool LapseThreatened(Player* bot, LapseWorld const& world);
+
+bool GetLapseApproach(Player* bot, LapseWorld const& world, LapseSpot const& station, bool allowBlocked,
+                      LapseSpot& out);
+
+void CollectMeleePhoenixExclusions(Player* bot, std::vector<ObjectGuid>& out);
+}
+
+#endif

--- a/src/Ai/Dungeon/MgT/MgTStrategy.cpp
+++ b/src/Ai/Dungeon/MgT/MgTStrategy.cpp
@@ -1,0 +1,93 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "MgTStrategy.h"
+#include "MgTMultipliers.h"
+#include "MgTTriggers.h"
+#include "Playerbots.h"
+
+void TbcDungeonMagistersTerraceStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+{
+    triggers.push_back(new TriggerNode("mgt out of room", {
+        NextAction("mgt return to room", ACTION_EMERGENCY + 10) }));
+
+    triggers.push_back(new TriggerNode("mgt crystal active", {
+        NextAction("mgt kill crystal", ACTION_EMERGENCY + 8) }));
+
+    triggers.push_back(new TriggerNode("mgt in dampening field", {
+        NextAction("mgt leave dampening field", ACTION_EMERGENCY + 6) }));
+
+    triggers.push_back(new TriggerNode("mgt priority interrupt", {
+        NextAction("mgt priority interrupt", ACTION_INTERRUPT + 5) }));
+
+    triggers.push_back(new TriggerNode("mgt arcane nova range", {
+        NextAction("mgt clear arcane nova", ACTION_EMERGENCY + 4) }));
+
+    triggers.push_back(new TriggerNode("mgt mage guard at range", {
+        NextAction("mgt close on mage guard", ACTION_MOVE + 5) }));
+
+    triggers.push_back(new TriggerNode("mgt enraged wretched", {
+        NextAction("mgt taunt enraged wretched", ACTION_HIGH + 2) }));
+
+    triggers.push_back(new TriggerNode("mgt focus target", {
+        NextAction("mgt focus target", ACTION_RAID + 2) }));
+
+    triggers.push_back(new TriggerNode("mgt delrissa interrupt", {
+        NextAction("mgt delrissa interrupt", ACTION_INTERRUPT + 5) }));
+
+    triggers.push_back(new TriggerNode("mgt delrissa focus target", {
+        NextAction("mgt delrissa focus target", ACTION_RAID + 2) }));
+
+    triggers.push_back(new TriggerNode("mgt delrissa tremor totem", {
+        NextAction("mgt delrissa tremor totem", ACTION_HIGH + 5) }));
+
+    triggers.push_back(new TriggerNode("mgt flame strike", {
+        NextAction("mgt leave flame strike", ACTION_EMERGENCY + 7) }));
+
+    triggers.push_back(new TriggerNode("mgt phoenix burn", {
+        NextAction("mgt leave phoenix burn", ACTION_EMERGENCY + 6) }));
+
+    triggers.push_back(new TriggerNode("mgt kael focus target", {
+        NextAction("mgt kael focus target", ACTION_RAID + 2) }));
+
+    triggers.push_back(new TriggerNode("mgt kael interrupt", {
+        NextAction("mgt kael interrupt", ACTION_INTERRUPT + 6) }));
+
+    triggers.push_back(new TriggerNode("mgt gravity lapse", {
+        NextAction("mgt take lapse spot", ACTION_MOVE + 8) }));
+}
+
+void TbcDungeonMagistersTerraceStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
+{
+    multipliers.push_back(new MgTCrystalFocusMultiplier(botAI));
+    multipliers.push_back(new MgTFocusOrderMultiplier(botAI));
+    multipliers.push_back(new MgTFocusBurstMultiplier(botAI));
+    multipliers.push_back(new MgTRoomLeashMultiplier(botAI));
+    multipliers.push_back(new MgTDampeningFieldMultiplier(botAI));
+    multipliers.push_back(new MgTDelrissaTremorTotemMultiplier(botAI));
+    multipliers.push_back(new MgTFlameStrikeMultiplier(botAI));
+    multipliers.push_back(new MgTPhoenixBurnMultiplier(botAI));
+    multipliers.push_back(new MgTKaelUnattackableMultiplier(botAI));
+    multipliers.push_back(new MgTGravityLapseMultiplier(botAI));
+}
+
+void TbcDungeonMagistersTerraceStrategy::AppendTargetExclusions(GuidSet& exclusions,
+                                                               TargetValueExclusionType type)
+{
+    AiObjectContext* context = botAI->GetAiObjectContext();
+
+    for (ObjectGuid const guid : context->GetValue<GuidVector>("mgt delrissa pets")->Get())
+        exclusions.insert(guid);
+
+    for (ObjectGuid const guid : context->GetValue<GuidVector>("mgt melee phoenix exclusions")->Get())
+        exclusions.insert(guid);
+
+    if (type != TargetValueExclusionType::Attacker)
+        return;
+
+    for (ObjectGuid const guid : context->GetValue<GuidVector>("mgt focus exclusions")->Get())
+        exclusions.insert(guid);
+}

--- a/src/Ai/Dungeon/MgT/MgTStrategy.h
+++ b/src/Ai/Dungeon/MgT/MgTStrategy.h
@@ -1,0 +1,28 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_MGTSTRATEGY_H
+#define PLAYERBOTS_MGTSTRATEGY_H
+
+#include "AiObjectContext.h"
+#include "Multiplier.h"
+#include "Strategy.h"
+
+class TbcDungeonMagistersTerraceStrategy : public Strategy
+{
+public:
+    TbcDungeonMagistersTerraceStrategy(PlayerbotAI* botAI) : Strategy(botAI) {}
+
+    std::string const getName() override { return "tbc-mgt"; }
+
+    void InitTriggers(std::vector<TriggerNode*>& triggers) override;
+    void InitMultipliers(std::vector<Multiplier*>& multipliers) override;
+
+    bool HasTargetExclusions() const override { return true; }
+    void AppendTargetExclusions(GuidSet& exclusions, TargetValueExclusionType type) override;
+};
+
+#endif

--- a/src/Ai/Dungeon/MgT/MgTTriggerContext.h
+++ b/src/Ai/Dungeon/MgT/MgTTriggerContext.h
@@ -1,0 +1,64 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_MGTTRIGGERCONTEXT_H
+#define PLAYERBOTS_MGTTRIGGERCONTEXT_H
+
+#include "AiObjectContext.h"
+#include "MgTTriggers.h"
+#include "TriggerContext.h"
+
+class TbcDungeonMagistersTerraceTriggerContext : public NamedObjectContext<Trigger>
+{
+public:
+    TbcDungeonMagistersTerraceTriggerContext()
+    {
+        creators["mgt crystal active"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_crystal_active;
+        creators["mgt out of room"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_out_of_room;
+        creators["mgt in dampening field"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_in_dampening_field;
+        creators["mgt mage guard at range"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_mage_guard_at_range;
+        creators["mgt arcane nova range"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_arcane_nova_range;
+        creators["mgt priority interrupt"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_priority_interrupt;
+        creators["mgt focus target"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_focus_target;
+        creators["mgt enraged wretched"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_enraged_wretched;
+        creators["mgt delrissa interrupt"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_delrissa_interrupt;
+        creators["mgt delrissa focus target"] =
+            &TbcDungeonMagistersTerraceTriggerContext::mgt_delrissa_focus_target;
+        creators["mgt delrissa tremor totem"] =
+            &TbcDungeonMagistersTerraceTriggerContext::mgt_delrissa_tremor_totem;
+        creators["mgt flame strike"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_flame_strike;
+        creators["mgt phoenix burn"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_phoenix_burn;
+        creators["mgt kael focus target"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_kael_focus_target;
+        creators["mgt kael interrupt"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_kael_interrupt;
+        creators["mgt gravity lapse"] = &TbcDungeonMagistersTerraceTriggerContext::mgt_gravity_lapse;
+    }
+
+private:
+    static Trigger* mgt_crystal_active(PlayerbotAI* botAI) { return new MgTCrystalActiveTrigger(botAI); }
+    static Trigger* mgt_out_of_room(PlayerbotAI* botAI) { return new MgTOutOfRoomTrigger(botAI); }
+    static Trigger* mgt_in_dampening_field(PlayerbotAI* botAI) { return new MgTInDampeningFieldTrigger(botAI); }
+    static Trigger* mgt_mage_guard_at_range(PlayerbotAI* botAI) { return new MgTMageGuardAtRangeTrigger(botAI); }
+    static Trigger* mgt_arcane_nova_range(PlayerbotAI* botAI) { return new MgTArcaneNovaRangeTrigger(botAI); }
+    static Trigger* mgt_priority_interrupt(PlayerbotAI* botAI) { return new MgTPriorityInterruptTrigger(botAI); }
+    static Trigger* mgt_focus_target(PlayerbotAI* botAI) { return new MgTFocusTargetTrigger(botAI); }
+    static Trigger* mgt_enraged_wretched(PlayerbotAI* botAI) { return new MgTEnragedWretchedTrigger(botAI); }
+    static Trigger* mgt_delrissa_interrupt(PlayerbotAI* botAI) { return new MgTDelrissaInterruptTrigger(botAI); }
+    static Trigger* mgt_delrissa_focus_target(PlayerbotAI* botAI)
+    {
+        return new MgTDelrissaFocusTargetTrigger(botAI);
+    }
+    static Trigger* mgt_delrissa_tremor_totem(PlayerbotAI* botAI)
+    {
+        return new MgTDelrissaTremorTotemTrigger(botAI);
+    }
+    static Trigger* mgt_flame_strike(PlayerbotAI* botAI) { return new MgTFlameStrikeTrigger(botAI); }
+    static Trigger* mgt_phoenix_burn(PlayerbotAI* botAI) { return new MgTPhoenixBurnTrigger(botAI); }
+    static Trigger* mgt_kael_focus_target(PlayerbotAI* botAI) { return new MgTKaelFocusTargetTrigger(botAI); }
+    static Trigger* mgt_kael_interrupt(PlayerbotAI* botAI) { return new MgTKaelInterruptTrigger(botAI); }
+    static Trigger* mgt_gravity_lapse(PlayerbotAI* botAI) { return new MgTGravityLapseTrigger(botAI); }
+};
+
+#endif

--- a/src/Ai/Dungeon/MgT/MgTTriggers.cpp
+++ b/src/Ai/Dungeon/MgT/MgTTriggers.cpp
@@ -1,0 +1,124 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "MgTTriggers.h"
+#include "AiObjectContext.h"
+#include "MgTShared.h"
+#include "Playerbots.h"
+
+bool MgTCrystalActiveTrigger::IsActive()
+{
+    return !AI_VALUE(ObjectGuid, "mgt crystal target").IsEmpty();
+}
+
+bool MgTOutOfRoomTrigger::IsActive()
+{
+    if (bot->GetPositionX() >= MagistersTerrace::SELIN_SAFE_X)
+        return false;
+
+    return MagistersTerrace::GetSelin(bot) != nullptr;
+}
+
+bool MgTInDampeningFieldTrigger::IsActive()
+{
+    auto const& spots = AI_VALUE_REF(MagistersTerrace::EscapeSpots, "mgt dampening escape");
+    return !spots.empty();
+}
+
+bool MgTMageGuardAtRangeTrigger::IsActive()
+{
+    return !AI_VALUE(ObjectGuid, "mgt mage guard target").IsEmpty();
+}
+
+bool MgTArcaneNovaRangeTrigger::IsActive()
+{
+    auto const& spots = AI_VALUE_REF(MagistersTerrace::EscapeSpots, "mgt nova escape");
+    return !spots.empty();
+}
+
+bool MgTPriorityInterruptTrigger::IsActive()
+{
+    return !AI_VALUE(ObjectGuid, "mgt interrupt target").IsEmpty();
+}
+
+bool MgTFocusTargetTrigger::IsActive()
+{
+    if (!bot->IsInCombat())
+        return false;
+
+    if (!PlayerbotAI::IsDps(bot) || PlayerbotAI::IsTank(bot))
+        return false;
+
+    if (!AI_VALUE(ObjectGuid, "mgt crystal target").IsEmpty())
+        return false;
+
+    ObjectGuid const order = AI_VALUE(ObjectGuid, "mgt focus target");
+    return !order.IsEmpty() && MagistersTerrace::ResolveFocusOrder(botAI) == order;
+}
+
+bool MgTEnragedWretchedTrigger::IsActive()
+{
+    return !AI_VALUE(ObjectGuid, "mgt enraged wretched").IsEmpty();
+}
+
+bool MgTDelrissaInterruptTrigger::IsActive()
+{
+    auto const& order = AI_VALUE_REF(GuidVector, "mgt delrissa interrupt order");
+    return !order.empty();
+}
+
+bool MgTDelrissaFocusTargetTrigger::IsActive()
+{
+    if (!bot->IsInCombat())
+        return false;
+
+    if (!PlayerbotAI::IsDps(bot) || PlayerbotAI::IsTank(bot))
+        return false;
+
+    ObjectGuid const order = AI_VALUE(ObjectGuid, "mgt delrissa focus target");
+    return !order.IsEmpty() && MagistersTerrace::ResolveFocusOrder(botAI) == order;
+}
+
+bool MgTDelrissaTremorTotemTrigger::IsActive()
+{
+    if (!AI_VALUE(bool, "mgt delrissa tremor totem"))
+        return false;
+
+    return !AI_VALUE2(bool, "has totem", "tremor totem");
+}
+
+bool MgTFlameStrikeTrigger::IsActive()
+{
+    auto const& spots = AI_VALUE_REF(MagistersTerrace::EscapeSpots, "mgt flame strike escape");
+    return !spots.empty();
+}
+
+bool MgTPhoenixBurnTrigger::IsActive()
+{
+    auto const& spots = AI_VALUE_REF(MagistersTerrace::EscapeSpots, "mgt phoenix escape");
+    return !spots.empty();
+}
+
+bool MgTKaelFocusTargetTrigger::IsActive()
+{
+    if (!bot->IsInCombat())
+        return false;
+
+    if (!PlayerbotAI::IsDps(bot) || PlayerbotAI::IsTank(bot))
+        return false;
+
+    return !AI_VALUE(ObjectGuid, "mgt kael focus target").IsEmpty();
+}
+
+bool MgTKaelInterruptTrigger::IsActive()
+{
+    return !AI_VALUE(ObjectGuid, "mgt kael interrupt target").IsEmpty();
+}
+
+bool MgTGravityLapseTrigger::IsActive()
+{
+    return AI_VALUE(bool, "mgt gravity lapse");
+}

--- a/src/Ai/Dungeon/MgT/MgTTriggers.h
+++ b/src/Ai/Dungeon/MgT/MgTTriggers.h
@@ -1,0 +1,125 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_MGTTRIGGERS_H
+#define PLAYERBOTS_MGTTRIGGERS_H
+
+#include "MgTShared.h"
+#include "Trigger.h"
+
+class MgTCrystalActiveTrigger : public Trigger
+{
+public:
+    MgTCrystalActiveTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt crystal active") {}
+    bool IsActive() override;
+};
+
+class MgTOutOfRoomTrigger : public Trigger
+{
+public:
+    MgTOutOfRoomTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt out of room") {}
+    bool IsActive() override;
+};
+
+class MgTInDampeningFieldTrigger : public Trigger
+{
+public:
+    MgTInDampeningFieldTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt in dampening field") {}
+    bool IsActive() override;
+};
+
+class MgTMageGuardAtRangeTrigger : public Trigger
+{
+public:
+    MgTMageGuardAtRangeTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt mage guard at range") {}
+    bool IsActive() override;
+};
+
+class MgTArcaneNovaRangeTrigger : public Trigger
+{
+public:
+    MgTArcaneNovaRangeTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt arcane nova range") {}
+    bool IsActive() override;
+};
+
+class MgTPriorityInterruptTrigger : public Trigger
+{
+public:
+    MgTPriorityInterruptTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt priority interrupt") {}
+    bool IsActive() override;
+};
+
+class MgTFocusTargetTrigger : public Trigger
+{
+public:
+    MgTFocusTargetTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt focus target") {}
+    bool IsActive() override;
+};
+
+class MgTEnragedWretchedTrigger : public Trigger
+{
+public:
+    MgTEnragedWretchedTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt enraged wretched") {}
+    bool IsActive() override;
+};
+
+class MgTDelrissaInterruptTrigger : public Trigger
+{
+public:
+    MgTDelrissaInterruptTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt delrissa interrupt") {}
+    bool IsActive() override;
+};
+
+class MgTDelrissaFocusTargetTrigger : public Trigger
+{
+public:
+    MgTDelrissaFocusTargetTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt delrissa focus target") {}
+    bool IsActive() override;
+};
+
+class MgTDelrissaTremorTotemTrigger : public Trigger
+{
+public:
+    MgTDelrissaTremorTotemTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt delrissa tremor totem") {}
+    bool IsActive() override;
+};
+
+class MgTFlameStrikeTrigger : public Trigger
+{
+public:
+    MgTFlameStrikeTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt flame strike") {}
+    bool IsActive() override;
+};
+
+class MgTPhoenixBurnTrigger : public Trigger
+{
+public:
+    MgTPhoenixBurnTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt phoenix burn") {}
+    bool IsActive() override;
+};
+
+class MgTKaelFocusTargetTrigger : public Trigger
+{
+public:
+    MgTKaelFocusTargetTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt kael focus target") {}
+    bool IsActive() override;
+};
+
+class MgTKaelInterruptTrigger : public Trigger
+{
+public:
+    MgTKaelInterruptTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt kael interrupt") {}
+    bool IsActive() override;
+};
+
+class MgTGravityLapseTrigger : public Trigger
+{
+public:
+    MgTGravityLapseTrigger(PlayerbotAI* botAI) : Trigger(botAI, "mgt gravity lapse") {}
+    bool IsActive() override;
+};
+
+#endif

--- a/src/Ai/Dungeon/MgT/MgTValueContext.h
+++ b/src/Ai/Dungeon/MgT/MgTValueContext.h
@@ -1,0 +1,376 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_MGTVALUECONTEXT_H
+#define PLAYERBOTS_MGTVALUECONTEXT_H
+
+#include "MgTShared.h"
+#include "NamedObjectContext.h"
+#include "ObjectGuid.h"
+#include "PlayerbotAI.h"
+#include "Unit.h"
+#include "Value.h"
+
+class MgTEscapeSpotsValue : public CalculatedValue<MagistersTerrace::EscapeSpots>
+{
+public:
+    MgTEscapeSpotsValue(PlayerbotAI* botAI, std::string const name)
+        : CalculatedValue<MagistersTerrace::EscapeSpots>(botAI, name, 200)
+    {
+    }
+};
+
+class MgTDampeningEscapeValue : public MgTEscapeSpotsValue
+{
+public:
+    MgTDampeningEscapeValue(PlayerbotAI* botAI) : MgTEscapeSpotsValue(botAI, "mgt dampening escape") {}
+
+protected:
+    MagistersTerrace::EscapeSpots Calculate() override
+    {
+        MagistersTerrace::EscapeSpots spots;
+        MagistersTerrace::CollectDampeningEscapes(bot, spots);
+        return spots;
+    }
+};
+
+class MgTNovaEscapeValue : public MgTEscapeSpotsValue
+{
+public:
+    MgTNovaEscapeValue(PlayerbotAI* botAI) : MgTEscapeSpotsValue(botAI, "mgt nova escape") {}
+
+protected:
+    MagistersTerrace::EscapeSpots Calculate() override
+    {
+        MagistersTerrace::EscapeSpots spots;
+        MagistersTerrace::CollectNovaEscapes(bot, spots);
+        return spots;
+    }
+};
+
+class MgTFlameStrikeEscapeValue : public MgTEscapeSpotsValue
+{
+public:
+    MgTFlameStrikeEscapeValue(PlayerbotAI* botAI) : MgTEscapeSpotsValue(botAI, "mgt flame strike escape") {}
+
+protected:
+    MagistersTerrace::EscapeSpots Calculate() override
+    {
+        MagistersTerrace::EscapeSpots spots;
+        MagistersTerrace::CollectFlameStrikeEscapes(bot, spots);
+        return spots;
+    }
+};
+
+class MgTPhoenixEscapeValue : public MgTEscapeSpotsValue
+{
+public:
+    MgTPhoenixEscapeValue(PlayerbotAI* botAI) : MgTEscapeSpotsValue(botAI, "mgt phoenix escape") {}
+
+protected:
+    MagistersTerrace::EscapeSpots Calculate() override
+    {
+        MagistersTerrace::EscapeSpots spots;
+        MagistersTerrace::CollectPhoenixEscapes(bot, spots);
+        return spots;
+    }
+};
+
+class MgTPhoenixRingValue : public CalculatedValue<MagistersTerrace::PhoenixRing>
+{
+public:
+    MgTPhoenixRingValue(PlayerbotAI* botAI)
+        : CalculatedValue<MagistersTerrace::PhoenixRing>(botAI, "mgt phoenix ring", 200)
+    {
+    }
+
+protected:
+    MagistersTerrace::PhoenixRing Calculate() override { return MagistersTerrace::GetPhoenixRing(bot); }
+};
+
+class MgTCrystalTargetValue : public ObjectGuidCalculatedValue
+{
+public:
+    MgTCrystalTargetValue(PlayerbotAI* botAI) : ObjectGuidCalculatedValue(botAI, "mgt crystal target", 200) {}
+
+protected:
+    ObjectGuid Calculate() override
+    {
+        Unit* crystal = MagistersTerrace::GetActiveFelCrystal(bot);
+        return crystal ? crystal->GetGUID() : ObjectGuid::Empty;
+    }
+};
+
+class MgTMageGuardTargetValue : public ObjectGuidCalculatedValue
+{
+public:
+    MgTMageGuardTargetValue(PlayerbotAI* botAI) : ObjectGuidCalculatedValue(botAI, "mgt mage guard target", 200) {}
+
+protected:
+    ObjectGuid Calculate() override
+    {
+        if (!PlayerbotAI::IsTank(bot))
+            return ObjectGuid::Empty;
+
+        Unit* guard = MagistersTerrace::GetGlaiveThrowingMageGuard(bot);
+        return guard ? guard->GetGUID() : ObjectGuid::Empty;
+    }
+};
+
+class MgTEnragedWretchedValue : public ObjectGuidCalculatedValue
+{
+public:
+    MgTEnragedWretchedValue(PlayerbotAI* botAI) : ObjectGuidCalculatedValue(botAI, "mgt enraged wretched", 200) {}
+
+protected:
+    ObjectGuid Calculate() override
+    {
+        if (!PlayerbotAI::IsTank(bot))
+            return ObjectGuid::Empty;
+
+        Unit* wretched = MagistersTerrace::GetEnragedWretched(bot);
+        return wretched ? wretched->GetGUID() : ObjectGuid::Empty;
+    }
+};
+
+class MgTInterruptTargetValue : public ObjectGuidCalculatedValue
+{
+public:
+    MgTInterruptTargetValue(PlayerbotAI* botAI) : ObjectGuidCalculatedValue(botAI, "mgt interrupt target", 200) {}
+
+protected:
+    ObjectGuid Calculate() override
+    {
+        Unit* target = MagistersTerrace::GetInterruptTarget(bot);
+        return target ? target->GetGUID() : ObjectGuid::Empty;
+    }
+};
+
+class MgTSunbladeFocusTargetValue : public ObjectGuidCalculatedValue
+{
+public:
+    MgTSunbladeFocusTargetValue(PlayerbotAI* botAI) : ObjectGuidCalculatedValue(botAI, "mgt focus target", 200) {}
+
+protected:
+    ObjectGuid Calculate() override
+    {
+        Unit* target = MagistersTerrace::GetFocusTarget(bot, _latched);
+        return target ? target->GetGUID() : ObjectGuid::Empty;
+    }
+
+private:
+    ObjectGuid _latched;
+};
+
+class MgTDelrissaInterruptOrderValue : public ObjectGuidListCalculatedValue
+{
+public:
+    MgTDelrissaInterruptOrderValue(PlayerbotAI* botAI)
+        : ObjectGuidListCalculatedValue(botAI, "mgt delrissa interrupt order", 200)
+    {
+    }
+
+protected:
+    GuidVector Calculate() override
+    {
+        std::vector<Unit*> preference;
+        MagistersTerrace::CollectDelrissaInterruptPreference(bot, preference);
+
+        GuidVector order;
+        order.reserve(preference.size());
+        for (Unit* caster : preference)
+            order.push_back(caster->GetGUID());
+
+        return order;
+    }
+};
+
+class MgTDelrissaFocusTargetValue : public ObjectGuidCalculatedValue
+{
+public:
+    MgTDelrissaFocusTargetValue(PlayerbotAI* botAI)
+        : ObjectGuidCalculatedValue(botAI, "mgt delrissa focus target", 200)
+    {
+    }
+
+protected:
+    ObjectGuid Calculate() override
+    {
+        Unit* target = MagistersTerrace::GetDelrissaFocusTarget(bot, _latched);
+        return target ? target->GetGUID() : ObjectGuid::Empty;
+    }
+
+private:
+    ObjectGuid _latched;
+};
+
+class MgTDelrissaTremorTotemValue : public BoolCalculatedValue
+{
+public:
+    MgTDelrissaTremorTotemValue(PlayerbotAI* botAI) : BoolCalculatedValue(botAI, "mgt delrissa tremor totem", 500) {}
+
+protected:
+    bool Calculate() override { return MagistersTerrace::ShouldHoldTremorTotem(bot); }
+};
+
+class MgTDelrissaPetsValue : public ObjectGuidListCalculatedValue
+{
+public:
+    MgTDelrissaPetsValue(PlayerbotAI* botAI) : ObjectGuidListCalculatedValue(botAI, "mgt delrissa pets", 500) {}
+
+protected:
+    GuidVector Calculate() override
+    {
+        GuidVector pets;
+        MagistersTerrace::CollectDelrissaPets(bot, pets);
+        return pets;
+    }
+};
+
+class MgTKaelFocusTargetValue : public ObjectGuidCalculatedValue
+{
+public:
+    MgTKaelFocusTargetValue(PlayerbotAI* botAI) : ObjectGuidCalculatedValue(botAI, "mgt kael focus target", 200) {}
+
+protected:
+    ObjectGuid Calculate() override
+    {
+        Unit* target = MagistersTerrace::GetKaelFocusTarget(bot);
+        return target ? target->GetGUID() : ObjectGuid::Empty;
+    }
+};
+
+class MgTGravityLapseValue : public BoolCalculatedValue
+{
+public:
+    MgTGravityLapseValue(PlayerbotAI* botAI) : BoolCalculatedValue(botAI, "mgt gravity lapse", 200) {}
+
+protected:
+    bool Calculate() override { return MagistersTerrace::IsGravityLapseActive(bot); }
+};
+
+class MgTKaelUnattackableValue : public BoolCalculatedValue
+{
+public:
+    MgTKaelUnattackableValue(PlayerbotAI* botAI) : BoolCalculatedValue(botAI, "mgt kael unattackable", 500) {}
+
+protected:
+    bool Calculate() override { return MagistersTerrace::IsKaelUnattackable(bot); }
+};
+
+class MgTKaelInterruptTargetValue : public ObjectGuidCalculatedValue
+{
+public:
+    MgTKaelInterruptTargetValue(PlayerbotAI* botAI)
+        : ObjectGuidCalculatedValue(botAI, "mgt kael interrupt target", 200)
+    {
+    }
+
+protected:
+    ObjectGuid Calculate() override
+    {
+        Unit* target = MagistersTerrace::GetKaelInterruptTarget(bot);
+        return target ? target->GetGUID() : ObjectGuid::Empty;
+    }
+};
+
+class MgTMeleePhoenixExclusionsValue : public ObjectGuidListCalculatedValue
+{
+public:
+    MgTMeleePhoenixExclusionsValue(PlayerbotAI* botAI)
+        : ObjectGuidListCalculatedValue(botAI, "mgt melee phoenix exclusions", 500)
+    {
+    }
+
+protected:
+    GuidVector Calculate() override
+    {
+        GuidVector phoenixes;
+        MagistersTerrace::CollectMeleePhoenixExclusions(bot, phoenixes);
+        return phoenixes;
+    }
+};
+
+class MgTFocusExclusionsValue : public ObjectGuidListCalculatedValue
+{
+public:
+    MgTFocusExclusionsValue(PlayerbotAI* botAI) : ObjectGuidListCalculatedValue(botAI, "mgt focus exclusions", 200) {}
+
+protected:
+    GuidVector Calculate() override
+    {
+        GuidVector exclusions;
+        MagistersTerrace::CollectFocusExclusions(bot, exclusions);
+        return exclusions;
+    }
+};
+
+class TbcDungeonMgTValueContext : public NamedObjectContext<UntypedValue>
+{
+public:
+    TbcDungeonMgTValueContext()
+    {
+        creators["mgt crystal target"] = &TbcDungeonMgTValueContext::mgt_crystal_target;
+        creators["mgt dampening escape"] = &TbcDungeonMgTValueContext::mgt_dampening_escape;
+        creators["mgt nova escape"] = &TbcDungeonMgTValueContext::mgt_nova_escape;
+        creators["mgt mage guard target"] = &TbcDungeonMgTValueContext::mgt_mage_guard_target;
+        creators["mgt enraged wretched"] = &TbcDungeonMgTValueContext::mgt_enraged_wretched;
+        creators["mgt interrupt target"] = &TbcDungeonMgTValueContext::mgt_interrupt_target;
+        creators["mgt focus target"] = &TbcDungeonMgTValueContext::mgt_focus_target;
+        creators["mgt delrissa interrupt order"] = &TbcDungeonMgTValueContext::mgt_delrissa_interrupt_order;
+        creators["mgt delrissa focus target"] = &TbcDungeonMgTValueContext::mgt_delrissa_focus_target;
+        creators["mgt delrissa tremor totem"] = &TbcDungeonMgTValueContext::mgt_delrissa_tremor_totem;
+        creators["mgt delrissa pets"] = &TbcDungeonMgTValueContext::mgt_delrissa_pets;
+        creators["mgt flame strike escape"] = &TbcDungeonMgTValueContext::mgt_flame_strike_escape;
+        creators["mgt phoenix escape"] = &TbcDungeonMgTValueContext::mgt_phoenix_escape;
+        creators["mgt phoenix ring"] = &TbcDungeonMgTValueContext::mgt_phoenix_ring;
+        creators["mgt kael focus target"] = &TbcDungeonMgTValueContext::mgt_kael_focus_target;
+        creators["mgt kael interrupt target"] = &TbcDungeonMgTValueContext::mgt_kael_interrupt_target;
+        creators["mgt kael unattackable"] = &TbcDungeonMgTValueContext::mgt_kael_unattackable;
+        creators["mgt gravity lapse"] = &TbcDungeonMgTValueContext::mgt_gravity_lapse;
+        creators["mgt melee phoenix exclusions"] = &TbcDungeonMgTValueContext::mgt_melee_phoenix_exclusions;
+        creators["mgt focus exclusions"] = &TbcDungeonMgTValueContext::mgt_focus_exclusions;
+    }
+
+private:
+    static UntypedValue* mgt_crystal_target(PlayerbotAI* botAI) { return new MgTCrystalTargetValue(botAI); }
+    static UntypedValue* mgt_dampening_escape(PlayerbotAI* botAI) { return new MgTDampeningEscapeValue(botAI); }
+    static UntypedValue* mgt_nova_escape(PlayerbotAI* botAI) { return new MgTNovaEscapeValue(botAI); }
+    static UntypedValue* mgt_mage_guard_target(PlayerbotAI* botAI) { return new MgTMageGuardTargetValue(botAI); }
+    static UntypedValue* mgt_enraged_wretched(PlayerbotAI* botAI) { return new MgTEnragedWretchedValue(botAI); }
+    static UntypedValue* mgt_interrupt_target(PlayerbotAI* botAI) { return new MgTInterruptTargetValue(botAI); }
+    static UntypedValue* mgt_focus_target(PlayerbotAI* botAI) { return new MgTSunbladeFocusTargetValue(botAI); }
+    static UntypedValue* mgt_delrissa_interrupt_order(PlayerbotAI* botAI)
+    {
+        return new MgTDelrissaInterruptOrderValue(botAI);
+    }
+    static UntypedValue* mgt_delrissa_focus_target(PlayerbotAI* botAI)
+    {
+        return new MgTDelrissaFocusTargetValue(botAI);
+    }
+    static UntypedValue* mgt_delrissa_tremor_totem(PlayerbotAI* botAI)
+    {
+        return new MgTDelrissaTremorTotemValue(botAI);
+    }
+    static UntypedValue* mgt_delrissa_pets(PlayerbotAI* botAI) { return new MgTDelrissaPetsValue(botAI); }
+    static UntypedValue* mgt_flame_strike_escape(PlayerbotAI* botAI) { return new MgTFlameStrikeEscapeValue(botAI); }
+    static UntypedValue* mgt_phoenix_escape(PlayerbotAI* botAI) { return new MgTPhoenixEscapeValue(botAI); }
+    static UntypedValue* mgt_phoenix_ring(PlayerbotAI* botAI) { return new MgTPhoenixRingValue(botAI); }
+    static UntypedValue* mgt_kael_focus_target(PlayerbotAI* botAI) { return new MgTKaelFocusTargetValue(botAI); }
+    static UntypedValue* mgt_kael_interrupt_target(PlayerbotAI* botAI)
+    {
+        return new MgTKaelInterruptTargetValue(botAI);
+    }
+    static UntypedValue* mgt_kael_unattackable(PlayerbotAI* botAI) { return new MgTKaelUnattackableValue(botAI); }
+    static UntypedValue* mgt_gravity_lapse(PlayerbotAI* botAI) { return new MgTGravityLapseValue(botAI); }
+    static UntypedValue* mgt_melee_phoenix_exclusions(PlayerbotAI* botAI)
+    {
+        return new MgTMeleePhoenixExclusionsValue(botAI);
+    }
+    static UntypedValue* mgt_focus_exclusions(PlayerbotAI* botAI) { return new MgTFocusExclusionsValue(botAI); }
+};
+
+#endif

--- a/src/Ai/Dungeon/Seth/SethActions.cpp
+++ b/src/Ai/Dungeon/Seth/SethActions.cpp
@@ -7,17 +7,18 @@
 #include "SethActions.h"
 #include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "SethData.h"
+#include "SethShared.h"
+#include <algorithm>
 #include <array>
 #include <cmath>
 
-using namespace SethData;
+using namespace SethShared;
 using namespace EncounterHelpers;
 
 bool TimeLostControllerMarkCharmingTotemWithSkullAction::Execute(Event /*event*/)
 {
     constexpr float searchRadius = 40.0f;
-    Unit* totem = bot->FindNearestCreature(Id(SethNpcs::NPC_CHARMING_TOTEM), searchRadius, true);
+    Unit* totem = bot->FindNearestCreature(Id(SethNpcs::NPC_CHARMING_TOTEM), searchRadius);
     return totem && MarkTargetWithSkull(bot, totem);
 }
 
@@ -71,7 +72,7 @@ bool AnzuCastHealOverTimeSpellOnBirdSpiritAction::Execute(Event /*event*/)
 
     for (uint32 entry : spiritEntries)
     {
-        Creature* spirit = bot->FindNearestCreature(entry, searchRadius, true);
+        Creature* spirit = bot->FindNearestCreature(entry, searchRadius);
         if (spirit && !spirit->GetAuraEffect(
                 SPELL_AURA_PERIODIC_HEAL, SPELLFAMILY_DRUID, REJUVENATION_SPELL_ICON_ID, 0))
         {
@@ -95,39 +96,29 @@ bool TalonKingIkissTankMoveBossToPillarPositionAction::Execute(Event /*event*/)
     if (!ikiss)
         return false;
 
-    if (ikiss->GetHealthPct() > 95.0f)
+    if (ikiss->GetHealthPct() > BOSS_ENGAGED_HEALTH_PCT)
         _hasReachedPillarPosition = false;
 
     if (_hasReachedPillarPosition == true)
         return false;
 
     Position const& position = PILLAR_POSITION;
-    float const distToPosition = bot->GetExactDist2d(position);
+    constexpr float arrivalDist = 2.0f;
 
-    if (distToPosition <= 2.0f)
+    if (bot->GetExactDist2d(position) <= arrivalDist)
     {
         _hasReachedPillarPosition = true;
         return false;
     }
 
-    float const posX = position.GetPositionX();
-    float const posY = position.GetPositionY();
-    float const botX = bot->GetPositionX();
-    float const botY = bot->GetPositionY();
-    float const toPosX = posX - botX;
-    float const toPosY = posY - botY;
-
-    float const toBossX = ikiss->GetPositionX() - botX;
-    float const toBossY = ikiss->GetPositionY() - botY;
-    bool const backwards = (toPosX * toBossX + toPosY * toBossY) < 0.0f;
-
-    float const maxMoveDist = backwards ? 2.25f : 3.5f;
-    float const moveDist = std::min(maxMoveDist, distToPosition);
-    float const moveX = botX + (toPosX / distToPosition) * moveDist;
-    float const moveY = botY + (toPosY / distToPosition) * moveDist;
+    float moveX;
+    float moveY;
+    bool backwards;
+    if (!GetStepToPosition(bot, position, arrivalDist, ikiss, moveX, moveY, backwards))
+        return false;
 
     return MoveTo(
-        SETH_MAP_ID, moveX, moveY, position.GetPositionZ(), false, false,
+        SETH_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false,
         false, false, MovementPriority::MOVEMENT_COMBAT, true, backwards);
 }
 

--- a/src/Ai/Dungeon/Seth/SethMultipliers.cpp
+++ b/src/Ai/Dungeon/Seth/SethMultipliers.cpp
@@ -13,14 +13,17 @@
 #include "Playerbots.h"
 #include "ReachTargetActions.h"
 #include "SethActions.h"
-#include "SethData.h"
+#include "SethShared.h"
 #include "ShamanActions.h"
 
-using namespace SethData;
+using namespace SethShared;
 using namespace EncounterHelpers;
 
 float SethekkProphetSetTremorTotemMultiplier::GetValue(Action* action)
 {
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
+        return 1.0f;
+
     if (bot->getClass() != CLASS_SHAMAN)
         return 1.0f;
 
@@ -32,10 +35,7 @@ float SethekkProphetSetTremorTotemMultiplier::GetValue(Action* action)
         return 1.0f;
     }
 
-    if (AI_VALUE2(Unit*, "find target", "sethekk prophet"))
-        return 0.0f;
-
-    return 1.0f;
+    return AI_VALUE2(Unit*, "find target", "sethekk prophet") ? 0.0f : 1.0f;
 }
 
 float AnzuControlSpellCastingWithSpellBombMultiplier::GetValue(Action* action)
@@ -54,14 +54,17 @@ float AnzuControlSpellCastingWithSpellBombMultiplier::GetValue(Action* action)
 
     // For healer
     Player* mainTank = GetGroupMainTank(bot);
-    if (mainTank && mainTank->GetHealthPct() > 50.0f)
-        return 0.0f;
+    if (!mainTank)
+        return 1.0f;
 
-    return 1.0f;
+    return mainTank->GetHealthPct() > 50.0f ? 0.0f : 1.0f;
 }
 
 float TalonKingIkissDelayBloodlustAndHeroismMultiplier::GetValue(Action* action)
 {
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
+        return 1.0f;
+
     if (bot->getClass() != CLASS_SHAMAN)
         return 1.0f;
 
@@ -72,33 +75,33 @@ float TalonKingIkissDelayBloodlustAndHeroismMultiplier::GetValue(Action* action)
     }
 
     Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");
-    if (ikiss && ikiss->GetHealthPct() > 95.0f)
-        return 0.0f;
+    if (!ikiss)
+        return 1.0f;
 
-    return 1.0f;
+    return ikiss->GetHealthPct() > BOSS_ENGAGED_HEALTH_PCT ? 0.0f : 1.0f;
 }
 
 float TalonKingIkissControlMovementMultiplier::GetValue(Action* action)
 {
-    if (dynamic_cast<TalonKingIkissLosArcaneExplosionAction*>(action) ||
-        dynamic_cast<TankFaceAction*>(action) ||
-        dynamic_cast<SetBehindTargetAction*>(action))
-    {
-        return 1.0f;
-    }
-
     bool const isAlwaysDisabled =
         dynamic_cast<CombatFormationMoveAction*>(action) ||
         dynamic_cast<FleeAction*>(action) ||
         dynamic_cast<CastBlinkBackAction*>(action) ||
         dynamic_cast<CastDisengageAction*>(action);
 
-    bool const isDisabledDuringArcaneExplosion =
-        dynamic_cast<CastReachTargetSpellAction*>(action) ||
-        dynamic_cast<MovementAction*>(action);
-
-    if (!isAlwaysDisabled && !isDisabledDuringArcaneExplosion)
+    if (!isAlwaysDisabled &&
+        !dynamic_cast<MovementAction*>(action) &&
+        !dynamic_cast<CastReachTargetSpellAction*>(action))
+    {
         return 1.0f;
+    }
+
+    if (dynamic_cast<TankFaceAction*>(action) ||
+        dynamic_cast<SetBehindTargetAction*>(action) ||
+        dynamic_cast<TalonKingIkissLosArcaneExplosionAction*>(action))
+    {
+        return 1.0f;
+    }
 
     Unit* ikiss = AI_VALUE2(Unit*, "find target", "talon king ikiss");
     if (!ikiss)
@@ -107,11 +110,5 @@ float TalonKingIkissControlMovementMultiplier::GetValue(Action* action)
     if (isAlwaysDisabled)
         return 0.0f;
 
-    if (!ikiss->HasAura(Id(SethSpells::SPELL_ARCANE_BUBBLE)))
-        return 1.0f;
-
-    if (isDisabledDuringArcaneExplosion)
-        return 0.0f;
-
-    return 1.0f;
+    return ikiss->HasAura(Id(SethSpells::SPELL_ARCANE_BUBBLE)) ? 0.0f : 1.0f;
 }

--- a/src/Ai/Dungeon/Seth/SethShared.h
+++ b/src/Ai/Dungeon/Seth/SethShared.h
@@ -4,14 +4,14 @@
  * or (at your option) any later version.
  */
 
-#ifndef PLAYERBOTS_SETHDATA_H
-#define PLAYERBOTS_SETHDATA_H
+#ifndef PLAYERBOTS_SETHSHARED_H
+#define PLAYERBOTS_SETHSHARED_H
 
 #include "Common.h"
 #include "Position.h"
 #include <type_traits>
 
-namespace SethData
+namespace SethShared
 {
 
 template <typename T, std::enable_if_t<std::is_enum_v<T>, int> = 0>

--- a/src/Ai/Dungeon/Seth/SethTriggers.cpp
+++ b/src/Ai/Dungeon/Seth/SethTriggers.cpp
@@ -7,9 +7,9 @@
 #include "SethTriggers.h"
 #include "EncounterHelpers.h"
 #include "Playerbots.h"
-#include "SethData.h"
+#include "SethShared.h"
 
-using namespace SethData;
+using namespace SethShared;
 using namespace EncounterHelpers;
 
 bool TimeLostControllerDropsCharmingTotemTrigger::IsActive()
@@ -35,7 +35,7 @@ bool DarkweaverSythBossSummonsElementalsTrigger::IsActive()
         return false;
 
     Unit* syth = AI_VALUE2(Unit*, "find target", "darkweaver syth");
-    return syth && syth->GetHealthPct() > 10.0f;
+    return syth && syth->GetHealthPct() > BOSS_BURN_HEALTH_PCT;
 }
 
 bool AnzuEncounterHasTwoPhasesTrigger::IsActive()

--- a/src/Ai/Dungeon/TbcDungeonActionContext.h
+++ b/src/Ai/Dungeon/TbcDungeonActionContext.h
@@ -9,6 +9,7 @@
 
 #include "ACActionContext.h"
 #include "MechActionContext.h"
+#include "MgTActionContext.h"
 #include "SethActionContext.h"
 #include "UBActionContext.h"
 

--- a/src/Ai/Dungeon/TbcDungeonTriggerContext.h
+++ b/src/Ai/Dungeon/TbcDungeonTriggerContext.h
@@ -9,6 +9,7 @@
 
 #include "ACTriggerContext.h"
 #include "MechTriggerContext.h"
+#include "MgTTriggerContext.h"
 #include "SethTriggerContext.h"
 #include "UBTriggerContext.h"
 

--- a/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgBaseAction.cpp
@@ -42,6 +42,13 @@ bool NewRpgBaseAction::MoveFarTo(WorldPosition dest)
     if (dest == WorldPosition())
         return false;
 
+    // Don't start a ground move while the bot is on a taxi: the MovePoint issued
+    // below would fight the active flight spline. Returning true consumes the tick
+    // instead of returning false, because the callers of MoveFarTo fall through to
+    // MoveRandomNear, which is also a ground move.
+    if (bot->IsInFlight())
+        return true;
+
     if (dest != botAI->rpgInfo.moveFarPos)
     {
         // clear stuck information if it's a new dest

--- a/src/Bot/Engine/BuildSharedActionContexts.cpp
+++ b/src/Bot/Engine/BuildSharedActionContexts.cpp
@@ -58,6 +58,7 @@ void AiObjectContext::BuildSharedActionContexts(SharedNamedObjectContextList<Act
     actionContexts.Add(new TbcDungeonSethekkHallsActionContext());
     actionContexts.Add(new TbcDungeonMechanarActionContext());
     actionContexts.Add(new TbcDungeonUnderbogActionContext());
+    actionContexts.Add(new TbcDungeonMagistersTerraceActionContext());
     actionContexts.Add(new WotlkDungeonUKActionContext());
     actionContexts.Add(new WotlkDungeonNexActionContext());
     actionContexts.Add(new WotlkDungeonANActionContext());

--- a/src/Bot/Engine/BuildSharedTriggerContexts.cpp
+++ b/src/Bot/Engine/BuildSharedTriggerContexts.cpp
@@ -58,6 +58,7 @@ void AiObjectContext::BuildSharedTriggerContexts(SharedNamedObjectContextList<Tr
     triggerContexts.Add(new TbcDungeonSethekkHallsTriggerContext());
     triggerContexts.Add(new TbcDungeonMechanarTriggerContext());
     triggerContexts.Add(new TbcDungeonUnderbogTriggerContext());
+    triggerContexts.Add(new TbcDungeonMagistersTerraceTriggerContext());
     triggerContexts.Add(new WotlkDungeonUKTriggerContext());
     triggerContexts.Add(new WotlkDungeonNexTriggerContext());
     triggerContexts.Add(new WotlkDungeonANTriggerContext());

--- a/src/Bot/Engine/BuildSharedValueContexts.cpp
+++ b/src/Bot/Engine/BuildSharedValueContexts.cpp
@@ -6,6 +6,7 @@
 
 #include "AiObjectContext.h"
 #include "MechValueContext.h"
+#include "MgTValueContext.h"
 #include "UBValueContext.h"
 #include "ValueContext.h"
 
@@ -14,4 +15,5 @@ void AiObjectContext::BuildSharedValueContexts(SharedNamedObjectContextList<Unty
     valueContexts.Add(new ValueContext());
     valueContexts.Add(new TbcDungeonMechValueContext());
     valueContexts.Add(new TbcDungeonUnderbogValueContext());
+    valueContexts.Add(new TbcDungeonMgTValueContext());
 }

--- a/src/Bot/Engine/BuildSharedValueContexts.cpp
+++ b/src/Bot/Engine/BuildSharedValueContexts.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "AiObjectContext.h"
+#include "GDValueContext.h"
 #include "MechValueContext.h"
 #include "MgTValueContext.h"
 #include "UBValueContext.h"
@@ -15,5 +16,6 @@ void AiObjectContext::BuildSharedValueContexts(SharedNamedObjectContextList<Unty
     valueContexts.Add(new ValueContext());
     valueContexts.Add(new TbcDungeonMechValueContext());
     valueContexts.Add(new TbcDungeonUnderbogValueContext());
+    valueContexts.Add(new WotlkDungeonGDValueContext());
     valueContexts.Add(new TbcDungeonMgTValueContext());
 }

--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -4861,6 +4861,9 @@ void PlayerbotFactory::InitGuild()
         return;
     }
 
+    if (sPlayerbotAIConfig.deleteRandomBotGuilds)
+        return;
+
     std::string guildName = PlayerbotGuildMgr::instance().AssignToGuild(bot);
     if (guildName.empty())
         return;

--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -35,6 +35,8 @@
 #include "ReputationMgr.h"
 #include "SharedDefines.h"
 #include "StatsWeightCalculator.h"
+#include "SpellMgr.h"
+#include "Trainer.h"
 #include "World.h"
 #include <array>
 #include <utility>
@@ -117,6 +119,111 @@ bool PlayerbotFactory::IsPrimaryTradeSkill(uint16 skillId)
 {
     SkillLineEntry const* skillLine = sSkillLineStore.LookupEntry(skillId);
     return skillLine && skillLine->categoryId == SKILL_CATEGORY_PROFESSION;
+}
+
+bool PlayerbotFactory::IsSecondaryTradeSkill(uint16 skillId)
+{
+    switch (skillId)
+    {
+        case SKILL_COOKING:
+        case SKILL_FIRST_AID:
+        case SKILL_FISHING:
+            return true;
+        default:
+            return false;
+    }
+}
+
+uint16 PlayerbotFactory::GetTrainerSpellTradeSkill(Trainer::Spell const* trainerSpell)
+{
+    if (!trainerSpell)
+        return 0;
+
+    auto getSpellTradeSkill = [](uint32 spellId) -> uint16
+    {
+        if (SpellLearnSkillNode const* learnSkill = sSpellMgr->GetSpellLearnSkill(spellId))
+        {
+            if (IsPrimaryTradeSkill(learnSkill->skill) || IsSecondaryTradeSkill(learnSkill->skill))
+                return learnSkill->skill;
+        }
+
+        SkillLineAbilityMapBounds bounds = sSpellMgr->GetSkillLineAbilityMapBounds(spellId);
+        for (auto itr = bounds.first; itr != bounds.second; ++itr)
+        {
+            uint16 const skillId = itr->second->SkillLine;
+            if (IsPrimaryTradeSkill(skillId) || IsSecondaryTradeSkill(skillId))
+                return skillId;
+        }
+
+        return 0;
+    };
+
+    uint16 const requiredSkill = static_cast<uint16>(trainerSpell->ReqSkillLine);
+    if (IsPrimaryTradeSkill(requiredSkill) || IsSecondaryTradeSkill(requiredSkill))
+        return requiredSkill;
+
+    if (uint16 const skillId = getSpellTradeSkill(trainerSpell->SpellId))
+        return skillId;
+
+    SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(trainerSpell->SpellId);
+    if (!spellInfo)
+        return 0;
+
+    for (uint8 effectIndex = 0; effectIndex < MAX_SPELL_EFFECTS; ++effectIndex)
+    {
+        if (spellInfo->Effects[effectIndex].Effect != SPELL_EFFECT_LEARN_SPELL)
+            continue;
+
+        uint32 const learnedSpellId = spellInfo->Effects[effectIndex].TriggerSpell;
+        if (!learnedSpellId)
+            continue;
+
+        if (uint16 const skillId = getSpellTradeSkill(learnedSpellId))
+            return skillId;
+    }
+
+    return 0;
+}
+
+bool PlayerbotFactory::IsTrainerSpellAllowedForBot(Player* bot, Trainer::Trainer const* trainer,
+                                                     Trainer::Spell const* trainerSpell)
+{
+    if (!bot || !trainer || !trainerSpell)
+        return false;
+
+    if (trainer->GetTrainerType() != Trainer::Type::Tradeskill || !sRandomPlayerbotMgr.IsRandomBot(bot))
+        return true;
+
+    uint16 const skillId = GetTrainerSpellTradeSkill(trainerSpell);
+    if (!skillId)
+        return false;
+
+    if (IsSecondaryTradeSkill(skillId))
+        return true;
+
+    if (!IsPrimaryTradeSkill(skillId))
+        return false;
+
+    uint16 const firstSkill = sRandomPlayerbotMgr.GetValue(bot, "firstSkill");
+    uint16 const secondSkill = sRandomPlayerbotMgr.GetValue(bot, "secondSkill");
+
+    if ((IsPrimaryTradeSkill(firstSkill) && skillId == firstSkill) ||
+        (IsPrimaryTradeSkill(secondSkill) && skillId == secondSkill))
+        return true;
+
+    if (IsPrimaryTradeSkill(firstSkill) || IsPrimaryTradeSkill(secondSkill))
+        return false;
+
+    uint32 knownPrimarySkills = 0;
+    for (uint32 tradeSkill : tradeSkills)
+    {
+        if (IsPrimaryTradeSkill(tradeSkill) && bot->HasSkill(tradeSkill))
+            ++knownPrimarySkills;
+    }
+
+    uint32 const maxPrimaryTradeSkills =
+        std::min<uint32>(2, sWorld->getIntConfig(CONFIG_MAX_PRIMARY_TRADE_SKILL));
+    return knownPrimarySkills <= maxPrimaryTradeSkills && bot->HasSkill(skillId);
 }
 
 bool PlayerbotFactory::IsGatheringTradeSkill(uint16 skillId)
@@ -257,18 +364,6 @@ std::pair<uint16, uint16> PlayerbotFactory::ChooseProfessionPair(
     return {fallback.firstSkill, fallback.secondSkill};
 }
 
-bool PlayerbotFactory::HasProfessionPair(std::vector<WeightedProfessionPair> const& professionPairs,
-                                         uint16 firstSkill, uint16 secondSkill)
-{
-    for (WeightedProfessionPair const& pair : professionPairs)
-    {
-        if (pair.firstSkill == firstSkill && pair.secondSkill == secondSkill)
-            return true;
-    }
-
-    return false;
-}
-
 uint16 PlayerbotFactory::ChooseSingleProfession(std::vector<WeightedProfessionPair> const& professionPairs)
 {
     std::vector<std::pair<uint16, uint32>> gatheringSkills;
@@ -329,6 +424,58 @@ uint16 PlayerbotFactory::ChooseSingleProfession(std::vector<WeightedProfessionPa
     }
 
     return selectedPool->back().first;
+}
+
+uint16 PlayerbotFactory::ChooseComplementaryProfession(
+    std::vector<WeightedProfessionPair> const& professionPairs, uint16 existingSkill)
+{
+    std::vector<std::pair<uint16, uint32>> candidates;
+    uint32 totalWeight = 0;
+
+    for (WeightedProfessionPair const& pair : professionPairs)
+    {
+        uint16 candidate = 0;
+        if (pair.firstSkill == existingSkill)
+            candidate = pair.secondSkill;
+        else if (pair.secondSkill == existingSkill)
+            candidate = pair.firstSkill;
+
+        if (!candidate || candidate == existingSkill)
+            continue;
+
+        bool merged = false;
+        for (std::pair<uint16, uint32>& existingCandidate : candidates)
+        {
+            if (existingCandidate.first != candidate)
+                continue;
+
+            existingCandidate.second += pair.weight;
+            merged = true;
+            break;
+        }
+
+        if (!merged)
+            candidates.push_back({candidate, pair.weight});
+
+        totalWeight += pair.weight;
+    }
+
+    if (candidates.empty() || !totalWeight)
+    {
+        std::pair<uint16, uint16> const fallback = ChooseProfessionPair(professionPairs);
+        return fallback.first != existingSkill ? fallback.first : fallback.second;
+    }
+
+    uint32 roll = urand(1, totalWeight);
+    for (std::pair<uint16, uint32> const& candidate : candidates)
+    {
+        if (roll <= candidate.second)
+            return candidate.first;
+
+        roll -= candidate.second;
+    }
+
+    return candidates.back().first;
 }
 
 uint32 PlayerbotFactory::GetStoredOrRandomValue(Player* bot,
@@ -2780,76 +2927,133 @@ void PlayerbotFactory::InitTradeSkills()
                                                               ? GetClassProfessionPairs(bot)
                                                               : GetRandomProfessionPairs();
 
-    bool const hasStoredProfessionPair = firstSkill && secondSkill && firstSkill != secondSkill &&
-                                         IsPrimaryTradeSkill(firstSkill) && IsPrimaryTradeSkill(secondSkill) &&
-                                         HasProfessionPair(professionPairs, firstSkill, secondSkill);
-    bool const keepExistingProfessionPair = maxPrimaryTradeSkills < 2 && hasStoredProfessionPair;
-
-    if (maxPrimaryTradeSkills == 1 && !keepExistingProfessionPair)
+    std::vector<uint16> knownPrimarySkills;
+    for (uint32 tradeSkill : tradeSkills)
     {
-        if (!IsPrimaryTradeSkill(firstSkill) || secondSkill != 0)
-        {
-            firstSkill = ChooseSingleProfession(professionPairs);
-            secondSkill = 0;
-
-            sRandomPlayerbotMgr.SetValue(bot, "firstSkill", firstSkill);
-            sRandomPlayerbotMgr.SetValue(bot, "secondSkill", secondSkill);
-        }
-    }
-    else if (maxPrimaryTradeSkills == 0 && !keepExistingProfessionPair)
-    {
-        firstSkill = 0;
-        secondSkill = 0;
-
-        sRandomPlayerbotMgr.SetValue(bot, "firstSkill", firstSkill);
-        sRandomPlayerbotMgr.SetValue(bot, "secondSkill", secondSkill);
-    }
-
-    if (maxPrimaryTradeSkills >= 2 &&
-        (!firstSkill || !secondSkill || firstSkill == secondSkill || !IsPrimaryTradeSkill(firstSkill) ||
-         !IsPrimaryTradeSkill(secondSkill) || !HasProfessionPair(professionPairs, firstSkill, secondSkill)))
-    {
-        auto const& professionPair = ChooseProfessionPair(professionPairs);
-        firstSkill = professionPair.first;
-        secondSkill = professionPair.second;
-
-        sRandomPlayerbotMgr.SetValue(bot, "firstSkill", firstSkill);
-        sRandomPlayerbotMgr.SetValue(bot, "secondSkill", secondSkill);
+        if (IsPrimaryTradeSkill(tradeSkill) && bot->HasSkill(tradeSkill))
+            knownPrimarySkills.push_back(static_cast<uint16>(tradeSkill));
     }
 
     std::vector<uint16> primarySkills;
-    if (keepExistingProfessionPair)
+    auto addPrimarySkill = [&primarySkills, maxPrimaryTradeSkills](uint16 skillId)
     {
-        primarySkills.push_back(firstSkill);
-        primarySkills.push_back(secondSkill);
+        if (!skillId || !IsPrimaryTradeSkill(skillId) || primarySkills.size() >= maxPrimaryTradeSkills)
+            return;
+
+        if (std::find(primarySkills.begin(), primarySkills.end(), skillId) == primarySkills.end())
+            primarySkills.push_back(skillId);
+    };
+
+    auto isKnownPrimarySkill = [&knownPrimarySkills](uint16 skillId)
+    {
+        return std::find(knownPrimarySkills.begin(), knownPrimarySkills.end(), skillId) != knownPrimarySkills.end();
+    };
+
+    if (knownPrimarySkills.empty())
+    {
+        // A full randomization clears skills before this method. Keep a valid stored assignment stable and relearn it.
+        addPrimarySkill(firstSkill);
+        addPrimarySkill(secondSkill);
     }
-    else if (maxPrimaryTradeSkills > 0)
-        primarySkills.push_back(firstSkill);
-    if (!keepExistingProfessionPair && maxPrimaryTradeSkills > 1)
-        primarySkills.push_back(secondSkill);
+    else if (knownPrimarySkills.size() == 1)
+    {
+        // The real skill is authoritative. Reuse a stored complement only when the stored pair contains that skill.
+        uint16 const knownSkill = knownPrimarySkills.front();
+        addPrimarySkill(knownSkill);
+
+        if (firstSkill == knownSkill && secondSkill != knownSkill)
+            addPrimarySkill(secondSkill);
+        else if (secondSkill == knownSkill && firstSkill != knownSkill)
+            addPrimarySkill(firstSkill);
+    }
+    else
+    {
+        // For contaminated bots, stored values are trusted only when the corresponding skill is actually present.
+        if (isKnownPrimarySkill(firstSkill))
+            addPrimarySkill(firstSkill);
+        if (isKnownPrimarySkill(secondSkill))
+            addPrimarySkill(secondSkill);
+
+        for (uint16 skillId : knownPrimarySkills)
+            addPrimarySkill(skillId);
+    }
+
+    if (primarySkills.empty() && maxPrimaryTradeSkills == 1)
+        addPrimarySkill(ChooseSingleProfession(professionPairs));
+    else if (primarySkills.empty() && maxPrimaryTradeSkills >= 2)
+    {
+        std::pair<uint16, uint16> const professionPair = ChooseProfessionPair(professionPairs);
+        addPrimarySkill(professionPair.first);
+        addPrimarySkill(professionPair.second);
+    }
+    else if (primarySkills.size() == 1 && maxPrimaryTradeSkills >= 2)
+    {
+        addPrimarySkill(ChooseComplementaryProfession(professionPairs, primarySkills.front()));
+
+        // Defensive fallback for an empty or malformed pair table.
+        if (primarySkills.size() == 1)
+        {
+            for (uint32 tradeSkill : tradeSkills)
+            {
+                if (IsPrimaryTradeSkill(tradeSkill) && tradeSkill != primarySkills.front())
+                {
+                    addPrimarySkill(static_cast<uint16>(tradeSkill));
+                    break;
+                }
+            }
+        }
+    }
+
+    firstSkill = primarySkills.empty() ? 0 : primarySkills[0];
+    secondSkill = primarySkills.size() > 1 ? primarySkills[1] : 0;
+    sRandomPlayerbotMgr.SetValue(bot, "firstSkill", firstSkill);
+    sRandomPlayerbotMgr.SetValue(bot, "secondSkill", secondSkill);
+
+    for (uint16 skillId : knownPrimarySkills)
+    {
+        if (std::find(primarySkills.begin(), primarySkills.end(), skillId) == primarySkills.end())
+            bot->SetSkill(skillId, 0, 0, 0);
+    }
 
     SetRandomSkill(SKILL_FIRST_AID);
     SetRandomSkill(SKILL_FISHING);
     SetRandomSkill(SKILL_COOKING);
 
-    for (uint16 skillId : primarySkills)
-        SetRandomSkill(skillId);
-
     std::vector<uint16> skillsToLearn = {SKILL_FIRST_AID, SKILL_FISHING, SKILL_COOKING};
     skillsToLearn.insert(skillsToLearn.end(), primarySkills.begin(), primarySkills.end());
 
+    uint32 selectedPrimaryStarterSpells = 0;
+    for (uint16 skillId : primarySkills)
+    {
+        uint32 const starterSpellId = GetProfessionStarterSpell(skillId);
+        if (starterSpellId && bot->HasSpell(starterSpellId))
+            ++selectedPrimaryStarterSpells;
+    }
+
+    bot->SetFreePrimaryProfessions(
+        static_cast<uint16>(maxPrimaryTradeSkills > selectedPrimaryStarterSpells
+                                ? maxPrimaryTradeSkills - selectedPrimaryStarterSpells
+                                : 0));
+
     for (uint16 skillId : skillsToLearn)
     {
-        uint32 spellId = GetProfessionStarterSpell(skillId);
+        uint32 const spellId = GetProfessionStarterSpell(skillId);
         if (!spellId || bot->HasSpell(spellId))
             continue;
 
-        if (IsPrimaryTradeSkill(skillId) && !bot->GetFreePrimaryProfessionPoints() &&
-            !(keepExistingProfessionPair && bot->HasSkill(skillId)))
+        if (IsPrimaryTradeSkill(skillId) && !bot->GetFreePrimaryProfessionPoints())
             continue;
 
         bot->learnSpell(spellId, false);
     }
+
+    for (uint16 skillId : primarySkills)
+        SetRandomSkill(skillId);
+
+    bot->SetFreePrimaryProfessions(
+        static_cast<uint16>(maxPrimaryTradeSkills > primarySkills.size()
+                                ? maxPrimaryTradeSkills - primarySkills.size()
+                                : 0));
 
     InitTradeSpecializations();
 }
@@ -3244,6 +3448,9 @@ void PlayerbotFactory::InitAvailableSpells()
 
             Trainer::Spell const* trainerSpell = trainer->GetSpell(spell.SpellId);
             if (!trainerSpell)
+                continue;
+
+            if (!IsTrainerSpellAllowedForBot(bot, trainer, trainerSpell))
                 continue;
 
             if (!trainer->CanTeachSpell(bot, trainerSpell))

--- a/src/Bot/Factory/PlayerbotFactory.cpp
+++ b/src/Bot/Factory/PlayerbotFactory.cpp
@@ -39,6 +39,7 @@
 #include "Trainer.h"
 #include "World.h"
 #include <array>
+#include <unordered_set>
 #include <utility>
 
 #include <array>
@@ -113,6 +114,29 @@ constexpr uint32 SPELL_IMPROVED_HOWL_OF_TERROR = 30057;
 constexpr uint32 SPELL_NEMESIS = 63123;
 constexpr uint32 SPELL_INTENSITY = 18136;
 constexpr uint32 SPELL_NETHER_PROTECTION = 30302;
+
+// Some creature_template rows are Blizzard developer leftovers or placeholders that carry the tameable
+// flag but have no spawn in the world - e.g. 5596 "Twain Test Prop", a wolf family beast wearing a
+// dragon whelp model. No player can ever tame those, so bots should not end up with them either.
+bool HasCreatureSpawnRow(uint32 entry)
+{
+    static std::unordered_set<uint32> const spawnedEntries = []  // built once, at first use
+    {
+        std::unordered_set<uint32> entries;
+        for (auto const& itr : sObjectMgr->GetAllCreatureData())
+        {
+            CreatureData const& data = itr.second;
+            entries.insert(data.id);
+            if (data.id2)
+                entries.insert(data.id2);
+            if (data.id3)
+                entries.insert(data.id3);
+        }
+        return entries;
+    }();
+
+    return spawnedEntries.find(entry) != spawnedEntries.end();
+}
 }
 
 bool PlayerbotFactory::IsPrimaryTradeSkill(uint16 skillId)
@@ -1452,6 +1476,9 @@ void PlayerbotFactory::InitPet()
         for (CreatureTemplateContainer::const_iterator itr = creatures->begin(); itr != creatures->end(); ++itr)
         {
             if (!itr->second.IsTameable(bot->CanTameExoticPets()))
+                continue;
+
+            if (!HasCreatureSpawnRow(itr->first))
                 continue;
 
             if (itr->second.minlevel > bot->GetLevel())

--- a/src/Bot/Factory/PlayerbotFactory.h
+++ b/src/Bot/Factory/PlayerbotFactory.h
@@ -15,6 +15,12 @@
 
 class Item;
 
+namespace Trainer
+{
+    class Trainer;
+    struct Spell;
+}
+
 struct ItemTemplate;
 
 struct EnchantTemplate
@@ -67,6 +73,8 @@ public:
     static void InitTalentsBySpecNo(Player* bot, int specNo, bool reset);
     static void InitTalentsByParsedSpecLink(Player* bot, std::vector<std::vector<uint32>> parsedSpecLink, bool reset);
     void InitAvailableSpells();
+    static bool IsTrainerSpellAllowedForBot(Player* bot, Trainer::Trainer const* trainer,
+                                             Trainer::Spell const* trainerSpell);
     void InitClassSpells();
     void InitSpecialSpells();
     void InitEquipment(bool incremental, bool second_chance = false);
@@ -158,14 +166,16 @@ private:
     bool CanEquipItem(ItemTemplate const* proto);
     bool CanEquipUnseenItem(uint8 slot, uint16& dest, uint32 item);
     static bool IsPrimaryTradeSkill(uint16 skillId);
+    static bool IsSecondaryTradeSkill(uint16 skillId);
+    static uint16 GetTrainerSpellTradeSkill(Trainer::Spell const* trainerSpell);
     static bool IsGatheringTradeSkill(uint16 skillId);
     static bool IsCraftingTradeSkill(uint16 skillId);
     static uint32 GetProfessionStarterSpell(uint16 skillId);
     static std::vector<WeightedProfessionPair> GetClassProfessionPairs(Player* bot);
     static std::vector<WeightedProfessionPair> GetRandomProfessionPairs();
     static std::pair<uint16, uint16> ChooseProfessionPair(std::vector<WeightedProfessionPair> const& professionPairs);
-    static bool HasProfessionPair(std::vector<WeightedProfessionPair> const& professionPairs,
-                                  uint16 firstSkill, uint16 secondSkill);
+    static uint16 ChooseComplementaryProfession(
+        std::vector<WeightedProfessionPair> const& professionPairs, uint16 existingSkill);
     static uint16 ChooseSingleProfession(std::vector<WeightedProfessionPair> const& professionPairs);
     static uint32 GetStoredOrRandomValue(Player* bot, std::string const& key, uint32 minValue, uint32 maxValue);
     static bool HasAnySpell(Player* bot, std::vector<uint32> const& spells);

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -665,7 +665,7 @@ void PlayerbotAI::HandleCommand(uint32 type, std::string const& text, Player& fr
     {
         std::string response = HandleRemoteCommand(filtered.substr(6));
         WorldPacket data;
-        ChatHandler::BuildChatPacket(data, CHAT_MSG_ADDON, response.c_str(), LANG_ADDON, CHAT_TAG_NONE, bot->GetGUID(),
+        ChatHandler::BuildChatPacket(data, CHAT_MSG_ADDON, LANG_ADDON, bot->GetGUID(), {}, response, CHAT_TAG_NONE,
                                      bot->GetName());
         ServerFacade::instance().SendPacket(&fromPlayer, &data);
         return;
@@ -2929,7 +2929,7 @@ bool PlayerbotAI::SayToParty(std::string const& msg)
         return false;
 
     WorldPacket data;
-    ChatHandler::BuildChatPacket(data, CHAT_MSG_PARTY, msg.c_str(), LANG_UNIVERSAL, CHAT_TAG_NONE, bot->GetGUID(),
+    ChatHandler::BuildChatPacket(data, CHAT_MSG_PARTY, LANG_UNIVERSAL, bot->GetGUID(), {}, msg, CHAT_TAG_NONE,
                                  bot->GetName());
 
     for (auto receiver : GetRealPlayersInGroup())
@@ -2946,7 +2946,7 @@ bool PlayerbotAI::SayToRaid(std::string const& msg)
         return false;
 
     WorldPacket data;
-    ChatHandler::BuildChatPacket(data, CHAT_MSG_RAID, msg.c_str(), LANG_UNIVERSAL, CHAT_TAG_NONE, bot->GetGUID(),
+    ChatHandler::BuildChatPacket(data, CHAT_MSG_RAID, LANG_UNIVERSAL, bot->GetGUID(), {}, msg, CHAT_TAG_NONE,
                                  bot->GetName());
 
     for (auto receiver : GetRealPlayersInGroup())

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -1541,7 +1541,7 @@ void PlayerbotAI::DoNextAction(bool min)
         SetNextCheckDelay(sPlayerbotAIConfig.passiveDelay);
         return;
     }
-    else if (bot->isAFK())
+    else if (bot->isAFK() && !IsSelfBot(bot))
         bot->ToggleAFK();
 
     if (master && master->IsInWorld())

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -1633,7 +1633,7 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
     static const std::vector<std::string> allInstanceStrategies =
     {
         "aq20", "blacktemple", "bwl", "gruulslair", "hyjal", "icc", "karazhan", "magtheridon",
-        "moltencore", "naxx", "onyxia", "rs", "ssc", "tbc-ac", "tbc-mech", "tbc-seth", "tbc-ub",
+        "moltencore", "naxx", "onyxia", "rs", "ssc", "tbc-ac", "tbc-mech", "tbc-mgt", "tbc-seth", "tbc-ub",
         "tempestkeep", "ulduar", "voa", "wotlk-an", "wotlk-cos", "wotlk-dtk", "wotlk-eoe",
         "wotlk-fos", "wotlk-gd", "wotlk-hol", "wotlk-hos", "wotlk-nex", "wotlk-occ", "wotlk-ok",
         "wotlk-os", "wotlk-pos", "wotlk-toc", "wotlk-uk", "wotlk-up", "wotlk-vh", "zulaman"
@@ -1710,6 +1710,9 @@ void PlayerbotAI::ApplyInstanceStrategies(uint32 mapId, bool tellMaster)
             break;
         case 578:
             strategyName = "wotlk-occ";  // The Oculus
+            break;
+        case 585:
+            strategyName = "tbc-mgt";  // Magisters' Terrace
             break;
         case 595:
             strategyName = "wotlk-cos";  // The Culling of Stratholme

--- a/src/Bot/RandomBotLevelMgr.cpp
+++ b/src/Bot/RandomBotLevelMgr.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "RandomBotLevelMgr.h"
+#include "ArenaTeamMgr.h"
 #include "DatabaseEnv.h"
 #include "LFGMgr.h"
 #include "Log.h"
@@ -47,14 +48,19 @@ static bool BotInFriendList(Player* bot, std::vector<uint32> const& socialFriend
         socialFriendsList.end();
 }
 
+static bool IsDisabledBracket(std::vector<LevelBracketConfig> const& configured, uint8 index)
+{
+    return index < configured.size() && configured[index].pct == 0;
+}
+
 // Checks if the given bot is a member of any arena team.
 static bool BotInArenaTeam(Player* bot)
 {
     if (!bot)
         return false;
-    for (uint32 slot = 0; slot < MAX_ARENA_SLOT; ++slot)
+    for (uint8 slot = ARENA_SLOT_2v2; slot <= ARENA_SLOT_5v5; ++slot)
     {
-        if (bot->GetArenaTeamId(slot))
+        if (sArenaTeamMgr->GetArenaTeamById(bot->GetArenaTeamId(slot)))
             return true;
     }
     return false;
@@ -431,6 +437,9 @@ int RandomBotLevelMgr::GetOrFlagPlayerBracket(Player* player)
         if (factionRanges[i].lower > factionRanges[i].upper)
             continue;
 
+        if (factionRanges[i].pct == 0)
+            continue;
+
         // Skip brackets that Death Knights cannot be assigned to.
         if (player->getClass() == CLASS_DEATH_KNIGHT && factionRanges[i].upper < dkMinLevel)
             continue;
@@ -600,8 +609,9 @@ void RandomBotLevelMgr::RunLevelBracketsDistribution()
                 int combinedReal = allianceRealCounts[i] + hordeRealCounts[i];
                 float weight = baseline + sPlayerbotAIConfig.levelBracketsRealPlayerWeight *
                     (totalCombinedReal > 0 ? (1.0f / float(totalCombinedReal)) : 1.0f) * std::log(1 + combinedReal);
-                allianceWeights[i] = weight;
-                hordeWeights[i] = weight;
+
+                allianceWeights[i] = IsDisabledBracket(sPlayerbotAIConfig.levelBracketsAlliance, i) ? 0.0f : weight;
+                hordeWeights[i] = IsDisabledBracket(sPlayerbotAIConfig.levelBracketsHorde, i) ? 0.0f : weight;
             }
         }
         else
@@ -609,14 +619,16 @@ void RandomBotLevelMgr::RunLevelBracketsDistribution()
             // Separate dynamic weighting for each faction.
             for (uint8 i = 0; i < _numRanges; ++i)
             {
-                if (_allianceRanges[i].lower > _allianceRanges[i].upper)
+                if (_allianceRanges[i].lower > _allianceRanges[i].upper ||
+                    IsDisabledBracket(sPlayerbotAIConfig.levelBracketsAlliance, i))
                     allianceWeights[i] = 0.0f;
                 else
                     allianceWeights[i] = baseline + sPlayerbotAIConfig.levelBracketsRealPlayerWeight *
                         (totalAllianceReal > 0 ? (1.0f / totalAllianceReal) : 1.0f) *
                         std::log(1 + allianceRealCounts[i]);
 
-                if (_hordeRanges[i].lower > _hordeRanges[i].upper)
+                if (_hordeRanges[i].lower > _hordeRanges[i].upper ||
+                    IsDisabledBracket(sPlayerbotAIConfig.levelBracketsHorde, i))
                     hordeWeights[i] = 0.0f;
                 else
                     hordeWeights[i] = baseline + sPlayerbotAIConfig.levelBracketsRealPlayerWeight *
@@ -1016,6 +1028,13 @@ void RandomBotLevelMgr::OnBotLevelChanged(Player* player, uint8 oldLevel)
         return;
 
     uint8 newLevel = player->GetLevel();
+
+    if (newLevel == 1)
+        return;
+
+    if (player->getClass() == CLASS_DEATH_KNIGHT &&
+        newLevel == static_cast<uint8>(sWorld->getIntConfig(CONFIG_START_HEROIC_PLAYER_LEVEL)))
+        return;
 
     // SkipFromLevel takes priority and is not affected by ScaledChance or RestrictTimePlayed.
     if (sPlayerbotAIConfig.resetBotLevelSkipFrom > 0 && newLevel == sPlayerbotAIConfig.resetBotLevelSkipFrom)

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -46,6 +46,8 @@
 #include <ctime>
 #include <iomanip>
 #include <random>
+#include <set>
+#include <utility>
 
 struct GuidClassRaceInfo
 {
@@ -1793,11 +1795,85 @@ void RandomPlayerbotMgr::RandomTeleportForLevel(Player* bot)
         }
     }
     std::vector<WorldLocation> locs = sTravelMgr.GetTeleportLocations(bot);
+
+    if (sPlayerbotAIConfig.randomBotConcentrateInPlayerZone && !locs.empty())
+    {
+        std::vector<WorldLocation> playerZoneLocs = GetPlayerZoneTeleportLocations(locs, bot);
+        if (!playerZoneLocs.empty())
+            locs = std::move(playerZoneLocs);
+    }
+
     if (!locs.empty())
     {
         RandomTeleport(bot, locs, false);
         return;
     }
+}
+
+// Returns the subset of teleport locations that lie in a zone currently occupied by a real
+// (non-GM) player, so random bots can be gathered where players actually are. Returns an empty
+// vector when no player is online or none of the locations match, letting the caller fall back
+// to the default world-wide behaviour.
+std::vector<WorldLocation> RandomPlayerbotMgr::GetPlayerZoneTeleportLocations(std::vector<WorldLocation> const& locs,
+                                                                              Player* bot)
+{
+    std::set<uint32> playerMaps;
+    std::set<std::pair<uint32, uint32>> playerMapZones;
+
+    // players only ever holds real (non random bot) players and is maintained on login/logout, so
+    // this is a pass over the online player list, not a world-wide scan.
+    for (Player* player : players)
+    {
+        if (!player || !player->IsInWorld() || player->IsGameMaster())
+            continue;
+
+        Map* map = player->GetMap();
+        if (!map)
+            continue;
+
+        // Instanceable maps (dungeons, raids, battlegrounds, arenas) are never valid targets: a
+        // WorldLocation carries no instance id, so a bot would be sent to another instance of the
+        // same map rather than to the player.
+        if (map->Instanceable())
+            continue;
+
+        // Resolve the player zone the same way as the candidate locations below (unphased terrain),
+        // so a player standing in a phased area still matches its underlying zone.
+        uint32 zoneId = map->GetZoneId(PHASEMASK_NORMAL, player->GetPositionX(), player->GetPositionY(),
+                                       player->GetPositionZ());
+        playerMaps.insert(map->GetId());
+        playerMapZones.insert(std::make_pair(map->GetId(), zoneId));
+    }
+
+    std::vector<WorldLocation> filtered;
+    if (playerMapZones.empty())
+        return filtered;
+
+    for (WorldLocation const& loc : locs)
+    {
+        if (playerMaps.find(loc.GetMapId()) == playerMaps.end())
+            continue;
+
+        uint32 zoneId = sMapMgr->GetZoneId(PHASEMASK_NORMAL, loc);
+        if (playerMapZones.find(std::make_pair(loc.GetMapId(), zoneId)) == playerMapZones.end())
+            continue;
+
+        // Skip enemy-faction zones, matching the check in RandomTeleport. This has to be done here:
+        // the caller only falls back to normal teleporting when the filtered set is empty, so keeping
+        // a hostile location would let the downstream team check drain the set and strand the bot.
+        if (AreaTableEntry const* zone = sAreaTableStore.LookupEntry(zoneId))
+        {
+            if (zone->team == 4 && bot->GetTeamId() == TEAM_ALLIANCE)
+                continue;
+
+            if (zone->team == 2 && bot->GetTeamId() == TEAM_HORDE)
+                continue;
+        }
+
+        filtered.push_back(loc);
+    }
+
+    return filtered;
 }
 
 void RandomPlayerbotMgr::RandomTeleportGrindForLevel(Player* bot)

--- a/src/Bot/RandomPlayerbotMgr.h
+++ b/src/Bot/RandomPlayerbotMgr.h
@@ -241,6 +241,7 @@ private:
     void RandomTeleport(Player* bot);
     void RandomTeleport(Player* bot, std::vector<WorldLocation>& locs, bool hearth = false);
     uint32 GetZoneLevel(uint16 mapId, float teleX, float teleY, float teleZ);
+    std::vector<WorldLocation> GetPlayerZoneTeleportLocations(std::vector<WorldLocation> const& locs, Player* bot);
     typedef void (RandomPlayerbotMgr::*ConsoleCommandHandler)(Player*);
     std::vector<Player*> players;
 

--- a/src/Mgr/Guild/PlayerbotGuildMgr.cpp
+++ b/src/Mgr/Guild/PlayerbotGuildMgr.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "PlayerbotGuildMgr.h"
+#include "CharacterCache.h"
 #include "DatabaseEnv.h"
 #include "Guild.h"
 #include "GuildMgr.h"
@@ -16,7 +17,7 @@ void PlayerbotGuildMgr::Init()
 {
     _guildCache.clear();
     if (sPlayerbotAIConfig.deleteRandomBotGuilds)
-        DeleteBotGuilds();
+        DeleteRandomBotGuilds();
 
     LoadGuildNames();
     ValidateGuildCache();
@@ -245,29 +246,32 @@ void PlayerbotGuildMgr::ValidateGuildCache()
     }
 }
 
-void PlayerbotGuildMgr::DeleteBotGuilds()
+void PlayerbotGuildMgr::DeleteRandomBotGuilds()
 {
-    LOG_INFO("playerbots", "Deleting random bot guilds...");
-    std::vector<uint32> randomBots;
+    LOG_INFO("playerbots", "Deleting randombot guilds...");
+    std::vector<uint32> guildsToDisband;
 
-    PlayerbotsDatabasePreparedStatement* stmt = PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_SEL_RANDOM_BOTS_BOT);
-    stmt->SetData(0, "add");
-    if (PreparedQueryResult result = PlayerbotsDatabase.Query(stmt))
+    if (QueryResult result = CharacterDatabase.Query("SELECT guildid, leaderguid FROM guild"))
     {
         do
         {
             Field* fields = result->Fetch();
-            uint32 bot = fields[0].Get<uint32>();
-            randomBots.push_back(bot);
+            uint32 guildId = fields[0].Get<uint32>();
+            ObjectGuid leader = ObjectGuid::Create<HighGuid::Player>(fields[1].Get<uint32>());
+
+            // The leader's account is checked instead of the 'add' event or anything else that depends on the
+            // bot being online.
+            if (sPlayerbotAIConfig.IsInRandomAccountList(sCharacterCache->GetCharacterAccountIdByGuid(leader)))
+                guildsToDisband.push_back(guildId);
         } while (result->NextRow());
     }
 
-    for (std::vector<uint32>::iterator i = randomBots.begin(); i != randomBots.end(); ++i)
+    for (uint32 guildId : guildsToDisband)
     {
-        if (Guild* guild = sGuildMgr->GetGuildByLeader(ObjectGuid::Create<HighGuid::Player>(*i)))
+        if (Guild* guild = sGuildMgr->GetGuildById(guildId))
             guild->Disband();
     }
-    LOG_INFO("playerbots", "Random bot guilds deleted");
+    LOG_INFO("playerbots", "Randombot guilds deleted");
 }
 
 bool PlayerbotGuildMgr::IsRealGuild(Player* bot)

--- a/src/Mgr/Guild/PlayerbotGuildMgr.h
+++ b/src/Mgr/Guild/PlayerbotGuildMgr.h
@@ -29,7 +29,7 @@ public:
     bool CreateGuild(Player* player, std::string guildName);
     void OnGuildUpdate  (Guild* guild);
     bool SetGuildEmblem(uint32 guildId);
-    void DeleteBotGuilds();
+    void DeleteRandomBotGuilds();
     bool IsRealGuild(uint32 guildId);
     bool IsRealGuild(Player* bot);
 

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -737,6 +737,8 @@ bool PlayerbotAIConfig::Initialize()
     RpgStatusProbWeight[RPG_OUTDOOR_PVP] = sConfigMgr->GetOption<int32>("AiPlayerbot.RpgStatusProbWeight.OutdoorPvp", 10);
 
     syncLevelWithPlayers = sConfigMgr->GetOption<bool>("AiPlayerbot.SyncLevelWithPlayers", false);
+    randomBotConcentrateInPlayerZone =
+        sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotConcentrateInPlayerZone", false);
     randomBotGroupNearby = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotGroupNearby", false);
 
     // arena

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -393,6 +393,7 @@ public:
     bool enableNewRpgStrategy;
     std::unordered_map<NewRpgStatus, uint32> RpgStatusProbWeight;
     bool syncLevelWithPlayers;
+    bool randomBotConcentrateInPlayerZone;
     bool autoLearnQuestSpells;
     bool autoTeleportForLevel;
     bool randomBotGroupNearby;

--- a/src/Script/Playerbots.cpp
+++ b/src/Script/Playerbots.cpp
@@ -512,6 +512,7 @@ public:
 };
 
 void AddPlayerbotsSecureLoginScripts();
+void AddPlayerbotsSelfBotAfkScripts();
 
 void AddSC_MagtheridonBotScripts();
 void AddSC_TempestKeepBotScripts();
@@ -531,6 +532,7 @@ void AddPlayerbotsScripts()
     new PlayerbotsScript();
     new PlayerBotsBGScript();
     AddPlayerbotsSecureLoginScripts();
+    AddPlayerbotsSelfBotAfkScripts();
     AddPlayerbotsCommandscripts();
     PlayerBotsGuildValidationScript();
     AddSC_MagtheridonBotScripts();

--- a/src/Script/Playerbots.cpp
+++ b/src/Script/Playerbots.cpp
@@ -386,7 +386,7 @@ public:
         {
             Player* player = ObjectAccessor::FindPlayer(guid);
 
-            if (guid.IsGroup() || (player && !PlayerbotsMgr::instance().GetPlayerbotAI(player)))
+            if (guid.IsGroup() || IsRealPlayer(player) || IsSelfBot(player))
             {
                 nonBotFound = true;
                 break;

--- a/src/Script/PlayerbotsSelfBotAfk.cpp
+++ b/src/Script/PlayerbotsSelfBotAfk.cpp
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "CharacterPackets.h"
+#include "Log.h"
+#include "Opcodes.h"
+#include "Player.h"
+#include "Playerbots.h"
+#include "ScriptMgr.h"
+#include "WorldPacket.h"
+#include "WorldSession.h"
+
+class PlayerbotsSelfBotAfkServerScript : public ServerScript
+{
+public:
+    PlayerbotsSelfBotAfkServerScript()
+        : ServerScript("PlayerbotsSelfBotAfkServerScript", { SERVERHOOK_CAN_PACKET_RECEIVE }) {}
+
+    using ServerScript::CanPacketReceive;
+
+    bool CanPacketReceive(WorldSession* session, WorldPacket const& packet) override
+    {
+        if (packet.GetOpcode() != CMSG_LOGOUT_REQUEST)
+            return true;
+
+        Player* player = session ? session->GetPlayer() : nullptr;
+        if (!player || !IsSelfBot(player) || !player->isAFK())
+            return true;
+
+        LOG_DEBUG("playerbots", "Selfbot {} stays in world: refused the AFK logout", player->GetName());
+
+        WorldPackets::Character::LogoutResponse logoutResponse;
+        logoutResponse.LogoutResult = 2;
+        logoutResponse.Instant = false;
+        session->SendPacket(logoutResponse.Write());
+
+        return false;
+    }
+};
+
+void AddPlayerbotsSelfBotAfkScripts()
+{
+    new PlayerbotsSelfBotAfkServerScript();
+}

--- a/src/Util/EncounterHelpers.cpp
+++ b/src/Util/EncounterHelpers.cpp
@@ -22,14 +22,62 @@
 #include "ShamanActions.h"
 #include "WarlockActions.h"
 #include "WarriorActions.h"
+#include <algorithm>
+#include <cmath>
 #include <list>
 
 namespace EncounterHelpers
-
 {
 
-// Functions to mark targets with raid target icons
-// Note that these functions do not allow the player to change the icon during the encounter
+// Calculate incremental movement to a position. No ground or collision is validated. The
+// Z position passed for the MoveTo() action using this helper should use the bot's Z, not the
+// position's. Returns false once the bot is within arrivalDist.
+bool GetStepToPosition(
+    Player* bot, Position const& position, float arrivalDist, Unit* facing, float& stepX,
+    float& stepY, bool& backwards)
+{
+    float const distToPosition = bot->GetExactDist2d(position);
+    if (distToPosition <= arrivalDist)
+        return false;
+
+    float const botX = bot->GetPositionX();
+    float const botY = bot->GetPositionY();
+    float const toPosX = position.GetPositionX() - botX;
+    float const toPosY = position.GetPositionY() - botY;
+
+    // 'facing' is optional and is for tanks. Pass the mob being tanked to allow the step to be
+    // walked backwards when (1) the bot has aggro on the mob it is tanking, (2) the bot is in
+    // melee range of the mob, and (3) the destination is on the opposite side of the bot from the
+    // mob. Generally, the entire movement would be gated on (1) and (2) anyway, but there are some
+    // exceptions and thus the checks are made again here. Pass nullptr for a plain forward step.
+    backwards = false;
+    if (facing && facing->GetVictim() == bot && bot->IsWithinMeleeRange(facing))
+    {
+        float const toFacingX = facing->GetPositionX() - botX;
+        float const toFacingY = facing->GetPositionY() - botY;
+        backwards = (toPosX * toFacingX + toPosY * toFacingY) < 0.0f;
+    }
+
+    // Default time between AI ticks is 100ms, and base movement speed for players is 7y/s forwards
+    // and 4.5y/s backwards (i.e., 0.7y/0.45y per tick). There is not really benefit to having the
+    // step be farther than the distance that can be covered in a single tick. But this helper
+    // uses 5x tick distance to account for possible speed boosts, latency, and longer configured
+    // AI ticks. In my experience, this is plenty short enough to navigate poor terrain, but if you
+    // are moving steeply uphill and find that movement is failing, it may be possible that the step
+    // distances would need to be even shorter (in which case you couldn't use this helper).
+    constexpr float backwardDistancePerStep = 2.25f;
+    constexpr float forwardDistancePerStep = 3.5f;
+    float const maxMoveDist = backwards ? backwardDistancePerStep : forwardDistancePerStep;
+    float const ratio = std::min(maxMoveDist, distToPosition) / distToPosition;
+
+    stepX = botX + toPosX * ratio;
+    stepY = botY + toPosY * ratio;
+
+    return true;
+}
+
+// Functions to mark targets with raid target icons.
+// Note that these functions do not allow the player to change the icon during the encounter.
 bool MarkTargetWithIcon(Player* bot, Unit* target, uint8 iconId)
 {
     if (!target)
@@ -89,6 +137,8 @@ bool MarkTargetWithMoon(Player* bot, Unit* target)
     return MarkTargetWithIcon(bot, target, RtiTargetValue::moonIndex);
 }
 
+// For clearing marks outside of combat so bots don't Leeroy on sight. This is best used when gated
+// behind an out-of-combat check (such as with IsInCombatValue).
 bool ClearTargetIcon(Player* bot, uint8 iconId)
 {
     Group* group = bot->GetGroup();
@@ -202,8 +252,7 @@ Player* GetGroupAssistTank(Player* bot, uint8 index)
     return nullptr;
 }
 
-// Return the first matching alive unit from PossibleTargetsValue within sightDistance from config
-// Note that PossibleTargetsValue picks up only hostile units
+// DO NOT USE. TO BE REMOVED HERE ONCE ALL CALL SITES ARE MODIFIED.
 Unit* GetFirstAliveUnitByEntry(PlayerbotAI* botAI, uint32 entry)
 {
     auto const& units =
@@ -219,7 +268,8 @@ Unit* GetFirstAliveUnitByEntry(PlayerbotAI* botAI, uint32 entry)
 }
 
 // Return the nearest alive player (human or bot) within the specified radius. Distance is
-// measured by GetExactDist2d(), which does not take into account player hitboxes (1.5y).
+// measured by GetExactDist2d(), which does not take into account either player's CombatReach
+// (i.e., their hitboxes), which are 1.5y for all races (or 1.95y with Bloodlust/Heroism active).
 Player* GetNearestPlayerInRadius(Player* bot, float radius)
 {
     Group* group = bot->GetGroup();
@@ -246,7 +296,7 @@ Player* GetNearestPlayerInRadius(Player* bot, float radius)
     return nearestPlayer;
 }
 
-// Grid search for dynamic objects for methods to avoid dynobj-based AoE hazards
+// Grid search for dynamic objects for methods to avoid dynobj-based AoE hazards.
 std::vector<Position> GetDynamicObjectPositions(Player* bot, float searchRadius, uint32 spellId)
 {
     std::list<WorldObject*> objs;
@@ -273,7 +323,7 @@ std::vector<Position> GetDynamicObjectPositions(Player* bot, float searchRadius,
 }
 
 // This function is primarily for use in multipliers during encounters where it is desirable
-// for bots to save cooldowns for particular phases (or for a bit after the pull)
+// for bots to save cooldowns for particular phases (or for a bit after the pull).
 bool IsDpsCooldownAction(Player* bot, Action* action)
 {
     if (bot->getClass() == CLASS_SHAMAN && // Before dps gate to capture Resto
@@ -399,7 +449,7 @@ bool IsTauntAction(Player* bot, Action* action)
     }
 }
 
-// These abilities can be particularly problematic on the pull for a council-type boss
+// These abilities can be particularly problematic on the pull for a council-type boss.
 bool IsAoeThreatAction(Player* bot, Action* action)
 {
     if (!PlayerbotAI::IsTank(bot))

--- a/src/Util/EncounterHelpers.h
+++ b/src/Util/EncounterHelpers.h
@@ -18,9 +18,17 @@ class PlayerbotAI;
 class Unit;
 
 namespace EncounterHelpers
-
 {
 
+// Cheap, rough proxies for how far along an encounter is. 95% HP means the boss and raid are
+// positioned, the tank has threat, and the fight proper has started, so it's time to use cooldowns.
+// 10% means the boss is almost dead, so ignore adds and finish off the boss.
+inline constexpr float BOSS_ENGAGED_HEALTH_PCT = 95.0f;
+inline constexpr float BOSS_BURN_HEALTH_PCT = 10.0f;
+
+bool GetStepToPosition(
+    Player* bot, Position const& position, float arrivalDist, Unit* facing, float& stepX,
+    float& stepY, bool& backwards);
 bool MarkTargetWithIcon(Player* bot, Unit* target, uint8 iconId);
 bool MarkTargetWithSkull(Player* bot, Unit* target);
 bool MarkTargetWithSquare(Player* bot, Unit* target);
@@ -35,7 +43,7 @@ void SetRtiTarget(PlayerbotAI* botAI, std::string const& rtiName);
 bool IsMechanicTrackerBot(Player* bot, uint32 mapId);
 Player* GetGroupMainTank(Player* bot);
 Player* GetGroupAssistTank(Player* bot, uint8 index);
-Unit* GetFirstAliveUnitByEntry(PlayerbotAI* botAI, uint32 entry);
+Unit* GetFirstAliveUnitByEntry(PlayerbotAI* botAI, uint32 entry); // DO NOT USE, WILL BE REMOVED
 Player* GetNearestPlayerInRadius(Player* bot, float radius);
 std::vector<Position> GetDynamicObjectPositions(Player* bot, float searchRadius, uint32 spellId);
 bool IsDpsCooldownAction(Player* bot, Action* action);


### PR DESCRIPTION
Maintenance PR

Changelog:
- Battleground bot handling has been corrected and no longer produces the related warning.
- Random bots can optionally concentrate in zones occupied by real players.
- Random bots now keep only their configured number of primary professions.
- A stability issue affecting RPG-target selection across multiple maps has been fixed.
- Bots now handle Magisters’ Terrace trash and key boss mechanics more effectively.
- Disabled level brackets now correctly remove bots from related battleground and arena activity.
- Bots can optionally sell unequipped normal-quality gear.
- Random-bot guild cleanup now works reliably and avoids creating replacement guilds while enabled.
- Bot chat behavior is unchanged following a compatibility cleanup.
- Bots now stop before opening or gathering from objects, preventing repeated failed attempts while moving.
- Selfbots can now receive group leadership from bots.
- Bot behavior in Auchenai Crypts and Sethekk Halls has been improved, especially around hazards and positioning.
- Hunter bots now select only pets that players can actually tame in the world.
- Tanks more reliably engage raid bosses, while bots better respect creatures already engaged with pets or totems.
- Bots no longer attempt ground movement while on flight paths.
- AFK selfbots now remain in the world instead of being logged out automatically.
- The `wipe` command now ignores bots that have already released.
- Priest bots now cast Fear Ward on the main tank.
- A Warrior naming typo has been corrected.
- Rogue bots now refresh weapon poisons during combat.
- Solo selfbots can now receive Dungeon Finder proposals with bot groups.
- Bots now handle Gundrak’s Slad’ran encounter with improved tank positioning, grouping, add control, and Snake Wrap response.
- Automated build checks now reject new compiler warnings.

AzerothCore fork: https://github.com/mod-playerbots/azerothcore-wotlk/tree/test-staging