### PR TITLE
feat: Rewrite bot periodic login rotation to a non-accounts-based system

### DIFF
--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -122,6 +122,8 @@ AiPlayerbot.DisabledWithoutRealPlayerLogoutDelay = 300
 #   0 = Static:     Fixed random count rolled once at server start, between Min/MaxRandomBots.
 #   1 = Variable:   Fluctuating random count rolled at server start, between Min/MaxRandomBots.
 #                   Re-rolled again at a time between RandomBotCountChangeMin/MaxInterval.
+#   2 = Scheduled:  Fluctuating time-cycled count, ranging from MinRandomBots at RandomBotCountMinTime,
+#                   to MaxRandomBots at RandomBotCountMaxTime.
 # When MinRandomBots = MaxRandomBots the count is constant and all modes behave identically.
 # Default: 0 (static)
 AiPlayerbot.RandomBotCountMode = 0
@@ -1687,10 +1689,18 @@ AiPlayerbot.FastReactInBG = 1
 # Default: 20
 AiPlayerbot.RandomBotUpdateInterval = 20
 
-# Minimum and maximum seconds before the manager re-evaluates and adjusts total randombot count
+# Minimum and maximum seconds before the randombot population count changes, when RandomBotCountMode = 1 or 2.
+# Bot count changes randomly at some random time between min and max interval value, when RandomBotCountMode = 1.
+# Bot count changes incrementally according to schedule, at every min interval value, when RandomBotCountMode = 2.
 # Defaults: 1800 (min), 7200 (max)
 AiPlayerbot.RandomBotCountChangeMinInterval = 1800
 AiPlayerbot.RandomBotCountChangeMaxInterval = 7200
+
+# Local server time of day when randombot population count is at minimum or maximum, when RandomBotCountMode = 2.
+# Range: Integer values from 0 to 23
+# Defaults: 5 (min), 20 (max)
+AiPlayerbot.RandomBotCountMinTime = 5
+AiPlayerbot.RandomBotCountMaxTime = 20
 
 # Some aspects of randombots are periodically randomized while they are logged in and idle,
 # including their inventories and, if EquipAndSpecPersistence is disabled, their equipment and specs.

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -90,8 +90,8 @@ AiPlayerbot.MinRandomBots = 500
 AiPlayerbot.MaxRandomBots = 500
 
 # Randombot accounts
-# Set to 0 to automatically calculate needed accounts based on MaxRandomBots, EnablePeriodicOnlineOffline
-# and its ratio, and AddClassAccountPoolSize. Set manually if you want to create more accounts than needed.
+# Set to 0 to automatically calculate needed accounts based on MaxRandomBots and AddClassAccountPoolSize.
+# Set manually if you want to create more accounts than needed.
 # If the manual value is less than the required, the system will override it with the required value.
 # Default: 0 (automatic)
 AiPlayerbot.RandomBotAccountCount = 0
@@ -735,16 +735,6 @@ AiPlayerbot.PreQuests = 0
 # Enable LFG for randombots
 # Default: 1 (enabled)
 AiPlayerbot.RandomBotJoinLfg = 1
-
-# Enable/Disable periodic online - offline of randombots to mimic the real-world scenario where not all players are online simultaneously
-# When enabled, randombots are randomly selected to go online or offline periodically from a larger set
-# Default: 0 (disabled, the set of online bots remains fixed)
-AiPlayerbot.EnablePeriodicOnlineOffline = 0
-
-# Defines the ratio between the total number of randombots (including offline ones) and the number of randombots currently online (MaxRandomBots)
-# This setting must greater than 1.0 and only applies when EnablePeriodicOnlineOffline
-# Default: 2.0 (total number of bots is twice the number of MaxRandomBots)
-AiPlayerbot.PeriodicOnlineOfflineRatio = 2.0
 
 # Percentage ratio of Alliance and Horde randombots
 AiPlayerbot.RandomBotAllianceRatio = 50

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -1692,11 +1692,6 @@ AiPlayerbot.RandomBotUpdateInterval = 20
 AiPlayerbot.RandomBotCountChangeMinInterval = 1800
 AiPlayerbot.RandomBotCountChangeMaxInterval = 7200
 
-# Minimum and maximum seconds a randombot will stay online before logging out
-# Defaults: 600 (min), 28800 (max)
-AiPlayerbot.MinRandomBotInWorldTime = 600
-AiPlayerbot.MaxRandomBotInWorldTime = 28800
-
 # Some aspects of randombots are periodically randomized while they are logged in and idle,
 # including their inventories and, if EquipAndSpecPersistence is disabled, their equipment and specs.
 # This config sets the minimum and maximum seconds between such randomization events.
@@ -1722,10 +1717,6 @@ AiPlayerbot.MaxRandomBotReviveTime = 300
 # Defaults: 3600 (min), 18000 (max)
 AiPlayerbot.MinRandomBotTeleportInterval = 3600
 AiPlayerbot.MaxRandomBotTeleportInterval = 18000
-
-# Number of seconds bots flagged as permanent stay in the world (31,104,000 ≈ 1 year)
-# Default: 31104000
-AiPlayerbot.PermanentlyInWorldTime = 31104000
 
 #
 #

--- a/conf/playerbots.conf.dist
+++ b/conf/playerbots.conf.dist
@@ -118,6 +118,14 @@ AiPlayerbot.DisabledWithoutRealPlayer = 0
 AiPlayerbot.DisabledWithoutRealPlayerLoginDelay = 30
 AiPlayerbot.DisabledWithoutRealPlayerLogoutDelay = 300
 
+# Online randombots count change
+#   0 = Static:     Fixed random count rolled once at server start, between Min/MaxRandomBots.
+#   1 = Variable:   Fluctuating random count rolled at server start, between Min/MaxRandomBots.
+#                   Re-rolled again at a time between RandomBotCountChangeMin/MaxInterval.
+# When MinRandomBots = MaxRandomBots the count is constant and all modes behave identically.
+# Default: 0 (static)
+AiPlayerbot.RandomBotCountMode = 0
+
 ####################################################################################################
 
 ###################################

--- a/src/Bot/Factory/RandomPlayerbotFactory.cpp
+++ b/src/Bot/Factory/RandomPlayerbotFactory.cpp
@@ -306,9 +306,8 @@ std::string const RandomPlayerbotFactory::CreateRandomBotName(NameRaceAndGender 
 }
 
 // Calculates the total number of required accounts, either using the specified randomBotAccountCount
-// or determining it dynamically based on MaxRandomBots, EnablePeriodicOnlineOffline and its ratio,
-// and AddClassAccountPoolSize. The system also factors in the types of existing account, as assigned by
-// AssignAccountTypes()
+// or determining it dynamically based on MaxRandomBots and AddClassAccountPoolSize.
+// The system also factors in the types of existing account, as assigned by AssignAccountTypes().
 uint32 RandomPlayerbotFactory::CalculateTotalAccountCount()
 {
     // Reset account types if features are disabled
@@ -365,9 +364,6 @@ uint32 RandomPlayerbotFactory::CalculateTotalAccountCount()
 
     // Calculate max bots
     int maxBots = sPlayerbotAIConfig.maxRandomBots;
-    // Take periodic online/offline into account
-    if (sPlayerbotAIConfig.enablePeriodicOnlineOffline)
-        maxBots *= sPlayerbotAIConfig.periodicOnlineOfflineRatio;
 
     // Calculate number of accounts needed for RNDbots
     // Result is rounded up for maxBots not cleanly divisible by the divisor

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -11,6 +11,7 @@
 #include "Cell.h"
 #include "CellImpl.h"
 #include "ChannelMgr.h"
+#include "Common.h" // Included for TimeConstants. Using DAY to mark a long time, and YEAR to mark permanence.
 #include "DBCStores.h"
 #include "DBCStructure.h"
 #include "DatabaseEnv.h"
@@ -302,7 +303,7 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 /*elapsed*/, bool /*minimal*/)
         if (!_staticBotCountRolled)
         {
             maxAllowedBotCount = urand(sPlayerbotAIConfig.minRandomBots, sPlayerbotAIConfig.maxRandomBots);
-            SetEventValue(0, "bot_count", maxAllowedBotCount, sPlayerbotAIConfig.permanentlyInWorldTime);
+            SetEventValue(0, "bot_count", maxAllowedBotCount, YEAR);
             _staticBotCountRolled = true;
         }
     }
@@ -728,7 +729,7 @@ uint32 RandomPlayerbotMgr::AddRandomBots()
                 return false;
             }
 
-            uint32 add_time = sPlayerbotAIConfig.permanentlyInWorldTime;
+            uint32 add_time = YEAR;
 
             SetEventValue(charInfo.guid, "add", 1, add_time);
             SetEventValue(charInfo.guid, "logout", 0, 0);
@@ -1506,8 +1507,7 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
                   player->GetLevel(), player->GetName().c_str());
         LogoutPlayerBot(botGUID);
         currentBots.erase(bot);
-        SetEventValue(bot, "logout", 1,
-                      urand(sPlayerbotAIConfig.minRandomBotInWorldTime, sPlayerbotAIConfig.maxRandomBotInWorldTime));
+        SetEventValue(bot, "logout", 1, DAY);
         return true;
     }
 
@@ -1538,7 +1538,7 @@ bool RandomPlayerbotMgr::ProcessBot(Player* bot)
                 urand(sPlayerbotAIConfig.minRandomBotReviveTime, sPlayerbotAIConfig.maxRandomBotReviveTime);
             LOG_DEBUG("playerbots", "Mark bot {} as dead, will be revived in {}s.", bot->GetName().c_str(),
                       randomTime);
-            SetEventValue(botId, "dead", 1, sPlayerbotAIConfig.maxRandomBotInWorldTime);
+            SetEventValue(botId, "dead", 1, DAY);
             SetEventValue(botId, "revive", 1, randomTime);
             return false;
         }
@@ -1983,37 +1983,34 @@ void RandomPlayerbotMgr::RandomizeFirst(Player* bot)
     if (sPlayerbotAIConfig.downgradeMaxLevelBot && bot->GetLevel() >= sPlayerbotAIConfig.randomBotMaxLevel)
     {
         if (bot->getClass() == CLASS_DEATH_KNIGHT)
-        {
             level = sWorld->getIntConfig(CONFIG_START_HEROIC_PLAYER_LEVEL);
-        }
         else
-        {
             level = sPlayerbotAIConfig.randomBotMinLevel;
-        }
     }
     else
     {
+        // Roll for the top or the bottom of the level range, otherwise land anywhere in between.
+        float maxLevelChance = sPlayerbotAIConfig.randomBotMaxLevelChance;
+        float minLevelChance = sPlayerbotAIConfig.randomBotMinLevelChance;
         uint32 roll = urand(1, 100);
-        if (roll <= 100 * sPlayerbotAIConfig.randomBotMaxLevelChance)
-        {
+
+        if (roll <= 100 * maxLevelChance)
             level = maxLevel;
-        }
-        else if (roll <=
-                 (100 * (sPlayerbotAIConfig.randomBotMaxLevelChance + sPlayerbotAIConfig.randomBotMinLevelChance)))
-        {
+        else if (roll <= 100 * (maxLevelChance + minLevelChance))
             level = minLevel;
-        }
         else
-        {
             level = urand(minLevel, maxLevel);
-        }
     }
 
     if (sPlayerbotAIConfig.disableRandomLevels)
     {
-        level = bot->getClass() == CLASS_DEATH_KNIGHT ? std::max(sPlayerbotAIConfig.randombotStartingLevel,
-                                                                 sWorld->getIntConfig(CONFIG_START_HEROIC_PLAYER_LEVEL))
-                                                      : sPlayerbotAIConfig.randombotStartingLevel;
+        // Death knights cannot exist below the heroic starting level.
+        if (bot->getClass() == CLASS_DEATH_KNIGHT)
+            level = std::max(sPlayerbotAIConfig.randombotStartingLevel,
+                             sWorld->getIntConfig(CONFIG_START_HEROIC_PLAYER_LEVEL));
+
+        else
+            level = sPlayerbotAIConfig.randombotStartingLevel;
     }
 
     SetValue(bot, "level", level);
@@ -2022,8 +2019,6 @@ void RandomPlayerbotMgr::RandomizeFirst(Player* bot)
 
     uint32 randomTime =
         urand(sPlayerbotAIConfig.minRandomBotRandomizeTime, sPlayerbotAIConfig.maxRandomBotRandomizeTime);
-    uint32 inworldTime =
-        urand(sPlayerbotAIConfig.minRandomBotInWorldTime, sPlayerbotAIConfig.maxRandomBotInWorldTime);
 
     PlayerbotsDatabasePreparedStatement* stmt = PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_UPD_RANDOM_BOTS);
     stmt->SetData(0, randomTime);
@@ -2032,7 +2027,7 @@ void RandomPlayerbotMgr::RandomizeFirst(Player* bot)
     PlayerbotsDatabase.Execute(stmt);
 
     stmt = PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_UPD_RANDOM_BOTS);
-    stmt->SetData(0, inworldTime);
+    stmt->SetData(0, DAY);
     stmt->SetData(1, "logout");
     stmt->SetData(2, bot->GetGUID().GetCounter());
     PlayerbotsDatabase.Execute(stmt);
@@ -2063,8 +2058,6 @@ void RandomPlayerbotMgr::RandomizeMin(Player* bot)
 
     uint32 randomTime =
         urand(sPlayerbotAIConfig.minRandomBotRandomizeTime, sPlayerbotAIConfig.maxRandomBotRandomizeTime);
-    uint32 inworldTime =
-        urand(sPlayerbotAIConfig.minRandomBotInWorldTime, sPlayerbotAIConfig.maxRandomBotInWorldTime);
 
     PlayerbotsDatabasePreparedStatement* stmt = PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_UPD_RANDOM_BOTS);
     stmt->SetData(0, randomTime);
@@ -2073,7 +2066,7 @@ void RandomPlayerbotMgr::RandomizeMin(Player* bot)
     PlayerbotsDatabase.Execute(stmt);
 
     stmt = PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_UPD_RANDOM_BOTS);
-    stmt->SetData(0, inworldTime);
+    stmt->SetData(0, DAY);
     stmt->SetData(1, "logout");
     stmt->SetData(2, bot->GetGUID().GetCounter());
     PlayerbotsDatabase.Execute(stmt);
@@ -2424,7 +2417,7 @@ std::string RandomPlayerbotMgr::GetData(uint32 bot, std::string const& type) { r
 
 void RandomPlayerbotMgr::SetValue(uint32 bot, std::string const& type, uint32 value, std::string const& data)
 {
-    SetEventValue(bot, type, value, sPlayerbotAIConfig.maxRandomBotInWorldTime, data);
+    SetEventValue(bot, type, value, DAY, data);
 }
 
 void RandomPlayerbotMgr::SetValue(Player* bot, std::string const& type, uint32 value, std::string const& data)
@@ -3016,7 +3009,7 @@ void RandomPlayerbotMgr::SetTradeDiscount(Player* bot, Player* master, uint32 va
 
     std::ostringstream name;
     name << "trade_discount_" << masterId;
-    SetEventValue(botId, name.str(), value, sPlayerbotAIConfig.maxRandomBotInWorldTime);
+    SetEventValue(botId, name.str(), value, DAY);
 }
 
 uint32 RandomPlayerbotMgr::GetTradeDiscount(Player* bot, Player* master)
@@ -3069,7 +3062,7 @@ void RandomPlayerbotMgr::ChangeStrategy(Player* player)
         LOG_INFO("playerbots", "Changing strategy for bot #{} <{}> to RPG", bot, player->GetName().c_str());
         LOG_INFO("playerbots", "Bot #{} <{}>: sent to inn", bot, player->GetName().c_str());
         RandomTeleportForLevel(player);
-        SetEventValue(bot, "teleport", 1, sPlayerbotAIConfig.maxRandomBotInWorldTime);
+        SetEventValue(bot, "teleport", 1, sPlayerbotAIConfig.maxRandomBotTeleportInterval);
     }
 
     ScheduleChangeStrategy(bot);

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -37,6 +37,7 @@
 #include "RandomPlayerbotFactory.h"
 #include "ServerFacade.h"
 #include "SharedDefines.h"
+#include "Timer.h"
 #include "TravelMgr.h"
 #include "Unit.h"
 #include "World.h"
@@ -297,24 +298,41 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 /*elapsed*/, bool /*minimal*/)
     }*/
 
     uint32 maxAllowedBotCount = GetEventValue(0, "bot_count");
-    if (sPlayerbotAIConfig.randomBotCountMode == 0)
+    switch (sPlayerbotAIConfig.randomBotCountMode)
     {
-        // Mode 0 (static): roll a count once at server start and hold it for the whole run.
-        if (!_staticBotCountRolled)
+        case 1:
+            // Mode 1 (variable): roll a count at server start and re-roll it every randomBotCountChangeMin/MaxInterval.
+            if (!maxAllowedBotCount || (maxAllowedBotCount < sPlayerbotAIConfig.minRandomBots ||
+                                        maxAllowedBotCount > sPlayerbotAIConfig.maxRandomBots))
+            {
+                maxAllowedBotCount = urand(sPlayerbotAIConfig.minRandomBots, sPlayerbotAIConfig.maxRandomBots);
+                SetEventValue(0, "bot_count", maxAllowedBotCount,
+                              urand(sPlayerbotAIConfig.randomBotCountChangeMinInterval,
+                                    sPlayerbotAIConfig.randomBotCountChangeMaxInterval));
+            }
+            break;
+        case 2:
         {
-            maxAllowedBotCount = urand(sPlayerbotAIConfig.minRandomBots, sPlayerbotAIConfig.maxRandomBots);
-            SetEventValue(0, "bot_count", maxAllowedBotCount, YEAR);
-            _staticBotCountRolled = true;
+            // Mode 2 (scheduled): population count is set according to a schedule from GetScheduledBotCount, that
+            // changes on a fixed timing, every randomBotCountChangeMinInterval.
+            time_t now = GameTime::GetGameTime().count();
+            if (now >= _nextScheduledCountUpdate)
+            {
+                maxAllowedBotCount = GetScheduledBotCount();
+                SetEventValue(0, "bot_count", maxAllowedBotCount, DAY);
+                _nextScheduledCountUpdate = now + sPlayerbotAIConfig.randomBotCountChangeMinInterval;
+            }
+            break;
         }
-    }
-    // Mode 1 (variable): roll a count at server start and re-roll it every randomBotCountChangeMin/MaxInterval.
-    else if (!maxAllowedBotCount || (maxAllowedBotCount < sPlayerbotAIConfig.minRandomBots ||
-                                     maxAllowedBotCount > sPlayerbotAIConfig.maxRandomBots))
-    {
-        maxAllowedBotCount = urand(sPlayerbotAIConfig.minRandomBots, sPlayerbotAIConfig.maxRandomBots);
-        SetEventValue(0, "bot_count", maxAllowedBotCount,
-                      urand(sPlayerbotAIConfig.randomBotCountChangeMinInterval,
-                            sPlayerbotAIConfig.randomBotCountChangeMaxInterval));
+        default:
+            // Mode 0 (static): roll a count once at server start and hold it for the whole run.
+            if (!_staticBotCountRolled)
+            {
+                maxAllowedBotCount = urand(sPlayerbotAIConfig.minRandomBots, sPlayerbotAIConfig.maxRandomBots);
+                SetEventValue(0, "bot_count", maxAllowedBotCount, YEAR);
+                _staticBotCountRolled = true;
+            }
+            break;
     }
 
     GetBots();
@@ -891,6 +909,37 @@ uint32 RandomPlayerbotMgr::RemoveRandomBots()
                   maxAllowedBotCount);
 
     return toLogout.size();
+}
+
+// Population target for RandomBotCountMode 2: a 24 hour cycle ramping from MinRandomBots at RandomBotCountMinTime
+// up to MaxRandomBots at RandomBotCountMaxTime, then back down. The target population count is calculated from the
+// clock at each interval, so the count is never desynced by a server shutdown/restart.
+uint32 RandomPlayerbotMgr::GetScheduledBotCount()
+{
+    uint32 minCount = sPlayerbotAIConfig.minRandomBots;
+    uint32 maxCount = sPlayerbotAIConfig.maxRandomBots;
+
+    // No variation if either of the min/max values are equal to each other.
+    if (sPlayerbotAIConfig.randomBotCountMinTime == sPlayerbotAIConfig.randomBotCountMaxTime || minCount == maxCount)
+        return maxCount;
+
+    // Timings are tracked by the second for accurate ramping.
+    std::tm localTime = Acore::Time::TimeBreakdown(GameTime::GetGameTime().count());
+    uint32 localTimeOfDay = localTime.tm_hour * HOUR + localTime.tm_min * MINUTE + localTime.tm_sec;
+    uint32 minCountTime = sPlayerbotAIConfig.randomBotCountMinTime * HOUR;
+    uint32 maxCountTime = sPlayerbotAIConfig.randomBotCountMaxTime * HOUR;
+
+    // Offsets run forward from minCountTime and wrap, so a maxCountTime earlier in the day needs no separate case.
+    uint32 sinceMinCount = (localTimeOfDay + DAY - minCountTime) % DAY;
+    uint32 riseDuration = (maxCountTime + DAY - minCountTime) % DAY;
+    uint32 fallDuration = DAY - riseDuration;
+
+    uint64 range = maxCount - minCount; // uint64, for a cursed server with more than 49710 bots.
+
+    if (sinceMinCount < riseDuration)
+        return static_cast<uint32>(minCount + range * sinceMinCount / riseDuration);
+
+    return static_cast<uint32>(maxCount - range * (sinceMinCount - riseDuration) / fallDuration);
 }
 
 void RandomPlayerbotMgr::LoadBattleMastersCache()

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -296,8 +296,19 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 /*elapsed*/, bool /*minimal*/)
     }*/
 
     uint32 maxAllowedBotCount = GetEventValue(0, "bot_count");
-    if (!maxAllowedBotCount || (maxAllowedBotCount < sPlayerbotAIConfig.minRandomBots ||
-                                maxAllowedBotCount > sPlayerbotAIConfig.maxRandomBots))
+    if (sPlayerbotAIConfig.randomBotCountMode == 0)
+    {
+        // Mode 0 (static): roll a count once at server start and hold it for the whole run.
+        if (!_staticBotCountRolled)
+        {
+            maxAllowedBotCount = urand(sPlayerbotAIConfig.minRandomBots, sPlayerbotAIConfig.maxRandomBots);
+            SetEventValue(0, "bot_count", maxAllowedBotCount, sPlayerbotAIConfig.permanentlyInWorldTime);
+            _staticBotCountRolled = true;
+        }
+    }
+    // Mode 1 (variable): roll a count at server start and re-roll it every randomBotCountChangeMin/MaxInterval.
+    else if (!maxAllowedBotCount || (maxAllowedBotCount < sPlayerbotAIConfig.minRandomBots ||
+                                     maxAllowedBotCount > sPlayerbotAIConfig.maxRandomBots))
     {
         maxAllowedBotCount = urand(sPlayerbotAIConfig.minRandomBots, sPlayerbotAIConfig.maxRandomBots);
         SetEventValue(0, "bot_count", maxAllowedBotCount,

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -499,10 +499,9 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 /*elapsed*/, bool /*minimal*/)
 //     setActivityPercentage(activityPercentage);
 // }
 
-// Assigns accounts as RNDbot accounts (type 1) based on MaxRandomBots and EnablePeriodicOnlineOffline and its ratio,
-// and assigns accounts as AddClass accounts (type 2) based AddClassAccountPoolSize. Type 1 and 2 assignments are
-// permenant, unless MaxRandomBots or AddClassAccountPoolSize are set to 0. If so, their associated accounts will
-// be unassigned (type 0)
+// Assigns accounts as RNDbot accounts (type 1) based on MaxRandomBots, and assigns accounts as AddClass
+// accounts (type 2) based AddClassAccountPoolSize. Type 1 and 2 assignments are permenant, unless MaxRandomBots
+// or AddClassAccountPoolSize are set to 0. If so, their associated accounts will be unassigned (type 0)
 void RandomPlayerbotMgr::AssignAccountTypes()
 {
     LOG_INFO("playerbots", "Assigning account types for random bot accounts...");
@@ -560,10 +559,6 @@ void RandomPlayerbotMgr::AssignAccountTypes()
     {
         int divisor = RandomPlayerbotFactory::CalculateAvailableCharsPerAccount();
         int maxBots = sPlayerbotAIConfig.maxRandomBots;
-
-        // Take periodic online-offline into account
-        if (sPlayerbotAIConfig.enablePeriodicOnlineOffline)
-            maxBots *= sPlayerbotAIConfig.periodicOnlineOfflineRatio;
 
         // Calculate base accounts needed for RNDbots, ensuring round up for maxBots not cleanly divisible by the divisor
         neededRndBotAccounts = (maxBots + divisor - 1) / divisor;
@@ -674,29 +669,7 @@ uint32 RandomPlayerbotMgr::AddRandomBots()
         if (remainder && urand(1, totalRatio) <= remainder)
             allowedAllianceCount++;
 
-        // Determine which accounts to use based on EnablePeriodicOnlineOffline
-        std::vector<uint32> accountsToUse;
-        if (sPlayerbotAIConfig.enablePeriodicOnlineOffline)
-        {
-
-            // Calculate how many accounts can be used
-            // With enablePeriodicOnlineOffline, don't use all of rndBotTypeAccounts right away. Fraction results are rounded up
-            uint32 accountsToUseCount = (rndBotTypeAccounts.size() + sPlayerbotAIConfig.periodicOnlineOfflineRatio - 1)
-                                        / sPlayerbotAIConfig.periodicOnlineOfflineRatio;
-
-            // Randomly select accounts
-            std::vector<uint32> shuffledAccounts = rndBotTypeAccounts;
-            std::shuffle(shuffledAccounts.begin(), shuffledAccounts.end(), rng);
-
-            for (uint32 i = 0; i < accountsToUseCount && i < shuffledAccounts.size(); i++)
-            {
-                accountsToUse.push_back(shuffledAccounts[i]);
-            }
-        }
-        else
-            accountsToUse = rndBotTypeAccounts;
-
-        // Pre-map all characters from selected accounts
+        // Pre-map all characters from every RNDbot account.
         struct CharacterInfo
         {
             uint32 guid;
@@ -706,7 +679,7 @@ uint32 RandomPlayerbotMgr::AddRandomBots()
         };
         std::vector<CharacterInfo> allCharacters;
 
-        for (uint32 accountId : accountsToUse)
+        for (uint32 accountId : rndBotTypeAccounts)
         {
             CharacterDatabasePreparedStatement* stmt =
                 CharacterDatabase.GetPreparedStatement(CHAR_SEL_CHARS_BY_ACCOUNT_ID);
@@ -755,10 +728,7 @@ uint32 RandomPlayerbotMgr::AddRandomBots()
                 return false;
             }
 
-            uint32 add_time = sPlayerbotAIConfig.enablePeriodicOnlineOffline
-                                ? urand(sPlayerbotAIConfig.minRandomBotInWorldTime,
-                                        sPlayerbotAIConfig.maxRandomBotInWorldTime)
-                                : sPlayerbotAIConfig.permanentlyInWorldTime;
+            uint32 add_time = sPlayerbotAIConfig.permanentlyInWorldTime;
 
             SetEventValue(charInfo.guid, "add", 1, add_time);
             SetEventValue(charInfo.guid, "logout", 0, 0);

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -721,7 +721,7 @@ uint32 RandomPlayerbotMgr::AddRandomBots()
         auto tryLoginBot = [&](const CharacterInfo& charInfo) -> bool
         {
             if (GetEventValue(charInfo.guid, "add") ||
-                GetEventValue(charInfo.guid, "logout") ||
+                // GetEventValue(charInfo.guid, "logout") ||    // Deprecated.
                 GetPlayerBot(charInfo.guid) ||
                 currentBots.contains(charInfo.guid) ||
                 (sPlayerbotAIConfig.disableDeathKnightLogin && charInfo.rClass == CLASS_DEATH_KNIGHT))
@@ -732,7 +732,7 @@ uint32 RandomPlayerbotMgr::AddRandomBots()
             uint32 add_time = YEAR;
 
             SetEventValue(charInfo.guid, "add", 1, add_time);
-            SetEventValue(charInfo.guid, "logout", 0, 0);
+            // SetEventValue(charInfo.guid, "logout", 0, 0);    // Deprecated.
             currentBots.insert(charInfo.guid);
 
             return true;
@@ -1500,6 +1500,11 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
         return true;
     }
 
+    /*
+    // Deprecated per-bot logout rotation timer code, part of the old EnablePeriodicOnlineOffline.
+    // Current login/logout system is based on population count, rather than based on an individual bot.
+    // Related code blocks here in ProcessBot, RandomizeFirst, and RandomizeMin remain commented-out
+    // for future reference.
     uint32 logout = GetEventValue(bot, "logout");
     if (player && !logout && !isValid)
     {
@@ -1510,6 +1515,7 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
         SetEventValue(bot, "logout", 1, DAY);
         return true;
     }
+    */
 
     return false;
 }
@@ -2026,11 +2032,14 @@ void RandomPlayerbotMgr::RandomizeFirst(Player* bot)
     stmt->SetData(2, bot->GetGUID().GetCounter());
     PlayerbotsDatabase.Execute(stmt);
 
+    /*
+    // Deprecated per-bot logout rotation timer code. Full details in ProcessBot.
     stmt = PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_UPD_RANDOM_BOTS);
     stmt->SetData(0, DAY);
     stmt->SetData(1, "logout");
     stmt->SetData(2, bot->GetGUID().GetCounter());
     PlayerbotsDatabase.Execute(stmt);
+    */
 
     // teleport to a random inn for bot level
     botAI->Reset(true);
@@ -2065,11 +2074,14 @@ void RandomPlayerbotMgr::RandomizeMin(Player* bot)
     stmt->SetData(2, bot->GetGUID().GetCounter());
     PlayerbotsDatabase.Execute(stmt);
 
+    /*
+    // Deprecated per-bot logout rotation timer code. Full details in ProcessBot.
     stmt = PlayerbotsDatabase.GetPreparedStatement(PLAYERBOTS_UPD_RANDOM_BOTS);
     stmt->SetData(0, DAY);
     stmt->SetData(1, "logout");
     stmt->SetData(2, bot->GetGUID().GetCounter());
     PlayerbotsDatabase.Execute(stmt);
+    */
 
     // teleport to a random inn for bot level
     botAI->Reset(true);

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -381,6 +381,12 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 /*elapsed*/, bool /*minimal*/)
         AddRandomBots();
     }
 
+    // If the randombot population requires a trim this cycle, it is not executed when DisabledWithoutRealPlayer is
+    // enabled and there are no real players logged-in. In that case, DisabledWithoutRealPlayer handles logouts.
+    if (availableBotCount > maxAllowedBotCount &&
+        (!sPlayerbotAIConfig.disabledWithoutRealPlayer || realPlayerIsLogged))
+        RemoveRandomBots();
+
     if (sPlayerbotAIConfig.syncLevelWithPlayers && !players.empty())
     {
         if (time(nullptr) > (PlayersCheckTimer + 60))
@@ -557,9 +563,7 @@ void RandomPlayerbotMgr::AssignAccountTypes()
 
         // Take periodic online-offline into account
         if (sPlayerbotAIConfig.enablePeriodicOnlineOffline)
-        {
             maxBots *= sPlayerbotAIConfig.periodicOnlineOfflineRatio;
-        }
 
         // Calculate base accounts needed for RNDbots, ensuring round up for maxBots not cleanly divisible by the divisor
         neededRndBotAccounts = (maxBots + divisor - 1) / divisor;
@@ -571,8 +575,10 @@ void RandomPlayerbotMgr::AssignAccountTypes()
 
     for (auto const& [accountId, accountType] : currentAssignments)
     {
-        if (accountType == 1) existingRndBotAccounts++;
-        else if (accountType == 2) existingAddClassAccounts++;
+        if (accountType == 1)
+            existingRndBotAccounts++;
+        else if (accountType == 2)
+            existingAddClassAccounts++;
     }
 
     // Assign RNDbot accounts from lowest position if needed
@@ -593,9 +599,7 @@ void RandomPlayerbotMgr::AssignAccountTypes()
         }
 
         if (assigned < toAssign)
-        {
             LOG_ERROR("playerbots", "Not enough unassigned accounts to fulfill RNDbot requirements. Need {} more accounts.", toAssign - assigned);
-        }
     }
 
     // Assign AddClass accounts from highest position if needed
@@ -618,16 +622,16 @@ void RandomPlayerbotMgr::AssignAccountTypes()
         }
 
         if (assigned < toAssign)
-        {
             LOG_ERROR("playerbots", "Not enough unassigned accounts to fulfill AddClass requirements. Need {} more accounts.", toAssign - assigned);
-        }
     }
 
     // Populate filtered account lists with ALL accounts of each type
     for (auto const& [accountId, accountType] : currentAssignments)
     {
-        if (accountType == 1) rndBotTypeAccounts.push_back(accountId);
-        else if (accountType == 2) addClassTypeAccounts.push_back(accountId);
+        if (accountType == 1)
+            rndBotTypeAccounts.push_back(accountId);
+        else if (accountType == 2)
+            addClassTypeAccounts.push_back(accountId);
     }
 
     LOG_INFO("playerbots", "Account type assignment complete: {} RNDbot accounts, {} AddClass accounts, {} unassigned",
@@ -644,8 +648,8 @@ bool RandomPlayerbotMgr::IsAccountType(uint32 accountId, uint8 accountType)
 // Logs-in bots in 4 phases. Phase 1 logs Alliance bots up to how much is expected according to the faction ratio,
 // and Phase 2 logs-in the remainder Horde bots to reach the total maxAllowedBotCount. If maxAllowedBotCount is not
 // reached after Phase 2, the function goes back to log-in Alliance bots and reach maxAllowedBotCount. This is done
-// because not every account is guaranteed 5A/5H bots, so the true ratio might be skewed by few percentages. Finally,
-// Phase 4 is reached if and only if the value of RandomBotAccountCount is lower than it should.
+// because not every account is guaranteed 5A/5H bots, so the true ratio might be skewed by a few percentages.
+// Finally, Phase 4 is reached if and only if the value of RandomBotAccountCount is lower than it should.
 uint32 RandomPlayerbotMgr::AddRandomBots()
 {
     uint32 maxAllowedBotCount = GetEventValue(0, "bot_count");
@@ -668,9 +672,7 @@ uint32 RandomPlayerbotMgr::AddRandomBots()
 
         // Fix #1082: Randomly add one based on reminder
         if (remainder && urand(1, totalRatio) <= remainder)
-        {
             allowedAllianceCount++;
-        }
 
         // Determine which accounts to use based on EnablePeriodicOnlineOffline
         std::vector<uint32> accountsToUse;
@@ -692,9 +694,7 @@ uint32 RandomPlayerbotMgr::AddRandomBots()
             }
         }
         else
-        {
             accountsToUse = rndBotTypeAccounts;
-        }
 
         // Pre-map all characters from selected accounts
         struct CharacterInfo
@@ -813,20 +813,113 @@ uint32 RandomPlayerbotMgr::AddRandomBots()
                 LOG_ERROR("playerbots",
                           "Can't log-in all the requested bots. Try increasing RandomBotAccountCount in your conf file.\n"
                           "{} more accounts needed.", moreAccountsNeeded);
-                missingBotsTimer = 0;    // Reset timer so error is not spammed every tick
+                missingBotsTimer = 0;   // Reset timer so error is not spammed every tick
             }
         }
         else
-        {
             missingBotsTimer = 0;       // Reset timer if logins for this interval were successful
-        }
     }
     else
-    {
         missingBotsTimer = 0;           // Reset timer if there's enough bots
-    }
 
     return currentBots.size();
+}
+
+// Whether a randombot can be safely logged out right now for a population downsize. Ineligible Bots are skipped
+// and simply get trimmed on a later tick, if they become free and there's still unfulfilled demand for logouts.
+bool RandomPlayerbotMgr::IsRemovableBot(Player* bot)
+{
+    if (!bot || !bot->IsInWorld() || !IsRandomBot(bot))
+        return false;
+
+    // In-flight or mid-teleport.
+    if (bot->HasUnitState(UNIT_STATE_IN_FLIGHT) || bot->IsBeingTeleported())
+        return false;
+
+    // In a battleground, battlefield (Wintergrasp), arena or any of their queues.
+    if (bot->InBattleground() || bot->InBattlefield() || bot->InArena() || bot->InBattlegroundQueue())
+        return false;
+
+    // In a dungeon or raid (IsDungeon() covers both).
+    if (bot->GetMap() && bot->GetMap()->IsDungeon())
+        return false;
+
+    // Controlled by a real player. IsRandomBot is not enough if a real player is logged into a randombot.
+    if (PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot))
+        if (botAI->HasRealPlayerMaster())
+            return false;
+
+    // Grouped with a real player. (PR #2592 may fold this into the master check above.)
+    if (Group* group = bot->GetGroup())
+    {
+        for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+        {
+            Player* member = ref->GetSource();
+            if (member && member != bot && !GET_PLAYERBOT_AI(member))
+                return false;
+        }
+    }
+
+    return true;
+}
+
+// Logs out randombots when the online population is above the target count for this cycle.
+uint32 RandomPlayerbotMgr::RemoveRandomBots()
+{
+    uint32 maxAllowedBotCount = GetEventValue(0, "bot_count");
+
+    if (currentBots.size() <= maxAllowedBotCount)
+        return 0;
+
+    // Per-tick cap keeps the downsize gradual, matching how AddRandomBots throttles logins.
+    uint32 toRemove = std::min(sPlayerbotAIConfig.randomBotsPerInterval,
+                               (uint32)(currentBots.size() - maxAllowedBotCount));
+
+    // Collect the online bots that are safe to log out, split by faction.
+    std::vector<ObjectGuid> allianceBots;
+    std::vector<ObjectGuid> hordeBots;
+    for (auto const& [guid, bot] : playerBots)
+    {
+        if (!IsRemovableBot(bot))
+            continue;
+
+        if (IsAlliance(bot->getRace()))
+            allianceBots.push_back(guid);
+        else
+            hordeBots.push_back(guid);
+    }
+
+    // Split the removal across factions by the configured ratio. The resulting ratio might be skewed by a few
+    // percentages, as the approach used here is the same approach as AddRandomBots.
+    uint32 totalRatio = sPlayerbotAIConfig.randomBotAllianceRatio + sPlayerbotAIConfig.randomBotHordeRatio;
+    uint32 removeAlliance = toRemove * sPlayerbotAIConfig.randomBotAllianceRatio / totalRatio;
+    uint32 remainder = toRemove * sPlayerbotAIConfig.randomBotAllianceRatio % totalRatio;
+    if (remainder && urand(1, totalRatio) <= remainder)
+        removeAlliance++;
+    uint32 removeHorde = toRemove - removeAlliance;
+
+    // Never remove more than are actually available in each faction this tick.
+    removeAlliance = std::min(removeAlliance, (uint32)allianceBots.size());
+    removeHorde = std::min(removeHorde, (uint32)hordeBots.size());
+
+    std::vector<ObjectGuid> toLogout;
+    toLogout.insert(toLogout.end(), allianceBots.begin(), allianceBots.begin() + removeAlliance);
+    toLogout.insert(toLogout.end(), hordeBots.begin(), hordeBots.begin() + removeHorde);
+
+    // Reuse the same teardown as the 'add' event expiry path from ProcessBot.
+    for (ObjectGuid guid : toLogout)
+    {
+        uint32 bot = guid.GetCounter();
+        SetEventValue(bot, "add", 0, 0);
+        currentBots.erase(bot);
+        LogoutPlayerBot(guid);
+    }
+
+    if (!toLogout.empty())
+        LOG_DEBUG("playerbots", "Logged-out {} randombots to match target count of {}", toLogout.size(),
+                  maxAllowedBotCount);
+
+    return toLogout.size();
 }
 
 void RandomPlayerbotMgr::LoadBattleMastersCache()

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -835,7 +835,7 @@ bool RandomPlayerbotMgr::IsRemovableBot(Player* bot)
 
     // Controlled by a real player. IsRandomBot is not enough if a real player is logged into a randombot.
     if (PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot))
-        if (botAI->HasRealPlayerMaster())
+        if (botAI->HasGameClientMaster())
             return false;
 
     // Grouped with a real player. (PR #2592 may fold this into the master check above.)

--- a/src/Bot/RandomPlayerbotMgr.h
+++ b/src/Bot/RandomPlayerbotMgr.h
@@ -220,6 +220,7 @@ private:
     float activityMod = 0.25;
     bool _isBotInitializing = true;
     bool _isBotLogging = true;
+    bool _staticBotCountRolled = false;
     NewRpgStatistic rpgStasticTotal;
     CachedEvent* FindEvent(uint32 bot, std::string const& event);
     uint32 GetEventValue(uint32 bot, std::string const& event);

--- a/src/Bot/RandomPlayerbotMgr.h
+++ b/src/Bot/RandomPlayerbotMgr.h
@@ -221,6 +221,7 @@ private:
     bool _isBotInitializing = true;
     bool _isBotLogging = true;
     bool _staticBotCountRolled = false;
+    time_t _nextScheduledCountUpdate = 0;
     NewRpgStatistic rpgStasticTotal;
     CachedEvent* FindEvent(uint32 bot, std::string const& event);
     uint32 GetEventValue(uint32 bot, std::string const& event);
@@ -237,6 +238,7 @@ private:
     time_t printStatsTimer;
     uint32 AddRandomBots();
     uint32 RemoveRandomBots();
+    uint32 GetScheduledBotCount();
     bool IsRemovableBot(Player* bot);
     bool ProcessBot(uint32 bot);
     void ScheduleRandomize(uint32 bot, uint32 time);

--- a/src/Bot/RandomPlayerbotMgr.h
+++ b/src/Bot/RandomPlayerbotMgr.h
@@ -236,6 +236,8 @@ private:
     time_t DelayLoginBotsTimer;
     time_t printStatsTimer;
     uint32 AddRandomBots();
+    uint32 RemoveRandomBots();
+    bool IsRemovableBot(Player* bot);
     bool ProcessBot(uint32 bot);
     void ScheduleRandomize(uint32 bot, uint32 time);
     void RandomTeleport(Player* bot);

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -248,8 +248,6 @@ bool PlayerbotAIConfig::Initialize()
         sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotCountChangeMinInterval", 30 * MINUTE);
     randomBotCountChangeMaxInterval =
         sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotCountChangeMaxInterval", 2 * HOUR);
-    minRandomBotInWorldTime = sConfigMgr->GetOption<int32>("AiPlayerbot.MinRandomBotInWorldTime", 2 * HOUR);
-    maxRandomBotInWorldTime = sConfigMgr->GetOption<int32>("AiPlayerbot.MaxRandomBotInWorldTime", 14 * 24 * HOUR);
     minRandomBotRandomizeTime = sConfigMgr->GetOption<int32>("AiPlayerbot.MinRandomBotRandomizeTime", 2 * HOUR);
     maxRandomBotRandomizeTime = sConfigMgr->GetOption<int32>("AiPlayerbot.MaxRandomBotRandomizeTime", 14 * 24 * HOUR);
     minRandomBotChangeStrategyTime =
@@ -260,8 +258,6 @@ bool PlayerbotAIConfig::Initialize()
     maxRandomBotReviveTime = sConfigMgr->GetOption<int32>("AiPlayerbot.MaxRandomBotReviveTime", 5 * MINUTE);
     minRandomBotTeleportInterval = sConfigMgr->GetOption<int32>("AiPlayerbot.MinRandomBotTeleportInterval", 1 * HOUR);
     maxRandomBotTeleportInterval = sConfigMgr->GetOption<int32>("AiPlayerbot.MaxRandomBotTeleportInterval", 5 * HOUR);
-    permanentlyInWorldTime =
-        sConfigMgr->GetOption<int32>("AiPlayerbot.PermanentlyInWorldTime", 1 * YEAR);
     randomBotTeleportDistance = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotTeleportDistance", 100);
     randomBotsPerInterval = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotsPerInterval", 60);
     randomBotPrintStatsInterval = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotPrintStatsInterval", 300);

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -242,6 +242,7 @@ bool PlayerbotAIConfig::Initialize()
     randomBotAutologin = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotAutologin", true);
     minRandomBots = sConfigMgr->GetOption<int32>("AiPlayerbot.MinRandomBots", 500);
     maxRandomBots = sConfigMgr->GetOption<int32>("AiPlayerbot.MaxRandomBots", 500);
+    randomBotCountMode = sConfigMgr->GetOption<uint32>("AiPlayerbot.RandomBotCountMode", 0);
     randomBotUpdateInterval = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotUpdateInterval", 20);
     randomBotCountChangeMinInterval =
         sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotCountChangeMinInterval", 30 * MINUTE);

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -695,9 +695,7 @@ bool PlayerbotAIConfig::Initialize()
     limitEnchantExpansion = sConfigMgr->GetOption<int32>("AiPlayerbot.LimitEnchantExpansion", 1);
     limitGearExpansion = sConfigMgr->GetOption<int32>("AiPlayerbot.LimitGearExpansion", 1);
     randombotStartingLevel = sConfigMgr->GetOption<int32>("AiPlayerbot.RandombotStartingLevel", 1);
-    enablePeriodicOnlineOffline = sConfigMgr->GetOption<bool>("AiPlayerbot.EnablePeriodicOnlineOffline", false);
     enableRandomBotTrading = sConfigMgr->GetOption<int32>("AiPlayerbot.EnableRandomBotTrading", 1);
-    periodicOnlineOfflineRatio = sConfigMgr->GetOption<float>("AiPlayerbot.PeriodicOnlineOfflineRatio", 2.0);
     gearscorecheck = sConfigMgr->GetOption<bool>("AiPlayerbot.GearScoreCheck", false);
     randomBotPreQuests = sConfigMgr->GetOption<bool>("AiPlayerbot.PreQuests", false);
 

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -17,6 +17,7 @@
 #include "RandomPlayerbotMgr.h"
 #include "Talentspec.h"
 #include "TravelMgr.h"
+#include <algorithm>
 #include <cctype>
 #include <iostream>
 #include <sstream>
@@ -258,6 +259,10 @@ bool PlayerbotAIConfig::Initialize()
         sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotCountChangeMinInterval", 30 * MINUTE);
     randomBotCountChangeMaxInterval =
         sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotCountChangeMaxInterval", 2 * HOUR);
+    randomBotCountMinTime =
+        std::min<uint32>(sConfigMgr->GetOption<uint32>("AiPlayerbot.RandomBotCountMinTime", 5), 23);
+    randomBotCountMaxTime =
+        std::min<uint32>(sConfigMgr->GetOption<uint32>("AiPlayerbot.RandomBotCountMaxTime", 20), 23);
     minRandomBotRandomizeTime = sConfigMgr->GetOption<int32>("AiPlayerbot.MinRandomBotRandomizeTime", 2 * HOUR);
     maxRandomBotRandomizeTime = sConfigMgr->GetOption<int32>("AiPlayerbot.MaxRandomBotRandomizeTime", 14 * 24 * HOUR);
     minRandomBotChangeStrategyTime =

--- a/src/PlayerbotAIConfig.cpp
+++ b/src/PlayerbotAIConfig.cpp
@@ -20,6 +20,7 @@
 #include <cctype>
 #include <iostream>
 #include <sstream>
+#include <utility>
 
 template <class T>
 void LoadList(std::string const value, T& list)
@@ -240,8 +241,17 @@ bool PlayerbotAIConfig::Initialize()
 
     botAutologin = sConfigMgr->GetOption<bool>("AiPlayerbot.BotAutologin", false);
     randomBotAutologin = sConfigMgr->GetOption<bool>("AiPlayerbot.RandomBotAutologin", true);
+
     minRandomBots = sConfigMgr->GetOption<int32>("AiPlayerbot.MinRandomBots", 500);
     maxRandomBots = sConfigMgr->GetOption<int32>("AiPlayerbot.MaxRandomBots", 500);
+    if (minRandomBots > maxRandomBots)
+    {
+        LOG_ERROR("server.loading",
+                  "AiPlayerbot.MinRandomBots ({}) is higher than AiPlayerbot.MaxRandomBots ({}). Swapping them.",
+                  minRandomBots, maxRandomBots);
+        std::swap(minRandomBots, maxRandomBots);
+    }
+
     randomBotCountMode = sConfigMgr->GetOption<uint32>("AiPlayerbot.RandomBotCountMode", 0);
     randomBotUpdateInterval = sConfigMgr->GetOption<int32>("AiPlayerbot.RandomBotUpdateInterval", 20);
     randomBotCountChangeMinInterval =

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -308,8 +308,6 @@ public:
     uint32 limitEnchantExpansion;
     uint32 limitGearExpansion;
     uint32 randombotStartingLevel;
-    bool enablePeriodicOnlineOffline;
-    float periodicOnlineOfflineRatio;
     bool gearscorecheck;
     bool randomBotPreQuests;
     bool botSendMailEnabled;

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -161,12 +161,10 @@ public:
     uint32 minRandomBots, maxRandomBots;
     uint32 randomBotCountMode;
     uint32 randomBotUpdateInterval, randomBotCountChangeMinInterval, randomBotCountChangeMaxInterval;
-    uint32 minRandomBotInWorldTime, maxRandomBotInWorldTime;
     uint32 minRandomBotRandomizeTime, maxRandomBotRandomizeTime;
     uint32 minRandomBotChangeStrategyTime, maxRandomBotChangeStrategyTime;
     uint32 minRandomBotReviveTime, maxRandomBotReviveTime;
     uint32 minRandomBotTeleportInterval, maxRandomBotTeleportInterval;
-    uint32 permanentlyInWorldTime;
     uint32 minRandomBotPvpTime, maxRandomBotPvpTime;
     uint32 randomBotsPerInterval;
     uint32 randomBotPrintStatsInterval;

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -161,6 +161,7 @@ public:
     uint32 minRandomBots, maxRandomBots;
     uint32 randomBotCountMode;
     uint32 randomBotUpdateInterval, randomBotCountChangeMinInterval, randomBotCountChangeMaxInterval;
+    uint32 randomBotCountMinTime, randomBotCountMaxTime;
     uint32 minRandomBotRandomizeTime, maxRandomBotRandomizeTime;
     uint32 minRandomBotChangeStrategyTime, maxRandomBotChangeStrategyTime;
     uint32 minRandomBotReviveTime, maxRandomBotReviveTime;

--- a/src/PlayerbotAIConfig.h
+++ b/src/PlayerbotAIConfig.h
@@ -159,6 +159,7 @@ public:
     float randomBotMinLevelChance, randomBotMaxLevelChance;
     float randomBotRpgChance;
     uint32 minRandomBots, maxRandomBots;
+    uint32 randomBotCountMode;
     uint32 randomBotUpdateInterval, randomBotCountChangeMinInterval, randomBotCountChangeMaxInterval;
     uint32 minRandomBotInWorldTime, maxRandomBotInWorldTime;
     uint32 minRandomBotRandomizeTime, maxRandomBotRandomizeTime;


### PR DESCRIPTION
<!--
Thank you for contributing to mod-playerbots, please make sure that you...
1. Submit your PR to the test-staging branch, not master.
2. Read the guidelines below before submitting.
3. Don't delete parts of this template.

DESIGN PHILOSOPHY: We prioritize STABILITY, PERFORMANCE, AND PREDICTABILITY over behavioral realism.

Every action and decision executes PER BOT AND PER TRIGGER. Small increases in logic complexity scale
poorly across thousands of bots and negatively affect all. We prioritize a stable system over a smarter
one. Bots don't need to behave perfectly; believable behavior is the goal, not human simulation.
Default behavior must be cheap in processing; expensive behavior must be opt-in.

Before submitting, make sure your changes aligns with these principles.
-->

## Pull Request Description
<!-- Describe what this change does and why it is needed -->
Marking this as a draft until I test this along with some of the more recent commits, but for now the summary of this is that it kills `EnablePeriodicOnlineOffline`, its ratio logic, and demand to create hundreds or thousands of accounts just to do what it needed.

The replacement system is both less convoluted in its execution and allows for more realism if the goal is for bot login cycles to mimic players login cycles on a live server. The config should explain the new behaviour:

```
# Online randombots count change
#   0 = Static:     Fixed random count rolled once at server start, between Min/MaxRandomBots.
#   1 = Variable:   Fluctuating random count rolled at server start, between Min/MaxRandomBots.
#                   Re-rolled again at a time between RandomBotCountChangeMin/MaxInterval.
#   2 = Scheduled:  Fluctuating time-cycled count, ranging from MinRandomBots at RandomBotCountMinTime,
#                   to MaxRandomBots at RandomBotCountMaxTime.
# When MinRandomBots = MaxRandomBots the count is constant and all modes behave identically.
# Default: 0 (static)
AiPlayerbot.RandomBotCountMode = 0
```


## Feature Evaluation
<!--
If your PR is very minimal (comment typo, wrong ID reference, etc), and it is very obvious it will not have
any impact on performance, you may skip these question. If necessary, a maintainer may ask you for them later.
-->

<!-- Please answer the following: -->
- Describe the **minimum logic** required to achieve the intended behavior.
- Describe the **processing cost** when this logic executes across many bots.



## How to Test the Changes
<!--
- Step-by-step instructions to test the change.
- Any required setup (e.g. multiple players, number of bots, specific configuration).
- Expected behavior and how to verify it.
-->



## Impact Assessment
<!--
As a generic test, pmon checks before and after your edits are helpful. To standardize the measurement, set the configs
BotActiveAlone = 100 & botActiveAloneSmartScale = 0. After server boot, enable the monitor `playerbot pmon toggle`
right after the bots finished logging-in, and run the stack command `playerbot pmon stack` 5 minutes after that.
The last "Total" line is the main result to look for.
-->
- Does this change increase per-bot/per-tick processing or risk scaling poorly with thousands of bots?
    - - [ ] No, not at all
    - - [ ] Minimal impact (**explain below**)
    - - [ ] Moderate impact (**explain below**)



- Does this change modify default bot behavior?
    - - [ ] No
    - - [ ] Yes (**explain why**)



- Does this change add new decision branches or increase maintenance complexity?
    - - [ ] No
    - - [ ] Yes (**explain below**)



## AI Assistance
<!--
AI assistance is allowed, but all submitted code must be fully understood, reviewed, and owned by the contributor.
We expect contributors to be honest about what they do and do not understand.
-->
Was AI assistance used while working on this change?
- - [ ] No
- - [ ] Yes (**explain below**)
<!--
If yes, please specify:
- Purpose of usage (e.g. brainstorming, refactoring, documentation, code generation).
- Which parts of the change were influenced or generated, and whether it was thoroughly reviewed.
-->



## Code Provenance / Attribution
<!--
mod-playerbots is GPLv2 and is derived from the CMaNGOS playerbots (ike3). Code may be ported or
adapted from other GPLv2 projects, but upstream attribution MUST be preserved (GPLv2 §1 and §2(a)).
Never replace an upstream copyright notice with the project header.
-->
Was any code in this PR copied or adapted from a sister / upstream project (e.g. CMaNGOS playerbots,
 MaNGOS, another module)?
- - [ ] No, all code in this PR is original
- - [ ] Yes (**name the project and the original author(s) below**)
<!--
If yes, please provide:
- Source project + URL (and the specific file/commit if known).
- Original author(s) — add a `Co-authored-by: Name <email>` trailer for each to your commit.
- Attribution in code: an in-file "Ported/adapted from <project>" note on substantially-ported files,
  or an inline "// Adapted from <project>" comment for small snippets.
-->



<!--
TRANSLATIONS:
Anything new that the bots say in chat must be in a translatable format. This is done using GetBotTextOrDefault,
which you can search for in the codebase to find examples. Your code needs to have English as the default fallback,
while the full translations need to be in an SQL update file. The languages in the file are the nine language
options supported by AzerothCore: English, Korean, French, German, Chinese, Taiwanese, Spanish, Spanish Mexico, and
Russian. See data/sql/playerbots/updates/2025_12_27_ai_playerbot_fishing_text.sql as an example of a translation SQL
update, whose content are called within the codebase at src/Ai/Base/Actions/FishingAction.cpp
-->

## Final Checklist

- - [ ] Changes are understood and tested for server stability and performance impact.
- - [ ] Any new bot dialogue lines are translated.
- - [ ] New source files use the GPLv2 header.
- - [ ] Documentation updated if needed (Code comments, Conf comments, WiKi commands).
- - [ ] New and modified files do not introduce new compiler warnings.

## Notes for Reviewers
<!-- Anything else that's helpful to review or test your pull request. -->


