### PR TITLE
Test staging

### DIFF
--- a/src/Ai/Base/Actions/InventoryAction.cpp
+++ b/src/Ai/Base/Actions/InventoryAction.cpp
@@ -327,11 +327,19 @@ std::vector<Item*> InventoryAction::parseItems(std::string const text, IterateIt
         found.insert(visitor.GetResult().begin(), visitor.GetResult().end());
     }
 
-    if (text.find("usage ") != std::string::npos)
+    // "usage <n>" is only meaningful at the start of the qualifier, which is how
+    // isReservedQualifier() reads it. Matching it anywhere handed stoi() the text at a fixed
+    // offset instead of the number, so "bandage usage 3" ended up in stoi("ge usage 3").
+    // At most nine digits so the value always fits an int.
+    if (text.rfind("usage ", 0) == 0)
     {
-        FindItemUsageVisitor visitor(bot, ItemUsage(stoi(text.substr(6))));
-        IterateItems(&visitor, ITERATE_ITEMS_IN_BAGS);
-        found.insert(visitor.GetResult().begin(), visitor.GetResult().end());
+        std::string const usage = text.substr(6, text.find(' ', 6) - 6);
+        if (!usage.empty() && usage.size() <= 9 && usage.find_first_not_of("0123456789") == std::string::npos)
+        {
+            FindItemUsageVisitor visitor(bot, ItemUsage(stoi(usage)));
+            IterateItems(&visitor, ITERATE_ITEMS_IN_BAGS);
+            found.insert(visitor.GetResult().begin(), visitor.GetResult().end());
+        }
     }
 
     if (!isReservedQualifier(text))

--- a/src/Ai/Class/Rogue/Action/RogueActions.cpp
+++ b/src/Ai/Class/Rogue/Action/RogueActions.cpp
@@ -37,7 +37,7 @@ bool CastStealthAction::isPossible()
 bool UnstealthAction::Execute(Event /*event*/)
 {
     botAI->RemoveAura("stealth");
-    // botAI->ChangeStrategy("+dps,-stealthed", BOT_STATE_COMBAT);
+    // botAI->ChangeStrategy("+combat,-stealthed", BOT_STATE_COMBAT);
 
     return true;
 }
@@ -46,11 +46,11 @@ bool CheckStealthAction::Execute(Event /*event*/)
 {
     if (botAI->HasAura("stealth", bot))
     {
-        botAI->ChangeStrategy("-dps,+stealthed", BOT_STATE_COMBAT);
+        botAI->ChangeStrategy("-combat,+stealthed", BOT_STATE_COMBAT);
     }
     else
     {
-        botAI->ChangeStrategy("+dps,-stealthed", BOT_STATE_COMBAT);
+        botAI->ChangeStrategy("+combat,-stealthed", BOT_STATE_COMBAT);
     }
 
     return true;

--- a/src/Ai/Class/Rogue/RogueAiObjectContext.cpp
+++ b/src/Ai/Class/Rogue/RogueAiObjectContext.cpp
@@ -7,7 +7,7 @@
 #include "RogueAiObjectContext.h"
 #include "AiObjectContext.h"
 #include "AssassinationRogueStrategy.h"
-#include "DpsRogueStrategy.h"
+#include "CombatRogueStrategy.h"
 #include "GenericRogueNonCombatStrategy.h"
 #include "NamedObjectContext.h"
 #include "Playerbots.h"
@@ -47,13 +47,15 @@ class RogueCombatStrategyFactoryInternal : public NamedObjectContext<Strategy>
 public:
     RogueCombatStrategyFactoryInternal() : NamedObjectContext<Strategy>(false, true)
     {
-        creators["dps"] = &RogueCombatStrategyFactoryInternal::dps;
-        creators["melee"] = &RogueCombatStrategyFactoryInternal::melee;
+        creators["combat"] = &RogueCombatStrategyFactoryInternal::combat;
+        creators["assassin"] = &RogueCombatStrategyFactoryInternal::assassin;
+        // creators["subtlety"] = &RogueCombatStrategyFactoryInternal::subtlety;
     }
 
 private:
-    static Strategy* dps(PlayerbotAI* botAI) { return new DpsRogueStrategy(botAI); }
-    static Strategy* melee(PlayerbotAI* botAI) { return new AssassinationRogueStrategy(botAI); }
+    static Strategy* combat(PlayerbotAI* botAI) { return new CombatRogueStrategy(botAI); }
+    static Strategy* assassin(PlayerbotAI* botAI) { return new AssassinationRogueStrategy(botAI); }
+    // static Strategy* subtlety(PlayerbotAI* botAI) { return new SubtletyRogueStrategy(botAI); }
 };
 
 class RogueTriggerFactoryInternal : public NamedObjectContext<Trigger>

--- a/src/Ai/Class/Rogue/RogueTriggers.cpp
+++ b/src/Ai/Class/Rogue/RogueTriggers.cpp
@@ -25,12 +25,15 @@ bool UnstealthTrigger::IsActive()
     if (!botAI->HasAura("stealth", bot))
         return false;
 
-    return botAI->HasAura("stealth", bot) && !AI_VALUE(uint8, "attacker count") &&
-           (AI_VALUE2(bool, "moving", "self target") &&
-            ((botAI->GetMaster() &&
-              ServerFacade::instance().IsDistanceGreaterThan(AI_VALUE2(float, "distance", "group leader"), 10.0f) &&
-              AI_VALUE2(bool, "moving", "group leader")) ||
-             !AI_VALUE(uint8, "attacker count")));
+    if (!AI_VALUE2(bool, "moving", "self target"))
+        return false;
+
+    if (!AI_VALUE(uint8, "attacker count"))
+        return true;
+
+    return botAI->GetMaster() &&
+           ServerFacade::instance().IsDistanceGreaterThan(AI_VALUE2(float, "distance", "group leader"), 10.0f) &&
+           AI_VALUE2(bool, "moving", "group leader");
 }
 
 bool StealthTrigger::IsActive()

--- a/src/Ai/Class/Rogue/RogueTriggers.h
+++ b/src/Ai/Class/Rogue/RogueTriggers.h
@@ -116,21 +116,21 @@ public:
 class MainHandWeaponNoEnchantTrigger : public BuffTrigger
 {
 public:
-    MainHandWeaponNoEnchantTrigger(PlayerbotAI* ai) : BuffTrigger(ai, "main hand", 1) {}
+    MainHandWeaponNoEnchantTrigger(PlayerbotAI* botAI) : BuffTrigger(botAI, "main hand", 1) {}
     virtual bool IsActive();
 };
 
 class OffHandWeaponNoEnchantTrigger : public BuffTrigger
 {
 public:
-    OffHandWeaponNoEnchantTrigger(PlayerbotAI* ai) : BuffTrigger(ai, "off hand", 1) {}
+    OffHandWeaponNoEnchantTrigger(PlayerbotAI* botAI) : BuffTrigger(botAI, "off hand", 1) {}
     virtual bool IsActive();
 };
 
 class TricksOfTheTradeOnMainTankTrigger : public BuffOnMainTankTrigger
 {
 public:
-    TricksOfTheTradeOnMainTankTrigger(PlayerbotAI* ai) : BuffOnMainTankTrigger(ai, "tricks of the trade", true) {}
+    TricksOfTheTradeOnMainTankTrigger(PlayerbotAI* botAI) : BuffOnMainTankTrigger(botAI, "tricks of the trade", true) {}
 };
 
 #endif

--- a/src/Ai/Class/Rogue/Strategy/CombatRogueStrategy.cpp
+++ b/src/Ai/Class/Rogue/Strategy/CombatRogueStrategy.cpp
@@ -4,13 +4,13 @@
  * or (at your option) any later version.
  */
 
-#include "DpsRogueStrategy.h"
+#include "CombatRogueStrategy.h"
 #include "Playerbots.h"
 
-class DpsRogueStrategyActionNodeFactory : public NamedObjectFactory<ActionNode>
+class CombatRogueStrategyActionNodeFactory : public NamedObjectFactory<ActionNode>
 {
 public:
-    DpsRogueStrategyActionNodeFactory()
+    CombatRogueStrategyActionNodeFactory()
     {
         creators["sinister strike"] = &sinister_strike;
         creators["kick"] = &kick;
@@ -61,12 +61,12 @@ private:
     }
 };
 
-DpsRogueStrategy::DpsRogueStrategy(PlayerbotAI* botAI) : GenericRogueStrategy(botAI)
+CombatRogueStrategy::CombatRogueStrategy(PlayerbotAI* botAI) : GenericRogueStrategy(botAI)
 {
-    actionNodeFactories.Add(new DpsRogueStrategyActionNodeFactory());
+    actionNodeFactories.Add(new CombatRogueStrategyActionNodeFactory());
 }
 
-std::vector<NextAction> DpsRogueStrategy::getDefaultActions()
+std::vector<NextAction> CombatRogueStrategy::getDefaultActions()
 {
     return {
         NextAction("killing spree", ACTION_DEFAULT + 0.1f),
@@ -74,7 +74,7 @@ std::vector<NextAction> DpsRogueStrategy::getDefaultActions()
     };
 }
 
-void DpsRogueStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+void CombatRogueStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
     GenericRogueStrategy::InitTriggers(triggers);
 

--- a/src/Ai/Class/Rogue/Strategy/CombatRogueStrategy.h
+++ b/src/Ai/Class/Rogue/Strategy/CombatRogueStrategy.h
@@ -4,20 +4,20 @@
  * or (at your option) any later version.
  */
 
-#ifndef PLAYERBOTS_DPSROGUESTRATEGY_H
-#define PLAYERBOTS_DPSROGUESTRATEGY_H
+#ifndef PLAYERBOTS_COMBATROGUESTRATEGY_H
+#define PLAYERBOTS_COMBATROGUESTRATEGY_H
 
 #include "GenericRogueStrategy.h"
 
 class PlayerbotAI;
 
-class DpsRogueStrategy : public GenericRogueStrategy
+class CombatRogueStrategy : public GenericRogueStrategy
 {
 public:
-    DpsRogueStrategy(PlayerbotAI* botAI);
+    CombatRogueStrategy(PlayerbotAI* botAI);
 
     void InitTriggers(std::vector<TriggerNode*>& triggers) override;
-    std::string const getName() override { return "dps"; }
+    std::string const getName() override { return "combat"; }
     std::vector<NextAction> getDefaultActions() override;
 };
 

--- a/src/Ai/Class/Rogue/Strategy/SubtletyRogueStrategy.cpp
+++ b/src/Ai/Class/Rogue/Strategy/SubtletyRogueStrategy.cpp
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "SubtletyRogueStrategy.h"
+
+ // To be implemented. For now, Subtlety uses Assassination's strategy (poorly).
+/* class SubtletyRogueStrategyActionNodeFactory : public NamedObjectFactory<ActionNode>
+{
+public:
+    SubtletyRogueStrategyActionNodeFactory()
+    {
+    }
+
+private:
+};
+
+SubtletyRogueStrategy::SubtletyRogueStrategy(PlayerbotAI* botAI) : GenericRogueStrategy(botAI)
+{
+    actionNodeFactories.Add(new SubtletyRogueStrategyActionNodeFactory());
+}
+
+std::vector<NextAction> SubtletyRogueStrategy::getDefaultActions()
+{
+    return {
+    };
+}
+
+void SubtletyRogueStrategyRogueStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
+{
+    GenericRogueStrategy::InitTriggers(triggers);
+}
+*/

--- a/src/Ai/Class/Rogue/Strategy/SubtletyRogueStrategy.h
+++ b/src/Ai/Class/Rogue/Strategy/SubtletyRogueStrategy.h
@@ -4,20 +4,22 @@
  * or (at your option) any later version.
  */
 
-#ifndef PLAYERBOTS_ASSASSINATIONROGUESTRATEGY_H
-#define PLAYERBOTS_ASSASSINATIONROGUESTRATEGY_H
+#ifndef PLAYERBOTS_SUBTLETYROGUESTRATEGY_H
+#define PLAYERBOTS_SUBTLETYROGUESTRATEGY_H
 
-#include "GenericRogueStrategy.h"
+// To be implemented. For now, Subtlety uses Assassination's strategy (poorly).
 
-class AssassinationRogueStrategy : public GenericRogueStrategy
+/*#include "GenericRogueStrategy.h"
+
+class SubtletyRogueStrategy : public GenericRogueStrategy
 {
 public:
-    AssassinationRogueStrategy(PlayerbotAI* botAI);
+    SubtletyRogueStrategy(PlayerbotAI* botAI);
 
 public:
     virtual void InitTriggers(std::vector<TriggerNode*>& triggers) override;
-    virtual std::string const getName() override { return "assassin"; }
+    virtual std::string const getName() override { return "subtlety"; }
     virtual std::vector<NextAction> getDefaultActions() override;
-};
+};*/
 
 #endif

--- a/src/Ai/Class/Warrior/Strategy/GenericWarriorNonCombatStrategy.cpp
+++ b/src/Ai/Class/Warrior/Strategy/GenericWarriorNonCombatStrategy.cpp
@@ -34,6 +34,7 @@ void GenericWarriorNonCombatStrategy::InitTriggers(std::vector<TriggerNode*>& tr
     NonCombatStrategy::InitTriggers(triggers);
 
     triggers.push_back(new TriggerNode("often", { NextAction("apply stone", 1.0f) }));
+    triggers.push_back(new TriggerNode("vigilance", { NextAction("vigilance", 10.0f) }));
     triggers.push_back(new TriggerNode(
         "fear sleep sap", { NextAction("berserker rage", ACTION_EMERGENCY + 1) }));
 }

--- a/src/Ai/Class/Warrior/WarriorActions.cpp
+++ b/src/Ai/Class/Warrior/WarriorActions.cpp
@@ -14,6 +14,7 @@ constexpr uint32 SPELL_RETALIATION = 20230;
 constexpr uint32 SPELL_DIVINE_SHIELD = 642;
 constexpr uint32 SPELL_ICE_BLOCK = 45438;
 constexpr uint32 SPELL_BLESSING_OF_PROTECTION = 41450;
+constexpr uint32 SPELL_VIGILANCE = 50720;
 constexpr uint32 SPELL_SHATTERING_THROW = 64382;
 }
 
@@ -75,89 +76,41 @@ Unit* CastVigilanceAction::GetTarget()
 {
     Group* group = bot->GetGroup();
     if (!group)
-    {
         return nullptr;
-    }
 
-    Player* currentVigilanceTarget = nullptr;
-    Player* mainTank = nullptr;
-    Player* assistTank1 = nullptr;
-    Player* assistTank2 = nullptr;
-    Player* highestGearScorePlayer = nullptr;
+    Player* vigilanceTarget = nullptr;
     uint32 highestGearScore = 0;
 
-    // Iterate once through the group to gather all necessary information
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
         Player* member = ref->GetSource();
         if (!member || member == bot || !member->IsAlive())
             continue;
 
-        // Check if member has Vigilance applied by the bot
-        if (!currentVigilanceTarget && botAI->HasAura("vigilance", member, false, true))
+        // Same as trigger: early return if the bot's own Vigilance is already applied to a member.
+        if (member->HasAura(SPELL_VIGILANCE, bot->GetGUID()))
+            return nullptr;
+
+        // A valid target must not have Vigilance from any source, not just the bot...
+        if (member->HasAura(SPELL_VIGILANCE))
+            continue;
+
+        // And it must be in range and be a dps.
+        if (member->GetMapId() != bot->GetMapId() || !PlayerbotAI::IsDps(member) ||
+            bot->GetDistance(member) > sPlayerbotAIConfig.spellDistance)
         {
-            currentVigilanceTarget = member;
+            continue;
         }
 
-        // Identify Main Tank
-        if (!mainTank && botAI->IsMainTank(member))
-        {
-            mainTank = member;
-        }
-
-        // Identify Assist Tanks
-        if (assistTank1 == nullptr && botAI->IsAssistTankOfIndex(member, 0))
-        {
-            assistTank1 = member;
-        }
-        else if (assistTank2 == nullptr && botAI->IsAssistTankOfIndex(member, 1))
-        {
-            assistTank2 = member;
-        }
-
-        // Determine Highest Gear Score
-        uint32 gearScore = botAI->GetEquipGearScore(member/*, false, false*/);
+        uint32 gearScore = botAI->GetEquipGearScore(member);
         if (gearScore > highestGearScore)
         {
             highestGearScore = gearScore;
-            highestGearScorePlayer = member;
+            vigilanceTarget = member;
         }
     }
 
-    // Determine the highest-priority target
-    Player* highestPriorityTarget = mainTank ? mainTank :
-                                      (assistTank1 ? assistTank1 :
-                                      (assistTank2 ? assistTank2 : highestGearScorePlayer));
-
-    // If no valid target, return nullptr
-    if (!highestPriorityTarget)
-    {
-        return nullptr;
-    }
-
-    // If the current target is already the highest-priority target, do nothing
-    if (currentVigilanceTarget == highestPriorityTarget)
-    {
-        return nullptr;
-    }
-
-    // Assign the new target
-    Unit* targetUnit = highestPriorityTarget->ToUnit();
-    if (targetUnit)
-    {
-        return targetUnit;
-    }
-
-    return nullptr;
-}
-
-bool CastVigilanceAction::Execute(Event /*event*/)
-{
-    Unit* target = GetTarget();
-    if (!target || target == bot)
-        return false;
-
-    return botAI->CastSpell("vigilance", target);
+    return vigilanceTarget;
 }
 
 bool CastRetaliationAction::isUseful()

--- a/src/Ai/Class/Warrior/WarriorActions.h
+++ b/src/Ai/Class/Warrior/WarriorActions.h
@@ -143,12 +143,11 @@ public:
     bool isUseful() override;
 };
 
-class CastVigilanceAction : public BuffOnPartyAction
+class CastVigilanceAction : public CastBuffSpellAction
 {
 public:
-    CastVigilanceAction(PlayerbotAI* botAI) : BuffOnPartyAction(botAI, "vigilance") {}
+    CastVigilanceAction(PlayerbotAI* botAI) : CastBuffSpellAction(botAI, "vigilance") {}
 
-    bool Execute(Event event) override;
     Unit* GetTarget() override;
 };
 

--- a/src/Ai/Class/Warrior/WarriorAiObjectContext.cpp
+++ b/src/Ai/Class/Warrior/WarriorAiObjectContext.cpp
@@ -93,13 +93,11 @@ public:
         creators["shockwave"] = &WarriorTriggerFactoryInternal::shockwave;
         creators["shockwave on snare target"] = &WarriorTriggerFactoryInternal::shockwave_on_snare_target;
         creators["taste for blood"] = &WarriorTriggerFactoryInternal::taste_for_blood;
-
         creators["thunder clap and rage"] = &WarriorTriggerFactoryInternal::thunderclap_and_rage;
         creators["intercept can cast"] = &WarriorTriggerFactoryInternal::intercept_can_cast;
         creators["intercept and far enemy"] = &WarriorTriggerFactoryInternal::intercept_and_far_enemy;
         creators["intercept and rage"] = &WarriorTriggerFactoryInternal::intercept_and_rage;
         // creators["slam"] = &WarriorTriggerFactoryInternal::slam;
-
         creators["vigilance"] = &WarriorTriggerFactoryInternal::vigilance;
         creators["shattering throw trigger"] = &WarriorTriggerFactoryInternal::shattering_throw_trigger;
     }
@@ -125,7 +123,6 @@ private:
     {
         return new ShieldBashInterruptEnemyHealerSpellTrigger(botAI);
     }
-
     static Trigger* thunderclap_and_rage(PlayerbotAI* botAI)
     {
         return new TwoTriggers(botAI, "thunder clap", "light rage available");
@@ -139,7 +136,6 @@ private:
     {
         return new TwoTriggers(botAI, "intercept and far enemy", "light rage available");
     }
-
     static Trigger* intercept_on_snare_target(PlayerbotAI* botAI) { return new InterceptSnareTrigger(botAI); }
     static Trigger* spell_reflection(PlayerbotAI* botAI) { return new SpellReflectionTrigger(botAI); }
     static Trigger* taste_for_blood(PlayerbotAI* botAI) { return new TasteForBloodTrigger(botAI); }
@@ -171,7 +167,6 @@ private:
     static Trigger* revenge(PlayerbotAI* botAI) { return new RevengeAvailableTrigger(botAI); }
     static Trigger* sunder_armor(PlayerbotAI* botAI) { return new SunderArmorDebuffTrigger(botAI); }
     // static Trigger* slam(PlayerbotAI* ai) { return new SlamTrigger(ai); }
-
     static Trigger* vigilance(PlayerbotAI* botAI) { return new VigilanceTrigger(botAI); }
     static Trigger* shattering_throw_trigger(PlayerbotAI* botAI) { return new ShatteringThrowTrigger(botAI); }
 };

--- a/src/Ai/Class/Warrior/WarriorTriggers.cpp
+++ b/src/Ai/Class/Warrior/WarriorTriggers.cpp
@@ -32,45 +32,19 @@ bool VigilanceTrigger::IsActive()
     if (!group)
         return false;
 
-    Player* currentVigilanceTarget = nullptr;
-    Player* mainTank = nullptr;
-    Player* assistTank1 = nullptr;
-    Player* assistTank2 = nullptr;
-    Player* highestGearScorePlayer = nullptr;
-    uint32 highestGearScore = 0;
-
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
         Player* member = ref->GetSource();
         if (!member || member == bot || !member->IsAlive())
             continue;
 
-        if (!currentVigilanceTarget && botAI->HasAura("vigilance", member, false, true))
-            currentVigilanceTarget = member;
-
-        if (!mainTank && botAI->IsMainTank(member))
-            mainTank = member;
-        else if (!assistTank1 && botAI->IsAssistTankOfIndex(member, 0))
-            assistTank1 = member;
-        else if (!assistTank2 && botAI->IsAssistTankOfIndex(member, 1))
-            assistTank2 = member;
-
-        uint32 gearScore = botAI->GetEquipGearScore(member);
-        if (gearScore > highestGearScore)
-        {
-            highestGearScore = gearScore;
-            highestGearScorePlayer = member;
-        }
+        // The action casts Vigilance on dps, but the trigger fails if any party member has
+        // Vigilance from the bot (so the player can have a bot cast Vigilance on any group member).
+        if (member->HasAura(SPELL_VIGILANCE, bot->GetGUID()))
+            return false;
     }
 
-    Player* highestPriorityTarget = mainTank ? mainTank :
-                                      (assistTank1 ? assistTank1 :
-                                      (assistTank2 ? assistTank2 : highestGearScorePlayer));
-
-    if (!currentVigilanceTarget || currentVigilanceTarget != highestPriorityTarget)
-        return true;
-
-    return false;
+    return true;
 }
 
 bool ShatteringThrowTrigger::IsActive()

--- a/src/Ai/Class/Warrior/WarriorTriggers.h
+++ b/src/Ai/Class/Warrior/WarriorTriggers.h
@@ -71,10 +71,10 @@ public:
     RendDebuffTrigger(PlayerbotAI* botAI) : DebuffTrigger(botAI, "rend", 1, true) {}
 };
 
-class VigilanceTrigger : public BuffOnPartyTrigger
+class VigilanceTrigger : public BuffTrigger
 {
 public:
-    VigilanceTrigger(PlayerbotAI* botAI) : BuffOnPartyTrigger(botAI, "vigilance") {}
+    VigilanceTrigger(PlayerbotAI* botAI) : BuffTrigger(botAI, "vigilance", 5 * IN_MILLISECONDS) {}
 
     bool IsActive() override;
 };

--- a/src/Ai/Raid/Gruul/GruulActionContext.h
+++ b/src/Ai/Raid/Gruul/GruulActionContext.h
@@ -15,15 +15,13 @@ class RaidGruulsLairActionContext : public NamedObjectContext<Action>
 public:
     RaidGruulsLairActionContext()
     {
-        // High King Maulgar
-        creators["high king maulgar main tank attack maulgar"] =
-            &RaidGruulsLairActionContext::high_king_maulgar_main_tank_attack_maulgar;
+        // General
+        creators["gruul's lair reset encounter states"] =
+            &RaidGruulsLairActionContext::gruuls_lair_reset_encounter_states;
 
-        creators["high king maulgar first assist tank attack olm"] =
-            &RaidGruulsLairActionContext::high_king_maulgar_first_assist_tank_attack_olm;
-
-        creators["high king maulgar second assist tank attack blindeye"] =
-            &RaidGruulsLairActionContext::high_king_maulgar_second_assist_tank_attack_blindeye;
+        // High King Maulgar <Lord of the Ogres>
+        creators["high king maulgar melee tanks position bosses"] =
+            &RaidGruulsLairActionContext::high_king_maulgar_melee_tanks_position_bosses;
 
         creators["high king maulgar mage tank attack krosh"] =
             &RaidGruulsLairActionContext::high_king_maulgar_mage_tank_attack_krosh;
@@ -37,8 +35,8 @@ public:
         creators["high king maulgar run away from whirlwind"] =
             &RaidGruulsLairActionContext::high_king_maulgar_run_away_from_whirlwind;
 
-        creators["high king maulgar move away from blast nova danger"] =
-            &RaidGruulsLairActionContext::high_king_maulgar_move_away_from_blast_nova_danger;
+        creators["high king maulgar back away from krosh"] =
+            &RaidGruulsLairActionContext::high_king_maulgar_back_away_from_krosh;
 
         creators["high king maulgar banish fel stalker"] =
             &RaidGruulsLairActionContext::high_king_maulgar_banish_fel_stalker;
@@ -53,20 +51,22 @@ public:
         creators["gruul the dragonkiller spread ranged"] =
             &RaidGruulsLairActionContext::gruul_the_dragonkiller_spread_ranged;
 
+        creators["gruul the dragonkiller get out of cave in"] =
+            &RaidGruulsLairActionContext::gruul_the_dragonkiller_get_out_of_cave_in;
+
         creators["gruul the dragonkiller shatter spread"] =
             &RaidGruulsLairActionContext::gruul_the_dragonkiller_shatter_spread;
     }
 
 private:
+    // General
+    static Action* gruuls_lair_reset_encounter_states(PlayerbotAI* botAI) {
+        return new GruulsLairResetEncounterStatesAction(botAI);
+    }
+
     // High King Maulgar
-    static Action* high_king_maulgar_main_tank_attack_maulgar(PlayerbotAI* botAI) {
-        return new HighKingMaulgarMainTankAttackMaulgarAction(botAI);
-    }
-    static Action* high_king_maulgar_first_assist_tank_attack_olm(PlayerbotAI* botAI) {
-        return new HighKingMaulgarFirstAssistTankAttackOlmAction(botAI);
-    }
-    static Action* high_king_maulgar_second_assist_tank_attack_blindeye(PlayerbotAI* botAI) {
-        return new HighKingMaulgarSecondAssistTankAttackBlindeyeAction(botAI);
+    static Action* high_king_maulgar_melee_tanks_position_bosses(PlayerbotAI* botAI) {
+        return new HighKingMaulgarMeleeTanksPositionBossesAction(botAI);
     }
     static Action* high_king_maulgar_mage_tank_attack_krosh(PlayerbotAI* botAI) {
         return new HighKingMaulgarMageTankAttackKroshAction(botAI);
@@ -75,13 +75,13 @@ private:
         return new HighKingMaulgarMoonkinTankAttackKigglerAction(botAI);
     }
     static Action* high_king_maulgar_assign_dps_priority(PlayerbotAI* botAI) {
-        return new HighKingMaulgarAssignDPSPriorityAction(botAI);
+        return new HighKingMaulgarAssignDpsPriorityAction(botAI);
     }
     static Action* high_king_maulgar_run_away_from_whirlwind(PlayerbotAI* botAI) {
         return new HighKingMaulgarRunAwayFromWhirlwindAction(botAI);
     }
-    static Action* high_king_maulgar_move_away_from_blast_nova_danger(PlayerbotAI* botAI) {
-        return new HighKingMaulgarMoveAwayFromBlastNovaDangerAction(botAI);
+    static Action* high_king_maulgar_back_away_from_krosh(PlayerbotAI* botAI) {
+        return new HighKingMaulgarBackAwayFromKroshAction(botAI);
     }
     static Action* high_king_maulgar_banish_fel_stalker(PlayerbotAI* botAI) {
         return new HighKingMaulgarBanishFelStalkerAction(botAI);
@@ -96,6 +96,9 @@ private:
     }
     static Action* gruul_the_dragonkiller_spread_ranged(PlayerbotAI* botAI) {
         return new GruulTheDragonkillerSpreadRangedAction(botAI);
+    }
+    static Action* gruul_the_dragonkiller_get_out_of_cave_in(PlayerbotAI* botAI) {
+        return new GruulTheDragonkillerGetOutOfCaveInAction(botAI);
     }
     static Action* gruul_the_dragonkiller_shatter_spread(PlayerbotAI* botAI) {
         return new GruulTheDragonkillerShatterSpreadAction(botAI);

--- a/src/Ai/Raid/Gruul/GruulActions.cpp
+++ b/src/Ai/Raid/Gruul/GruulActions.cpp
@@ -5,288 +5,202 @@
  */
 
 #include "GruulActions.h"
-#include "CreatureAI.h"
 #include "EncounterHelpers.h"
 #include "GruulHelpers.h"
 #include "Playerbots.h"
-#include "Unit.h"
+#include "RtiTargetValue.h"
+#include <algorithm>
+#include <cmath>
+#include <iterator>
+#include <vector>
 
-using namespace GruulsLairHelpers;
+using namespace GruulHelpers;
 using namespace EncounterHelpers;
 
-// High King Maulgar Actions
+// General
 
-// Main tank on Maulgar
-bool HighKingMaulgarMainTankAttackMaulgarAction::Execute(Event /*event*/)
+bool GruulsLairResetEncounterStatesAction::Execute(Event /*event*/)
 {
-    Unit* maulgar = AI_VALUE2(Unit*, "find target", "high king maulgar");
-    if (!maulgar)
-        return false;
+    bool reset = false;
 
-    if (MarkTargetWithSquare(bot, maulgar))
-        return true;
-
-    SetRtiTarget(botAI, "square");
-
-    if (AI_VALUE(Unit*, "current target") != maulgar)
-        return Attack(maulgar);
-
-    if (maulgar->GetVictim() == bot)
+    Action* action = context->GetAction("gruul the dragonkiller spread ranged");
+    if (action &&
+        static_cast<GruulTheDragonkillerSpreadRangedAction*>(action)->ResetInitialPosition())
     {
-        Position const& position = MAULGAR_TANK_POSITION;
-        const float distToPosition =
-            bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY());
-
-        if (distToPosition > 3.0f)
-        {
-            const float dX = position.GetPositionX() - bot->GetPositionX();
-            const float dY = position.GetPositionY() - bot->GetPositionY();
-            const float moveDist = std::min(5.0f, distToPosition);
-            const float moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
-            const float moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
-
-            return MoveTo(GRUULS_LAIR_MAP_ID, moveX, moveY, position.GetPositionZ(), false, false,
-                          false, false, MovementPriority::MOVEMENT_COMBAT, true, true);
-        }
+        reset = true;
     }
 
-    return false;
-}
-
-// First offtank on Olm
-bool HighKingMaulgarFirstAssistTankAttackOlmAction::Execute(Event /*event*/)
-{
-    Unit* olm = AI_VALUE2(Unit*, "find target", "olm the summoner");
-    if (!olm)
-        return false;
-
-    if (MarkTargetWithCircle(bot, olm))
-        return true;
-
-    SetRtiTarget(botAI, "circle");
-
-    if (AI_VALUE(Unit*, "current target") != olm)
-        return Attack(olm);
-
-    if (olm->GetVictim() == bot)
+    if (IsMechanicTrackerBot(bot, GRUUL_MAP_ID) && !AI_VALUE2(bool, "combat", "self target"))
     {
-        Position const& position = OLM_TANK_POSITION;
-        const float distToPosition =
-            bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY());
-
-        if (distToPosition > 3.0f)
-        {
-            const float dX = position.GetPositionX() - bot->GetPositionX();
-            const float dY = position.GetPositionY() - bot->GetPositionY();
-            const float moveDist = std::min(5.0f, distToPosition);
-            const float moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
-            const float moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
-
-            return MoveTo(GRUULS_LAIR_MAP_ID, moveX, moveY, position.GetPositionZ(), false, false,
-                          false, false, MovementPriority::MOVEMENT_COMBAT, true, true);
-        }
+        reset |= ClearTargetIcon(bot, RtiTargetValue::skullIndex);
+        reset |= ClearTargetIcon(bot, RtiTargetValue::crossIndex);
     }
 
-    return false;
+    return reset;
 }
 
-// Second offtank on Blindeye
-bool HighKingMaulgarSecondAssistTankAttackBlindeyeAction::Execute(Event /*event*/)
+// High King Maulgar <Lord of the Ogres>
+
+bool HighKingMaulgarMeleeTanksPositionBossesAction::Execute(Event /*event*/)
 {
-    Unit* blindeye = AI_VALUE2(Unit*, "find target", "blindeye the seer");
-    if (!blindeye)
-        return false;
-
-    if (MarkTargetWithStar(bot, blindeye))
-        return true;
-
-    SetRtiTarget(botAI, "star");
-
-    if (AI_VALUE(Unit*, "current target") != blindeye)
-        return Attack(blindeye);
-
-    if (blindeye->GetVictim() == bot)
+    Unit* target = nullptr;
+    Position position;
+    if (IsMaulgarTank(bot))
     {
-        Position const& position = BLINDEYE_TANK_POSITION;
-        const float distToPosition =
-            bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY());
-
-        if (distToPosition > 3.0f)
-        {
-            const float dX = position.GetPositionX() - bot->GetPositionX();
-            const float dY = position.GetPositionY() - bot->GetPositionY();
-            const float moveDist = std::min(5.0f, distToPosition);
-            const float moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
-            const float moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
-
-            return MoveTo(GRUULS_LAIR_MAP_ID, moveX, moveY, position.GetPositionZ(), false, false,
-                          false, false, MovementPriority::MOVEMENT_COMBAT, true, true);
-        }
+        target = AI_VALUE2(Unit*, "find target", "high king maulgar");
+        position = MAULGAR_TANK_POSITION;
+    }
+    else if (IsOlmTank(bot))
+    {
+        target = AI_VALUE2(Unit*, "find target", "olm the summoner");
+        position = OLM_TANK_POSITION;
+    }
+    else if (IsBlindeyeTank(bot))
+    {
+        target = AI_VALUE2(Unit*, "find target", "blindeye the seer");
+        position = BLINDEYE_TANK_POSITION;
     }
 
-    return false;
+    if (!target)
+        return false;
+
+    if (AI_VALUE(Unit*, "current target") != target)
+        return Attack(target);
+
+    if (target->GetVictim() != bot || !bot->IsWithinMeleeRange(target))
+        return false;
+
+    constexpr float arrivalDist = 3.0f;
+    float moveX;
+    float moveY;
+    bool backwards;
+    if (!GetStepToPosition(bot, position, arrivalDist, target, moveX, moveY, backwards))
+        return false;
+
+    return MoveTo(
+        GRUUL_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false, false, false,
+        MovementPriority::MOVEMENT_COMBAT, true, backwards);
 }
 
-// Mage with highest max HP on Krosh
 bool HighKingMaulgarMageTankAttackKroshAction::Execute(Event /*event*/)
 {
     Unit* krosh = AI_VALUE2(Unit*, "find target", "krosh firehand");
     if (!krosh)
         return false;
 
-    if (MarkTargetWithTriangle(bot, krosh))
+    if (AttackAndCast(krosh))
         return true;
 
-    SetRtiTarget(botAI, "triangle");
+    if (krosh->GetVictim() != bot)
+        return false;
 
-    if (krosh->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_SPELL_SHIELD)) &&
-        botAI->CanCastSpell("spellsteal", krosh))
-    {
-        return botAI->CastSpell("spellsteal", krosh);
-    }
+    return MoveToDesiredDistance(krosh);
+}
 
-    if (!bot->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_SPELL_SHIELD)) &&
-        botAI->CanCastSpell("fire ward", bot))
+bool HighKingMaulgarMageTankAttackKroshAction::AttackAndCast(Unit* krosh)
+{
+    if (krosh->HasAura(Id(GruulSpells::SPELL_SPELL_SHIELD)) &&
+        botAI->CanCastSpell(Id(GruulSpells::SPELL_SPELLSTEAL), krosh) &&
+        botAI->CastSpell(Id(GruulSpells::SPELL_SPELLSTEAL), krosh))
     {
-        return botAI->CastSpell("fire ward", bot);
+        return true;
     }
 
     if (AI_VALUE(Unit*, "current target") != krosh)
         return Attack(krosh);
 
-    if (krosh->GetVictim() == bot)
-    {
-        Position const& position = KROSH_TANK_POSITION;
-        const float distanceKroshToPosition =
-            krosh->GetExactDist2d(position.GetPositionX(), position.GetPositionY());
-        constexpr float minDistance = 17.0f;
-        constexpr float maxDistance = 30.0f;
+    if (bot->HasAura(Id(GruulSpells::SPELL_SPELL_SHIELD)))
+        return false;
 
-        if (distanceKroshToPosition > minDistance && distanceKroshToPosition < maxDistance &&
-            bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY()) > 1.0f)
-        {
-            return MoveTo(GRUULS_LAIR_MAP_ID, position.GetPositionX(), position.GetPositionY(),
-                          position.GetPositionZ(), false, false, false, false,
-                          MovementPriority::MOVEMENT_COMBAT, true, false);
-        }
-        else
-        {
-            constexpr float safeDistance = 15.0f;
-            const float currentDistance = bot->GetDistance2d(krosh);
-
-            if (currentDistance < safeDistance)
-            {
-                bot->CastStop();
-                return MoveAway(krosh, safeDistance - currentDistance);
-            }
-        }
-    }
-
-    return false;
+    return botAI->CanCastSpell("fire ward", bot) && botAI->CastSpell("fire ward", bot);
 }
 
-// Moonkin with highest max HP on Kiggler
+// The Mage tank moves to a designated position only if Krosh is far enough from that position to
+// be tanked from it without standing in Blast Wave, and close enough to still be tanked at all.
+bool HighKingMaulgarMageTankAttackKroshAction::MoveToDesiredDistance(Unit* krosh)
+{
+    Position const& position = KROSH_TANK_POSITION;
+    float const distanceKroshToPosition = krosh->GetExactDist2d(position);
+    constexpr float minDistance = KROSH_BLAST_WAVE_SAFE_DISTANCE;
+    constexpr float maxDistance = 30.0f;
+
+    if (distanceKroshToPosition > minDistance && distanceKroshToPosition < maxDistance &&
+        bot->GetExactDist2d(position) > 1.0f)
+    {
+        return MoveTo(
+            GRUUL_MAP_ID, position.GetPositionX(), position.GetPositionY(), position.GetPositionZ(),
+            false, false, false, false, MovementPriority::MOVEMENT_COMBAT, true, false);
+    }
+
+    float const currentDistance = bot->GetExactDist2d(krosh);
+    if (currentDistance >= KROSH_BLAST_WAVE_SAFE_DISTANCE)
+        return false;
+
+    bot->CastStop();
+    return MoveAway(krosh, KROSH_BLAST_WAVE_SAFE_DISTANCE - currentDistance);
+}
+
+// The moonkin tank has no tank position, but usually Kiggler remains close to where he starts.
 bool HighKingMaulgarMoonkinTankAttackKigglerAction::Execute(Event /*event*/)
 {
     Unit* kiggler = AI_VALUE2(Unit*, "find target", "kiggler the crazed");
     if (!kiggler)
         return false;
 
-    if (MarkTargetWithDiamond(bot, kiggler))
-        return true;
-
-    SetRtiTarget(botAI, "diamond");
-
     if (AI_VALUE(Unit*, "current target") != kiggler)
         return Attack(kiggler);
 
-    if (kiggler->GetVictim() == bot)
-    {
-        constexpr float safeDistance = 28.5f;
-        const float currentDistance = bot->GetDistance2d(kiggler);
+    if (kiggler->GetVictim() != bot)
+        return false;
 
-        if (currentDistance < safeDistance)
-        {
-            bot->CastStop();
-            return MoveAway(kiggler, safeDistance - currentDistance);
-        }
-    }
+    float const currentDistance = bot->GetExactDist2d(kiggler);
+    if (currentDistance >= KIGGLER_ARCANE_EXPLOSION_SAFE_DISTANCE)
+        return false;
 
-    return false;
+    return MoveAway(kiggler, KIGGLER_ARCANE_EXPLOSION_SAFE_DISTANCE - currentDistance);
 }
 
-bool HighKingMaulgarAssignDPSPriorityAction::Execute(Event /*event*/)
+// Priority: (1) Blindeye, (2) Olm, (3) Krosh (ranged only), (4) Kiggler, and (5) Maulgar
+bool HighKingMaulgarAssignDpsPriorityAction::Execute(Event /*event*/)
 {
-    // Target priority 1: Blindeye
+    Unit* target = nullptr;
+    Unit* krosh = nullptr;
     if (Unit* blindeye = AI_VALUE2(Unit*, "find target", "blindeye the seer"))
     {
-        if (MarkTargetWithStar(bot, blindeye))
-            return true;
-
-        SetRtiTarget(botAI, "star");
-
-        if (AI_VALUE(Unit*, "current target") != blindeye)
-            return Attack(blindeye);
-
-        return false;
+        target = blindeye;
     }
-
-    // Target priority 2: Olm
-    if (Unit* olm = AI_VALUE2(Unit*, "find target", "olm the summoner"))
+    else if (Unit* olm = AI_VALUE2(Unit*, "find target", "olm the summoner"))
     {
-        if (MarkTargetWithCircle(bot, olm))
-            return true;
-
-        SetRtiTarget(botAI, "circle");
-
-        if (AI_VALUE(Unit*, "current target") != olm)
-            return Attack(olm);
-
-        return false;
+        target = olm;
     }
-
-    // Target priority 3a: Krosh (ranged only)
-    if (Unit* krosh = AI_VALUE2(Unit*, "find target", "krosh firehand");
-        krosh && botAI->IsRanged(bot))
+    else if (PlayerbotAI::IsRanged(bot) &&
+        (krosh = AI_VALUE2(Unit*, "find target", "krosh firehand")))
     {
-        if (MarkTargetWithTriangle(bot, krosh))
-            return true;
-
-        SetRtiTarget(botAI, "triangle");
-
-        if (AI_VALUE(Unit*, "current target") != krosh)
-            return Attack(krosh);
-
-        return false;
+        target = krosh;
     }
-
-    // Target priority 3b: Kiggler
-    if (Unit* kiggler = AI_VALUE2(Unit*, "find target", "kiggler the crazed"))
+    else if (Unit* kiggler = AI_VALUE2(Unit*, "find target", "kiggler the crazed"))
     {
-        if (MarkTargetWithDiamond(bot, kiggler))
-            return true;
-
-        SetRtiTarget(botAI, "diamond");
-
-        if (AI_VALUE(Unit*, "current target") != kiggler)
-            return Attack(kiggler);
-
-        return false;
+        target = kiggler;
     }
-
-    // Target priority 4: Maulgar
-    if (Unit* maulgar = AI_VALUE2(Unit*, "find target", "high king maulgar"))
+    else if (Unit* maulgar = AI_VALUE2(Unit*, "find target", "high king maulgar"))
     {
-        if (MarkTargetWithSquare(bot, maulgar))
-            return true;
-
-        SetRtiTarget(botAI, "square");
-
-        if (AI_VALUE(Unit*, "current target") != maulgar)
-            return Attack(maulgar);
+        target = maulgar;
     }
 
-    return false;
+    if (!target)
+        return false;
+
+    if (target == krosh)
+    {
+        if (MarkTargetWithCross(bot, target))
+            return true;
+    }
+    else if (MarkTargetWithSkull(bot, target))
+    {
+        return true;
+    }
+
+    return AI_VALUE(Unit*, "current target") != target && Attack(target);
 }
 
 bool HighKingMaulgarRunAwayFromWhirlwindAction::Execute(Event /*event*/)
@@ -295,35 +209,26 @@ bool HighKingMaulgarRunAwayFromWhirlwindAction::Execute(Event /*event*/)
     if (!maulgar)
         return false;
 
-    constexpr float safeDistance = 8.0f;
-    const float currentDistance = bot->GetDistance2d(maulgar);
+    float const currentDistance = bot->GetExactDist2d(maulgar);
+    if (currentDistance >= MAULGAR_WHIRLWIND_SAFE_DISTANCE)
+        return false;
 
-    if (currentDistance < safeDistance)
-    {
-        bot->CastStop();
-        return MoveAway(maulgar, safeDistance - currentDistance);
-    }
-
-    return false;
+    bot->CastStop();
+    return MoveAway(maulgar, MAULGAR_WHIRLWIND_SAFE_DISTANCE - currentDistance);
 }
 
-bool HighKingMaulgarMoveAwayFromBlastNovaDangerAction::Execute(Event /*event*/)
+bool HighKingMaulgarBackAwayFromKroshAction::Execute(Event /*event*/)
 {
     Unit* krosh = AI_VALUE2(Unit*, "find target", "krosh firehand");
     if (!krosh)
         return false;
 
-    constexpr float safeDistance = 20.0f;
-    constexpr uint32 minInterval = 1000;
-    const float currentDistance = bot->GetDistance2d(krosh);
+    float const currentDistance = bot->GetExactDist2d(krosh);
+    if (currentDistance >= KROSH_BLAST_WAVE_SAFE_DISTANCE)
+        return false;
 
-    if (currentDistance < safeDistance)
-    {
-        bot->CastStop();
-        return FleePosition(krosh->GetPosition(), safeDistance, minInterval);
-    }
-
-    return false;
+    bot->CastStop();
+    return FleePosition(krosh->GetPosition(), KROSH_BLAST_WAVE_SAFE_DISTANCE);
 }
 
 bool HighKingMaulgarBanishFelStalkerAction::Execute(Event /*event*/)
@@ -332,58 +237,36 @@ bool HighKingMaulgarBanishFelStalkerAction::Execute(Event /*event*/)
     if (!group)
         return false;
 
-    std::vector<Unit*> felStalkers;
-    std::list<Creature*> creatureList;
-    constexpr float searchRadius = 50.0f;
-    bot->GetCreatureListWithEntryInGrid(
-        creatureList, static_cast<uint32>(GruulsLairNpcs::NPC_WILD_FEL_STALKER), searchRadius);
-
-    for (Creature* creature : creatureList)
-    {
-        if (creature && creature->IsAlive())
-            felStalkers.push_back(creature);
-    }
-
+    // Ordered by GUID so that every bot warlock indexes the same list.
+    std::vector<Unit*> const felStalkers = GetNearbyWildFelStalkers(botAI);
     std::vector<Player*> warlocks;
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
         Player* member = ref->GetSource();
-        if (member && member->IsAlive() && member->getClass() == CLASS_WARLOCK &&
-            GET_PLAYERBOT_AI(member))
+        if (member && member->IsAlive() && member->GetMapId() == GRUUL_MAP_ID &&
+            member->getClass() == CLASS_WARLOCK && GET_PLAYERBOT_AI(member))
         {
             warlocks.push_back(member);
         }
     }
 
-    int warlockIndex = -1;
-    for (size_t i = 0; i < warlocks.size(); ++i)
-    {
-        if (warlocks[i] == bot)
-        {
-            warlockIndex = static_cast<int>(i);
-            break;
-        }
-    }
+    auto const it = std::find(warlocks.begin(), warlocks.end(), bot);
+    if (it == warlocks.end())
+        return false;
 
-    const uint8 felStalkersSize = felStalkers.size();
+    size_t const warlockIndex = static_cast<size_t>(std::distance(warlocks.begin(), it));
+    if (warlockIndex >= felStalkers.size())
+        return false;
 
-    if (warlockIndex >= 0 && warlockIndex < felStalkersSize)
-    {
-        Unit* assignedFelStalker = felStalkers[warlockIndex];
-        if (!botAI->HasAura("banish", assignedFelStalker) &&
-            botAI->CanCastSpell("banish", assignedFelStalker))
-        {
-            return botAI->CastSpell("banish", assignedFelStalker);
-        }
-    }
+    Unit* assignedFelStalker = felStalkers[warlockIndex];
+    if (botAI->HasAura("banish", assignedFelStalker))
+        return false;
 
-    return false;
+    return botAI->CanCastSpell("banish", assignedFelStalker) &&
+        botAI->CastSpell("banish", assignedFelStalker);
 }
 
-// Hunter 1: Misdirect Blindeye to second offtank
-// Hunter 2: Misdirect Olm to first offtank
-// Hunter 3: Misdirect Kiggler to Moonkin tank
-// Hunter 4: Misdirect Krosh to Mage tank
+// Misdirect order: Blindeye, Olm, Kiggler, Krosh
 bool HighKingMaulgarMisdirectOgresToTanksAction::Execute(Event /*event*/)
 {
     Group* group = bot->GetGroup();
@@ -395,7 +278,7 @@ bool HighKingMaulgarMisdirectOgresToTanksAction::Execute(Event /*event*/)
     {
         Player* member = ref->GetSource();
         if (member && member->IsAlive() && member->getClass() == CLASS_HUNTER &&
-            GET_PLAYERBOT_AI(member))
+            member->GetMapId() == GRUUL_MAP_ID && GET_PLAYERBOT_AI(member))
         {
             hunters.push_back(member);
         }
@@ -416,68 +299,43 @@ bool HighKingMaulgarMisdirectOgresToTanksAction::Execute(Event /*event*/)
     if (hunterIndex == -1)
         return false;
 
-    Unit* ogreTarget = nullptr;
-    Player* tankTarget = nullptr;
+    Unit* ogre = nullptr;
+    Player* tank = nullptr;
     if (hunterIndex == 0)
     {
-        ogreTarget = AI_VALUE2(Unit*, "find target", "blindeye the seer");
-        tankTarget = GetGroupAssistTank(bot, 1);
+        ogre = AI_VALUE2(Unit*, "find target", "blindeye the seer");
+        tank = GetGroupAssistTank(bot, 1);
     }
     else if (hunterIndex == 1)
     {
-        ogreTarget = AI_VALUE2(Unit*, "find target", "olm the summoner");
-        for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
-        {
-            if (Player* member = GetGroupAssistTank(bot, 0))
-            {
-                tankTarget = member;
-                break;
-            }
-        }
+        ogre = AI_VALUE2(Unit*, "find target", "olm the summoner");
+        tank = GetGroupAssistTank(bot, 0);
     }
     else if (hunterIndex == 2)
     {
-        ogreTarget = AI_VALUE2(Unit*, "find target", "kiggler the crazed");
-        for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
-        {
-            if (Player* member = GetKigglerMoonkinTank(bot))
-            {
-                tankTarget = member;
-                break;
-            }
-        }
+        ogre = AI_VALUE2(Unit*, "find target", "kiggler the crazed");
+        tank = GetKigglerMoonkinTank(botAI);
     }
     else if (hunterIndex == 3)
     {
-        ogreTarget = AI_VALUE2(Unit*, "find target", "krosh firehand");
-        for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
-        {
-            if (Player* member = GetKroshMageTank(bot))
-            {
-                tankTarget = member;
-                break;
-            }
-        }
+        ogre = AI_VALUE2(Unit*, "find target", "krosh firehand");
+        tank = GetKroshMageTank(botAI);
     }
 
-    if (!ogreTarget || !tankTarget || !tankTarget->IsAlive())
+    if (!ogre || !tank || !tank->IsAlive())
         return false;
 
-    if (botAI->CanCastSpell("misdirection", tankTarget))
-        return botAI->CastSpell("misdirection", tankTarget);
+    if (botAI->CanCastSpell("misdirection", tank))
+        return botAI->CastSpell("misdirection", tank);
 
-    if (bot->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_MISDIRECTION)) &&
-        botAI->CanCastSpell("steady shot", ogreTarget))
-    {
-        return botAI->CastSpell("steady shot", ogreTarget);
-    }
+    if (!bot->HasAura(Id(GruulSpells::SPELL_MISDIRECTION)))
+        return false;
 
-    return false;
+    return botAI->CanCastSpell("steady shot", ogre) && botAI->CastSpell("steady shot", ogre);
 }
 
-// Gruul the Dragonkiller Actions
+// Gruul the Dragonkiller
 
-// Position in center of the room
 bool GruulTheDragonkillerTanksPositionBossAction::Execute(Event /*event*/)
 {
     Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
@@ -487,124 +345,109 @@ bool GruulTheDragonkillerTanksPositionBossAction::Execute(Event /*event*/)
     if (AI_VALUE(Unit*, "current target") != gruul)
         return Attack(gruul);
 
-    if (gruul->GetVictim() == bot)
-    {
-        Position const& position = GRUUL_TANK_POSITION;
-        const float distToPosition =
-            bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY());
-
-        if (distToPosition > 3.0f)
-        {
-            const float dX = position.GetPositionX() - bot->GetPositionX();
-            const float dY = position.GetPositionY() - bot->GetPositionY();
-            const float moveDist = std::min(5.0f, distToPosition);
-            const float moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
-            const float moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
-
-            return MoveTo(GRUULS_LAIR_MAP_ID, moveX, moveY, position.GetPositionZ(), false, false,
-                          false, false, MovementPriority::MOVEMENT_COMBAT, true, true);
-        }
-    }
-
-    return false;
-}
-
-// Ranged will take initial positions around the middle of the room, 25-40 yards from center
-// Ranged should spread out 10 yards from each other
-bool GruulTheDragonkillerSpreadRangedAction::Execute(Event /*event*/)
-{
-    Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
-    if (!gruul)
+    if (gruul->GetVictim() != bot || !bot->IsWithinMeleeRange(gruul))
         return false;
 
-    if (gruul->GetHealth() == gruul->GetMaxHealth())
-        _hasReachedInitialPosition = false;
+    constexpr float arrivalDist = 3.0f;
+    float moveX;
+    float moveY;
+    bool backwards;
+    if (!GetStepToPosition(bot, GRUUL_TANK_POSITION, arrivalDist, gruul, moveX, moveY, backwards))
+        return false;
 
+    return MoveTo(
+        GRUUL_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false, false, false,
+        MovementPriority::MOVEMENT_COMBAT, true, backwards);
+}
+
+bool GruulTheDragonkillerSpreadRangedAction::Execute(Event /*event*/)
+{
     Group* group = bot->GetGroup();
     if (!group)
         return false;
 
-    std::vector<Player*> members;
-    Player* closestMember = nullptr;
-    float closestDist = std::numeric_limits<float>::max();
-    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
-    {
-        Player* member = ref->GetSource();
-        if (!member || !member->IsAlive())
-            continue;
-
-        members.push_back(member);
-
-        if (member != bot)
-        {
-            float dist = bot->GetExactDist2d(member);
-            if (dist < closestDist)
-            {
-                closestDist = dist;
-                closestMember = member;
-            }
-        }
-    }
-
     Position const& position = GRUUL_TANK_POSITION;
 
-    if (_initialPosition.GetPositionX() == 0.0f && _initialPosition.GetPositionY() == 0.0f)
+    if (!_hasInitialPosition)
     {
+        std::vector<Player*> members;
+        for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+        {
+            Player* member = ref->GetSource();
+            if (!member || !member->IsAlive() || member->GetMapId() != GRUUL_MAP_ID ||
+                !GET_PLAYERBOT_AI(member) || !PlayerbotAI::IsRanged(member))
+            {
+                continue;
+            }
+
+            members.push_back(member);
+        }
+
+        if (members.empty())
+            return false;
+
         auto it = std::find(members.begin(), members.end(), bot);
-        uint8 botIndex = (it != members.end()) ? std::distance(members.begin(), it) : 0;
-        uint8 count = members.size();
+        size_t const botIndex = (it != members.end()) ? std::distance(members.begin(), it) : 0;
 
         constexpr float minRadius = 25.0f;
         constexpr float maxRadius = 40.0f;
-        float angle = 2 * M_PI * botIndex / count;
-        float radius = minRadius + static_cast<float>(rand()) /
-                       static_cast<float>(RAND_MAX) * (maxRadius - minRadius);
-        float targetX = position.GetPositionX() + radius * cos(angle);
-        float targetY = position.GetPositionY() + radius * sin(angle);
+        float const angle = 2.0f * M_PI * botIndex / members.size();
+        float const radius = frand(minRadius, maxRadius);
+        float const targetX = position.GetPositionX() + radius * std::cos(angle);
+        float const targetY = position.GetPositionY() + radius * std::sin(angle);
 
         _initialPosition = Position(targetX, targetY, position.GetPositionZ());
+        _hasInitialPosition = true;
     }
 
     if (!_hasReachedInitialPosition)
     {
-        const float distanceToTarget =
-            bot->GetExactDist2d(_initialPosition.GetPositionX(), _initialPosition.GetPositionY());
-        if (distanceToTarget > 2.0f)
+        float const distToTarget = bot->GetExactDist2d(_initialPosition);
+        if (distToTarget <= 2.0f)
         {
-            float destX = _initialPosition.GetPositionX();
-            float destY = _initialPosition.GetPositionY();
-            float destZ = _initialPosition.GetPositionZ();
-
-            if (!bot->GetMap()->CheckCollisionAndGetValidCoords(bot, bot->GetPositionX(),
-                bot->GetPositionY(), bot->GetPositionZ(), destX, destY, destZ))
-            {
-                return false;
-            }
-
-            return MoveTo(GRUULS_LAIR_MAP_ID, destX, destY, destZ, false, false, false,
-                          false, MovementPriority::MOVEMENT_COMBAT, true, false);
+             _hasReachedInitialPosition = true;
+            return false;
         }
 
-        _hasReachedInitialPosition = true;
-    }
-    else
-    {
-        constexpr float minSpreadDistance = 10.0f;
-        constexpr uint32 minInterval = 1000;
-        if (closestMember && closestDist < minSpreadDistance)
-            return FleePosition(closestMember->GetPosition(), minSpreadDistance, minInterval);
+        float const moveDist = std::min(3.5f, distToTarget);
+        float const botX = bot->GetPositionX();
+        float const botY = bot->GetPositionY();
+        float const moveX =
+            botX + ((_initialPosition.GetPositionX() - botX) / distToTarget) * moveDist;
+        float const moveY =
+            botY + ((_initialPosition.GetPositionY() - botY) / distToTarget) * moveDist;
+
+        return MoveTo(
+            GRUUL_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false, false, false,
+            MovementPriority::MOVEMENT_COMBAT, true, false);
     }
 
-    return false;
+    constexpr float minSpreadDistance = 10.0f;
+    Player* nearestPlayer = GetNearestPlayerInRadius(bot, minSpreadDistance);
+    return nearestPlayer && FleePosition(nearestPlayer->GetPosition(), minSpreadDistance);
 }
 
-// Try to get away from other group members when Ground Slam is cast
+// This method attempts to have more preemptive avoidance and post-avoidance awareness for Cave-ins
+// as compared to avoid aoe (which recognizes the dynobj only once the bot actually has a damaging
+// aura applied to it and immediately forgets the dynobj once the bot is out of danger).
+bool GruulTheDragonkillerGetOutOfCaveInAction::Execute(Event /*event*/)
+{
+    Position pool;
+    if (!GetNearestCaveInPosition(botAI, pool))
+        return false;
+
+    constexpr uint32 minInterval = 0;
+    return FleePosition(pool, CAVE_IN_RADIUS, minInterval);
+}
+
 bool GruulTheDragonkillerShatterSpreadAction::Execute(Event /*event*/)
 {
-    constexpr float safeDistance = 10.0f;
-    constexpr uint32 minInterval = 0;
-    if (Player* nearestPlayer = GetNearestPlayerInRadius(bot, safeDistance))
-        return FleePosition(nearestPlayer->GetPosition(), safeDistance, minInterval);
+    Player* nearestPlayer = GetNearestPlayerInRadius(bot, GRUUL_SHATTER_SAFE_DISTANCE);
+    if (!nearestPlayer)
+        return false;
 
-    return false;
+    float const distToNearest = bot->GetExactDist2d(nearestPlayer);
+    float const moveDist = std::min(3.5f, GRUUL_SHATTER_SAFE_DISTANCE - distToNearest);
+
+    return MoveAway(nearestPlayer, moveDist);
 }

--- a/src/Ai/Raid/Gruul/GruulActions.h
+++ b/src/Ai/Raid/Gruul/GruulActions.h
@@ -10,112 +10,133 @@
 #include "Action.h"
 #include "AttackAction.h"
 #include "MovementActions.h"
+#include "Position.h"
 
-class HighKingMaulgarMainTankAttackMaulgarAction : public AttackAction
+// General
+
+class GruulsLairResetEncounterStatesAction : public Action
 {
 public:
-    HighKingMaulgarMainTankAttackMaulgarAction(
-        PlayerbotAI* botAI, std::string const name = "high king maulgar main tank attack maulgar") : AttackAction(botAI, name) {};
+    GruulsLairResetEncounterStatesAction(PlayerbotAI* botAI)
+        : Action(botAI, "gruul's lair reset encounter states") {}
     bool Execute(Event event) override;
 };
 
-class HighKingMaulgarFirstAssistTankAttackOlmAction : public AttackAction
-{
-public:
-    HighKingMaulgarFirstAssistTankAttackOlmAction(
-        PlayerbotAI* botAI, std::string const name = "high king maulgar first assist tank attack olm") : AttackAction(botAI, name) {};
-    bool Execute(Event event) override;
-};
+// High King Maulgar <Lord of the Ogres>
 
-class HighKingMaulgarSecondAssistTankAttackBlindeyeAction : public AttackAction
+class HighKingMaulgarMeleeTanksPositionBossesAction : public AttackAction
 {
 public:
-    HighKingMaulgarSecondAssistTankAttackBlindeyeAction(
-        PlayerbotAI* botAI, std::string const name = "high king maulgar second assist tank attack blindeye") : AttackAction(botAI, name) {};
+    HighKingMaulgarMeleeTanksPositionBossesAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "high king maulgar melee tanks position bosses") {}
     bool Execute(Event event) override;
 };
 
 class HighKingMaulgarMageTankAttackKroshAction : public AttackAction
 {
 public:
-    HighKingMaulgarMageTankAttackKroshAction(
-        PlayerbotAI* botAI, std::string const name = "high king maulgar mage tank attack krosh") : AttackAction(botAI, name) {};
+    HighKingMaulgarMageTankAttackKroshAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "high king maulgar mage tank attack krosh") {}
     bool Execute(Event event) override;
+
+private:
+    bool AttackAndCast(Unit* krosh);
+    bool MoveToDesiredDistance(Unit* krosh);
 };
 
 class HighKingMaulgarMoonkinTankAttackKigglerAction : public AttackAction
 {
 public:
-    HighKingMaulgarMoonkinTankAttackKigglerAction(
-        PlayerbotAI* botAI, std::string const name = "high king maulgar moonkin tank attack kiggler") : AttackAction(botAI, name) {};
+    HighKingMaulgarMoonkinTankAttackKigglerAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "high king maulgar moonkin tank attack kiggler") {}
     bool Execute(Event event) override;
 };
 
-class HighKingMaulgarAssignDPSPriorityAction : public AttackAction
+class HighKingMaulgarAssignDpsPriorityAction : public AttackAction
 {
 public:
-    HighKingMaulgarAssignDPSPriorityAction(
-        PlayerbotAI* botAI, std::string const name = "high king maulgar assign dps priority") : AttackAction(botAI, name) {};
+    HighKingMaulgarAssignDpsPriorityAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "high king maulgar assign dps priority") {}
     bool Execute(Event event) override;
 };
 
 class HighKingMaulgarRunAwayFromWhirlwindAction : public MovementAction
 {
 public:
-    HighKingMaulgarRunAwayFromWhirlwindAction(
-        PlayerbotAI* botAI, std::string const name = "high king maulgar run away from whirlwind") : MovementAction(botAI, name) {};
+    HighKingMaulgarRunAwayFromWhirlwindAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "high king maulgar run away from whirlwind") {}
     bool Execute(Event event) override;
 };
 
-class HighKingMaulgarMoveAwayFromBlastNovaDangerAction : public MovementAction
+class HighKingMaulgarBackAwayFromKroshAction : public MovementAction
 {
 public:
-    HighKingMaulgarMoveAwayFromBlastNovaDangerAction(
-        PlayerbotAI* botAI, std::string const name = "high king maulgar move away from blast nova danger") : MovementAction(botAI, name) {};
+    HighKingMaulgarBackAwayFromKroshAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "high king maulgar back away from krosh") {}
     bool Execute(Event event) override;
 };
 
-class HighKingMaulgarBanishFelStalkerAction : public AttackAction
+class HighKingMaulgarBanishFelStalkerAction : public Action
 {
 public:
-    HighKingMaulgarBanishFelStalkerAction(
-        PlayerbotAI* botAI, std::string const name = "high king maulgar banish fel stalker") : AttackAction(botAI, name) {};
+    HighKingMaulgarBanishFelStalkerAction(PlayerbotAI* botAI)
+        : Action(botAI, "high king maulgar banish fel stalker") {}
     bool Execute(Event event) override;
 };
 
-class HighKingMaulgarMisdirectOgresToTanksAction : public AttackAction
+class HighKingMaulgarMisdirectOgresToTanksAction : public Action
 {
 public:
-    HighKingMaulgarMisdirectOgresToTanksAction(
-        PlayerbotAI* botAI, std::string const name = "high king maulgar misdirect ogres to tanks") : AttackAction(botAI, name) {};
+    HighKingMaulgarMisdirectOgresToTanksAction(PlayerbotAI* botAI)
+        : Action(botAI, "high king maulgar misdirect ogres to tanks") {}
     bool Execute(Event event) override;
 };
+
+// Gruul the Dragonkiller
 
 class GruulTheDragonkillerTanksPositionBossAction : public AttackAction
 {
 public:
-    GruulTheDragonkillerTanksPositionBossAction(
-        PlayerbotAI* botAI, std::string const name = "gruul the dragonkiller tanks position boss") : AttackAction(botAI, name) {};
+    GruulTheDragonkillerTanksPositionBossAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "gruul the dragonkiller tanks position boss") {}
     bool Execute(Event event) override;
 };
 
 class GruulTheDragonkillerSpreadRangedAction : public MovementAction
 {
 public:
-    GruulTheDragonkillerSpreadRangedAction(
-        PlayerbotAI* botAI, std::string const name = "gruul the dragonkiller spread ranged") : MovementAction(botAI, name) {};
+    GruulTheDragonkillerSpreadRangedAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "gruul the dragonkiller spread ranged") {}
     bool Execute(Event event) override;
+    bool ResetInitialPosition()
+    {
+        if (!_hasReachedInitialPosition && !_hasInitialPosition)
+            return false;
+
+        _hasReachedInitialPosition = false;
+        _hasInitialPosition = false;
+        return true;
+    }
 
 private:
     Position _initialPosition;
+    bool _hasInitialPosition = false;
     bool _hasReachedInitialPosition = false;
+};
+
+class GruulTheDragonkillerGetOutOfCaveInAction : public MovementAction
+{
+public:
+    GruulTheDragonkillerGetOutOfCaveInAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "gruul the dragonkiller get out of cave in") {}
+    bool Execute(Event event) override;
 };
 
 class GruulTheDragonkillerShatterSpreadAction : public MovementAction
 {
 public:
-    GruulTheDragonkillerShatterSpreadAction(
-        PlayerbotAI* botAI, std::string const name = "gruul the dragonkiller shatter spread") : MovementAction(botAI, name) {};
+    GruulTheDragonkillerShatterSpreadAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "gruul the dragonkiller shatter spread") {}
     bool Execute(Event event) override;
 };
 

--- a/src/Ai/Raid/Gruul/GruulHelpers.cpp
+++ b/src/Ai/Raid/Gruul/GruulHelpers.cpp
@@ -6,102 +6,233 @@
 
 #include "GruulHelpers.h"
 #include "AiFactory.h"
-#include "GroupReference.h"
+#include "ObjectAccessor.h"
 #include "Playerbots.h"
-#include "Unit.h"
+#include <algorithm>
+#include <limits>
+#include <list>
 
-namespace GruulsLairHelpers
+namespace GruulHelpers
 {
 
-const Position MAULGAR_TANK_POSITION  = {  90.686f, 167.047f, -13.234f };
-const Position OLM_TANK_POSITION      = { 101.050f, 219.359f,  -9.503f };
-const Position BLINDEYE_TANK_POSITION = {  99.681f, 213.989f, -10.345f };
-const Position KROSH_TANK_POSITION    = { 116.880f, 166.208f, -14.231f };
-const Position MAULGAR_ROOM_CENTER    = {  88.754f, 150.759f, -11.569f };
-const Position GRUUL_TANK_POSITION    = { 241.238f, 365.025f,  -4.220f };
+// High King Maulgar
 
-Player* GetKroshMageTank(Player* bot)
+bool IsMaulgarTank(Player* bot)
+{
+    // Note: IsMainTank() is not necessarily a tank (by either strategy or spec). It can be anybody
+    // with the main tank flag. Raid strategies will have problems with non-tank main tanks so this
+    // assumes you are using a real tank for your main tank.
+    return PlayerbotAI::IsTank(bot) && PlayerbotAI::IsMainTank(bot);
+}
+
+bool IsOlmTank(Player* bot)
+{
+    // Although passing true for indexLivingOnly means a death will swap the Blindeye tank to Olm,
+    // this is intended since Blindeye dies first and Olm is more important to control anyway.
+    return PlayerbotAI::IsAssistTankOfIndex(bot, 0, true);
+}
+
+bool IsBlindeyeTank(Player* bot)
+{
+    return PlayerbotAI::IsAssistTankOfIndex(bot, 1, true);
+}
+
+ObjectGuid FindKroshMageTankGuid(Player* bot)
 {
     Group* group = bot->GetGroup();
     if (!group)
-        return nullptr;
+        return ObjectGuid::Empty;
 
-    // (1) First loop: Return the first assistant Mage (real player or bot)
-    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
-    {
-        Player* member = ref->GetSource();
-        if (!member || !member->IsAlive() || member->getClass() != CLASS_MAGE)
-            continue;
-
-        if (group->IsAssistant(member->GetGUID()))
-            return member;
-
-    }
-
-    // (2) Fall back to bot Mage with highest HP
-    Player* highestHpMage = nullptr;
+    // If an assistant Mage (player or bot) is found, return immediately.
+    // Otherwise, return the bot Mage with the highest HP as fallback.
+    Player* highestHpBotMage = nullptr;
     uint32 highestHp = 0;
 
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
         Player* member = ref->GetSource();
-        if (!member || !member->IsAlive() || !GET_PLAYERBOT_AI(member) ||
+        if (!member || !member->IsAlive() || member->GetMapId() != GRUUL_MAP_ID ||
             member->getClass() != CLASS_MAGE)
         {
             continue;
         }
 
-        uint32 hp = member->GetMaxHealth();
-        if (!highestHpMage || hp > highestHp)
+        if (group->IsAssistant(member->GetGUID()))
+            return member->GetGUID();
+
+        if (!GET_PLAYERBOT_AI(member))
+            continue;
+
+        uint32 const hp = member->GetMaxHealth();
+        if (!highestHpBotMage || hp > highestHp)
         {
-            highestHpMage = member;
+            highestHpBotMage = member;
             highestHp = hp;
         }
     }
 
-    return highestHpMage;
+    return highestHpBotMage ? highestHpBotMage->GetGUID() : ObjectGuid::Empty;
 }
 
-Player* GetKigglerMoonkinTank(Player* bot)
+Player* GetKroshMageTank(PlayerbotAI* botAI)
+{
+    AiObjectContext* context = botAI->GetAiObjectContext();
+    ObjectGuid const guid = AI_VALUE(ObjectGuid, "high king maulgar krosh mage tank");
+
+    return guid.IsEmpty() ? nullptr : ObjectAccessor::FindPlayer(guid);
+}
+
+bool IsKroshMageTank(PlayerbotAI* botAI)
+{
+    Player* bot = botAI->GetBot();
+    return bot->getClass() == CLASS_MAGE && GetKroshMageTank(botAI) == bot;
+}
+
+ObjectGuid FindKigglerMoonkinTankGuid(Player* bot)
 {
     Group* group = bot->GetGroup();
     if (!group)
-        return nullptr;
+        return ObjectGuid::Empty;
 
-    uint8 tab = AiFactory::GetPlayerSpecTab(bot);
-
-    // (1) First loop: Return the first assistant Moonkin (real player or bot)
-    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
-    {
-        Player* member = ref->GetSource();
-        if (!member || !member->IsAlive() || member->getClass() != CLASS_DRUID)
-            continue;
-
-        if (group->IsAssistant(member->GetGUID()) && tab == DRUID_TAB_BALANCE)
-            return member;
-    }
-
-    // (2) Fall back to bot Moonkin with highest HP
-    Player* highestHpMoonkin = nullptr;
+    // If an assistant Balance Druid (player or bot) is found, return immediately.
+    // Otherwise, return the bot Balance Druid with the highest HP as fallback.
+    Player* highestHpBotMoonkin = nullptr;
     uint32 highestHp = 0;
+
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
         Player* member = ref->GetSource();
-        if (!member || !member->IsAlive() || member->getClass() != CLASS_DRUID ||
-            !GET_PLAYERBOT_AI(member) || tab != DRUID_TAB_BALANCE)
+        if (!member || !member->IsAlive() || member->GetMapId() != GRUUL_MAP_ID ||
+            member->getClass() != CLASS_DRUID ||
+            AiFactory::GetPlayerSpecTab(member) != DRUID_TAB_BALANCE)
         {
             continue;
         }
 
-        uint32 hp = member->GetMaxHealth();
-        if (!highestHpMoonkin || hp > highestHp)
+        if (group->IsAssistant(member->GetGUID()))
+            return member->GetGUID();
+
+        if (!GET_PLAYERBOT_AI(member))
+            continue;
+
+        uint32 const hp = member->GetMaxHealth();
+        if (!highestHpBotMoonkin || hp > highestHp)
         {
-            highestHpMoonkin = member;
+            highestHpBotMoonkin = member;
             highestHp = hp;
         }
     }
 
-    return highestHpMoonkin;
+    return highestHpBotMoonkin ? highestHpBotMoonkin->GetGUID() : ObjectGuid::Empty;
+}
+
+Player* GetKigglerMoonkinTank(PlayerbotAI* botAI)
+{
+    AiObjectContext* context = botAI->GetAiObjectContext();
+    ObjectGuid const guid = AI_VALUE(ObjectGuid, "high king maulgar kiggler moonkin tank");
+
+    return guid.IsEmpty() ? nullptr : ObjectAccessor::FindPlayer(guid);
+}
+
+bool IsKigglerMoonkinTank(PlayerbotAI* botAI)
+{
+    Player* bot = botAI->GetBot();
+    return bot->getClass() == CLASS_DRUID && GetKigglerMoonkinTank(botAI) == bot;
+}
+
+GuidVector FindNearbyWildFelStalkerGuids(Player* bot)
+{
+    if (bot->GetMapId() != GRUUL_MAP_ID)
+        return {};
+
+    std::list<Creature*> creatureList;
+    bot->GetCreatureListWithEntryInGrid(
+        creatureList, Id(GruulNpcs::NPC_WILD_FEL_STALKER), WILD_FEL_STALKER_SEARCH_RADIUS);
+
+    GuidVector guids;
+    guids.reserve(creatureList.size());
+    for (Creature* creature : creatureList)
+    {
+        if (creature && creature->IsAlive())
+            guids.push_back(creature->GetGUID());
+    }
+
+    std::sort(guids.begin(), guids.end(), [](ObjectGuid const& lhs, ObjectGuid const& rhs)
+    {
+        return lhs.GetCounter() < rhs.GetCounter();
+    });
+
+    return guids;
+}
+
+std::vector<Unit*> GetNearbyWildFelStalkers(PlayerbotAI* botAI)
+{
+    AiObjectContext* context = botAI->GetAiObjectContext();
+    auto const& guids = AI_VALUE_REF(GuidVector, "high king maulgar wild fel stalkers");
+
+    std::vector<Unit*> felStalkers;
+    felStalkers.reserve(guids.size());
+    for (ObjectGuid const& guid : guids)
+    {
+        Unit* felStalker = botAI->GetUnit(guid);
+        if (felStalker && felStalker->IsAlive())
+            felStalkers.push_back(felStalker);
+    }
+
+    return felStalkers;
+}
+
+// Gruul the Dragonkiller
+
+namespace
+{
+std::vector<Position> const& GetCaveInPositions(PlayerbotAI* botAI)
+{
+    return botAI->GetAiObjectContext()
+        ->GetValue<std::vector<Position>>("gruul the dragonkiller cave in")->RefGet();
+}
+}
+
+bool GetNearestCaveInPosition(PlayerbotAI* botAI, Position& pool)
+{
+    Player* bot = botAI->GetBot();
+    bool found = false;
+    float nearestDistance = std::numeric_limits<float>::max();
+    for (Position const& position : GetCaveInPositions(botAI))
+    {
+        float const distance = bot->GetExactDist2d(position);
+        if (distance < nearestDistance)
+        {
+            nearestDistance = distance;
+            pool = position;
+            found = true;
+        }
+    }
+
+    return found;
+}
+
+bool IsNearCaveIn(PlayerbotAI* botAI, float radius)
+{
+    Player* bot = botAI->GetBot();
+    for (Position const& position : GetCaveInPositions(botAI))
+    {
+        if (bot->GetExactDist2d(position) < radius)
+            return true;
+    }
+
+    return false;
+}
+
+bool IsInCaveIn(PlayerbotAI* botAI)
+{
+    return IsNearCaveIn(botAI, CAVE_IN_RADIUS);
+}
+
+bool HasGroundSlam(Player* bot)
+{
+    return bot->HasAura(Id(GruulSpells::SPELL_GROUND_SLAM_1)) ||
+        bot->HasAura(Id(GruulSpells::SPELL_GROUND_SLAM_2));
 }
 
 }

--- a/src/Ai/Raid/Gruul/GruulHelpers.h
+++ b/src/Ai/Raid/Gruul/GruulHelpers.h
@@ -7,14 +7,28 @@
 #ifndef PLAYERBOTS_GRUULHELPERS_H
 #define PLAYERBOTS_GRUULHELPERS_H
 
-#include "PlayerbotAI.h"
+#include "Common.h"
+#include "ObjectGuid.h"
+#include "Position.h"
+#include <type_traits>
+#include <vector>
 
-namespace GruulsLairHelpers
+class Player;
+class PlayerbotAI;
+class Unit;
+
+namespace GruulHelpers
 {
 
-enum class GruulsLairSpells : uint32
+template <typename T, std::enable_if_t<std::is_enum_v<T>, int> = 0>
+constexpr uint32 Id(T value)
 {
-    // High King Maulgar
+    return static_cast<uint32>(value);
+}
+
+enum class GruulSpells : uint32
+{
+    // High King Maulgar <Lord of the Ogres>
     SPELL_WHIRLWIND     = 33238,
 
     // Krosh Firehand
@@ -23,27 +37,86 @@ enum class GruulsLairSpells : uint32
     // Hunter
     SPELL_MISDIRECTION  = 35079,
 
+    // Mage
+    SPELL_SPELLSTEAL    = 30449,
+
     // Gruul the Dragonkiller
     SPELL_GROUND_SLAM_1 = 33525,
     SPELL_GROUND_SLAM_2 = 39187,
+    SPELL_CAVE_IN       = 36240,
 };
 
-enum class GruulsLairNpcs : uint32
+enum class GruulNpcs : uint32
 {
     NPC_WILD_FEL_STALKER = 18847,
 };
 
-constexpr uint32 GRUULS_LAIR_MAP_ID = 565;
+inline constexpr uint32 GRUUL_MAP_ID = 565;
 
-Player* GetKroshMageTank(Player* bot);
-Player* GetKigglerMoonkinTank(Player* bot);
+// High King Maulgar
 
-extern const Position MAULGAR_TANK_POSITION;
-extern const Position OLM_TANK_POSITION;
-extern const Position BLINDEYE_TANK_POSITION;
-extern const Position KROSH_TANK_POSITION;
-extern const Position MAULGAR_ROOM_CENTER;
-extern const Position GRUUL_TANK_POSITION;
+// Ogre combat reaches:
+// (1) Maulgar = 3.5y, (2) Olm = 2.2y, (3) Blindeye = 3.525y, (4) Krosh = 2y, (5) Kiggler = 3.3y
+
+// For the "high king maulgar krosh mage tank" and "high king maulgar kiggler moonkin tank" values.
+inline constexpr uint32 CASTER_TANK_CACHE_INTERVAL_MS = 1000;
+// Hold cooldowns until Blindeye is at this percent health. Also the gate for on-pull Misdirects.
+inline constexpr float BLINDEYE_ENGAGED_HEALTH_PCT = 75.0f;
+// Radius is 30y with 2y of MoveAway padding. Stays inside the mod's "enemy out of spell" threshold
+// (spellDistance + CONTACT_DISTANCE + both reaches, ~34y exact against Kiggler), allowing the
+// boomie to attack Kiggler, even without reach-increasing talents, without being in range of
+// Kiggler's Arcane Explosion.
+inline constexpr float KIGGLER_ARCANE_EXPLOSION_SAFE_DISTANCE = 32.0f;
+// Radius is 15y with 2y of MoveAway padding.
+inline constexpr float KROSH_BLAST_WAVE_SAFE_DISTANCE = 17.0f;
+// Radius is 8y, padded to 8 * sqrt(2) rather than the 2y used elsewhere. The tl;dr is MoveAway()'s
+// fallback candidates (when running straight back is blocked) can end up moving the bot less than
+// the prescribed distance. Maulgar is tanked against a wall and fears and charges and can end up
+// turned away from the wall as a result, with melee dps between him and the wall and failing the
+// straight-away movement.
+inline constexpr float MAULGAR_WHIRLWIND_SAFE_DISTANCE = 12.0f;
+// Distance for the multiplier, which as usual, is a little more than the escape distance.
+inline constexpr float MAULGAR_WHIRLWIND_HOLD_DISTANCE = 15.0f;
+// For the "high king maulgar wild fel stalkers" value.
+inline constexpr uint32 WILD_FEL_STALKER_CACHE_INTERVAL_MS = 1000;
+inline constexpr float WILD_FEL_STALKER_SEARCH_RADIUS = 50.0f;
+
+inline Position const MAULGAR_TANK_POSITION  = {  90.686f, 167.047f, -13.234f };
+inline Position const OLM_TANK_POSITION      = { 101.050f, 219.359f,  -9.503f };
+inline Position const BLINDEYE_TANK_POSITION = {  99.681f, 213.989f, -10.345f };
+inline Position const KROSH_TANK_POSITION    = { 116.880f, 166.208f, -14.231f };
+inline Position const GRUUL_TANK_POSITION    = { 241.238f, 365.025f,  -4.220f };
+
+bool IsMaulgarTank(Player* bot);
+bool IsOlmTank(Player* bot);
+bool IsBlindeyeTank(Player* bot);
+ObjectGuid FindKroshMageTankGuid(Player* bot);
+Player* GetKroshMageTank(PlayerbotAI* botAI);
+bool IsKroshMageTank(PlayerbotAI* botAI);
+ObjectGuid FindKigglerMoonkinTankGuid(Player* bot);
+Player* GetKigglerMoonkinTank(PlayerbotAI* botAI);
+bool IsKigglerMoonkinTank(PlayerbotAI* botAI);
+GuidVector FindNearbyWildFelStalkerGuids(Player* bot);
+std::vector<Unit*> GetNearbyWildFelStalkers(PlayerbotAI* botAI);
+
+// Gruul the Dragonkiller
+
+// For the "gruul the dragonkiller cave in" value.
+inline constexpr uint32 CAVE_IN_CACHE_INTERVAL_MS = 100;
+// Radius is 8y, plus the 1.5y CombatReach the membership check adds for the player, rounded up.
+// The pool lasts 15s and is cast as often as every 3.5s, so 5 can be on the ground at once.
+inline constexpr float CAVE_IN_RADIUS = 10.0f;
+// Distance for the multiplier. As usual, wider than the avoidance to prevent running back in.
+inline constexpr float CAVE_IN_CONTROL_RADIUS = CAVE_IN_RADIUS + 5.0f;
+inline constexpr float CAVE_IN_SEARCH_RADIUS = CAVE_IN_CONTROL_RADIUS + 2.0f;
+// Radius is 20y with 2y of MoveAway padding. Sort of. The details are not really important; I note
+// only that damage has a linear relationship with distance.
+inline constexpr float GRUUL_SHATTER_SAFE_DISTANCE = 22.0f;
+
+bool GetNearestCaveInPosition(PlayerbotAI* botAI, Position& pool);
+bool IsNearCaveIn(PlayerbotAI* botAI, float radius);
+bool IsInCaveIn(PlayerbotAI* botAI);
+bool HasGroundSlam(Player* bot);
 
 }
 

--- a/src/Ai/Raid/Gruul/GruulMultipliers.cpp
+++ b/src/Ai/Raid/Gruul/GruulMultipliers.cpp
@@ -6,157 +6,251 @@
 
 #include "GruulMultipliers.h"
 #include "ChooseTargetActions.h"
-#include "GenericSpellActions.h"
+#include "EncounterHelpers.h"
 #include "GruulActions.h"
 #include "GruulHelpers.h"
 #include "HunterActions.h"
+#include "MageActions.h"
 #include "Playerbots.h"
 #include "ReachTargetActions.h"
-#include "ShamanActions.h"
 
-using namespace GruulsLairHelpers;
+using namespace GruulHelpers;
+using namespace EncounterHelpers;
 
-float HighKingMaulgarDelayBloodlustAndHeroismMultiplier::GetValue(Action* action)
+// General
+
+float GruulsLairDelayDpsCooldownsMultiplier::GetValueInEncounter(Action* action)
 {
-    if (bot->getClass() != CLASS_SHAMAN)
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
         return 1.0f;
+
+    if (!IsDpsCooldownAction(bot, action))
+        return 1.0f;
+
+    Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
+    if (gruul && gruul->GetHealthPct() > BOSS_ENGAGED_HEALTH_PCT)
+        return 0.0f;
 
     Unit* blindeye = AI_VALUE2(Unit*, "find target", "blindeye the seer");
-    if (!blindeye || blindeye->GetHealthPct() < 75.0f)
-        return 1.0f;
-
-    if (dynamic_cast<CastHeroismAction*>(action) ||
-        dynamic_cast<CastBloodlustAction*>(action))
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
+    return blindeye && blindeye->GetHealthPct() > BLINDEYE_ENGAGED_HEALTH_PCT ? 0.0f : 1.0f;
 }
 
-float HighKingMaulgarControlTankActionsMultiplier::GetValue(Action* action)
+// High King Maulgar <Lord of the Ogres>
+
+float HighKingMaulgarControlTankActionsMultiplier::GetValueInEncounter(Action* action)
 {
-    if (!botAI->IsTank(bot))
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
         return 1.0f;
 
-    if (!AI_VALUE2(Unit*, "find target", "high king maulgar"))
+    if (!PlayerbotAI::IsTank(bot))
         return 1.0f;
 
-    if (dynamic_cast<CombatFormationMoveAction*>(action) ||
-        (bot->GetVictim() != nullptr && dynamic_cast<TankAssistAction*>(action)))
+    if (!dynamic_cast<TankAssistAction*>(action) &&
+        !dynamic_cast<CombatFormationMoveAction*>(action))
     {
-        return 0.0f;
+        return 1.0f;
     }
 
-    return 1.0f;
+    return AI_VALUE2(Unit*, "find target", "high king maulgar") ? 0.0f : 1.0f;
 }
 
-float HighKingMaulgarAvoidWhirlwindMultiplier::GetValue(Action* action)
+float HighKingMaulgarRestrictTauntingMultiplier::GetValueInEncounter(Action* action)
 {
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
+        return 1.0f;
+
+    if (!PlayerbotAI::IsTank(bot))
+        return 1.0f;
+
+    bool const isAoeThreat = IsAoeThreatAction(bot, action);
+    if (!isAoeThreat && !IsTauntAction(bot, action))
+        return 1.0f;
+
+    // The main tank stays on Maulgar the whole time so it can do whatever.
+    if (PlayerbotAI::IsMainTank(bot))
+        return 1.0f;
+
+    // Blindeye and Olm are tanked next to each other by separate tanks; until Blindeye is dead,
+    // don't use AoE threat abilities.
+    if (isAoeThreat && AI_VALUE2(Unit*, "find target", "blindeye the seer"))
+        return 0.0f;
+
+    // Kiggler is the only ogre for which taunting is a problem because he is the only one that is
+    // both (1) tanked by a non-traditional-tank and (2) directed to be attacked by traditional
+    // tanks (the Blindeye and Olm tanks after both are down).
+    Unit* kiggler = AI_VALUE2(Unit*, "find target", "kiggler the crazed");
+    if (!kiggler)
+        return 1.0f;
+
+    if (!GetKigglerMoonkinTank(botAI))
+        return 1.0f;
+
+    return AI_VALUE(Unit*, "current target") == kiggler ? 0.0f : 1.0f;
+}
+
+float HighKingMaulgarDisableDpsAssistMultiplier::GetValueInEncounter(Action* action)
+{
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
+        return 1.0f;
+
+    if (PlayerbotAI::IsTank(bot))
+        return 1.0f;
+
+    if (!dynamic_cast<DpsAssistAction*>(action))
+        return 1.0f;
+
+    return AI_VALUE2(Unit*, "find target", "high king maulgar") ? 0.0f : 1.0f;
+}
+
+float HighKingMaulgarAvoidWhirlwindMultiplier::GetValueInEncounter(Action* action)
+{
+    if (!dynamic_cast<MovementAction*>(action) &&
+        !dynamic_cast<CastReachTargetSpellAction*>(action))
+    {
+        return 1.0f;
+    }
+
+    if (dynamic_cast<AttackAction*>(action))
+        return 1.0f;
+
+    if (dynamic_cast<HighKingMaulgarRunAwayFromWhirlwindAction*>(action))
+        return 1.0f;
+
     Unit* maulgar = AI_VALUE2(Unit*, "find target", "high king maulgar");
-    if (!maulgar ||
-        !maulgar->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_WHIRLWIND)))
-    {
-        return 1.0f;
-    }
-
-    if (AI_VALUE(Unit*, "current target") != maulgar)
+    if (!maulgar || !maulgar->HasAura(Id(GruulSpells::SPELL_WHIRLWIND)))
         return 1.0f;
 
-    if (botAI->IsMainTank(bot))
+    if (PlayerbotAI::IsMainTank(bot))
         return 1.0f;
 
-    if (dynamic_cast<CastReachTargetSpellAction*>(action) ||
-        (dynamic_cast<MovementAction*>(action) &&
-         !dynamic_cast<HighKingMaulgarRunAwayFromWhirlwindAction*>(action)))
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
+    return bot->GetExactDist2d(maulgar) < MAULGAR_WHIRLWIND_HOLD_DISTANCE ? 0.0f : 1.0f;
 }
 
-// Arcane Shot will remove Spell Shield, which the mage tank needs to survive
-float HighKingMaulgarDisableArcaneShotOnKroshMultiplier::GetValue(Action* action)
+float HighKingMaulgarControlHunterActionsMultiplier::GetValueInEncounter(Action* action)
 {
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
+        return 1.0f;
+
     if (bot->getClass() != CLASS_HUNTER)
         return 1.0f;
 
-    Unit* krosh = AI_VALUE2(Unit*, "find target", "krosh firehand");
-    if (!krosh || AI_VALUE(Unit*, "current target") != krosh)
+    bool const isMainTankMisdirect = dynamic_cast<CastMisdirectionOnMainTankAction*>(action);
+    if (!isMainTankMisdirect && !dynamic_cast<CastArcaneShotAction*>(action))
         return 1.0f;
 
-    if (dynamic_cast<CastArcaneShotAction*>(action))
+    // Krosh/Kiggler will be the last to die before Maulgar.
+    // When only Maulgar is left, the standard Misdirection strategy is fine.
+    Unit* krosh = AI_VALUE2(Unit*, "find target", "krosh firehand");
+    if (isMainTankMisdirect &&
+        (krosh || AI_VALUE2(Unit*, "find target", "kiggler the crazed")))
+    {
         return 0.0f;
+    }
 
-    return 1.0f;
+    // Arcane Shot removes Spell Shield, which the mage tank needs to survive.
+    return krosh && action->GetTarget() == krosh ? 0.0f : 1.0f;
 }
 
-float HighKingMaulgarDisableMageTankAoeMultiplier::GetValue(Action* action)
+float HighKingMaulgarControlMageTankActionsMultiplier::GetValueInEncounter(Action* action)
 {
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
+        return 1.0f;
+
     if (bot->getClass() != CLASS_MAGE)
         return 1.0f;
+
+    if (action->getThreatType() != Action::ActionThreatType::Aoe &&
+        !dynamic_cast<CastIceBlockAction*>(action) &&
+        !dynamic_cast<CastInvisibilityAction*>(action))
+    {
+        return 1.0f;
+    }
 
     if (!AI_VALUE2(Unit*, "find target", "krosh firehand"))
         return 1.0f;
 
-    auto castSpellAction = dynamic_cast<CastSpellAction*>(action);
-    if (castSpellAction &&
-        castSpellAction->getThreatType() == Action::ActionThreatType::Aoe)
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
+    return GetKroshMageTank(botAI) == bot ? 0.0f : 1.0f;
 }
 
-float GruulTheDragonkillerDelayBloodlustAndHeroismMultiplier::GetValue(Action* action)
+// Gruul the Dragonkiller
+
+float GruulTheDragonkillerControlTankMovementMultiplier::GetValueInEncounter(Action* action)
 {
-    if (bot->getClass() != CLASS_SHAMAN)
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
+        return 1.0f;
+
+    if (!PlayerbotAI::IsTank(bot))
+        return 1.0f;
+
+    if (!dynamic_cast<CombatFormationMoveAction*>(action) &&
+        !dynamic_cast<AvoidAoeAction*>(action))
+    {
+        return 1.0f;
+    }
+
+    return AI_VALUE2(Unit*, "find target", "gruul the dragonkiller") ? 0.0f : 1.0f;
+}
+
+float GruulTheDragonkillerStaySpreadForShatterMultiplier::GetValueInEncounter(Action* action)
+{
+    if (!HasGroundSlam(bot))
+        return 1.0f;
+
+    if (!dynamic_cast<MovementAction*>(action) &&
+        !dynamic_cast<CastReachTargetSpellAction*>(action))
+    {
+        return 1.0f;
+    }
+
+    return dynamic_cast<GruulTheDragonkillerShatterSpreadAction*>(action) ||
+        dynamic_cast<GruulTheDragonkillerGetOutOfCaveInAction*>(action) ? 1.0f : 0.0f;
+}
+
+// When near a cave in, ignore the ranged spread, as well as standard movement actions like reaching
+// the target, with some exceptions for tanks (and full exception for the active tank on Gruul).
+float GruulTheDragonkillerControlAvoidanceMultiplier::GetValueInEncounter(Action* action)
+{
+    if (dynamic_cast<AttackAction*>(action))
+        return 1.0f;
+
+    bool const isReachTargetSpell = dynamic_cast<CastReachTargetSpellAction*>(action);
+
+    if (PlayerbotAI::IsTank(bot) &&
+        (isReachTargetSpell || dynamic_cast<ReachTargetAction*>(action)))
+    {
+        return 1.0f;
+    }
+
+    if (!isReachTargetSpell && !dynamic_cast<MovementAction*>(action))
+        return 1.0f;
+
+    if (dynamic_cast<GruulTheDragonkillerGetOutOfCaveInAction*>(action))
+        return 1.0f;
+
+    // The shatter spread multiplier takes over during Ground Slam (and allows the Cave In escape).
+    if (HasGroundSlam(bot))
         return 1.0f;
 
     Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
-    if (!gruul || gruul->GetHealthPct() < 95.0f)
+    if (!gruul)
         return 1.0f;
 
-    if (dynamic_cast<CastHeroismAction*>(action) ||
-        dynamic_cast<CastBloodlustAction*>(action))
-    {
-        return 0.0f;
-    }
+    if (gruul->GetVictim() == bot)
+        return 1.0f;
 
-    return 1.0f;
+    return IsNearCaveIn(botAI, CAVE_IN_CONTROL_RADIUS) ? 0.0f : 1.0f;
 }
 
-float GruulTheDragonkillerControlTankMovementMultiplier::GetValue(Action* action)
+// MoveTo does not check speed, and thus even with a snare of -100% or more, it starts a spline
+// and MoveDelay calculates distance / speed for IsWaitingForLastMove, which is infinite in that
+// case and clamps to MaxWaitForMove (5s), blocking all movements for that duration.
+float GruulTheDragonkillerHoldWhileSnaredMultiplier::GetValueInEncounter(Action* action)
 {
-    Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
-    if (!gruul || gruul->GetVictim() != bot)
+    if (bot->GetSpeed(MOVE_RUN) > 0.0f)
         return 1.0f;
 
-    if (dynamic_cast<CombatFormationMoveAction*>(action) ||
-        dynamic_cast<AvoidAoeAction*>(action))
-    {
-        return 0.0f;
-    }
-
-    return 1.0f;
-}
-
-float GruulTheDragonkillerStaySpreadForShatterMultiplier::GetValue(Action* action)
-{
-    if (!bot->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_GROUND_SLAM_1)) &&
-        !bot->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_GROUND_SLAM_2)))
-    {
+    if (!dynamic_cast<MovementAction*>(action))
         return 1.0f;
-    }
 
-    if (dynamic_cast<CastReachTargetSpellAction*>(action) ||
-        (dynamic_cast<MovementAction*>(action) &&
-         !dynamic_cast<GruulTheDragonkillerShatterSpreadAction*>(action)))
-    {
-         return 0.0f;
-    }
-
-    return 1.0f;
+    return AI_VALUE2(Unit*, "find target", "gruul the dragonkiller") ? 0.0f : 1.0f;
 }

--- a/src/Ai/Raid/Gruul/GruulMultipliers.h
+++ b/src/Ai/Raid/Gruul/GruulMultipliers.h
@@ -7,70 +7,141 @@
 #ifndef PLAYERBOTS_GRUULMULTIPLIERS_H
 #define PLAYERBOTS_GRUULMULTIPLIERS_H
 
+#include "EncounterHelpers.h"
+#include "GruulHelpers.h"
 #include "Multiplier.h"
+#include <string>
 
-class HighKingMaulgarDelayBloodlustAndHeroismMultiplier : public Multiplier
+// General
+
+class GruulsLairEncounterMultiplier : public Multiplier
 {
 public:
-    HighKingMaulgarDelayBloodlustAndHeroismMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "high king maulgar delay bloodlust and heroism multiplier") {}
-    float GetValue(Action* action) override;
+    GruulsLairEncounterMultiplier(
+        PlayerbotAI* botAI, std::string const name) : Multiplier(botAI, name) {}
+
+    float GetValue(Action* action) final
+    {
+        return EncounterHelpers::IsEncounterInProgress(bot, GruulHelpers::GRUUL_MAP_ID)
+            ? GetValueInEncounter(action) : 1.0f;
+    }
+
+protected:
+    virtual float GetValueInEncounter(Action* action) = 0;
 };
 
-class HighKingMaulgarControlTankActionsMultiplier : public Multiplier
+class GruulsLairDelayDpsCooldownsMultiplier : public GruulsLairEncounterMultiplier
 {
 public:
-    HighKingMaulgarControlTankActionsMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "high king maulgar control tank actions multiplier") {}
-    float GetValue(Action* action) override;
+    GruulsLairDelayDpsCooldownsMultiplier(PlayerbotAI* botAI)
+        : GruulsLairEncounterMultiplier(botAI, "gruul's lair delay dps cooldowns") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
 };
 
-class HighKingMaulgarAvoidWhirlwindMultiplier : public Multiplier
+// High King Maulgar <Lord of the Ogres>
+
+class HighKingMaulgarControlTankActionsMultiplier : public GruulsLairEncounterMultiplier
 {
 public:
-    HighKingMaulgarAvoidWhirlwindMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "high king maulgar avoid whirlwind multiplier") {}
-    float GetValue(Action* action) override;
+    HighKingMaulgarControlTankActionsMultiplier(PlayerbotAI* botAI)
+        : GruulsLairEncounterMultiplier(botAI, "high king maulgar control tank actions") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
 };
 
-class HighKingMaulgarDisableArcaneShotOnKroshMultiplier : public Multiplier
+class HighKingMaulgarRestrictTauntingMultiplier : public GruulsLairEncounterMultiplier
 {
 public:
-    HighKingMaulgarDisableArcaneShotOnKroshMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "high king maulgar disable arcane shot on krosh multiplier") {}
-    float GetValue(Action* action) override;
+    HighKingMaulgarRestrictTauntingMultiplier(PlayerbotAI* botAI)
+        : GruulsLairEncounterMultiplier(botAI, "high king maulgar restrict taunting") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
 };
 
-class HighKingMaulgarDisableMageTankAoeMultiplier : public Multiplier
+class HighKingMaulgarDisableDpsAssistMultiplier : public GruulsLairEncounterMultiplier
 {
 public:
-    HighKingMaulgarDisableMageTankAoeMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "high king maulgar disable mage tank aoe multiplier") {}
-    float GetValue(Action* action) override;
+    HighKingMaulgarDisableDpsAssistMultiplier(PlayerbotAI* botAI)
+        : GruulsLairEncounterMultiplier(botAI, "high king maulgar disable dps assist") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
 };
 
-class GruulTheDragonkillerDelayBloodlustAndHeroismMultiplier : public Multiplier
+class HighKingMaulgarAvoidWhirlwindMultiplier : public GruulsLairEncounterMultiplier
 {
 public:
-    GruulTheDragonkillerDelayBloodlustAndHeroismMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "gruul the dragonkiller delay bloodlust and heroism multiplier") {}
-    float GetValue(Action* action) override;
+    HighKingMaulgarAvoidWhirlwindMultiplier(PlayerbotAI* botAI)
+        : GruulsLairEncounterMultiplier(botAI, "high king maulgar avoid whirlwind") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
 };
 
-class GruulTheDragonkillerControlTankMovementMultiplier : public Multiplier
+class HighKingMaulgarControlHunterActionsMultiplier : public GruulsLairEncounterMultiplier
 {
 public:
-    GruulTheDragonkillerControlTankMovementMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "gruul the dragonkiller control tank movement multiplier") {}
-    float GetValue(Action* action) override;
+    HighKingMaulgarControlHunterActionsMultiplier(PlayerbotAI* botAI)
+        : GruulsLairEncounterMultiplier(botAI, "high king maulgar control hunter actions") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
 };
 
-class GruulTheDragonkillerStaySpreadForShatterMultiplier : public Multiplier
+class HighKingMaulgarControlMageTankActionsMultiplier : public GruulsLairEncounterMultiplier
 {
 public:
-    GruulTheDragonkillerStaySpreadForShatterMultiplier(
-        PlayerbotAI* botAI) : Multiplier(botAI, "gruul the dragonkiller stay spread for shatter multiplier") {}
-    float GetValue(Action* action) override;
+    HighKingMaulgarControlMageTankActionsMultiplier(PlayerbotAI* botAI)
+        : GruulsLairEncounterMultiplier(botAI, "high king maulgar control mage tank actions") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
+};
+
+// Gruul the Dragonkiller
+
+class GruulTheDragonkillerControlTankMovementMultiplier : public GruulsLairEncounterMultiplier
+{
+public:
+    GruulTheDragonkillerControlTankMovementMultiplier(PlayerbotAI* botAI)
+        : GruulsLairEncounterMultiplier(botAI, "gruul the dragonkiller control tank movement") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
+};
+
+class GruulTheDragonkillerStaySpreadForShatterMultiplier : public GruulsLairEncounterMultiplier
+{
+public:
+    GruulTheDragonkillerStaySpreadForShatterMultiplier(PlayerbotAI* botAI)
+        : GruulsLairEncounterMultiplier(botAI, "gruul the dragonkiller stay spread for shatter") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
+};
+
+class GruulTheDragonkillerControlAvoidanceMultiplier : public GruulsLairEncounterMultiplier
+{
+public:
+    GruulTheDragonkillerControlAvoidanceMultiplier(PlayerbotAI* botAI)
+        : GruulsLairEncounterMultiplier(botAI, "gruul the dragonkiller control avoidance") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
+};
+
+class GruulTheDragonkillerHoldWhileSnaredMultiplier : public GruulsLairEncounterMultiplier
+{
+public:
+    GruulTheDragonkillerHoldWhileSnaredMultiplier(PlayerbotAI* botAI)
+        : GruulsLairEncounterMultiplier(botAI, "gruul the dragonkiller hold while snared") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
 };
 
 #endif

--- a/src/Ai/Raid/Gruul/GruulStrategy.cpp
+++ b/src/Ai/Raid/Gruul/GruulStrategy.cpp
@@ -9,43 +9,44 @@
 
 void RaidGruulsLairStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
+    // General
+    triggers.push_back(new TriggerNode("gruul's lair no encounter in progress", {
+        NextAction("gruul's lair reset encounter states", ACTION_EMERGENCY + 10) }));
+
     // High King Maulgar
-    triggers.push_back(new TriggerNode("high king maulgar boss engaged by main tank", {
-        NextAction("high king maulgar main tank attack maulgar", ACTION_RAID + 1) }));
+    triggers.push_back(new TriggerNode("high king maulgar three ogres need melee tanks", {
+        NextAction("high king maulgar melee tanks position bosses", ACTION_RAID + 1) }));
 
-    triggers.push_back(new TriggerNode("high king maulgar olm engaged by first assist tank", {
-        NextAction("high king maulgar first assist tank attack olm", ACTION_RAID + 1) }));
-
-    triggers.push_back(new TriggerNode("high king maulgar blindeye engaged by second assist tank", {
-        NextAction("high king maulgar second assist tank attack blindeye", ACTION_RAID + 1) }));
-
-    triggers.push_back(new TriggerNode("high king maulgar krosh engaged by mage tank", {
+    triggers.push_back(new TriggerNode("high king maulgar krosh needs mage tank", {
         NextAction("high king maulgar mage tank attack krosh", ACTION_RAID + 1) }));
 
-    triggers.push_back(new TriggerNode("high king maulgar kiggler engaged by moonkin tank", {
+    triggers.push_back(new TriggerNode("high king maulgar kiggler needs moonkin tank", {
         NextAction("high king maulgar moonkin tank attack kiggler", ACTION_RAID + 1) }));
 
     triggers.push_back(new TriggerNode("high king maulgar determining kill order", {
-        NextAction("high king maulgar assign dps priority", ACTION_RAID + 1) }));
+        NextAction("high king maulgar assign dps priority", ACTION_RAID) }));
 
-    triggers.push_back(new TriggerNode("high king maulgar boss channeling whirlwind", {
-        NextAction("high king maulgar run away from whirlwind", ACTION_EMERGENCY + 7) }));
+    triggers.push_back(new TriggerNode("high king maulgar channeling whirlwind", {
+        NextAction("high king maulgar run away from whirlwind", ACTION_EMERGENCY + 6) }));
 
-    triggers.push_back(new TriggerNode("high king maulgar krosh casts blast wave", {
-        NextAction("high king maulgar move away from blast nova danger", ACTION_EMERGENCY + 6) }));
+    triggers.push_back(new TriggerNode("high king maulgar should stand back from krosh", {
+        NextAction("high king maulgar back away from krosh", ACTION_RAID + 3) }));
 
     triggers.push_back(new TriggerNode("high king maulgar wild fel stalker spawned", {
-        NextAction("high king maulgar banish fel stalker", ACTION_RAID + 2) }));
+        NextAction("high king maulgar banish fel stalker", ACTION_RAID + 1) }));
 
     triggers.push_back(new TriggerNode("high king maulgar pulling ogre council", {
-        NextAction("high king maulgar misdirect ogres to tanks", ACTION_RAID + 2) }));
+        NextAction("high king maulgar misdirect ogres to tanks", ACTION_RAID + 1) }));
 
     // Gruul the Dragonkiller
-    triggers.push_back(new TriggerNode("gruul the dragonkiller boss engaged by tanks", {
-        NextAction("gruul the dragonkiller tanks position boss", ACTION_RAID + 1) }));
+    triggers.push_back(new TriggerNode("gruul the dragonkiller should be tanked", {
+        NextAction("gruul the dragonkiller tanks position boss", ACTION_RAID) }));
 
-    triggers.push_back(new TriggerNode("gruul the dragonkiller boss engaged by ranged", {
-        NextAction("gruul the dragonkiller spread ranged", ACTION_RAID + 1) }));
+    triggers.push_back(new TriggerNode("gruul the dragonkiller ranged should spread", {
+        NextAction("gruul the dragonkiller spread ranged", ACTION_RAID) }));
+
+    triggers.push_back(new TriggerNode("gruul the dragonkiller in cave in", {
+        NextAction("gruul the dragonkiller get out of cave in", ACTION_EMERGENCY + 7) }));
 
     triggers.push_back(new TriggerNode("gruul the dragonkiller incoming shatter", {
         NextAction("gruul the dragonkiller shatter spread", ACTION_EMERGENCY + 6) }));
@@ -53,15 +54,20 @@ void RaidGruulsLairStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 
 void RaidGruulsLairStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
 {
+    // General
+    multipliers.push_back(new GruulsLairDelayDpsCooldownsMultiplier(botAI));
+
     // High King Maulgar
-    multipliers.push_back(new HighKingMaulgarDelayBloodlustAndHeroismMultiplier(botAI));
     multipliers.push_back(new HighKingMaulgarControlTankActionsMultiplier(botAI));
+    multipliers.push_back(new HighKingMaulgarRestrictTauntingMultiplier(botAI));
+    multipliers.push_back(new HighKingMaulgarDisableDpsAssistMultiplier(botAI));
     multipliers.push_back(new HighKingMaulgarAvoidWhirlwindMultiplier(botAI));
-    multipliers.push_back(new HighKingMaulgarDisableArcaneShotOnKroshMultiplier(botAI));
-    multipliers.push_back(new HighKingMaulgarDisableMageTankAoeMultiplier(botAI));
+    multipliers.push_back(new HighKingMaulgarControlHunterActionsMultiplier(botAI));
+    multipliers.push_back(new HighKingMaulgarControlMageTankActionsMultiplier(botAI));
 
     // Gruul the Dragonkiller
-    multipliers.push_back(new GruulTheDragonkillerDelayBloodlustAndHeroismMultiplier(botAI));
     multipliers.push_back(new GruulTheDragonkillerControlTankMovementMultiplier(botAI));
     multipliers.push_back(new GruulTheDragonkillerStaySpreadForShatterMultiplier(botAI));
+    multipliers.push_back(new GruulTheDragonkillerControlAvoidanceMultiplier(botAI));
+    multipliers.push_back(new GruulTheDragonkillerHoldWhileSnaredMultiplier(botAI));
 }

--- a/src/Ai/Raid/Gruul/GruulStrategy.h
+++ b/src/Ai/Raid/Gruul/GruulStrategy.h
@@ -8,12 +8,13 @@
 #define PLAYERBOTS_GRUULSTRATEGY_H
 
 #include "Strategy.h"
+#include <string>
+#include <vector>
 
 class RaidGruulsLairStrategy : public Strategy
 {
 public:
     RaidGruulsLairStrategy(PlayerbotAI* botAI) : Strategy(botAI) {}
-
     std::string const getName() override { return "gruulslair"; }
 
     void InitTriggers(std::vector<TriggerNode*>& triggers) override;

--- a/src/Ai/Raid/Gruul/GruulTriggerContext.h
+++ b/src/Ai/Raid/Gruul/GruulTriggerContext.h
@@ -15,30 +15,28 @@ class RaidGruulsLairTriggerContext : public NamedObjectContext<Trigger>
 public:
     RaidGruulsLairTriggerContext() : NamedObjectContext<Trigger>()
     {
-        // High King Maulgar
-        creators["high king maulgar boss engaged by main tank"] =
-            &RaidGruulsLairTriggerContext::high_king_maulgar_boss_engaged_by_main_tank;
+        // General
+        creators["gruul's lair no encounter in progress"] =
+            &RaidGruulsLairTriggerContext::gruuls_lair_no_encounter_in_progress;
 
-        creators["high king maulgar olm engaged by first assist tank"] =
-            &RaidGruulsLairTriggerContext::high_king_maulgar_olm_engaged_by_first_assist_tank;
+        // High King Maulgar <Lord of the Ogres>
+        creators["high king maulgar three ogres need melee tanks"] =
+            &RaidGruulsLairTriggerContext::high_king_maulgar_three_ogres_need_melee_tanks;
 
-        creators["high king maulgar blindeye engaged by second assist tank"] =
-            &RaidGruulsLairTriggerContext::high_king_maulgar_blindeye_engaged_by_second_assist_tank;
+        creators["high king maulgar krosh needs mage tank"] =
+            &RaidGruulsLairTriggerContext::high_king_maulgar_krosh_needs_mage_tank;
 
-        creators["high king maulgar krosh engaged by mage tank"] =
-            &RaidGruulsLairTriggerContext::high_king_maulgar_krosh_engaged_by_mage_tank;
-
-        creators["high king maulgar kiggler engaged by moonkin tank"] =
-            &RaidGruulsLairTriggerContext::high_king_maulgar_kiggler_engaged_by_moonkin_tank;
+        creators["high king maulgar kiggler needs moonkin tank"] =
+            &RaidGruulsLairTriggerContext::high_king_maulgar_kiggler_needs_moonkin_tank;
 
         creators["high king maulgar determining kill order"] =
             &RaidGruulsLairTriggerContext::high_king_maulgar_determining_kill_order;
 
-        creators["high king maulgar boss channeling whirlwind"] =
-            &RaidGruulsLairTriggerContext::high_king_maulgar_boss_channeling_whirlwind;
+        creators["high king maulgar channeling whirlwind"] =
+            &RaidGruulsLairTriggerContext::high_king_maulgar_channeling_whirlwind;
 
-        creators["high king maulgar krosh casts blast wave"] =
-            &RaidGruulsLairTriggerContext::high_king_maulgar_krosh_casts_blast_wave;
+        creators["high king maulgar should stand back from krosh"] =
+            &RaidGruulsLairTriggerContext::high_king_maulgar_should_stand_back_from_krosh;
 
         creators["high king maulgar wild fel stalker spawned"] =
             &RaidGruulsLairTriggerContext::high_king_maulgar_wild_fel_stalker_spawned;
@@ -47,41 +45,43 @@ public:
             &RaidGruulsLairTriggerContext::high_king_maulgar_pulling_ogre_council;
 
         // Gruul the Dragonkiller
-        creators["gruul the dragonkiller boss engaged by tanks"] =
-            &RaidGruulsLairTriggerContext::gruul_the_dragonkiller_boss_engaged_by_tanks;
+        creators["gruul the dragonkiller should be tanked"] =
+            &RaidGruulsLairTriggerContext::gruul_the_dragonkiller_should_be_tanked;
 
-        creators["gruul the dragonkiller boss engaged by ranged"] =
-            &RaidGruulsLairTriggerContext::gruul_the_dragonkiller_boss_engaged_by_ranged;
+        creators["gruul the dragonkiller ranged should spread"] =
+            &RaidGruulsLairTriggerContext::gruul_the_dragonkiller_ranged_should_spread;
+
+        creators["gruul the dragonkiller in cave in"] =
+            &RaidGruulsLairTriggerContext::gruul_the_dragonkiller_in_cave_in;
 
         creators["gruul the dragonkiller incoming shatter"] =
             &RaidGruulsLairTriggerContext::gruul_the_dragonkiller_incoming_shatter;
     }
 
 private:
-    // High King Maulgar
-    static Trigger* high_king_maulgar_boss_engaged_by_main_tank(PlayerbotAI* botAI) {
-        return new HighKingMaulgarBossEngagedByMainTankTrigger(botAI);
+    // General
+    static Trigger* gruuls_lair_no_encounter_in_progress(PlayerbotAI* botAI) {
+        return new GruulsLairNoEncounterInProgressTrigger(botAI);
     }
-    static Trigger* high_king_maulgar_olm_engaged_by_first_assist_tank(PlayerbotAI* botAI) {
-        return new HighKingMaulgarOlmEngagedByFirstAssistTankTrigger(botAI);
+
+    // High King Maulgar <Lord of the Ogres>
+    static Trigger* high_king_maulgar_three_ogres_need_melee_tanks(PlayerbotAI* botAI) {
+        return new HighKingMaulgarThreeOgresNeedMeleeTanksTrigger(botAI);
     }
-    static Trigger* high_king_maulgar_blindeye_engaged_by_second_assist_tank(PlayerbotAI* botAI) {
-        return new HighKingMaulgarBlindeyeEngagedBySecondAssistTankTrigger(botAI);
+    static Trigger* high_king_maulgar_krosh_needs_mage_tank(PlayerbotAI* botAI) {
+        return new HighKingMaulgarKroshNeedsMageTankTrigger(botAI);
     }
-    static Trigger* high_king_maulgar_krosh_engaged_by_mage_tank(PlayerbotAI* botAI) {
-        return new HighKingMaulgarKroshEngagedByMageTankTrigger(botAI);
-    }
-    static Trigger* high_king_maulgar_kiggler_engaged_by_moonkin_tank(PlayerbotAI* botAI) {
-        return new HighKingMaulgarKigglerEngagedByMoonkinTankTrigger(botAI);
+    static Trigger* high_king_maulgar_kiggler_needs_moonkin_tank(PlayerbotAI* botAI) {
+        return new HighKingMaulgarKigglerNeedsMoonkinTankTrigger(botAI);
     }
     static Trigger* high_king_maulgar_determining_kill_order(PlayerbotAI* botAI) {
         return new HighKingMaulgarDeterminingKillOrderTrigger(botAI);
     }
-    static Trigger* high_king_maulgar_boss_channeling_whirlwind(PlayerbotAI* botAI) {
-        return new HighKingMaulgarBossChannelingWhirlwindTrigger(botAI);
+    static Trigger* high_king_maulgar_channeling_whirlwind(PlayerbotAI* botAI) {
+        return new HighKingMaulgarChannelingWhirlwindTrigger(botAI);
     }
-    static Trigger* high_king_maulgar_krosh_casts_blast_wave(PlayerbotAI* botAI) {
-        return new HighKingMaulgarKroshCastsBlastWaveTrigger(botAI);
+    static Trigger* high_king_maulgar_should_stand_back_from_krosh(PlayerbotAI* botAI) {
+        return new HighKingMaulgarShouldStandBackFromKroshTrigger(botAI);
     }
     static Trigger* high_king_maulgar_wild_fel_stalker_spawned(PlayerbotAI* botAI) {
         return new HighKingMaulgarWildFelStalkerSpawnedTrigger(botAI);
@@ -91,11 +91,14 @@ private:
     }
 
     // Gruul the Dragonkiller
-    static Trigger* gruul_the_dragonkiller_boss_engaged_by_tanks(PlayerbotAI* botAI) {
-        return new GruulTheDragonkillerBossEngagedByTanksTrigger(botAI);
+    static Trigger* gruul_the_dragonkiller_should_be_tanked(PlayerbotAI* botAI) {
+        return new GruulTheDragonkillerShouldBeTankedTrigger(botAI);
     }
-    static Trigger* gruul_the_dragonkiller_boss_engaged_by_ranged(PlayerbotAI* botAI) {
-        return new GruulTheDragonkillerBossEngagedByRangedTrigger(botAI);
+    static Trigger* gruul_the_dragonkiller_ranged_should_spread(PlayerbotAI* botAI) {
+        return new GruulTheDragonkillerRangedShouldSpreadTrigger(botAI);
+    }
+    static Trigger* gruul_the_dragonkiller_in_cave_in(PlayerbotAI* botAI) {
+        return new GruulTheDragonkillerInCaveInTrigger(botAI);
     }
     static Trigger* gruul_the_dragonkiller_incoming_shatter(PlayerbotAI* botAI) {
         return new GruulTheDragonkillerIncomingShatterTrigger(botAI);

--- a/src/Ai/Raid/Gruul/GruulTriggers.cpp
+++ b/src/Ai/Raid/Gruul/GruulTriggers.cpp
@@ -5,120 +5,124 @@
  */
 
 #include "GruulTriggers.h"
+#include "EncounterHelpers.h"
 #include "GruulHelpers.h"
 #include "Playerbots.h"
 
-using namespace GruulsLairHelpers;
+using namespace GruulHelpers;
+using namespace EncounterHelpers;
 
-// High King Maulgar Triggers
+// General
 
-bool HighKingMaulgarBossEngagedByMainTankTrigger::IsActive()
+bool GruulsLairNoEncounterInProgressTrigger::IsActive()
 {
-    return botAI->IsMainTank(bot) &&
-           AI_VALUE2(Unit*, "find target", "high king maulgar");
+    return !IsEncounterInProgress(bot, GRUUL_MAP_ID);
 }
 
-bool HighKingMaulgarOlmEngagedByFirstAssistTankTrigger::IsActive()
+// High King Maulgar <Lord of the Ogres>
+
+bool HighKingMaulgarThreeOgresNeedMeleeTanksTrigger::IsActiveInEncounter()
 {
-    return botAI->IsAssistTankOfIndex(bot, 0, false) &&
-           AI_VALUE2(Unit*, "find target", "olm the summoner");
+    if (IsBlindeyeTank(bot))
+        return AI_VALUE2(Unit*, "find target", "blindeye the seer");
+
+    if (IsOlmTank(bot))
+        return AI_VALUE2(Unit*, "find target", "olm the summoner");
+
+    return IsMaulgarTank(bot) && AI_VALUE2(Unit*, "find target", "high king maulgar");
 }
 
-bool HighKingMaulgarBlindeyeEngagedBySecondAssistTankTrigger::IsActive()
+bool HighKingMaulgarKroshNeedsMageTankTrigger::IsActiveInEncounter()
 {
-    return botAI->IsAssistTankOfIndex(bot, 1, false) &&
-           AI_VALUE2(Unit*, "find target", "blindeye the seer");
+    return IsKroshMageTank(botAI) && AI_VALUE2(Unit*, "find target", "krosh firehand");
 }
 
-bool HighKingMaulgarKroshEngagedByMageTankTrigger::IsActive()
+bool HighKingMaulgarKigglerNeedsMoonkinTankTrigger::IsActiveInEncounter()
 {
-    return bot->getClass() == CLASS_MAGE &&
-           AI_VALUE2(Unit*, "find target", "krosh firehand") &&
-           GetKroshMageTank(bot) == bot;
+    return IsKigglerMoonkinTank(botAI) && AI_VALUE2(Unit*, "find target", "kiggler the crazed");
 }
 
-bool HighKingMaulgarKigglerEngagedByMoonkinTankTrigger::IsActive()
+bool HighKingMaulgarDeterminingKillOrderTrigger::IsActiveInEncounter()
 {
-    return bot->getClass() == CLASS_DRUID &&
-           AI_VALUE2(Unit*, "find target", "kiggler the crazed") &&
-           GetKigglerMoonkinTank(bot) == bot;
-}
-
-bool HighKingMaulgarDeterminingKillOrderTrigger::IsActive()
-{
-    if (botAI->IsHeal(bot) || botAI->IsMainTank(bot))
+    if (!AI_VALUE2(Unit*, "find target", "high king maulgar"))
         return false;
 
-    Unit* maulgar = AI_VALUE2(Unit*, "find target", "high king maulgar");
-    if (!maulgar)
+    if (IsMaulgarTank(bot))
         return false;
 
-    if (botAI->IsAssistTankOfIndex(bot, 0, false))
+    if (IsOlmTank(bot))
         return !AI_VALUE2(Unit*, "find target", "olm the summoner");
 
-    if (botAI->IsAssistTankOfIndex(bot, 1, false))
+    if (IsBlindeyeTank(bot))
         return !AI_VALUE2(Unit*, "find target", "blindeye the seer");
 
-    if (bot->getClass() == CLASS_MAGE && GetKroshMageTank(bot) == bot)
+    if (IsKroshMageTank(botAI))
         return !AI_VALUE2(Unit*, "find target", "krosh firehand");
 
-    if (bot->getClass() == CLASS_DRUID && GetKigglerMoonkinTank(bot) == bot)
+    if (IsKigglerMoonkinTank(botAI))
         return !AI_VALUE2(Unit*, "find target", "kiggler the crazed");
 
     return true;
 }
 
-bool HighKingMaulgarBossChannelingWhirlwindTrigger::IsActive()
+bool HighKingMaulgarChannelingWhirlwindTrigger::IsActiveInEncounter()
 {
     Unit* maulgar = AI_VALUE2(Unit*, "find target", "high king maulgar");
-    if (!maulgar ||
-        !maulgar->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_WHIRLWIND)))
-    {
-        return false;
-    }
-
-    return !botAI->IsMainTank(bot);
-}
-
-bool HighKingMaulgarKroshCastsBlastWaveTrigger::IsActive()
-{
-    if (!AI_VALUE2(Unit*, "find target", "krosh firehand"))
+    if (!maulgar || !maulgar->HasAura(Id(GruulSpells::SPELL_WHIRLWIND)))
         return false;
 
-    return !botAI->IsTank(bot) && GetKroshMageTank(bot) != bot;
+    return !IsMaulgarTank(bot);
 }
 
-bool HighKingMaulgarWildFelStalkerSpawnedTrigger::IsActive()
+bool HighKingMaulgarShouldStandBackFromKroshTrigger::IsActiveInEncounter()
 {
-    return bot->getClass() == CLASS_WARLOCK &&
-           AI_VALUE2(Unit*, "find target", "wild fel stalker");
+    if (PlayerbotAI::IsTank(bot) || IsKroshMageTank(botAI))
+        return false;
+
+    return AI_VALUE2(Unit*, "find target", "krosh firehand");
 }
 
-bool HighKingMaulgarPullingOgreCouncilTrigger::IsActive()
+bool HighKingMaulgarWildFelStalkerSpawnedTrigger::IsActiveInEncounter()
+{
+    return bot->getClass() == CLASS_WARLOCK && !GetNearbyWildFelStalkers(botAI).empty();
+}
+
+bool HighKingMaulgarPullingOgreCouncilTrigger::IsActiveInEncounter()
 {
     if (bot->getClass() != CLASS_HUNTER)
         return false;
 
     Unit* blindeye = AI_VALUE2(Unit*, "find target", "blindeye the seer");
-    return blindeye && blindeye->GetHealthPct() > 80.0f;
+    return blindeye && blindeye->GetHealthPct() > BLINDEYE_ENGAGED_HEALTH_PCT;
 }
 
-// Gruul the Dragonkiller Triggers
+// Gruul the Dragonkiller
 
-bool GruulTheDragonkillerBossEngagedByTanksTrigger::IsActive()
+bool GruulTheDragonkillerShouldBeTankedTrigger::IsActiveInEncounter()
 {
-    return botAI->IsTank(bot) &&
-           AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
+    return PlayerbotAI::IsTank(bot) && AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
 }
 
-bool GruulTheDragonkillerBossEngagedByRangedTrigger::IsActive()
+bool GruulTheDragonkillerRangedShouldSpreadTrigger::IsActiveInEncounter()
 {
-    return botAI->IsRanged(bot) &&
-           AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
+    return PlayerbotAI::IsRanged(bot) && AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
 }
 
-bool GruulTheDragonkillerIncomingShatterTrigger::IsActive()
+bool GruulTheDragonkillerInCaveInTrigger::IsActiveInEncounter()
 {
-    return bot->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_GROUND_SLAM_1)) ||
-           bot->HasAura(static_cast<uint32>(GruulsLairSpells::SPELL_GROUND_SLAM_2));
+    Unit* gruul = AI_VALUE2(Unit*, "find target", "gruul the dragonkiller");
+    if (!gruul)
+        return false;
+
+    // The tank holding Gruul eats it. Moving him messes up the spread and puts other bots in
+    // danger.
+    if (gruul->GetVictim() == bot)
+        return false;
+
+    return IsInCaveIn(botAI);
+}
+
+bool GruulTheDragonkillerIncomingShatterTrigger::IsActiveInEncounter()
+{
+    return HasGroundSlam(bot);
 }

--- a/src/Ai/Raid/Gruul/GruulTriggers.h
+++ b/src/Ai/Raid/Gruul/GruulTriggers.h
@@ -7,110 +7,161 @@
 #ifndef PLAYERBOTS_GRUULTRIGGERS_H
 #define PLAYERBOTS_GRUULTRIGGERS_H
 
+#include "EncounterHelpers.h"
+#include "GruulHelpers.h"
 #include "Trigger.h"
+#include <string>
 
-class HighKingMaulgarBossEngagedByMainTankTrigger : public Trigger
+// General
+
+class GruulsLairEncounterTrigger : public Trigger
 {
 public:
-    HighKingMaulgarBossEngagedByMainTankTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar engaged by main tank") {}
+    GruulsLairEncounterTrigger(PlayerbotAI* botAI, std::string const name, int32 checkInterval = 1)
+        : Trigger(botAI, name, checkInterval) {}
+
+    bool IsActive() final
+    {
+        return EncounterHelpers::IsEncounterInProgress(bot, GruulHelpers::GRUUL_MAP_ID) &&
+            IsActiveInEncounter();
+    }
+
+protected:
+    virtual bool IsActiveInEncounter() = 0;
+};
+
+class GruulsLairNoEncounterInProgressTrigger : public Trigger
+{
+public:
+    // Throttled to once per second. This trigger is true for all trash and downtime and, being
+    // for between-encounter clean-up, has no real urgency to it.
+    GruulsLairNoEncounterInProgressTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "gruul's lair no encounter in progress", 1000) {}
     bool IsActive() override;
 };
 
-class HighKingMaulgarOlmEngagedByFirstAssistTankTrigger : public Trigger
+// High King Maulgar <Lord of the Ogres>
+
+class HighKingMaulgarThreeOgresNeedMeleeTanksTrigger : public GruulsLairEncounterTrigger
 {
 public:
-    HighKingMaulgarOlmEngagedByFirstAssistTankTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar olm engaged by first assist tank") {}
-    bool IsActive() override;
+    HighKingMaulgarThreeOgresNeedMeleeTanksTrigger(PlayerbotAI* botAI)
+        : GruulsLairEncounterTrigger(botAI, "high king maulgar three ogres need melee tanks") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class HighKingMaulgarBlindeyeEngagedBySecondAssistTankTrigger : public Trigger
+class HighKingMaulgarKroshNeedsMageTankTrigger : public GruulsLairEncounterTrigger
 {
 public:
-    HighKingMaulgarBlindeyeEngagedBySecondAssistTankTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar blindeye engaged by second assist tank") {}
-    bool IsActive() override;
+    HighKingMaulgarKroshNeedsMageTankTrigger(PlayerbotAI* botAI)
+        : GruulsLairEncounterTrigger(botAI, "high king maulgar krosh needs mage tank") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class HighKingMaulgarKroshEngagedByMageTankTrigger : public Trigger
+class HighKingMaulgarKigglerNeedsMoonkinTankTrigger : public GruulsLairEncounterTrigger
 {
 public:
-    HighKingMaulgarKroshEngagedByMageTankTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar krosh engaged by mage tank") {}
-    bool IsActive() override;
+    HighKingMaulgarKigglerNeedsMoonkinTankTrigger(PlayerbotAI* botAI)
+        : GruulsLairEncounterTrigger(botAI, "high king maulgar kiggler needs moonkin tank") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class HighKingMaulgarKigglerEngagedByMoonkinTankTrigger : public Trigger
+class HighKingMaulgarDeterminingKillOrderTrigger : public GruulsLairEncounterTrigger
 {
 public:
-    HighKingMaulgarKigglerEngagedByMoonkinTankTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar kiggler engaged by moonkin tank") {}
-    bool IsActive() override;
+    HighKingMaulgarDeterminingKillOrderTrigger(PlayerbotAI* botAI)
+        : GruulsLairEncounterTrigger(botAI, "high king maulgar determining kill order") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class HighKingMaulgarDeterminingKillOrderTrigger : public Trigger
+class HighKingMaulgarChannelingWhirlwindTrigger : public GruulsLairEncounterTrigger
 {
 public:
-    HighKingMaulgarDeterminingKillOrderTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar determining kill order") {}
-    bool IsActive() override;
+    HighKingMaulgarChannelingWhirlwindTrigger(PlayerbotAI* botAI)
+        : GruulsLairEncounterTrigger(botAI, "high king maulgar channeling whirlwind") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class HighKingMaulgarBossChannelingWhirlwindTrigger : public Trigger
+class HighKingMaulgarShouldStandBackFromKroshTrigger : public GruulsLairEncounterTrigger
 {
 public:
-    HighKingMaulgarBossChannelingWhirlwindTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar boss channeling whirlwind") {}
-    bool IsActive() override;
+    HighKingMaulgarShouldStandBackFromKroshTrigger(PlayerbotAI* botAI)
+        : GruulsLairEncounterTrigger(botAI, "high king maulgar should stand back from krosh") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class HighKingMaulgarKroshCastsBlastWaveTrigger : public Trigger
+class HighKingMaulgarWildFelStalkerSpawnedTrigger : public GruulsLairEncounterTrigger
 {
 public:
-    HighKingMaulgarKroshCastsBlastWaveTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar krosh casts blast wave") {}
-    bool IsActive() override;
+    HighKingMaulgarWildFelStalkerSpawnedTrigger(PlayerbotAI* botAI)
+        : GruulsLairEncounterTrigger(botAI, "high king maulgar wild fel stalker spawned") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class HighKingMaulgarWildFelStalkerSpawnedTrigger : public Trigger
+class HighKingMaulgarPullingOgreCouncilTrigger : public GruulsLairEncounterTrigger
 {
 public:
-    HighKingMaulgarWildFelStalkerSpawnedTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar wild fel stalker spawned") {}
-    bool IsActive() override;
+    HighKingMaulgarPullingOgreCouncilTrigger(PlayerbotAI* botAI)
+        : GruulsLairEncounterTrigger(botAI, "high king maulgar pulling ogre council") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class HighKingMaulgarPullingOgreCouncilTrigger : public Trigger
+// Gruul the Dragonkiller
+
+class GruulTheDragonkillerShouldBeTankedTrigger : public GruulsLairEncounterTrigger
 {
 public:
-    HighKingMaulgarPullingOgreCouncilTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "high king maulgar pulling ogre council") {}
-    bool IsActive() override;
+    GruulTheDragonkillerShouldBeTankedTrigger(PlayerbotAI* botAI)
+        : GruulsLairEncounterTrigger(botAI, "gruul the dragonkiller should be tanked") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class GruulTheDragonkillerBossEngagedByTanksTrigger : public Trigger
+class GruulTheDragonkillerRangedShouldSpreadTrigger : public GruulsLairEncounterTrigger
 {
 public:
-    GruulTheDragonkillerBossEngagedByTanksTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "gruul the dragonkiller boss engaged by tanks") {}
-    bool IsActive() override;
+    GruulTheDragonkillerRangedShouldSpreadTrigger(PlayerbotAI* botAI)
+        : GruulsLairEncounterTrigger(botAI, "gruul the dragonkiller ranged should spread") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class GruulTheDragonkillerBossEngagedByRangedTrigger : public Trigger
+class GruulTheDragonkillerInCaveInTrigger : public GruulsLairEncounterTrigger
 {
 public:
-    GruulTheDragonkillerBossEngagedByRangedTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "gruul the dragonkiller boss engaged by ranged") {}
-    bool IsActive() override;
+    GruulTheDragonkillerInCaveInTrigger(PlayerbotAI* botAI)
+        : GruulsLairEncounterTrigger(botAI, "gruul the dragonkiller in cave in") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class GruulTheDragonkillerIncomingShatterTrigger : public Trigger
+class GruulTheDragonkillerIncomingShatterTrigger : public GruulsLairEncounterTrigger
 {
 public:
-    GruulTheDragonkillerIncomingShatterTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "gruul the dragonkiller incoming shatter") {}
-    bool IsActive() override;
+    GruulTheDragonkillerIncomingShatterTrigger(PlayerbotAI* botAI)
+        : GruulsLairEncounterTrigger(botAI, "gruul the dragonkiller incoming shatter") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
 #endif

--- a/src/Ai/Raid/Gruul/GruulValueContext.h
+++ b/src/Ai/Raid/Gruul/GruulValueContext.h
@@ -1,0 +1,106 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_GRUULVALUECONTEXT_H
+#define PLAYERBOTS_GRUULVALUECONTEXT_H
+
+#include "EncounterHelpers.h"
+#include "GruulHelpers.h"
+#include "NamedObjectContext.h"
+#include "ObjectGuid.h"
+#include "Value.h"
+#include <vector>
+
+// Olm summons a Wild Fel Stalker every 48.5s (practically, that means you're not going to see more
+// than 1 or 2, but we cache the grid search anyway).
+class HighKingMaulgarWildFelStalkersValue : public CalculatedValue<GuidVector>
+{
+public:
+    HighKingMaulgarWildFelStalkersValue(PlayerbotAI* botAI)
+        : CalculatedValue<GuidVector>(
+              botAI, "high king maulgar wild fel stalkers",
+              GruulHelpers::WILD_FEL_STALKER_CACHE_INTERVAL_MS) {}
+
+protected:
+    GuidVector Calculate() override { return GruulHelpers::FindNearbyWildFelStalkerGuids(bot); }
+};
+
+// Both ogre caster tanks are chosen by iterating the raid.
+class HighKingMaulgarKroshMageTankValue : public ObjectGuidCalculatedValue
+{
+public:
+    HighKingMaulgarKroshMageTankValue(PlayerbotAI* botAI)
+        : ObjectGuidCalculatedValue(
+              botAI, "high king maulgar krosh mage tank",
+              GruulHelpers::CASTER_TANK_CACHE_INTERVAL_MS) {}
+
+protected:
+    ObjectGuid Calculate() override { return GruulHelpers::FindKroshMageTankGuid(bot); }
+};
+
+class HighKingMaulgarKigglerMoonkinTankValue : public ObjectGuidCalculatedValue
+{
+public:
+    HighKingMaulgarKigglerMoonkinTankValue(PlayerbotAI* botAI)
+        : ObjectGuidCalculatedValue(
+              botAI, "high king maulgar kiggler moonkin tank",
+              GruulHelpers::CASTER_TANK_CACHE_INTERVAL_MS) {}
+
+protected:
+    ObjectGuid Calculate() override { return GruulHelpers::FindKigglerMoonkinTankGuid(bot); }
+};
+
+class GruulTheDragonkillerCaveInValue : public CalculatedValue<std::vector<Position>>
+{
+public:
+    GruulTheDragonkillerCaveInValue(PlayerbotAI* botAI)
+        : CalculatedValue<std::vector<Position>>(
+              botAI, "gruul the dragonkiller cave in",
+              GruulHelpers::CAVE_IN_CACHE_INTERVAL_MS) {}
+
+protected:
+    std::vector<Position> Calculate() override
+    {
+        return EncounterHelpers::GetDynamicObjectPositions(
+            bot, GruulHelpers::CAVE_IN_SEARCH_RADIUS,
+            GruulHelpers::Id(GruulHelpers::GruulSpells::SPELL_CAVE_IN));
+    }
+};
+
+class RaidGruulsLairValueContext : public NamedObjectContext<UntypedValue>
+{
+public:
+    RaidGruulsLairValueContext()
+    {
+        creators["high king maulgar wild fel stalkers"] =
+            &RaidGruulsLairValueContext::high_king_maulgar_wild_fel_stalkers;
+        creators["high king maulgar krosh mage tank"] =
+            &RaidGruulsLairValueContext::high_king_maulgar_krosh_mage_tank;
+        creators["high king maulgar kiggler moonkin tank"] =
+            &RaidGruulsLairValueContext::high_king_maulgar_kiggler_moonkin_tank;
+        creators["gruul the dragonkiller cave in"] =
+            &RaidGruulsLairValueContext::gruul_the_dragonkiller_cave_in;
+    }
+
+private:
+    static UntypedValue* high_king_maulgar_wild_fel_stalkers(PlayerbotAI* botAI) {
+        return new HighKingMaulgarWildFelStalkersValue(botAI);
+    }
+
+    static UntypedValue* high_king_maulgar_krosh_mage_tank(PlayerbotAI* botAI) {
+        return new HighKingMaulgarKroshMageTankValue(botAI);
+    }
+
+    static UntypedValue* high_king_maulgar_kiggler_moonkin_tank(PlayerbotAI* botAI) {
+        return new HighKingMaulgarKigglerMoonkinTankValue(botAI);
+    }
+
+    static UntypedValue* gruul_the_dragonkiller_cave_in(PlayerbotAI* botAI) {
+        return new GruulTheDragonkillerCaveInValue(botAI);
+    }
+};
+
+#endif

--- a/src/Ai/Raid/ZA/ZAActionContext.h
+++ b/src/Ai/Raid/ZA/ZAActionContext.h
@@ -9,12 +9,17 @@
 
 #include "NamedObjectContext.h"
 #include "ZAActions.h"
+#include "ZAHelpers.h"
 
 class RaidZulAmanActionContext : public NamedObjectContext<Action>
 {
 public:
     RaidZulAmanActionContext()
     {
+        // General
+        creators["zul'aman reset encounter states"] =
+            &RaidZulAmanActionContext::zulaman_reset_encounter_states;
+
         // Trash
         creators["amani'shi medicine man mark ward"] =
             &RaidZulAmanActionContext::amanishi_medicine_man_mark_ward;
@@ -26,14 +31,13 @@ public:
         creators["akil'zon tanks position boss"] =
             &RaidZulAmanActionContext::akilzon_tanks_position_boss;
 
-        creators["akil'zon spread ranged"] =
-            &RaidZulAmanActionContext::akilzon_spread_ranged;
+        creators["akil'zon spread ranged"] = &RaidZulAmanActionContext::akilzon_spread_ranged;
 
         creators["akil'zon move to eye of the storm"] =
             &RaidZulAmanActionContext::akilzon_move_to_eye_of_the_storm;
 
-        creators["akil'zon manage electrical storm timer"] =
-            &RaidZulAmanActionContext::akilzon_manage_electrical_storm_timer;
+        creators["akil'zon start electrical storm timer"] =
+            &RaidZulAmanActionContext::akilzon_start_electrical_storm_timer;
 
         // Nalorakk <Bear Avatar>
         creators["nalorakk misdirect boss to main tank"] =
@@ -42,8 +46,7 @@ public:
         creators["nalorakk tanks position boss"] =
             &RaidZulAmanActionContext::nalorakk_tanks_position_boss;
 
-        creators["nalorakk spread ranged"] =
-            &RaidZulAmanActionContext::nalorakk_spread_ranged;
+        creators["nalorakk spread ranged"] = &RaidZulAmanActionContext::nalorakk_spread_ranged;
 
         // Jan'alai <Dragonhawk Avatar>
         creators["jan'alai misdirect boss to main tank"] =
@@ -55,8 +58,7 @@ public:
         creators["jan'alai spread ranged in circle"] =
             &RaidZulAmanActionContext::janalai_spread_ranged_in_circle;
 
-        creators["jan'alai avoid fire bombs"] =
-            &RaidZulAmanActionContext::janalai_avoid_fire_bombs;
+        creators["jan'alai avoid fire bombs"] = &RaidZulAmanActionContext::janalai_avoid_fire_bombs;
 
         creators["jan'alai mark amani'shi hatchers"] =
             &RaidZulAmanActionContext::janalai_mark_amanishi_hatchers;
@@ -71,8 +73,8 @@ public:
         creators["halazzi first assist tank attack spirit lynx"] =
             &RaidZulAmanActionContext::halazzi_first_assist_tank_attack_spirit_lynx;
 
-        creators["halazzi assign dps priority"] =
-            &RaidZulAmanActionContext::halazzi_assign_dps_priority;
+        creators["halazzi dps attack totem and boss"] =
+            &RaidZulAmanActionContext::halazzi_dps_attack_totem_and_boss;
 
         // Hex Lord Malacrass
         creators["hex lord malacrass misdirect boss to main tank"] =
@@ -83,9 +85,6 @@ public:
 
         creators["hex lord malacrass run away from whirlwind"] =
             &RaidZulAmanActionContext::hex_lord_malacrass_run_away_from_whirlwind;
-
-        creators["hex lord malacrass casters stop attacking"] =
-            &RaidZulAmanActionContext::hex_lord_malacrass_casters_stop_attacking;
 
         creators["hex lord malacrass move away from freezing trap"] =
             &RaidZulAmanActionContext::hex_lord_malacrass_move_away_from_freezing_trap;
@@ -100,14 +99,21 @@ public:
         creators["zul'jin run away from whirlwind"] =
             &RaidZulAmanActionContext::zuljin_run_away_from_whirlwind;
 
-        creators["zul'jin avoid cyclones"] =
-            &RaidZulAmanActionContext::zuljin_avoid_cyclones;
+        creators["zul'jin mass dispel creeping paralysis"] =
+            &RaidZulAmanActionContext::zuljin_mass_dispel_creeping_paralysis;
 
-        creators["zul'jin spread ranged"] =
-            &RaidZulAmanActionContext::zuljin_spread_ranged;
+        creators["zul'jin position ranged for cyclones"] =
+            &RaidZulAmanActionContext::zuljin_position_ranged_for_cyclones;
+
+        creators["zul'jin spread ranged"] = &RaidZulAmanActionContext::zuljin_spread_ranged;
     }
 
 private:
+    // General
+    static Action* zulaman_reset_encounter_states(PlayerbotAI* botAI) {
+        return new ZulAmanResetEncounterStatesAction(botAI);
+    }
+
     // Trash
     static Action* amanishi_medicine_man_mark_ward(PlayerbotAI* botAI) {
         return new AmanishiMedicineManMarkWardAction(botAI);
@@ -115,38 +121,44 @@ private:
 
     // Akil'zon <Eagle Avatar>
     static Action* akilzon_misdirect_boss_to_main_tank(PlayerbotAI* botAI) {
-        return new AkilzonMisdirectBossToMainTankAction(botAI);
+        return new ZulAmanMisdirectBossToMainTankAction(
+            botAI, "akil'zon misdirect boss to main tank", "akil'zon");
     }
     static Action* akilzon_tanks_position_boss(PlayerbotAI* botAI) {
-        return new AkilzonTanksPositionBossAction(botAI);
+        return new ZulAmanTanksPositionBossAction(
+            botAI, "akil'zon tanks position boss", "akil'zon", ZaHelpers::AKILZON_TANK_POSITION);
     }
     static Action* akilzon_spread_ranged(PlayerbotAI* botAI) {
-        return new AkilzonSpreadRangedAction(botAI);
+        return new ZulAmanSpreadRangedAction(botAI, "akil'zon spread ranged", 13.0f);
     }
     static Action* akilzon_move_to_eye_of_the_storm(PlayerbotAI* botAI) {
         return new AkilzonMoveToEyeOfTheStormAction(botAI);
     }
-    static Action* akilzon_manage_electrical_storm_timer(PlayerbotAI* botAI) {
-        return new AkilzonManageElectricalStormTimerAction(botAI);
+    static Action* akilzon_start_electrical_storm_timer(PlayerbotAI* botAI) {
+        return new AkilzonStartElectricalStormTimerAction(botAI);
     }
 
     // Nalorakk <Bear Avatar>
     static Action* nalorakk_misdirect_boss_to_main_tank(PlayerbotAI* botAI) {
-        return new NalorakkMisdirectBossToMainTankAction(botAI);
+        return new ZulAmanMisdirectBossToMainTankAction(
+            botAI, "nalorakk misdirect boss to main tank", "nalorakk");
     }
     static Action* nalorakk_tanks_position_boss(PlayerbotAI* botAI) {
         return new NalorakkTanksPositionBossAction(botAI);
     }
     static Action* nalorakk_spread_ranged(PlayerbotAI* botAI) {
-        return new NalorakkSpreadRangedAction(botAI);
+        return new ZulAmanSpreadRangedAction(botAI, "nalorakk spread ranged", 11.0f);
     }
 
     // Jan'alai <Dragonhawk Avatar>
     static Action* janalai_misdirect_boss_to_main_tank(PlayerbotAI* botAI) {
-        return new JanalaiMisdirectBossToMainTankAction(botAI);
+        return new ZulAmanMisdirectBossToMainTankAction(
+            botAI, "jan'alai misdirect boss to main tank", "jan'alai");
     }
     static Action* janalai_tanks_position_boss(PlayerbotAI* botAI) {
-        return new JanalaiTanksPositionBossAction(botAI);
+        return new ZulAmanTanksPositionBossAction(
+            botAI, "jan'alai tanks position boss", "jan'alai",
+            ZaHelpers::JANALAI_TANK_POSITION);
     }
     static Action* janalai_spread_ranged_in_circle(PlayerbotAI* botAI) {
         return new JanalaiSpreadRangedInCircleAction(botAI);
@@ -160,30 +172,31 @@ private:
 
     // Halazzi <Lynx Avatar>
     static Action* halazzi_misdirect_boss_to_main_tank(PlayerbotAI* botAI) {
-        return new HalazziMisdirectBossToMainTankAction(botAI);
+        return new ZulAmanMisdirectBossToMainTankAction(
+            botAI, "halazzi misdirect boss to main tank", "halazzi");
     }
     static Action* halazzi_main_tank_position_boss(PlayerbotAI* botAI) {
-        return new HalazziMainTankPositionBossAction(botAI);
+        return new ZulAmanTanksPositionBossAction(
+            botAI, "halazzi main tank position boss", "halazzi", ZaHelpers::HALAZZI_TANK_POSITION);
     }
     static Action* halazzi_first_assist_tank_attack_spirit_lynx(PlayerbotAI* botAI) {
         return new HalazziFirstAssistTankAttackSpiritLynxAction(botAI);
     }
-    static Action* halazzi_assign_dps_priority(PlayerbotAI* botAI) {
-        return new HalazziAssignDpsPriorityAction(botAI);
+    static Action* halazzi_dps_attack_totem_and_boss(PlayerbotAI* botAI) {
+        return new HalazziDpsAttackTotemAndBossAction(botAI);
     }
 
     // Hex Lord Malacrass
     static Action* hex_lord_malacrass_misdirect_boss_to_main_tank(PlayerbotAI* botAI) {
-        return new HexLordMalacrassMisdirectBossToMainTankAction(botAI);
+        return new ZulAmanMisdirectBossToMainTankAction(
+            botAI, "hex lord malacrass misdirect boss to main tank", "hex lord malacrass");
     }
     static Action* hex_lord_malacrass_assign_dps_priority(PlayerbotAI* botAI) {
         return new HexLordMalacrassAssignDpsPriorityAction(botAI);
     }
     static Action* hex_lord_malacrass_run_away_from_whirlwind(PlayerbotAI* botAI) {
-        return new HexLordMalacrassRunAwayFromWhirlwindAction(botAI);
-    }
-    static Action* hex_lord_malacrass_casters_stop_attacking(PlayerbotAI* botAI) {
-        return new HexLordMalacrassCastersStopAttackingAction(botAI);
+        return new ZulAmanRunAwayFromWhirlwindAction(
+            botAI, "hex lord malacrass run away from whirlwind", "hex lord malacrass");
     }
     static Action* hex_lord_malacrass_move_away_from_freezing_trap(PlayerbotAI* botAI) {
         return new HexLordMalacrassMoveAwayFromFreezingTrapAction(botAI);
@@ -191,19 +204,25 @@ private:
 
     // Zul'jin
     static Action* zuljin_misdirect_boss_to_main_tank(PlayerbotAI* botAI) {
-        return new ZuljinMisdirectBossToMainTankAction(botAI);
+        return new ZulAmanMisdirectBossToMainTankAction(
+            botAI, "zul'jin misdirect boss to main tank", "zul'jin");
     }
     static Action* zuljin_tanks_position_boss(PlayerbotAI* botAI) {
-        return new ZuljinTanksPositionBossAction(botAI);
-    }
-    static Action* zuljin_run_away_from_whirlwind(PlayerbotAI* botAI) {
-        return new ZuljinRunAwayFromWhirlwindAction(botAI);
-    }
-    static Action* zuljin_avoid_cyclones(PlayerbotAI* botAI) {
-        return new ZuljinAvoidCyclonesAction(botAI);
+        return new ZulAmanTanksPositionBossAction(
+            botAI, "zul'jin tanks position boss", "zul'jin", ZaHelpers::ZULJIN_TANK_POSITION);
     }
     static Action* zuljin_spread_ranged(PlayerbotAI* botAI) {
-        return new ZuljinSpreadRangedAction(botAI);
+        return new ZulAmanSpreadRangedAction(botAI, "zul'jin spread ranged", 6.0f);
+    }
+    static Action* zuljin_run_away_from_whirlwind(PlayerbotAI* botAI) {
+        return new ZulAmanRunAwayFromWhirlwindAction(
+            botAI, "zul'jin run away from whirlwind", "zul'jin");
+    }
+    static Action* zuljin_mass_dispel_creeping_paralysis(PlayerbotAI* botAI) {
+        return new ZuljinMassDispelCreepingParalysisAction(botAI);
+    }
+    static Action* zuljin_position_ranged_for_cyclones(PlayerbotAI* botAI) {
+        return new ZuljinPositionRangedForCyclonesAction(botAI);
     }
 };
 

--- a/src/Ai/Raid/ZA/ZAActions.cpp
+++ b/src/Ai/Raid/ZA/ZAActions.cpp
@@ -7,288 +7,178 @@
 #include "ZAActions.h"
 #include "EncounterHelpers.h"
 #include "Playerbots.h"
+#include "RtiTargetValue.h"
 #include "ZAHelpers.h"
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <iterator>
+#include <vector>
 
-using namespace ZulAmanHelpers;
+using namespace ZaHelpers;
 using namespace EncounterHelpers;
+
+// General
+
+bool ZulAmanResetEncounterStatesAction::Execute(Event /*event*/)
+{
+    bool reset = false;
+    reset |= akilzonStormTimer.erase(bot->GetInstanceId()) > 0;
+
+    if (!AI_VALUE2(bool, "combat", "self target"))
+    {
+        reset |= ClearTargetIcon(bot, RtiTargetValue::skullIndex);
+        reset |= ClearTargetIcon(bot, RtiTargetValue::moonIndex);
+    }
+
+    return reset;
+}
+
+bool ZulAmanMisdirectBossToMainTankAction::Execute(Event /*event*/)
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", _bossName);
+    if (!boss)
+        return false;
+
+    Player* mainTank = GetGroupMainTank(bot);
+    if (!mainTank || !mainTank->IsAlive())
+        return false;
+
+    if (botAI->CanCastSpell("misdirection", mainTank))
+        return botAI->CastSpell("misdirection", mainTank);
+
+    if (!bot->HasAura(Id(ZaSpells::SPELL_MISDIRECTION)))
+        return false;
+
+    return botAI->CanCastSpell("steady shot", boss) && botAI->CastSpell("steady shot", boss);
+}
+
+bool ZulAmanTanksPositionBossAction::Execute(Event /*event*/)
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", _bossName);
+    if (!boss)
+        return false;
+
+    if (AI_VALUE(Unit*, "current target") != boss && PlayerbotAI::IsMainTank(bot))
+        return Attack(boss);
+
+    if (boss->GetVictim() != bot || !bot->IsWithinMeleeRange(boss))
+        return false;
+
+    constexpr float arrivalDist = 2.0f;
+    float moveX;
+    float moveY;
+    bool backwards;
+    if (!GetStepToPosition(bot, _position, arrivalDist, boss, moveX, moveY, backwards))
+        return false;
+
+    return MoveTo(
+        ZA_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false, false, false,
+        MovementPriority::MOVEMENT_COMBAT, true, backwards);
+}
+
+bool ZulAmanSpreadRangedAction::Execute(Event /*event*/)
+{
+    Player* nearestPlayer = GetNearestPlayerInRadius(bot, _minDistance);
+    return nearestPlayer && FleePosition(nearestPlayer->GetPosition(), _minDistance);
+}
+
+bool ZulAmanRunAwayFromWhirlwindAction::Execute(Event /*event*/)
+{
+    Unit* boss = AI_VALUE2(Unit*, "find target", _bossName);
+    if (!boss)
+        return false;
+
+    float const currentDistance = bot->GetExactDist2d(boss);
+    if (currentDistance >= ZA_WHIRLWIND_SAFE_DISTANCE)
+        return false;
+
+    bot->CastStop();
+    return MoveAway(boss, ZA_WHIRLWIND_SAFE_DISTANCE - currentDistance);
+}
 
 // Trash
 
 bool AmanishiMedicineManMarkWardAction::Execute(Event /*event*/)
 {
-    if (Unit* protectiveWard = GetFirstAliveUnitByEntry(
-            botAI, static_cast<uint32>(ZulAmanNPCs::NPC_AMANI_PROTECTIVE_WARD)))
-    {
+    Creature* protectiveWard = bot->FindNearestCreature(
+        Id(ZaNpcs::NPC_AMANI_PROTECTIVE_WARD), ZA_CREATURE_SEARCH_RADIUS);
+    if (protectiveWard)
         return MarkTargetWithSkull(bot, protectiveWard);
-    }
 
-    if (Unit* healingWard = GetFirstAliveUnitByEntry(
-            botAI, static_cast<uint32>(ZulAmanNPCs::NPC_AMANI_HEALING_WARD)))
-    {
-        return MarkTargetWithSkull(bot, healingWard);
-    }
-
-    return false;
+    Creature* healingWard = bot->FindNearestCreature(
+        Id(ZaNpcs::NPC_AMANI_HEALING_WARD), ZA_CREATURE_SEARCH_RADIUS);
+    return healingWard && MarkTargetWithSkull(bot, healingWard);
 }
 
 // Akil'zon <Eagle Avatar>
 
-bool AkilzonMisdirectBossToMainTankAction::Execute(Event /*event*/)
-{
-    Unit* akilzon = AI_VALUE2(Unit*, "find target", "akil'zon");
-    if (!akilzon)
-        return false;
-
-    Player* mainTank = GetGroupMainTank(bot);
-    if (!mainTank)
-        return false;
-
-    if (botAI->CanCastSpell("misdirection", mainTank))
-        return botAI->CastSpell("misdirection", mainTank);
-
-    if (bot->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_MISDIRECTION)) &&
-        botAI->CanCastSpell("steady shot", akilzon))
-        return botAI->CastSpell("steady shot", akilzon);
-
-    return false;
-}
-
-bool AkilzonTanksPositionBossAction::Execute(Event /*event*/)
-{
-    Unit* akilzon = AI_VALUE2(Unit*, "find target", "akil'zon");
-    if (!akilzon)
-        return false;
-
-    if (AI_VALUE(Unit*, "current target") != akilzon)
-        return Attack(akilzon);
-
-    if (akilzon->GetVictim() == bot)
-    {
-        Position const& position = AKILZON_TANK_POSITION;
-        float distToPosition =
-            bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY());
-
-        if (distToPosition > 2.0f)
-        {
-            float dX = position.GetPositionX() - bot->GetPositionX();
-            float dY = position.GetPositionY() - bot->GetPositionY();
-            float moveDist = std::min(10.0f, distToPosition);
-            float moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
-            float moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
-
-            return MoveTo(ZULAMAN_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false,
-                          false, false, MovementPriority::MOVEMENT_COMBAT, true, false);
-        }
-    }
-
-    return false;
-}
-
-bool AkilzonSpreadRangedAction::Execute(Event /*event*/)
-{
-    constexpr float minDistance = 13.0f;
-    constexpr uint32 minInterval = 1000;
-    if (Player* nearestPlayer = GetNearestPlayerInRadius(bot, minDistance))
-        return FleePosition(nearestPlayer->GetPosition(), minDistance, minInterval);
-
-    return false;
-}
-
 bool AkilzonMoveToEyeOfTheStormAction::Execute(Event /*event*/)
 {
     Player* target = GetElectricalStormTarget(bot);
-    if (!target && !botAI->IsMainTank(bot))
+    if (!target && !PlayerbotAI::IsMainTank(bot))
         target = GetGroupMainTank(bot);
 
-    if (target && bot->GetExactDist2d(target) > 2.0f)
-    {
-        botAI->Reset();
-        return MoveTo(ZULAMAN_MAP_ID, target->GetPositionX(), target->GetPositionY(),
-                      bot->GetPositionZ(), false, false, false, false,
-                      MovementPriority::MOVEMENT_FORCED, true, false);
-    }
+    constexpr float arrivalDist = 3.0f;
+    if (!target || bot->GetExactDist2d(target) <= arrivalDist)
+        return false;
 
-    return false;
+    bot->CastStop();
+    return MoveTo(
+        ZA_MAP_ID, target->GetPositionX(), target->GetPositionY(), bot->GetPositionZ(),
+        false, false, false, false, MovementPriority::MOVEMENT_FORCED, true, false);
 }
 
-bool AkilzonManageElectricalStormTimerAction::Execute(Event /*event*/)
+bool AkilzonStartElectricalStormTimerAction::Execute(Event /*event*/)
 {
-    const time_t now = std::time(nullptr);
-    const uint32 instanceId = bot->GetMap()->GetInstanceId();
-
-    Unit* akilzon = AI_VALUE2(Unit*, "find target", "akil'zon");
-    if (akilzon)
-    {
-        auto [it, inserted] = akilzonStormTimer.try_emplace(instanceId, now);
-        return inserted;
-    }
-    else if (!bot->IsInCombat() && !akilzon && akilzonStormTimer.erase(instanceId) > 0)
-    {
-        return true;
-    }
-
-    return false;
+    return akilzonStormTimer.try_emplace(bot->GetInstanceId(), getMSTime()).second;
 }
 
 // Nalorakk <Bear Avatar>
 
-bool NalorakkMisdirectBossToMainTankAction::Execute(Event /*event*/)
+bool NalorakkTanksPositionBossAction::Execute(Event event)
 {
     Unit* nalorakk = AI_VALUE2(Unit*, "find target", "nalorakk");
     if (!nalorakk)
         return false;
 
-    Player* mainTank = GetGroupMainTank(bot);
-    if (!mainTank)
-        return false;
+    if (AI_VALUE(Unit*, "current target") != nalorakk)
+        return Attack(nalorakk);
 
-    if (botAI->CanCastSpell("misdirection", mainTank))
-        return botAI->CastSpell("misdirection", mainTank);
-
-    if (bot->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_MISDIRECTION)) &&
-        botAI->CanCastSpell("steady shot", nalorakk))
-        return botAI->CastSpell("steady shot", nalorakk);
-
-    return false;
-}
-
-bool NalorakkTanksPositionBossAction::Execute(Event /*event*/)
-{
-    if (!botAI->IsMainTank(bot) && !botAI->IsAssistTankOfIndex(bot, 0, true))
-        return false;
-
-    Unit* nalorakk = AI_VALUE2(Unit*, "find target", "nalorakk");
-    if (!nalorakk)
-        return false;
-
-    if (botAI->IsMainTank(bot))
-        return MainTankPositionTrollForm(nalorakk);
+    // Main tank takes bear, assist tank takes troll
+    Player* nalorakkTank = nullptr;
+    if (IsNalorakkInBearForm(nalorakk))
+        nalorakkTank = GetGroupMainTank(bot);
     else
-        return FirstAssistTankPositionBearForm(nalorakk);
-}
+        nalorakkTank = GetGroupAssistTank(bot, 0);
 
-bool NalorakkTanksPositionBossAction::MainTankPositionTrollForm(Unit* nalorakk)
-{
-    if (!nalorakk->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_BEARFORM)))
+    if (nalorakkTank && nalorakkTank == bot)
     {
-        if (AI_VALUE(Unit*, "current target") != nalorakk)
-            return Attack(nalorakk);
-
         if (nalorakk->GetVictim() != bot)
-            return botAI->DoSpecificAction("taunt spell", Event(), true);
+            return botAI->DoSpecificAction("taunt spell", event, true);
+
+        if (!bot->IsWithinMeleeRange(nalorakk))
+            return false;
     }
 
-    Position const& position = NALORAKK_TANK_POSITION;
-    float distToPosition =
-        bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY());
-
-    if (distToPosition > 2.0f)
+    // Both always move to the position but should back to it only when holding Nalorakk, so
+    // whether movement is forwards or backwards is determined by GetStepToPosition().
+    constexpr float arrivalDist = 2.0f;
+    float moveX;
+    float moveY;
+    bool backwards;
+    if (!GetStepToPosition(
+            bot, NALORAKK_TANK_POSITION, arrivalDist, nalorakk, moveX, moveY, backwards))
     {
-        float dX = position.GetPositionX() - bot->GetPositionX();
-        float dY = position.GetPositionY() - bot->GetPositionY();
-        float moveDist = std::min(10.0f, distToPosition);
-        float moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
-        float moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
-
-        return MoveTo(ZULAMAN_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false,
-                        false, false, MovementPriority::MOVEMENT_COMBAT, true, false);
+        return false;
     }
 
-    return false;
-}
-
-bool NalorakkTanksPositionBossAction::FirstAssistTankPositionBearForm(Unit* nalorakk)
-{
-    if (nalorakk->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_BEARFORM)))
-    {
-        if (AI_VALUE(Unit*, "current target") != nalorakk)
-            return Attack(nalorakk);
-
-        if (nalorakk->GetVictim() != bot)
-            return botAI->DoSpecificAction("taunt spell", Event(), true);
-    }
-
-    Position const& position = NALORAKK_TANK_POSITION;
-    float distToPosition =
-        bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY());
-
-    if (distToPosition > 2.0f)
-    {
-        float dX = position.GetPositionX() - bot->GetPositionX();
-        float dY = position.GetPositionY() - bot->GetPositionY();
-        float moveDist = std::min(10.0f, distToPosition);
-        float moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
-        float moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
-
-        return MoveTo(ZULAMAN_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false,
-                        false, false, MovementPriority::MOVEMENT_COMBAT, true, false);
-    }
-
-    return false;
-}
-
-bool NalorakkSpreadRangedAction::Execute(Event /*event*/)
-{
-    constexpr float minDistance = 11.0f;
-    constexpr uint32 minInterval = 1000;
-    if (Player* nearestPlayer = GetNearestPlayerInRadius(bot, minDistance))
-        return FleePosition(nearestPlayer->GetPosition(), minDistance, minInterval);
-
-    return false;
+    return MoveTo(
+        ZA_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false, false, false,
+        MovementPriority::MOVEMENT_COMBAT, true, backwards);
 }
 
 // Jan'alai <Dragonhawk Avatar>
-
-bool JanalaiMisdirectBossToMainTankAction::Execute(Event /*event*/)
-{
-    Unit* janalai = AI_VALUE2(Unit*, "find target", "jan'alai");
-    if (!janalai)
-        return false;
-
-    Player* mainTank = GetGroupMainTank(bot);
-    if (!mainTank)
-        return false;
-
-    if (botAI->CanCastSpell("misdirection", mainTank))
-        return botAI->CastSpell("misdirection", mainTank);
-
-    if (bot->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_MISDIRECTION)) &&
-        botAI->CanCastSpell("steady shot", janalai))
-        return botAI->CastSpell("steady shot", janalai);
-
-    return false;
-}
-
-bool JanalaiTanksPositionBossAction::Execute(Event /*event*/)
-{
-    Unit* janalai = AI_VALUE2(Unit*, "find target", "jan'alai");
-    if (!janalai)
-        return false;
-
-    if (AI_VALUE(Unit*, "current target") != janalai)
-        return Attack(janalai);
-
-    if (janalai->GetVictim() == bot)
-    {
-        Position const& position = JANALAI_TANK_POSITION;
-        float distToPosition =
-            bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY());
-
-        if (distToPosition > 2.0f)
-        {
-            float dX = position.GetPositionX() - bot->GetPositionX();
-            float dY = position.GetPositionY() - bot->GetPositionY();
-            float moveDist = std::min(10.0f, distToPosition);
-            float moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
-            float moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
-
-            return MoveTo(ZULAMAN_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false,
-                          false, false, MovementPriority::MOVEMENT_COMBAT, true, false);
-        }
-    }
-
-    return false;
-}
 
 bool JanalaiSpreadRangedInCircleAction::Execute(Event /*event*/)
 {
@@ -300,7 +190,7 @@ bool JanalaiSpreadRangedInCircleAction::Execute(Event /*event*/)
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
         Player* member = ref->GetSource();
-        if (!member || !botAI->IsRanged(member))
+        if (!member || member->GetMapId() != ZA_MAP_ID || !PlayerbotAI::IsRanged(member))
             continue;
 
         rangedMembers.push_back(member);
@@ -313,38 +203,34 @@ bool JanalaiSpreadRangedInCircleAction::Execute(Event /*event*/)
     size_t botIndex =
         (findIt != rangedMembers.end()) ? std::distance(rangedMembers.begin(), findIt) : 0;
     size_t count = rangedMembers.size();
-    if (count == 0)
+    float angle = (count == 1) ? 0.0f
+        : (2.0f * M_PI * static_cast<float>(botIndex) / static_cast<float>(count));
+
+    float targetX =
+        JANALAI_TANK_POSITION.GetPositionX() + JANALAI_RANGED_SPREAD_RADIUS * std::cos(angle);
+    float targetY =
+        JANALAI_TANK_POSITION.GetPositionY() + JANALAI_RANGED_SPREAD_RADIUS * std::sin(angle);
+
+    constexpr float arrivalDist = 2.0f;
+    if (bot->GetExactDist2d(targetX, targetY) <= arrivalDist)
         return false;
 
-    constexpr float radius = 15.0f;
-    float angle = (count == 1) ? 0.0f :
-            (2.0f * M_PI * static_cast<float>(botIndex) / static_cast<float>(count));
-
-    float targetX = JANALAI_TANK_POSITION.GetPositionX() + radius * std::cos(angle);
-    float targetY = JANALAI_TANK_POSITION.GetPositionY() + radius * std::sin(angle);
-
-    if (bot->GetExactDist2d(targetX, targetY) > 2.0f)
-    {
-        return MoveTo(ZULAMAN_MAP_ID, targetX, targetY, bot->GetPositionZ(), false, false,
-                      false, false, MovementPriority::MOVEMENT_COMBAT, true, false);
-    }
-
-    return false;
+    return MoveTo(
+        ZA_MAP_ID, targetX, targetY, bot->GetPositionZ(), false, false, false, false,
+        MovementPriority::MOVEMENT_COMBAT, true, false);
 }
 
 bool JanalaiAvoidFireBombsAction::Execute(Event /*event*/)
 {
-    auto const& bombs = GetAllHazardTriggers(
-        bot, static_cast<uint32>(ZulAmanNPCs::NPC_FIRE_BOMB), 50.0f);
+    std::vector<Unit*> const bombs = GetNearbyFireBombs(botAI);
 
     if (bombs.empty())
         return false;
 
-    constexpr float hazardRadius = 5.0f;
     bool inDanger = false;
     for (Unit* bomb : bombs)
     {
-        if (bot->GetDistance2d(bomb) < hazardRadius)
+        if (bot->GetExactDist2d(bomb) < JANALAI_FIRE_BOMB_SAFE_DISTANCE)
         {
             inDanger = true;
             break;
@@ -354,166 +240,77 @@ bool JanalaiAvoidFireBombsAction::Execute(Event /*event*/)
     if (!inDanger)
         return false;
 
-    Position const& janalaiCenter = JANALAI_TANK_POSITION;
-    constexpr float safeZoneRadius = 17.0f;
+    constexpr float maxFloorDeviation = 5.0f;
+    if (std::fabs(bot->GetPositionZ() - JANALAI_PLATFORM_Z) > maxFloorDeviation)
+        return false;
 
-    Position safestPos =
-        FindSafestNearbyPosition(bot, bombs, janalaiCenter, safeZoneRadius, hazardRadius, false);
+    constexpr float moveDist = 3.5f;
 
-    bot->AttackStop();
+    float stepX;
+    float stepY;
+    float stepZ;
+    if (!FindSafeStepInJanalaiZone(
+            bot, bombs, JANALAI_SAFE_ZONE, JANALAI_FIRE_BOMB_MAX_SEARCH_DISTANCE,
+            JANALAI_FIRE_BOMB_SAFE_DISTANCE, moveDist, stepX, stepY, stepZ))
+    {
+        return false;
+    }
+
     bot->CastStop();
-    return MoveTo(ZULAMAN_MAP_ID, safestPos.GetPositionX(), safestPos.GetPositionY(),
-                  bot->GetPositionZ(), false, false, false, false,
-                  MovementPriority::MOVEMENT_FORCED, true, false);
+    return MoveTo(
+        ZA_MAP_ID, stepX, stepY, stepZ, false, false, false, false,
+        MovementPriority::MOVEMENT_FORCED, true, false);
 }
 
 bool JanalaiMarkAmanishiHatchersAction::Execute(Event /*event*/)
 {
     auto [hatcherLow, hatcherHigh] = GetAmanishiHatcherPair(botAI);
+    if (!hatcherLow || !hatcherHigh || hatcherHigh == hatcherLow)
+        return false;
 
-    if (hatcherLow && hatcherHigh && hatcherHigh != hatcherLow)
-    {
-        return MarkTargetWithMoon(bot, hatcherHigh) ||
-               MarkTargetWithSkull(bot, hatcherLow);
-    }
-
-    return false;
+    return MarkTargetWithMoon(bot, hatcherHigh) || MarkTargetWithSkull(bot, hatcherLow);
 }
 
 // Halazzi <Lynx Avatar>
 
-bool HalazziMisdirectBossToMainTankAction::Execute(Event /*event*/)
+bool HalazziFirstAssistTankAttackSpiritLynxAction::Execute(Event event)
 {
-    Unit* halazzi = AI_VALUE2(Unit*, "find target", "halazzi");
-    if (!halazzi)
-        return false;
-
-    Player* mainTank = GetGroupMainTank(bot);
-    if (!mainTank)
-        return false;
-
-    if (botAI->CanCastSpell("misdirection", mainTank))
-        return botAI->CastSpell("misdirection", mainTank);
-
-    if (bot->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_MISDIRECTION)) &&
-        botAI->CanCastSpell("steady shot", halazzi))
-        return botAI->CastSpell("steady shot", halazzi);
-
-    return false;
-}
-
-bool HalazziMainTankPositionBossAction::Execute(Event /*event*/)
-{
-    Unit* halazzi = AI_VALUE2(Unit*, "find target", "halazzi");
-    if (!halazzi)
-        return false;
-
-    if (MarkTargetWithStar(bot, halazzi))
-        return true;
-
-    SetRtiTarget(botAI, "star");
-
-    if (AI_VALUE(Unit*, "current target") != halazzi)
-        return Attack(halazzi);
-
-    if (halazzi->GetVictim() == bot)
-    {
-        Position const& position = HALAZZI_TANK_POSITION;
-        float distToPosition =
-            bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY());
-
-        if (distToPosition > 2.0f)
-        {
-            float dX = position.GetPositionX() - bot->GetPositionX();
-            float dY = position.GetPositionY() - bot->GetPositionY();
-            float moveDist = std::min(10.0f, distToPosition);
-            float moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
-            float moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
-
-            return MoveTo(ZULAMAN_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false,
-                          false, false, MovementPriority::MOVEMENT_COMBAT, true, false);
-        }
-    }
-
-    return false;
-}
-
-bool HalazziFirstAssistTankAttackSpiritLynxAction::Execute(Event /*event*/)
-{
-    bool targetFound = false;
-
     if (Unit* lynx = AI_VALUE2(Unit*, "find target", "spirit of the lynx"))
     {
-        if (MarkTargetWithCircle(bot, lynx))
-            return true;
-
-        SetRtiTarget(botAI, "circle");
-
         if (AI_VALUE(Unit*, "current target") != lynx)
             return Attack(lynx);
 
         if (lynx->GetVictim() != bot)
-            return botAI->DoSpecificAction("taunt spell", Event(), true);
-
-        targetFound = true;
+            return botAI->DoSpecificAction("taunt spell", event, true);
     }
-    else if (Unit* halazzi = AI_VALUE2(Unit*, "find target", "halazzi"))
-    {
-        SetRtiTarget(botAI, "star");
-
-        if (AI_VALUE(Unit*, "current target") != halazzi)
-            return Attack(halazzi);
-
-        targetFound = true;
-    }
-
-    if (!targetFound)
-        return false;
 
     Position const& position = HALAZZI_TANK_POSITION;
-    float distToPosition =
-        bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY());
+    float const distToPosition = bot->GetExactDist2d(position);
+    constexpr float arrivalDist = 2.0f;
 
-    if (distToPosition > 2.0f)
-    {
-        float dX = position.GetPositionX() - bot->GetPositionX();
-        float dY = position.GetPositionY() - bot->GetPositionY();
-        float moveDist = std::min(10.0f, distToPosition);
-        float moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
-        float moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
+    if (distToPosition <= arrivalDist)
+        return false;
 
-        return MoveTo(ZULAMAN_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false,
-                      false, false, MovementPriority::MOVEMENT_COMBAT, true, false);
-    }
-
-    return false;
+    return MoveTo(
+        ZA_MAP_ID, position.GetPositionX(), position.GetPositionY(), bot->GetPositionZ(),
+        false, false, false, false, MovementPriority::MOVEMENT_COMBAT, true, false);
 }
 
-bool HalazziAssignDpsPriorityAction::Execute(Event /*event*/)
+bool HalazziDpsAttackTotemAndBossAction::Execute(Event /*event*/)
 {
     // Target priority 1: Corrupted Lightning Totems
-    if (Unit* totem = GetFirstAliveUnitByEntry(
-            botAI, static_cast<uint32>(ZulAmanNPCs::NPC_CORRUPTED_LIGHTNING_TOTEM)))
+    if (Creature* totem = bot->FindNearestCreature(
+            Id(ZaNpcs::NPC_CORRUPTED_LIGHTNING_TOTEM), ZA_CREATURE_SEARCH_RADIUS))
     {
         if (MarkTargetWithSkull(bot, totem))
             return true;
 
-        SetRtiTarget(botAI, "skull");
-
-        if (AI_VALUE(Unit*, "current target") != totem)
-            return Attack(totem);
-
-        return false;
+        return AI_VALUE(Unit*, "current target") != totem && Attack(totem);
     }
 
     // Target priority 2: Halazzi
     if (Unit* halazzi = AI_VALUE2(Unit*, "find target", "halazzi"))
-    {
-        SetRtiTarget(botAI, "star");
-
-        if (AI_VALUE(Unit*, "current target") != halazzi)
-            return Attack(halazzi);
-    }
+        return AI_VALUE(Unit*, "current target") != halazzi && Attack(halazzi);
 
     // Don't attack the Lynx
     return false;
@@ -521,235 +318,80 @@ bool HalazziAssignDpsPriorityAction::Execute(Event /*event*/)
 
 // Hex Lord Malacrass
 
-bool HexLordMalacrassMisdirectBossToMainTankAction::Execute(Event /*event*/)
-{
-    Unit* malacrass = AI_VALUE2(Unit*, "find target", "hex lord malacrass");
-    if (!malacrass)
-        return false;
-
-    Player* mainTank = GetGroupMainTank(bot);
-    if (!mainTank)
-        return false;
-
-    if (botAI->CanCastSpell("misdirection", mainTank))
-        return botAI->CastSpell("misdirection", mainTank);
-
-    if (bot->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_MISDIRECTION)) &&
-        botAI->CanCastSpell("steady shot", malacrass))
-        return botAI->CastSpell("steady shot", malacrass);
-
-    return false;
-}
-
 bool HexLordMalacrassAssignDpsPriorityAction::Execute(Event /*event*/)
 {
-    static constexpr uint32 priorityEntries[] =
-    {
-        static_cast<uint32>(ZulAmanNPCs::NPC_LORD_RAADAN),
-        static_cast<uint32>(ZulAmanNPCs::NPC_ALYSON_ANTILLE),
-        static_cast<uint32>(ZulAmanNPCs::NPC_KORAGG),
-        static_cast<uint32>(ZulAmanNPCs::NPC_DARKHEART),
-        static_cast<uint32>(ZulAmanNPCs::NPC_FENSTALKER),
-        static_cast<uint32>(ZulAmanNPCs::NPC_GAZAKROTH),
-        static_cast<uint32>(ZulAmanNPCs::NPC_THURG),
-        static_cast<uint32>(ZulAmanNPCs::NPC_SLITHER),
-        static_cast<uint32>(ZulAmanNPCs::NPC_HEX_LORD_MALACRASS)
+    static constexpr std::array hexLordAdds = {
+        Id(ZaNpcs::NPC_LORD_RAADAN),
+        Id(ZaNpcs::NPC_ALYSON_ANTILLE),
+        Id(ZaNpcs::NPC_KORAGG),
+        Id(ZaNpcs::NPC_DARKHEART),
+        Id(ZaNpcs::NPC_FENSTALKER),
+        Id(ZaNpcs::NPC_GAZAKROTH),
+        Id(ZaNpcs::NPC_THURG),
+        Id(ZaNpcs::NPC_SLITHER),
+        Id(ZaNpcs::NPC_HEX_LORD_MALACRASS)
     };
 
-    auto const& targets =
-        botAI->GetAiObjectContext()->GetValue<GuidVector>("possible targets no los")->Get();
-
     Unit* priorityTarget = nullptr;
-
-    for (uint32 entry : priorityEntries)
+    size_t bestRank = hexLordAdds.size();
+    for (auto const& guid : AI_VALUE(GuidVector, "possible targets no los"))
     {
-        for (auto const& guid : targets)
+        Unit* unit = botAI->GetUnit(guid);
+        if (!unit || !unit->IsAlive())
+            continue;
+
+        auto const it = std::find(hexLordAdds.begin(), hexLordAdds.end(), unit->GetEntry());
+        size_t const rank = std::distance(hexLordAdds.begin(), it);
+        if (rank < bestRank)
         {
-            Unit* unit = botAI->GetUnit(guid);
-            if (unit && unit->IsAlive() && unit->GetEntry() == entry)
-            {
-                priorityTarget = unit;
-                break;
-            }
-        }
-
-        if (priorityTarget)
-            break;
-    }
-
-    if (priorityTarget)
-    {
-        if (MarkTargetWithSkull(bot, priorityTarget))
-            return true;
-
-        SetRtiTarget(botAI, "skull");
-    }
-
-    return false;
-}
-
-bool HexLordMalacrassRunAwayFromWhirlwindAction::Execute(Event /*event*/)
-{
-    if (Unit* malacrass = AI_VALUE2(Unit*, "find target", "hex lord malacrass"))
-    {
-        float currentDistance = bot->GetDistance2d(malacrass);
-        constexpr float safeDistance = 9.0f;
-        if (currentDistance < safeDistance)
-        {
-            bot->AttackStop();
-            bot->CastStop();
-            return MoveAway(malacrass, safeDistance - currentDistance);
+            bestRank = rank;
+            priorityTarget = unit;
         }
     }
 
-    return false;
-}
-
-bool HexLordMalacrassCastersStopAttackingAction::Execute(Event /*event*/)
-{
-    Unit* malacrass = AI_VALUE2(Unit*, "find target", "hex lord malacrass");
-    if (!malacrass ||
-        !malacrass->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_HEX_LORD_SPELL_REFLECTION)))
-        return false;
-
-    if (AI_VALUE(Unit*, "current target") == malacrass)
-    {
-        bot->AttackStop();
-        bot->CastStop();
-        return true;
-    }
-
-    return false;
+    return priorityTarget && MarkTargetWithSkull(bot, priorityTarget);
 }
 
 bool HexLordMalacrassMoveAwayFromFreezingTrapAction::Execute(Event /*event*/)
 {
-    GameObject* trapGo = bot->FindNearestGameObject(
-        static_cast<uint32>(ZulAmanObjects::GO_FREEZING_TRAP), 20.0f, true);
-
-    if (!trapGo)
+    GameObject* trap = GetNearbyFreezingTrap(botAI);
+    if (!trap)
         return false;
 
-    float currentDistance = bot->GetDistance2d(trapGo);
-    constexpr float safeDistance = 6.0f;
-    constexpr uint32 minInterval = 0;
-    if (currentDistance < safeDistance)
-        return FleePosition(trapGo->GetPosition(), safeDistance, minInterval);
+    float const currentDistance = bot->GetExactDist2d(trap);
+    if (currentDistance >= ZA_FREEZING_TRAP_SAFE_DISTANCE)
+        return false;
 
-    return false;
+    constexpr uint32 minInterval = 0;
+    return FleePosition(trap->GetPosition(), ZA_FREEZING_TRAP_SAFE_DISTANCE, minInterval);
 }
 
 // Zul'jin
 
-bool ZuljinMisdirectBossToMainTankAction::Execute(Event /*event*/)
+bool ZuljinMassDispelCreepingParalysisAction::Execute(Event /*event*/)
 {
-    Unit* zuljin = AI_VALUE2(Unit*, "find target", "zul'jin");
-    if (!zuljin)
-        return false;
-
-    Player* mainTank = GetGroupMainTank(bot);
-    if (!mainTank)
-        return false;
-
-    if (botAI->CanCastSpell("misdirection", mainTank))
-        return botAI->CastSpell("misdirection", mainTank);
-
-    if (bot->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_MISDIRECTION)) &&
-        botAI->CanCastSpell("steady shot", zuljin))
-        return botAI->CastSpell("steady shot", zuljin);
-
-    return false;
+    Player* paralysisTarget = GetZuljinCreepingParalysisDispelTarget(bot);
+    return paralysisTarget &&
+        botAI->CanCastSpell(Id(ZaSpells::SPELL_MASS_DISPEL), paralysisTarget) &&
+        botAI->CastSpell(Id(ZaSpells::SPELL_MASS_DISPEL), paralysisTarget);
 }
 
-bool ZuljinTanksPositionBossAction::Execute(Event /*event*/)
+bool ZuljinPositionRangedForCyclonesAction::Execute(Event /*event*/)
 {
-    Unit* zuljin = AI_VALUE2(Unit*, "find target", "zul'jin");
-    if (!zuljin)
+    size_t slotIndex;
+    if (!GetZuljinSpreadSlotIndex(bot, ZULJIN_SPREAD_POSITIONS.size(), slotIndex))
         return false;
 
-    if (AI_VALUE(Unit*, "current target") != zuljin)
-        return Attack(zuljin);
+    Position const& position = ZULJIN_SPREAD_POSITIONS[slotIndex];
 
-    if (zuljin->GetVictim() == bot)
-    {
-        Position const& position = ZULJIN_TANK_POSITION;
-        float distToPosition =
-            bot->GetExactDist2d(position.GetPositionX(), position.GetPositionY());
-
-        if (distToPosition > 2.0f)
-        {
-            float dX = position.GetPositionX() - bot->GetPositionX();
-            float dY = position.GetPositionY() - bot->GetPositionY();
-            float moveDist = std::min(10.0f, distToPosition);
-            float moveX = bot->GetPositionX() + (dX / distToPosition) * moveDist;
-            float moveY = bot->GetPositionY() + (dY / distToPosition) * moveDist;
-
-            return MoveTo(ZULAMAN_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false,
-                          false, false, MovementPriority::MOVEMENT_COMBAT, true, true);
-        }
-    }
-
-    return false;
-}
-
-bool ZuljinRunAwayFromWhirlwindAction::Execute(Event /*event*/)
-{
-    if (Unit* zuljin = AI_VALUE2(Unit*, "find target", "zul'jin"))
-    {
-        float currentDistance = bot->GetExactDist2d(zuljin);
-        constexpr float safeDistance = 10.0f;
-        if (currentDistance < safeDistance)
-        {
-            bot->AttackStop();
-            bot->CastStop();
-            return MoveAway(zuljin, safeDistance - currentDistance);
-        }
-    }
-
-    return false;
-}
-
-bool ZuljinAvoidCyclonesAction::Execute(Event /*event*/)
-{
-    auto const& cyclones = GetAllHazardTriggers(
-        bot, static_cast<uint32>(ZulAmanNPCs::NPC_FEATHER_VORTEX), 50.0f);
-
-    if (cyclones.empty())
+    constexpr float arrivalDist = 2.0f;
+    float moveX;
+    float moveY;
+    bool backwards;
+    if (!GetStepToPosition(bot, position, arrivalDist, nullptr, moveX, moveY, backwards))
         return false;
 
-    constexpr float hazardRadius = 6.0f;
-    bool inDanger = false;
-    for (Unit* cyclone : cyclones)
-    {
-        if (bot->GetDistance2d(cyclone) < hazardRadius)
-        {
-            inDanger = true;
-            break;
-        }
-    }
-
-    if (!inDanger)
-        return false;
-
-    Position const& zuljinCenter = ZULJIN_TANK_POSITION;
-    constexpr float safeZoneRadius = 30.0f;
-
-    Position safestPos =
-        FindSafestNearbyPosition(bot, cyclones, zuljinCenter, safeZoneRadius, hazardRadius, true);
-
-    bot->AttackStop();
-    bot->CastStop();
-    return MoveTo(ZULAMAN_MAP_ID, safestPos.GetPositionX(), safestPos.GetPositionY(),
-                  bot->GetPositionZ(), false, false, false, false,
-                  MovementPriority::MOVEMENT_FORCED, true, false);
-}
-
-bool ZuljinSpreadRangedAction::Execute(Event /*event*/)
-{
-    constexpr float minDistance = 6.0f;
-    constexpr uint32 minInterval = 1000;
-    if (Player* nearestPlayer = GetNearestPlayerInRadius(bot, minDistance))
-        return FleePosition(nearestPlayer->GetPosition(), minDistance, minInterval);
-
-    return false;
+    return MoveTo(
+        ZA_MAP_ID, moveX, moveY, bot->GetPositionZ(), false, false, false, false,
+        MovementPriority::MOVEMENT_COMBAT, true, backwards);
 }

--- a/src/Ai/Raid/ZA/ZAActions.h
+++ b/src/Ai/Raid/ZA/ZAActions.h
@@ -10,244 +10,183 @@
 #include "Action.h"
 #include "AttackAction.h"
 #include "MovementActions.h"
+#include <string>
+
+// General
+
+class ZulAmanResetEncounterStatesAction : public Action
+{
+public:
+    ZulAmanResetEncounterStatesAction(PlayerbotAI* botAI)
+        : Action(botAI, "zul'aman reset encounter states") {}
+    bool Execute(Event event) override;
+};
+
+class ZulAmanMisdirectBossToMainTankAction : public Action
+{
+public:
+    ZulAmanMisdirectBossToMainTankAction(
+        PlayerbotAI* botAI, std::string const& name, std::string const& bossName)
+        : Action(botAI, name), _bossName(bossName) {}
+    bool Execute(Event event) override;
+
+private:
+    std::string const _bossName;
+};
+
+class ZulAmanTanksPositionBossAction : public AttackAction
+{
+public:
+    ZulAmanTanksPositionBossAction(
+        PlayerbotAI* botAI, std::string const& name, std::string const& bossName,
+        Position const& position)
+        : AttackAction(botAI, name), _bossName(bossName), _position(position) {}
+    bool Execute(Event event) override;
+
+private:
+    std::string const _bossName;
+    Position const _position;
+};
+
+class ZulAmanSpreadRangedAction : public MovementAction
+{
+public:
+    ZulAmanSpreadRangedAction(
+        PlayerbotAI* botAI, std::string const& name, float minDistance)
+        : MovementAction(botAI, name), _minDistance(minDistance) {}
+    bool Execute(Event event) override;
+
+private:
+    float const _minDistance;
+};
+
+class ZulAmanRunAwayFromWhirlwindAction : public MovementAction
+{
+public:
+    ZulAmanRunAwayFromWhirlwindAction(
+        PlayerbotAI* botAI, std::string const& name, std::string const& bossName)
+        : MovementAction(botAI, name), _bossName(bossName) {}
+    bool Execute(Event event) override;
+
+private:
+    std::string const _bossName;
+};
 
 // Trash
 
 class AmanishiMedicineManMarkWardAction : public Action
 {
 public:
-    AmanishiMedicineManMarkWardAction(
-        PlayerbotAI* botAI, std::string const name = "amani'shi medicine man mark ward") : Action(botAI, name) {}
+    AmanishiMedicineManMarkWardAction(PlayerbotAI* botAI)
+        : Action(botAI, "amani'shi medicine man mark ward") {}
     bool Execute(Event event) override;
 };
 
 // Akil'zon <Eagle Avatar>
 
-class AkilzonMisdirectBossToMainTankAction : public AttackAction
-{
-public:
-    AkilzonMisdirectBossToMainTankAction(
-        PlayerbotAI* botAI, std::string const name = "akil'zon misdirect boss to main tank") : AttackAction(botAI, name) {}
-    bool Execute(Event event) override;
-};
-
-class AkilzonTanksPositionBossAction : public AttackAction
-{
-public:
-    AkilzonTanksPositionBossAction(
-        PlayerbotAI* botAI, std::string const name = "akil'zon tanks position boss") : AttackAction(botAI, name) {}
-    bool Execute(Event event) override;
-};
-
-class AkilzonSpreadRangedAction : public MovementAction
-{
-public:
-    AkilzonSpreadRangedAction(
-        PlayerbotAI* botAI, std::string const name = "akil'zon spread ranged") : MovementAction(botAI, name) {}
-    bool Execute(Event event) override;
-};
-
 class AkilzonMoveToEyeOfTheStormAction : public MovementAction
 {
 public:
-    AkilzonMoveToEyeOfTheStormAction(
-        PlayerbotAI* botAI, std::string const name = "akil'zon move to eye of the storm") : MovementAction(botAI, name) {}
+    AkilzonMoveToEyeOfTheStormAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "akil'zon move to eye of the storm") {}
     bool Execute(Event event) override;
 };
 
-class AkilzonManageElectricalStormTimerAction : public Action
+class AkilzonStartElectricalStormTimerAction : public Action
 {
 public:
-    AkilzonManageElectricalStormTimerAction(
-        PlayerbotAI* botAI, std::string const name = "akil'zon manage electrical storm timer") : Action(botAI, name) {}
+    AkilzonStartElectricalStormTimerAction(PlayerbotAI* botAI)
+        : Action(botAI, "akil'zon start electrical storm timer") {}
     bool Execute(Event event) override;
 };
 
 // Nalorakk <Bear Avatar>
 
-class NalorakkMisdirectBossToMainTankAction : public AttackAction
-{
-public:
-    NalorakkMisdirectBossToMainTankAction(
-        PlayerbotAI* botAI, std::string const name = "nalorakk misdirect boss to main tank") : AttackAction(botAI, name) {}
-    bool Execute(Event event) override;
-};
-
 class NalorakkTanksPositionBossAction : public AttackAction
 {
 public:
-    NalorakkTanksPositionBossAction(
-        PlayerbotAI* botAI, std::string const name = "nalorakk tanks position boss") : AttackAction(botAI, name) {}
-    bool Execute(Event event) override;
-
-private:
-    bool MainTankPositionTrollForm(Unit* nalorakk);
-    bool FirstAssistTankPositionBearForm(Unit* nalorakk);
-};
-
-class NalorakkSpreadRangedAction : public MovementAction
-{
-public:
-    NalorakkSpreadRangedAction(
-        PlayerbotAI* botAI, std::string const name = "nalorakk spread ranged") : MovementAction(botAI, name) {}
+    NalorakkTanksPositionBossAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "nalorakk tanks position boss") {}
     bool Execute(Event event) override;
 };
 
 // Jan'alai <Dragonhawk Avatar>
 
-class JanalaiMisdirectBossToMainTankAction : public AttackAction
-{
-public:
-    JanalaiMisdirectBossToMainTankAction(
-        PlayerbotAI* botAI, std::string const name = "jan'alai misdirect boss to main tank") : AttackAction(botAI, name) {}
-    bool Execute(Event event) override;
-};
-
-class JanalaiTanksPositionBossAction : public AttackAction
-{
-public:
-    JanalaiTanksPositionBossAction(
-        PlayerbotAI* botAI, std::string const name = "jan'alai tanks position boss") : AttackAction(botAI, name) {}
-    bool Execute(Event event) override;
-};
-
 class JanalaiSpreadRangedInCircleAction : public MovementAction
 {
 public:
-    JanalaiSpreadRangedInCircleAction(
-        PlayerbotAI* botAI, std::string const name = "jan'alai spread ranged in circle") : MovementAction(botAI, name) {}
+    JanalaiSpreadRangedInCircleAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "jan'alai spread ranged in circle") {}
     bool Execute(Event event) override;
 };
 
 class JanalaiAvoidFireBombsAction : public MovementAction
 {
 public:
-    JanalaiAvoidFireBombsAction(PlayerbotAI* botAI, std::string const name = "jan'alai avoid fire bombs") : MovementAction(botAI, name) {}
+    JanalaiAvoidFireBombsAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "jan'alai avoid fire bombs") {}
     bool Execute(Event event) override;
 };
 
 class JanalaiMarkAmanishiHatchersAction : public Action
 {
 public:
-    JanalaiMarkAmanishiHatchersAction(
-        PlayerbotAI* botAI, std::string const name = "jan'alai mark amani'shi hatchers") : Action(botAI, name) {}
+    JanalaiMarkAmanishiHatchersAction(PlayerbotAI* botAI)
+        : Action(botAI, "jan'alai mark amani'shi hatchers") {}
     bool Execute(Event event) override;
 };
 
 // Halazzi <Lynx Avatar>
 
-class HalazziMisdirectBossToMainTankAction : public AttackAction
-{
-public:
-    HalazziMisdirectBossToMainTankAction(
-        PlayerbotAI* botAI, std::string const name = "halazzi misdirect boss to main tank") : AttackAction(botAI, name) {}
-    bool Execute(Event event) override;
-};
-
-class HalazziMainTankPositionBossAction : public AttackAction
-{
-public:
-    HalazziMainTankPositionBossAction(
-        PlayerbotAI* botAI, std::string const name = "halazzi main tank position boss") : AttackAction(botAI, name) {}
-    bool Execute(Event event) override;
-};
-
 class HalazziFirstAssistTankAttackSpiritLynxAction : public AttackAction
 {
 public:
-    HalazziFirstAssistTankAttackSpiritLynxAction(
-        PlayerbotAI* botAI, std::string const name = "halazzi first assist tank attack spirit lynx") : AttackAction(botAI, name) {}
+    HalazziFirstAssistTankAttackSpiritLynxAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "halazzi first assist tank attack spirit lynx") {}
     bool Execute(Event event) override;
 };
 
-class HalazziAssignDpsPriorityAction : public AttackAction
+class HalazziDpsAttackTotemAndBossAction : public AttackAction
 {
 public:
-    HalazziAssignDpsPriorityAction(
-        PlayerbotAI* botAI, std::string const name = "halazzi assign dps priority") : AttackAction(botAI, name) {}
+    HalazziDpsAttackTotemAndBossAction(PlayerbotAI* botAI)
+        : AttackAction(botAI, "halazzi dps attack totem and boss") {}
     bool Execute(Event event) override;
 };
 
 // Hex Lord Malacrass
 
-class HexLordMalacrassMisdirectBossToMainTankAction : public AttackAction
-{
-public:
-    HexLordMalacrassMisdirectBossToMainTankAction(
-        PlayerbotAI* botAI, std::string const name = "hex lord malacrass misdirect boss to main tank") : AttackAction(botAI, name) {}
-    bool Execute(Event event) override;
-};
-
 class HexLordMalacrassAssignDpsPriorityAction : public AttackAction
 {
 public:
-    HexLordMalacrassAssignDpsPriorityAction(
-        PlayerbotAI* botAI, std::string const name = "hex lord malacrass assign dps priority") : AttackAction(botAI, name) {}
-    bool Execute(Event event) override;
-};
-
-class HexLordMalacrassRunAwayFromWhirlwindAction : public MovementAction
-{
-public:
-    HexLordMalacrassRunAwayFromWhirlwindAction(
-        PlayerbotAI* botAI, std::string const name = "hex lord malacrass run away from whirlwind") : MovementAction(botAI, name) {}
-    bool Execute(Event event) override;
-};
-
-class HexLordMalacrassCastersStopAttackingAction : public Action
-{
-public:
-    HexLordMalacrassCastersStopAttackingAction(
-        PlayerbotAI* botAI, std::string const name = "hex lord malacrass casters stop attacking") : Action(botAI, name) {}
+    HexLordMalacrassAssignDpsPriorityAction(PlayerbotAI* botAI)
+        : AttackAction(botAI,  "hex lord malacrass assign dps priority") {}
     bool Execute(Event event) override;
 };
 
 class HexLordMalacrassMoveAwayFromFreezingTrapAction : public MovementAction
 {
 public:
-    HexLordMalacrassMoveAwayFromFreezingTrapAction(
-        PlayerbotAI* botAI, std::string const name = "hex lord malacrass move away from freezing trap") : MovementAction(botAI, name) {}
+    HexLordMalacrassMoveAwayFromFreezingTrapAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "hex lord malacrass move away from freezing trap") {}
     bool Execute(Event event) override;
 };
 
 // Zul'jin
 
-class ZuljinMisdirectBossToMainTankAction : public AttackAction
+class ZuljinMassDispelCreepingParalysisAction : public Action
 {
 public:
-    ZuljinMisdirectBossToMainTankAction(
-        PlayerbotAI* botAI, std::string const name = "zul'jin misdirect boss to main tank") : AttackAction(botAI, name) {}
+    ZuljinMassDispelCreepingParalysisAction(PlayerbotAI* botAI)
+        : Action(botAI, "zul'jin mass dispel creeping paralysis") {}
     bool Execute(Event event) override;
 };
 
-class ZuljinTanksPositionBossAction : public AttackAction
+class ZuljinPositionRangedForCyclonesAction : public MovementAction
 {
 public:
-    ZuljinTanksPositionBossAction(
-        PlayerbotAI* botAI, std::string const name = "zul'jin tanks position boss") : AttackAction(botAI, name) {}
-    bool Execute(Event event) override;
-};
-
-class ZuljinRunAwayFromWhirlwindAction : public MovementAction
-{
-public:
-    ZuljinRunAwayFromWhirlwindAction(
-        PlayerbotAI* botAI, std::string const name = "zul'jin run away from whirlwind") : MovementAction(botAI, name) {}
-    bool Execute(Event event) override;
-};
-
-class ZuljinAvoidCyclonesAction : public MovementAction
-{
-public:
-    ZuljinAvoidCyclonesAction(PlayerbotAI* botAI, std::string const name = "zul'jin avoid cyclones") : MovementAction(botAI, name) {}
-    bool Execute(Event event) override;
-};
-
-class ZuljinSpreadRangedAction : public MovementAction
-{
-public:
-    ZuljinSpreadRangedAction(
-        PlayerbotAI* botAI, std::string const name = "zul'jin spread ranged") : MovementAction(botAI, name) {}
+    ZuljinPositionRangedForCyclonesAction(PlayerbotAI* botAI)
+        : MovementAction(botAI, "zul'jin position ranged for cyclones") {}
     bool Execute(Event event) override;
 };
 

--- a/src/Ai/Raid/ZA/ZAHelpers.cpp
+++ b/src/Ai/Raid/ZA/ZAHelpers.cpp
@@ -5,79 +5,40 @@
  */
 
 #include "ZAHelpers.h"
-#include "Group.h"
+#include "EncounterHelpers.h"
 #include "Playerbots.h"
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <list>
 
-namespace ZulAmanHelpers
+using namespace EncounterHelpers;
+
+namespace
 {
 
-// General
-Position FindSafestNearbyPosition(Player* bot,
-    std::vector<Unit*> const& hazards, Position const& safeZoneCenter,
-    float safeZoneRadius, float hazardRadius, bool requireSafePath)
+bool IsInsideSafeZone(std::vector<Position> const& corners, float x, float y)
 {
-    constexpr float searchStep = M_PI / 8.0f;
-    constexpr float distanceStep = 1.0f;
-
-    Position bestPos;
-    float minMoveDistance = std::numeric_limits<float>::max();
-    bool foundSafe = false;
-
-    for (float distance = 0.0f;
-            distance <= safeZoneRadius; distance += distanceStep)
+    // The safe zone's shape is pentagonal, sort of like a rectangle with one of the corners cut
+    // out (to exclude a fenced-off broken corner of the stage).
+    size_t const count = corners.size();
+    int8 insideSign = 0;
+    for (size_t i = 0; i < count; ++i)
     {
-        for (float angle = 0.0f; angle < 2 * M_PI; angle += searchStep)
-        {
-            float x = bot->GetPositionX() + distance * std::cos(angle);
-            float y = bot->GetPositionY() + distance * std::sin(angle);
+        Position const& edgeStart = corners[i];
+        Position const& edgeEnd = corners[(i + 1) % count];
 
-            if (safeZoneCenter.GetExactDist2d(x, y) > safeZoneRadius)
-                continue;
+        float cross =
+            (edgeEnd.GetPositionX() - edgeStart.GetPositionX()) * (y - edgeStart.GetPositionY()) -
+            (edgeEnd.GetPositionY() - edgeStart.GetPositionY()) * (x - edgeStart.GetPositionX());
 
-            if (!IsPositionSafeFromHazards(x, y, hazards, hazardRadius))
-                continue;
+        if (cross == 0.0f)
+            continue;
 
-            Position testPos(x, y, bot->GetPositionZ());
-
-            bool pathSafe = true;
-            if (requireSafePath)
-            {
-                pathSafe =
-                    IsPathSafeFromHazards(bot->GetPosition(), testPos, hazards, hazardRadius);
-                if (!pathSafe)
-                    continue;
-            }
-
-            float moveDistance = bot->GetExactDist2d(x, y);
-            if (!foundSafe || moveDistance < minMoveDistance)
-            {
-                bestPos = testPos;
-                minMoveDistance = moveDistance;
-                foundSafe = pathSafe;
-            }
-        }
-
-        if (foundSafe)
-            break;
-    }
-
-    return bestPos;
-}
-
-bool IsPathSafeFromHazards(Position const& start, Position const& end,
-    std::vector<Unit*> const& hazards, float hazardRadius)
-{
-    constexpr uint8 numChecks = 10;
-    float dx = end.GetPositionX() - start.GetPositionX();
-    float dy = end.GetPositionY() - start.GetPositionY();
-
-    for (uint8 i = 1; i <= numChecks; ++i)
-    {
-        float ratio = static_cast<float>(i) / numChecks;
-        float checkX = start.GetPositionX() + dx * ratio;
-        float checkY = start.GetPositionY() + dy * ratio;
-
-        if (!IsPositionSafeFromHazards(checkX, checkY, hazards, hazardRadius))
+        int8 const sign = cross > 0.0f ? 1 : -1;
+        if (insideSign == 0)
+            insideSign = sign;
+        else if (insideSign != sign)
             return false;
     }
 
@@ -89,37 +50,30 @@ bool IsPositionSafeFromHazards(
 {
     for (Unit* hazard : hazards)
     {
-        if (hazard->GetDistance2d(x, y) < hazardRadius)
+        if (hazard->GetExactDist2d(x, y) < hazardRadius)
             return false;
     }
 
     return true;
 }
 
-std::vector<Unit*> GetAllHazardTriggers(Player* bot, uint32 entry, float searchRadius)
+}  // end anonymous namespace
+
+namespace ZaHelpers
 {
-    std::vector<Unit*> triggers;
-    std::list<Creature*> creatureList;
-    bot->GetCreatureListWithEntryInGrid(creatureList, entry, searchRadius);
-
-    for (Creature* creature : creatureList)
-    {
-        if (creature && creature->IsAlive())
-            triggers.push_back(creature);
-    }
-
-    return triggers;
-}
 
 // Akil'zon <Eagle Avatar>
-const Position AKILZON_TANK_POSITION = { 378.369f, 1407.718f, 74.797f };
-std::unordered_map<uint32, time_t> akilzonStormTimer;
 
-bool IsInStormWindow(time_t start, time_t now)
+std::unordered_map<uint32, uint32> akilzonStormTimer;
+
+bool IsInStormWindow(uint32 startMs)
 {
-    time_t elapsed = now - start;
-    uint32 seconds = elapsed % 60;
-    return elapsed >= 55 && (seconds >= 55 || seconds < 10);
+    uint32 const elapsed = GetMSTimeDiffToNow(startMs);
+    if (elapsed < AKILZON_STORM_PERIOD_MS - AKILZON_STORM_LEAD_MS)
+        return false;
+
+    uint32 const phase = (elapsed + AKILZON_STORM_LEAD_MS) % AKILZON_STORM_PERIOD_MS;
+    return phase < AKILZON_STORM_LEAD_MS + AKILZON_STORM_DURATION_MS;
 }
 
 Player* GetElectricalStormTarget(Player* bot)
@@ -131,8 +85,7 @@ Player* GetElectricalStormTarget(Player* bot)
     for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
     {
         Player* member = ref->GetSource();
-        if (member &&
-            member->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_ELECTRICAL_STORM)))
+        if (member && member->HasAura(Id(ZaSpells::SPELL_ELECTRICAL_STORM)))
             return member;
     }
 
@@ -140,38 +93,24 @@ Player* GetElectricalStormTarget(Player* bot)
 }
 
 // Nalorakk <Bear Avatar>
-const Position NALORAKK_TANK_POSITION = { -80.208f, 1324.530f, 40.942f };
+
+bool IsNalorakkInBearForm(Unit* nalorakk)
+{
+    return nalorakk && nalorakk->HasAura(Id(ZaSpells::SPELL_BEARFORM));
+}
 
 // Jan'alai <Dragonhawk Avatar>
-const Position JANALAI_TANK_POSITION = { -33.873f, 1149.571f, 19.146f };
-
-bool HasFireBombNearby(Player* bot)
-{
-    constexpr float searchRadius = 30.0f;
-    std::list<Creature*> creatureList;
-    bot->GetCreatureListWithEntryInGrid(
-        creatureList, static_cast<uint32>(ZulAmanNPCs::NPC_FIRE_BOMB), searchRadius);
-
-    for (Creature* creature : creatureList)
-    {
-        if (creature && creature->IsAlive())
-            return true;
-    }
-
-    return false;
-}
 
 std::pair<Unit*, Unit*> GetAmanishiHatcherPair(PlayerbotAI* botAI)
 {
     Unit* lowest = nullptr;
     Unit* highest = nullptr;
 
-    for (auto const& guid :
-            botAI->GetAiObjectContext()->GetValue<GuidVector>("possible targets no los")->Get())
+    AiObjectContext* context = botAI->GetAiObjectContext();
+    for (auto const& targetGuid : AI_VALUE(GuidVector, "possible targets no los"))
     {
-        Unit* unit = botAI->GetUnit(guid);
-        if (unit &&
-            unit->GetEntry() == static_cast<uint32>(ZulAmanNPCs::NPC_AMANISHI_HATCHER))
+        Unit* unit = botAI->GetUnit(targetGuid);
+        if (unit && unit->GetEntry() == Id(ZaNpcs::NPC_AMANISHI_HATCHER))
         {
             if (!lowest || unit->GetGUID().GetCounter() < lowest->GetGUID().GetCounter())
                 lowest = unit;
@@ -184,10 +123,190 @@ std::pair<Unit*, Unit*> GetAmanishiHatcherPair(PlayerbotAI* botAI)
     return {lowest, highest};
 }
 
+uint32 CountJanalaiHatchlingsByEntry(PlayerbotAI* botAI)
+{
+    uint32 count = 0;
+
+    AiObjectContext* context = botAI->GetAiObjectContext();
+    for (auto const& targetGuid : AI_VALUE(GuidVector, "attackers"))
+    {
+        Unit* unit = botAI->GetUnit(targetGuid);
+        if (unit && unit->IsAlive() &&
+            unit->GetEntry() == Id(ZaNpcs::NPC_AMANI_DRAGONHAWK_HATCHLING))
+        {
+            ++count;
+        }
+    }
+
+    return count;
+}
+
+bool IsJanalaiBombing(Unit* janalai)
+{
+    return janalai && janalai->HasAura(Id(ZaSpells::SPELL_FIRE_BOMB_CHANNEL));
+}
+
+GuidVector FindNearbyFireBombGuids(Player* bot)
+{
+    std::list<Creature*> creatureList;
+    bot->GetCreatureListWithEntryInGrid(
+        creatureList, Id(ZaNpcs::NPC_FIRE_BOMB), JANALAI_FIRE_BOMB_SEARCH_RADIUS);
+
+    GuidVector guids;
+    guids.reserve(creatureList.size());
+    for (Creature* creature : creatureList)
+    {
+        if (creature && creature->IsAlive())
+            guids.push_back(creature->GetGUID());
+    }
+
+    return guids;
+}
+
+std::vector<Unit*> GetNearbyFireBombs(PlayerbotAI* botAI)
+{
+    GuidVector const& guids =
+        botAI->GetAiObjectContext()->GetValue<GuidVector>("jan'alai fire bombs")->RefGet();
+
+    std::vector<Unit*> bombs;
+    bombs.reserve(guids.size());
+    for (ObjectGuid const& guid : guids)
+    {
+        Unit* unit = botAI->GetUnit(guid);
+        if (unit && unit->IsAlive())
+            bombs.push_back(unit);
+    }
+
+    return bombs;
+}
+
+// Shortest move to a spot that is safe from Fire Bombs, within the measured area
+bool FindSafeStepInJanalaiZone(
+    Player* bot, std::vector<Unit*> const& hazards, std::vector<Position> const& safeZone,
+    float maxSearchDistance, float hazardRadius, float moveDist,
+    float& stepX, float& stepY, float& stepZ)
+{
+    constexpr uint8 angleCount = 16;
+    constexpr float angleStep = 2.0f * M_PI / angleCount;
+    constexpr float distanceStep = 1.0f;
+
+    uint32 const ringCount = static_cast<uint32>(maxSearchDistance / distanceStep);
+
+    for (uint32 ring = 1; ring <= ringCount; ++ring)
+    {
+        float const distance = ring * distanceStep;
+        for (uint8 i = 0; i < angleCount; ++i)
+        {
+            float const angle = i * angleStep;
+            float const x = bot->GetPositionX() + distance * std::cos(angle);
+            float const y = bot->GetPositionY() + distance * std::sin(angle);
+
+            if (!IsInsideSafeZone(safeZone, x, y))
+                continue;
+
+            if (!IsPositionSafeFromHazards(x, y, hazards, hazardRadius))
+                continue;
+
+            if (!CanTakeStepTowards(bot, x, y, moveDist, stepX, stepY, stepZ))
+                continue;
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
 // Halazzi <Lynx Avatar>
-const Position HALAZZI_TANK_POSITION = { 370.733f, 1131.202f, 6.516f };
+// N/A
+
+// Hex Lord Malacrass
+
+ObjectGuid FindNearbyFreezingTrapGuid(Player* bot)
+{
+    if (bot->GetMapId() != ZA_MAP_ID)
+        return ObjectGuid::Empty;
+
+    GameObject* trap = bot->FindNearestGameObject(
+        Id(ZaObjects::GO_FREEZING_TRAP), ZA_FREEZING_TRAP_SEARCH_RADIUS, true);
+
+    return trap ? trap->GetGUID() : ObjectGuid::Empty;
+}
+
+GameObject* GetNearbyFreezingTrap(PlayerbotAI* botAI)
+{
+    ObjectGuid const guid = botAI->GetAiObjectContext()
+        ->GetValue<ObjectGuid>("hex lord malacrass freezing trap")->Get();
+
+    return guid.IsEmpty() ? nullptr : botAI->GetGameObject(guid);
+}
 
 // Zul'jin
-const Position ZULJIN_TANK_POSITION = { 120.210f, 705.564f, 45.111f };
+
+bool GetZuljinSpreadSlotIndex(Player* bot, size_t slotCount, size_t& slotIndex)
+{
+    if (slotCount == 0)
+        return false;
+
+    Group* group = bot->GetGroup();
+    if (!group)
+        return false;
+
+    std::vector<Player*> healers;
+    std::vector<Player*> rangedDps;
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member || member->GetMapId() != ZA_MAP_ID || !PlayerbotAI::IsRanged(member))
+            continue;
+
+        if (PlayerbotAI::IsHeal(member))
+            healers.push_back(member);
+        else
+            rangedDps.push_back(member);
+    }
+
+    auto const healerIt = std::find(healers.begin(), healers.end(), bot);
+    if (healerIt != healers.end())
+    {
+        slotIndex = static_cast<size_t>(std::distance(healers.begin(), healerIt)) % slotCount;
+        return true;
+    }
+
+    auto const dpsIt = std::find(rangedDps.begin(), rangedDps.end(), bot);
+    if (dpsIt == rangedDps.end())
+        return false;
+
+    size_t const ordinal =
+        healers.size() + static_cast<size_t>(std::distance(rangedDps.begin(), dpsIt));
+    slotIndex = ordinal % slotCount;
+    return true;
+}
+
+Player* GetZuljinCreepingParalysisDispelTarget(Player* bot)
+{
+    Group* group = bot->GetGroup();
+    if (!group)
+        return nullptr;
+
+    Player* closestTarget = nullptr;
+    float closestDistance = std::numeric_limits<float>::max();
+
+    for (GroupReference* ref = group->GetFirstMember(); ref; ref = ref->next())
+    {
+        Player* member = ref->GetSource();
+        if (!member || !member->HasAura(Id(ZaSpells::SPELL_CREEPING_PARALYSIS)))
+            continue;
+
+        float distance = bot->GetExactDist(member);
+        if (distance < closestDistance)
+        {
+            closestTarget = member;
+            closestDistance = distance;
+        }
+    }
+
+    return closestTarget;
+}
 
 }

--- a/src/Ai/Raid/ZA/ZAHelpers.h
+++ b/src/Ai/Raid/ZA/ZAHelpers.h
@@ -7,104 +7,229 @@
 #ifndef PLAYERBOTS_ZAHELPERS_H
 #define PLAYERBOTS_ZAHELPERS_H
 
-#include "AiObject.h"
+#include "Common.h"
+#include "ObjectGuid.h"
 #include "Position.h"
-#include "Unit.h"
+#include <array>
+#include <type_traits>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
-namespace ZulAmanHelpers
+class GameObject;
+class Player;
+class PlayerbotAI;
+class Unit;
+
+namespace ZaHelpers
 {
-    enum class ZulAmanSpells : uint32
-    {
-        // Akil'zon <Eagle Avatar>
-        SPELL_ELECTRICAL_STORM          = 43648,
 
-        // Nalorakk <Bear Avatar>
-        SPELL_BEARFORM                  = 42377,
+template <typename T, std::enable_if_t<std::is_enum_v<T>, int> = 0>
+constexpr uint32 Id(T value)
+{
+    return static_cast<uint32>(value);
+}
 
-        // Hex Lord Malacrass
-        SPELL_HEX_LORD_WHIRLWIND        = 43442,
-        SPELL_HEX_LORD_SPELL_REFLECTION = 43443,
-        SPELL_UNSTABLE_AFFLICTION       = 43522,
-
-        // Zul'jin
-        SPELL_ZULJIN_WHIRLWIND          = 17207,
-        SPELL_SHAPE_OF_THE_BEAR         = 42594,
-        SPELL_SHAPE_OF_THE_EAGLE        = 42606,
-        SPELL_SHAPE_OF_THE_LYNX         = 42607,
-        SPELL_SHAPE_OF_THE_DRAGONHAWK   = 42608,
-        // SPELL_CLAW_RAGE              = 43149, // Would require getting Zul'jin's bossai
-
-        // Hunter
-        SPELL_MISDIRECTION              = 35079,
-    };
-
-    enum class ZulAmanNPCs : uint32
-    {
-        // Trash
-        NPC_AMANI_HEALING_WARD          = 23757,
-        NPC_AMANI_PROTECTIVE_WARD       = 23822,
-
-        // Jan'alai <Dragonhawk Avatar>
-        NPC_AMANI_DRAGONHAWK_HATCHLING  = 23598,
-        NPC_AMANISHI_HATCHER            = 23818,
-        NPC_FIRE_BOMB                   = 23920,
-
-        // Halazzi <Lynx Avatar>
-        NPC_CORRUPTED_LIGHTNING_TOTEM   = 24224,
-
-        // Hex Lord Malacrass
-        NPC_HEX_LORD_MALACRASS          = 24239,
-        NPC_ALYSON_ANTILLE              = 24240,
-        NPC_THURG                       = 24241,
-        NPC_SLITHER                     = 24242,
-        NPC_LORD_RAADAN                 = 24243,
-        NPC_GAZAKROTH                   = 24244,
-        NPC_FENSTALKER                  = 24245,
-        NPC_DARKHEART                   = 24246,
-        NPC_KORAGG                      = 24247,
-
-        // Zul'jin
-        NPC_FEATHER_VORTEX              = 24136,
-    };
-
-    enum class ZulAmanObjects : uint32
-    {
-        GO_FREEZING_TRAP                = 186669,
-    };
-
-    // General
-    constexpr uint32 ZULAMAN_MAP_ID = 568;
-    Position FindSafestNearbyPosition(
-        Player* bot, std::vector<Unit*> const& hazards, Position const& center,
-        float safeZoneRadius, float hazardRadius, bool requireSafePath);
-    bool IsPathSafeFromHazards(
-        Position const& start, Position const& end,
-        std::vector<Unit*> const& hazards, float hazardRadius);
-    bool IsPositionSafeFromHazards(
-        float x, float y, std::vector<Unit*> const& hazards, float hazardRadius);
-    std::vector<Unit*> GetAllHazardTriggers(
-        Player* bot, uint32 entry, float searchRadius);
-
+enum class ZaSpells : uint32
+{
     // Akil'zon <Eagle Avatar>
-    extern const Position AKILZON_TANK_POSITION;
-    extern std::unordered_map<uint32, time_t> akilzonStormTimer;
-    bool IsInStormWindow(time_t start, time_t now);
-    Player* GetElectricalStormTarget(Player* bot);
+    SPELL_ELECTRICAL_STORM          = 43648,
 
     // Nalorakk <Bear Avatar>
-    extern const Position NALORAKK_TANK_POSITION;
+    SPELL_BEARFORM                  = 42377,
 
     // Jan'alai <Dragonhawk Avatar>
-    extern const Position JANALAI_TANK_POSITION;
-    bool HasFireBombNearby(Player* bot);
-    std::pair<Unit*, Unit*> GetAmanishiHatcherPair(PlayerbotAI* botAI);
+    SPELL_FIRE_BOMB_CHANNEL         = 42621,
 
-    // Halazzi <Lynx Avatar>
-    extern const Position HALAZZI_TANK_POSITION;
+    // Hex Lord Malacrass
+    SPELL_HEX_LORD_WHIRLWIND        = 43442,
+    SPELL_HEX_LORD_SPELL_REFLECTION = 43443,
+    SPELL_UNSTABLE_AFFLICTION       = 43522,
 
     // Zul'jin
-    extern const Position ZULJIN_TANK_POSITION;
+    SPELL_ZULJIN_WHIRLWIND          = 17207,
+    SPELL_SHAPE_OF_THE_BEAR         = 42594,
+    SPELL_SHAPE_OF_THE_EAGLE        = 42606,
+    SPELL_SHAPE_OF_THE_LYNX         = 42607,
+    SPELL_SHAPE_OF_THE_DRAGONHAWK   = 42608,
+    SPELL_CREEPING_PARALYSIS        = 43095,
+
+    // Hunter
+    SPELL_MISDIRECTION              = 35079,
+
+    // Priest
+    SPELL_MASS_DISPEL               = 32375,
+};
+
+enum class ZaNpcs : uint32
+{
+    // Trash
+    NPC_AMANI_HEALING_WARD          = 23757,
+    NPC_AMANI_PROTECTIVE_WARD       = 23822,
+
+    // Jan'alai <Dragonhawk Avatar>
+    NPC_JANALAI                     = 23578,
+    NPC_AMANI_DRAGONHAWK_HATCHLING  = 23598,
+    NPC_AMANISHI_HATCHER            = 23818,
+    NPC_FIRE_BOMB                   = 23920,
+
+    // Halazzi <Lynx Avatar>
+    NPC_HALAZZI                     = 23577,
+    NPC_SPIRIT_OF_THE_LYNX          = 24143,
+    NPC_CORRUPTED_LIGHTNING_TOTEM   = 24224,
+
+    // Hex Lord Malacrass
+    NPC_HEX_LORD_MALACRASS          = 24239,
+    NPC_ALYSON_ANTILLE              = 24240,
+    NPC_THURG                       = 24241,
+    NPC_SLITHER                     = 24242,
+    NPC_LORD_RAADAN                 = 24243,
+    NPC_GAZAKROTH                   = 24244,
+    NPC_FENSTALKER                  = 24245,
+    NPC_DARKHEART                   = 24246,
+    NPC_KORAGG                      = 24247,
+
+    // Zul'jin
+    NPC_ZULJIN                      = 23863,
+};
+
+enum class ZaObjects : uint32
+{
+    GO_FREEZING_TRAP                = 186669,
+};
+
+// General
+
+inline constexpr uint32 ZA_MAP_ID = 568;
+// For Hex Lord and Zul'jin. Whirlwind radius is 8y. Safe distance has 4y of MoveAway padding;
+// hold distance is for the don't run back in multiplier and adds another 3y of padding.
+inline constexpr float ZA_WHIRLWIND_SAFE_DISTANCE = 12.0f;
+inline constexpr float ZA_WHIRLWIND_HOLD_DISTANCE = 15.0f;
+// For Medicine Man totems, Halazzi totem, and Jan'alai Hatchers
+inline constexpr float ZA_CREATURE_SEARCH_RADIUS = 40.0f;
+
+// Akil'zon <Eagle Avatar>
+
+// Electrical Storm runs on a fixed 60s cycle once the encounter starts. Bots react from
+// AKILZON_STORM_LEAD_MS before each cast until the storm itself has expired.
+inline constexpr uint32 AKILZON_STORM_PERIOD_MS = 60000;
+inline constexpr uint32 AKILZON_STORM_LEAD_MS = 5000;
+inline constexpr uint32 AKILZON_STORM_DURATION_MS = 10000;
+
+// Centerish of the platform
+inline Position const AKILZON_TANK_POSITION = { 378.369f, 1407.718f, 74.797f };
+
+extern std::unordered_map<uint32, uint32> akilzonStormTimer;
+
+bool IsInStormWindow(uint32 startMs);
+Player* GetElectricalStormTarget(Player* bot);
+
+// Nalorakk <Bear Avatar>
+
+// Toward the back, down the stairs from his starting position
+inline Position const NALORAKK_TANK_POSITION = { -80.208f, 1324.530f, 40.942f };
+
+bool IsNalorakkInBearForm(Unit* nalorakk);
+
+// Jan'alai <Dragonhawk Avatar>
+
+inline constexpr float JANALAI_PLATFORM_Z = 19.146f;
+// Hatchers open eggs at increasing speed: 1 on the first tick, then 2, then 3, every 5s. There are
+// 20 eggs per side. Bloodlust is held until this many Hatchlings are active.
+inline constexpr uint32 JANALAI_BLOODLUST_HATCHLING_COUNT = 6;
+// Ranged spread evenly around the tank position to reduce players hit by Flame Breath.
+inline constexpr float JANALAI_RANGED_SPREAD_RADIUS = 15.0f;
+// How far bots search for a safe spot from Fire Bombs.
+inline constexpr float JANALAI_FIRE_BOMB_MAX_SEARCH_DISTANCE = 30.0f;
+// How far bots search for the Fire Bombs themselves, which obviously needs to be farther.
+inline constexpr float JANALAI_FIRE_BOMB_SEARCH_RADIUS = 40.0f;
+// Fire Bomb (42630) has a 4y radius. It does not include CombatReach so the 1.5y is just extra
+// padding. The padding is not needed strategically since bots are standing in place, but I don't
+// think humans would stand closer than this because it looks very dangerous, Thus, 5.5y is a
+// compromise to allow enough safe spots without looking too unrealistic.
+inline constexpr float JANALAI_FIRE_BOMB_SAFE_DISTANCE = 5.5f;
+inline constexpr uint32 FIRE_BOMB_CACHE_INTERVAL_MS = 1000;
+// Jan'alai hatches every remaining egg at once at 35% HP. If somehow a group killed both sides of
+// eggs incrementally and so fast that 6 Hatchlings were never up at a time, then Bloodlust goes out
+// at this point. Using 33% accounts for some delay for the hatching event to occur.
+inline constexpr float JANALAI_HATCH_ALL_HEALTH_PCT = 33.0f;
+
+// Centerish of the platform
+inline Position const JANALAI_TANK_POSITION = { -33.873f, 1149.571f, 19.146f };
+// The safe zone is about the entire reachable platform, minus the destroyed, fenced-off corner and
+// the parts that jut out on each side and connect to the bridges to the eggs. The measured area
+// is right up against the Fire Wall, but that's fine because the Fire Wall's damage actually comes
+// from the same Fire Bomb trigger NPCs so the Fire Bomb avoidance will keep away from the wall too.
+inline std::vector<Position> const JANALAI_SAFE_ZONE = {
+    Position(-12.576924f, 1131.9163f, JANALAI_PLATFORM_Z),
+    Position(-52.068108f, 1132.8198f, JANALAI_PLATFORM_Z),
+    Position(-51.508590f, 1158.4890f, JANALAI_PLATFORM_Z),
+    Position(-44.008713f, 1168.6125f, JANALAI_PLATFORM_Z),
+    Position(-12.115170f, 1167.6681f, JANALAI_PLATFORM_Z)
+};
+
+std::pair<Unit*, Unit*> GetAmanishiHatcherPair(PlayerbotAI* botAI);
+uint32 CountJanalaiHatchlingsByEntry(PlayerbotAI* botAI);
+// Jan'alai casts Fire Bomb Channel at the beginning of each Fire Bomb event until the bombs
+// detonate. This is the best check for the event being active because the bomb trigger NPCs stick
+// around for 4s after the detonation.
+bool IsJanalaiBombing(Unit* janalai);
+GuidVector FindNearbyFireBombGuids(Player* bot);
+std::vector<Unit*> GetNearbyFireBombs(PlayerbotAI* botAI);
+bool FindSafeStepInJanalaiZone(
+    Player* bot, std::vector<Unit*> const& hazards, std::vector<Position> const& safeZone,
+    float maxSearchDistance, float hazardRadius, float moveDist,
+    float& stepX, float& stepY, float& stepZ);
+
+// Halazzi <Lynx Avatar>
+
+// Right near his starting position
+inline Position const HALAZZI_TANK_POSITION = { 370.733f, 1131.202f, 6.516f };
+
+// Hex Lord Malacrass
+
+// Freezing Trap (43448) stuns for 10s across a 10y radius, even though its trigger radius is much
+// shorter at 2.5y. Padded by 1y instead of 2y because without a dedicated tank spot, the boss tends
+// to be toward the back of the room, and bots can run through the door to Zul'jin if sent too far.
+inline constexpr float ZA_FREEZING_TRAP_SAFE_DISTANCE = 11.0f;
+// Also used for HexLordMalacrassStayAwayFromFreezingTrapMultiplier.
+inline constexpr float ZA_FREEZING_TRAP_SEARCH_RADIUS = 16.0f;
+// For the "hex lord malacrass freezing trap" value.
+inline constexpr uint32 FREEZING_TRAP_CACHE_INTERVAL_MS = 200;
+
+ObjectGuid FindNearbyFreezingTrapGuid(Player* bot);
+GameObject* GetNearbyFreezingTrap(PlayerbotAI* botAI);
+
+// Zul'jin
+
+// 4 Cyclones (NPC_FEATHER_VORTEX) chase random raid members at 7y/s (player run speed) and have
+// a 4y radius. They're not really dodgeable as a result, so the approach is just to spread ranged
+// out for the Cyclones to have to travel farther and not be able to hit as many targets at once.
+inline constexpr float ZULJIN_SPREAD_Z = 45.111f;
+
+// Centerish of the platform
+inline Position const ZULJIN_TANK_POSITION = { 120.210f, 705.564f, 45.111f };
+inline std::array<Position, 8> const ZULJIN_SPREAD_POSITIONS = {{
+    // Healer slots.
+    Position(120.462f, 728.502f, ZULJIN_SPREAD_Z),
+    Position(119.984f, 693.188f, ZULJIN_SPREAD_Z),
+    // Ranged dps slots.
+    Position(94.939f, 713.698f, ZULJIN_SPREAD_Z),
+    Position(145.286f, 713.034f, ZULJIN_SPREAD_Z),
+    Position(103.869f, 728.703f, ZULJIN_SPREAD_Z),
+    Position(135.847f, 728.816f, ZULJIN_SPREAD_Z),
+    Position(143.862f, 697.302f, ZULJIN_SPREAD_Z),
+    Position(95.618f, 698.439f, ZULJIN_SPREAD_Z)
+}};
+
+// Ranged are ordered by healers first. The first two positions are centered at the bottom of the
+// stairs leading to Zul'jin's starting spot and the top of the stairs where his battle area begins.
+// Presumably, players will bring 2 healers, and the intent is to allow each healer to reach every
+// other bot's position (accordingly, no two spots are more than 39y apart).
+bool GetZuljinSpreadSlotIndex(Player* bot, size_t slotCount, size_t& slotIndex);
+// Find the closest target with Creeping Paralysis to cast Mass Dispel on.
+Player* GetZuljinCreepingParalysisDispelTarget(Player* bot);
+
 }
 
 #endif

--- a/src/Ai/Raid/ZA/ZAMultipliers.cpp
+++ b/src/Ai/Raid/ZA/ZAMultipliers.cpp
@@ -6,8 +6,6 @@
 
 #include "ZAMultipliers.h"
 #include "ChooseTargetActions.h"
-#include "DKActions.h"
-#include "DruidBearActions.h"
 #include "EncounterHelpers.h"
 #include "FollowActions.h"
 #include "GenericSpellActions.h"
@@ -19,366 +17,401 @@
 #include "ReachTargetActions.h"
 #include "RogueActions.h"
 #include "ShamanActions.h"
-#include "WarlockActions.h"
 #include "WarriorActions.h"
 #include "ZAActions.h"
 #include "ZAHelpers.h"
 
-using namespace ZulAmanHelpers;
+using namespace ZaHelpers;
 using namespace EncounterHelpers;
 
-// Akil'zon <Eagle Avatar>
-
-float AkilzonDisableCombatFormationMoveMultiplier::GetValue(Action* action)
+namespace
 {
-    if (!AI_VALUE2(Unit*, "find target", "akil'zon"))
+
+bool IsApproachMovement(Action* action)
+{
+    return dynamic_cast<ReachTargetAction*>(action) ||
+        dynamic_cast<CastReachTargetSpellAction*>(action) ||
+        dynamic_cast<CombatFormationMoveAction*>(action);
+        // CombatFormationMoveAction is the parent of SetBehindTargetAction, which circles around
+        // targets when they are near, even if the bot is otherwise held in position.
+}
+
+bool IsHazardousMovement(Action* action)
+{
+    return (dynamic_cast<MovementAction*>(action) && !dynamic_cast<AttackAction*>(action)) ||
+        dynamic_cast<CastReachTargetSpellAction*>(action) ||
+        dynamic_cast<CastKillingSpreeAction*>(action) ||
+        dynamic_cast<CastBlinkBackAction*>(action) ||
+        dynamic_cast<CastDisengageAction*>(action);
+}
+
+}
+
+// General
+
+float ZulAmanDelayDpsCooldownsMultiplier::GetValueInEncounter(Action* action)
+{
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
         return 1.0f;
 
-    if (dynamic_cast<CombatFormationMoveAction*>(action) &&
-        !dynamic_cast<SetBehindTargetAction*>(action))
+    if (!IsDpsCooldownAction(bot, action))
+        return 1.0f;
+
+    Unit* boss = nullptr;
+    if (Unit* zuljin = AI_VALUE2(Unit*, "find target", "zul'jin"))
+        boss = zuljin;
+    else if (Unit* malacrass = AI_VALUE2(Unit*, "find target", "hex lord malacrass"))
+        boss = malacrass;
+    else if (Unit* janalai = AI_VALUE2(Unit*, "find target", "jan'alai"))
+        boss = janalai;
+    else if (Unit* nalorakk = AI_VALUE2(Unit*, "find target", "nalorakk"))
+        boss = nalorakk;
+    else if (Unit* akilzon = AI_VALUE2(Unit*, "find target", "akil'zon"))
+        boss = akilzon;
+
+    if (!boss)
+        return 1.0f;
+
+    if (boss->GetHealthPct() > BOSS_ENGAGED_HEALTH_PCT)
         return 0.0f;
+
+    // Further restrictions on Bloodlust for Zul'jin and Jan'alai
+    if (bot->getClass() != CLASS_SHAMAN)
+        return 1.0f;
+
+    if (!dynamic_cast<CastBloodlustAction*>(action) &&
+        !dynamic_cast<CastHeroismAction*>(action))
+    {
+        return 1.0f;
+    }
+
+    // Zul'jin: hold until Phase 3 (or later)
+    if (boss->GetEntry() == Id(ZaNpcs::NPC_ZULJIN))
+    {
+        return (boss->HasAura(Id(ZaSpells::SPELL_SHAPE_OF_THE_EAGLE)) ||
+            boss->HasAura(Id(ZaSpells::SPELL_SHAPE_OF_THE_LYNX)) ||
+            boss->HasAura(Id(ZaSpells::SPELL_SHAPE_OF_THE_DRAGONHAWK))) ? 1.0f : 0.0f;
+    }
+
+    // Jan'alai: hold until time to burn Hatchlings (see comments to the constants in ZAHelpers.h)
+    if (boss->GetEntry() == Id(ZaNpcs::NPC_JANALAI))
+    {
+        if (boss->GetHealthPct() <= JANALAI_HATCH_ALL_HEALTH_PCT)
+            return 1.0f;
+
+        return CountJanalaiHatchlingsByEntry(botAI) >= JANALAI_BLOODLUST_HATCHLING_COUNT ?
+            1.0f : 0.0f;
+    }
 
     return 1.0f;
 }
 
-float AkilzonStayInEyeOfTheStormMultiplier::GetValue(Action* action)
+// Malacrass siphoning a Warrior soul and Zul'jin have very similar Whirlwinds
+float ZulAmanAvoidWhirlwindMultiplier::GetValueInEncounter(Action* action)
 {
-    if (!AI_VALUE2(Unit*, "find target", "akil'zon") /* ||
-        !GetElectricalStormTarget(bot)*/)
+    if (!IsApproachMovement(action) && !dynamic_cast<CastKillingSpreeAction*>(action))
         return 1.0f;
 
-    auto it = akilzonStormTimer.find(bot->GetMap()->GetInstanceId());
-    if (it == akilzonStormTimer.end() ||
-        !IsInStormWindow(it->second, std::time(nullptr)))
+    Unit* boss = nullptr;
+    uint32 whirlwind = 0;
+    if (Unit* zuljin = AI_VALUE2(Unit*, "find target", "zul'jin"))
+    {
+        boss = zuljin;
+        whirlwind = Id(ZaSpells::SPELL_ZULJIN_WHIRLWIND);
+    }
+    else if (Unit* malacrass = AI_VALUE2(Unit*, "find target", "hex lord malacrass"))
+    {
+        boss = malacrass;
+        whirlwind = Id(ZaSpells::SPELL_HEX_LORD_WHIRLWIND);
+    }
+
+    if (!boss)
         return 1.0f;
 
-    if (dynamic_cast<CastReachTargetSpellAction*>(action) ||
-        dynamic_cast<CastKillingSpreeAction*>(action) ||
-        dynamic_cast<CastBlinkBackAction*>(action) ||
-        dynamic_cast<CastDisengageAction*>(action) ||
-        dynamic_cast<SetBehindTargetAction*>(action) ||
-        dynamic_cast<FleeAction*>(action) ||
-        dynamic_cast<FollowAction*>(action) ||
-        dynamic_cast<ReachTargetAction*>(action))
+    if (boss->GetVictim() == bot)
+        return 1.0f;
+
+    if (!boss->HasAura(whirlwind))
+        return 1.0f;
+
+    return bot->GetExactDist2d(boss) <= ZA_WHIRLWIND_HOLD_DISTANCE ? 0.0f : 1.0f;
+}
+
+float ZulAmanDisableTankActionsMultiplier::GetValueInEncounter(Action* action)
+{
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
+        return 1.0f;
+
+    if (!PlayerbotAI::IsTank(bot))
+        return 1.0f;
+
+    bool const isTankFace = dynamic_cast<TankFaceAction*>(action);
+    bool const isTankAssist = dynamic_cast<TankAssistAction*>(action);
+    bool const isTaunt = IsTauntAction(bot, action);
+
+    if (!isTankFace && !isTankAssist && !isTaunt)
+        return 1.0f;
+
+    // Nalorakk: A tank swap is used by form, so only the tank assigned to the current form may
+    // taunt. Same as NalorakkTanksPositionBossAction: main tank gets bear, assist tank gets troll.
+    if (Unit* nalorakk = AI_VALUE2(Unit*, "find target", "nalorakk"))
+    {
+        if (!isTaunt)
+            return 0.0f;
+
+        bool const isFormTank = IsNalorakkInBearForm(nalorakk)
+            ? PlayerbotAI::IsMainTank(bot) : PlayerbotAI::IsAssistTankOfIndex(bot, 0, true);
+
+        return isFormTank ? 1.0f : 0.0f;
+    }
+
+    // Halazzi: The assist tank picks up the lynx so disable the main tank from taunting it.
+    if (AI_VALUE2(Unit*, "find target", "halazzi"))
+    {
+        if (!isTaunt)
+            return 0.0f;
+
+        if (!PlayerbotAI::IsMainTank(bot))
+            return 1.0f;
+
+        Unit* target = action->GetTarget();
+        return target && target->GetEntry() == Id(ZaNpcs::NPC_SPIRIT_OF_THE_LYNX) ? 0.0f : 1.0f;
+    }
+
+    if (isTaunt)
+        return 1.0f;
+
+    // Zul'jin: Allow tank face in Phase 5 for the tank to turn him away from the raid.
+    if (Unit* zuljin = AI_VALUE2(Unit*, "find target", "zul'jin"))
+    {
+        return isTankFace &&
+            !zuljin->HasAura(Id(ZaSpells::SPELL_SHAPE_OF_THE_DRAGONHAWK)) ? 0.0f : 1.0f;
+    }
+
+    // Jan'alai: Allow tank assist for the assist tank to pick up the Hatchlings. Tank face is
+    // already disabled as part of ZulAmanDisableCombatFormationMoveMultiplier so the addition here
+    // is just belt-and-suspenders for no cost.
+    if (AI_VALUE2(Unit*, "find target", "jan'alai"))
+        return isTankFace || PlayerbotAI::IsMainTank(bot) ? 0.0f : 1.0f;
+
+    // Akil'zon disables only tank face action, and that is already handled by
+    // ZulAmanDisableCombatFormationMoveMultiplier.
+    return 1.0f;
+}
+
+// Nalorakk's troll form and Halazzi's lynx add need to be handled by the assist tank.
+float ZulAmanControlMisdirectionMultiplier::GetValueInEncounter(Action* action)
+{
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
+        return 1.0f;
+
+    if (bot->getClass() != CLASS_HUNTER)
+        return 1.0f;
+
+    if (!dynamic_cast<CastMisdirectionOnMainTankAction*>(action))
+        return 1.0f;
+
+    return AI_VALUE2(Unit*, "find target", "nalorakk") ||
+        AI_VALUE2(Unit*, "find target", "halazzi") ? 0.0f : 1.0f;
+}
+
+// CombatFormationMoveAction is the action for the "disperse" command. It is also the parent class
+// for SetBehindTargetAction and TankFaceAction.
+float ZulAmanDisableCombatFormationMoveMultiplier::GetValueInEncounter(Action* action)
+{
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
+        return 1.0f;
+
+    if (!dynamic_cast<CombatFormationMoveAction*>(action))
+        return 1.0f;
+
+    if (dynamic_cast<SetBehindTargetAction*>(action))
+        return 1.0f;
+
+    Unit* zuljin = AI_VALUE2(Unit*, "find target", "zul'jin");
+    if (zuljin && zuljin->HasAura(Id(ZaSpells::SPELL_SHAPE_OF_THE_EAGLE)))
         return 0.0f;
 
-    return 1.0f;
+    return AI_VALUE2(Unit*, "find target", "jan'alai") ||
+        AI_VALUE2(Unit*, "find target", "akil'zon") ? 0.0f : 1.0f;
+}
+
+// Akil'zon <Eagle Avatar>
+
+float AkilzonStayInEyeOfTheStormMultiplier::GetValueInEncounter(Action* action)
+{
+    if (!IsHazardousMovement(action))
+        return 1.0f;
+
+    Unit* akilzon = AI_VALUE2(Unit*, "find target", "akil'zon");
+    if (!akilzon)
+        return 1.0f;
+
+    if (dynamic_cast<AkilzonMoveToEyeOfTheStormAction*>(action))
+        return 1.0f;
+
+    auto it = akilzonStormTimer.find(bot->GetInstanceId());
+    if (it == akilzonStormTimer.end())
+        return 1.0f;
+
+    return IsInStormWindow(it->second) ? 0.0f : 1.0f;
 }
 
 // Nalorakk <Bear Avatar>
 
-float NalorakkDisableTankActionsMultiplier::GetValue(Action* action)
-{
-    if (!botAI->IsTank(bot))
-        return 1.0f;
-
-    Unit* nalorakk = AI_VALUE2(Unit*, "find target", "nalorakk");
-    if (!nalorakk)
-        return 1.0f;
-
-    if (dynamic_cast<TankFaceAction*>(action))
-        return 0.0f;
-
-    if (bot->GetVictim() == nullptr)
-        return 1.0f;
-
-    bool shouldTankBoss = false;
-
-    if (botAI->IsMainTank(bot) &&
-        !nalorakk->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_BEARFORM)))
-        shouldTankBoss = true;
-
-    if (botAI->IsAssistTankOfIndex(bot, 0, true) &&
-        nalorakk->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_BEARFORM)))
-        shouldTankBoss = true;
-
-    if (!shouldTankBoss &&
-        (dynamic_cast<TankAssistAction*>(action) ||
-         dynamic_cast<CastTauntAction*>(action) ||
-         dynamic_cast<CastGrowlAction*>(action) ||
-         dynamic_cast<CastHandOfReckoningAction*>(action) ||
-         dynamic_cast<CastDarkCommandAction*>(action)))
-        return 0.0f;
-
-    return 1.0f;
-}
-
-float NalorakkControlMisdirectionMultiplier::GetValue(Action* action)
-{
-    if (bot->getClass() != CLASS_HUNTER ||
-        !AI_VALUE2(Unit*, "find target", "nalorakk"))
-        return 1.0f;
-
-    if (dynamic_cast<CastMisdirectionOnMainTankAction*>(action))
-        return 0.0f;
-
-    return 1.0f;
-}
+// N/A
 
 // Jan'alai <Dragonhawk Avatar>
 
-float JanalaiDisableTankActionsMultiplier::GetValue(Action* action)
+float JanalaiStayAwayFromFireBombsMultiplier::GetValueInEncounter(Action* action)
 {
-    if (!botAI->IsTank(bot) ||
-        !AI_VALUE2(Unit*, "find target", "jan'alai"))
+    if (!IsHazardousMovement(action))
         return 1.0f;
 
-    if (dynamic_cast<TankFaceAction*>(action))
-        return 0.0f;
-
-    if (bot->GetVictim() == nullptr)
+    if (dynamic_cast<JanalaiAvoidFireBombsAction*>(action))
         return 1.0f;
 
-    if (botAI->IsMainTank(bot) &&
-        dynamic_cast<TankAssistAction*>(action))
-        return 0.0f;
+    Unit* janalai = AI_VALUE2(Unit*, "find target", "jan'alai");
+    if (!janalai)
+        return 1.0f;
 
-    if (botAI->IsAssistTank(bot) &&
-        !GetFirstAliveUnitByEntry(
-            botAI, static_cast<uint32>(ZulAmanNPCs::NPC_AMANI_DRAGONHAWK_HATCHLING)) &&
-        dynamic_cast<TankAssistAction*>(action))
-        return 0.0f;
-
-    return 1.0f;
+    return IsJanalaiBombing(janalai) ? 0.0f : 1.0f;
 }
 
-float JanalaiDisableCombatFormationMoveMultiplier::GetValue(Action* action)
+float JanalaiDoNotCrowdControlHatchersMultiplier::GetValueInEncounter(Action* action)
 {
-    if (!AI_VALUE2(Unit*, "find target", "jan'alai"))
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
         return 1.0f;
 
-    if (dynamic_cast<CombatFormationMoveAction*>(action) &&
-        !dynamic_cast<SetBehindTargetAction*>(action))
-        return 0.0f;
-
-    return 1.0f;
-}
-
-float JanalaiStayAwayFromFireBombsMultiplier::GetValue(Action* action)
-{
-    if (!AI_VALUE2(Unit*, "find target", "jan'alai"))
+    if (!dynamic_cast<CastCrowdControlSpellAction*>(action))
         return 1.0f;
 
-    if (!HasFireBombNearby(bot))
-        return 1.0f;
-
-    if (dynamic_cast<CastReachTargetSpellAction*>(action) ||
-        dynamic_cast<CastKillingSpreeAction*>(action) ||
-        dynamic_cast<CastBlinkBackAction*>(action) ||
-        dynamic_cast<CastDisengageAction*>(action) ||
-        dynamic_cast<FleeAction*>(action) ||
-        dynamic_cast<FollowAction*>(action) ||
-        dynamic_cast<ReachTargetAction*>(action))
-        return 0.0f;
-
-    return 1.0f;
-}
-
-float JanalaiDoNotCrowdControlHatchersMultiplier::GetValue(Action* action)
-{
-    if (!AI_VALUE2(Unit*, "find target", "amani'shi hatcher"))
-        return 1.0f;
-
-    if (dynamic_cast<CastCrowdControlSpellAction*>(action) ||
-        dynamic_cast<CastPolymorphAction*>(action))
-        return 0.0f;
-
-    return 1.0f;
-}
-
-float JanalaiDelayBloodlustAndHeroismMultiplier::GetValue(Action* action)
-{
-    if (bot->getClass() != CLASS_SHAMAN)
-        return 1.0f;
-
-    if (!AI_VALUE2(Unit*, "find target", "jan'alai"))
-        return 1.0f;
-
-    if (AI_VALUE2(Unit*, "find target", "amani dragonhawk hatchling"))
-        return 1.0f;
-
-    if (dynamic_cast<CastBloodlustAction*>(action) ||
-        dynamic_cast<CastHeroismAction*>(action))
-        return 0.0f;
-
-    return 1.0f;
+    Unit* target = action->GetTarget();
+    return target && target->GetEntry() == Id(ZaNpcs::NPC_AMANISHI_HATCHER) ? 0.0f : 1.0f;
 }
 
 // Halazzi <Lynx Avatar>
 
-float HalazziDisableTankActionsMultiplier::GetValue(Action* action)
+float HalazziDisableAutoDpsTargetingMultiplier::GetValueInEncounter(Action* action)
 {
-    if (!botAI->IsTank(bot) ||
-        !AI_VALUE2(Unit*, "find target", "halazzi"))
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
         return 1.0f;
 
-    if (dynamic_cast<TankFaceAction*>(action))
-        return 0.0f;
-
-    if (bot->GetVictim() != nullptr &&
-        dynamic_cast<TankAssistAction*>(action))
-        return 0.0f;
-
-    return 1.0f;
-}
-
-float HalazziControlMisdirectionMultiplier::GetValue(Action* action)
-{
-    if (bot->getClass() != CLASS_HUNTER ||
-        !AI_VALUE2(Unit*, "find target", "halazzi"))
+    if (!PlayerbotAI::IsDps(bot))
         return 1.0f;
 
-    if (dynamic_cast<CastMisdirectionOnMainTankAction*>(action))
-        return 0.0f;
+    if (!dynamic_cast<DpsAssistAction*>(action) &&
+        !dynamic_cast<CastDebuffSpellOnAttackerAction*>(action))
+    {
+        return 1.0f;
+    }
 
-    return 1.0f;
+    return AI_VALUE2(Unit*, "find target", "halazzi") ? 0.0f : 1.0f;
 }
 
 // Hex Lord Malacrass
 
-float HexLordMalacrassAvoidWhirlwindMultiplier::GetValue(Action* action)
+// Weirdly, Unstable Affliction is considered a magic effect, not a curse.
+float HexLordMalacrassUnstableAfflictionMultiplier::GetValueInEncounter(Action* action)
 {
-    if (botAI->IsMainTank(bot))
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
         return 1.0f;
 
-    Unit* malacrass = AI_VALUE2(Unit*, "find target", "hex lord malacrass");
-    if (!malacrass ||
-        !malacrass->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_HEX_LORD_WHIRLWIND)))
-        return 1.0f;
-
-    if (dynamic_cast<CastReachTargetSpellAction*>(action) ||
-        dynamic_cast<CastKillingSpreeAction*>(action) ||
-        dynamic_cast<ReachTargetAction*>(action))
-        return 0.0f;
-
-    return 1.0f;
-}
-
-float HexLordMalacrassStopAttackingDuringSpellReflectionMultiplier::GetValue(Action* action)
-{
-    if (!botAI->IsCaster(bot))
-        return 1.0f;
-
-    Unit* malacrass = AI_VALUE2(Unit*, "find target", "hex lord malacrass");
-    if (!malacrass ||
-        !malacrass->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_HEX_LORD_SPELL_REFLECTION)))
-        return 1.0f;
-
-    auto castSpellAction = dynamic_cast<CastSpellAction*>(action);
-    if (!castSpellAction)
-        return 1.0f;
-
-    if (castSpellAction->getThreatType() == Action::ActionThreatType::Aoe ||
-        (AI_VALUE(Unit*, "current target") == malacrass &&
-         castSpellAction->getThreatType() == Action::ActionThreatType::Single))
-        return 0.0f;
-
-    return 1.0f;
-}
-
-float HexLordMalacrassDoNotDispelUnstableAfflictionMultiplier::GetValue(Action* action)
-{
-    if (bot->getClass() != CLASS_PRIEST &&
-        bot->getClass() != CLASS_PALADIN &&
-        bot->getClass() != CLASS_WARLOCK)
-        return 1.0f;
-
-    if (!AI_VALUE2(Unit*, "find target", "hex lord malacrass"))
-        return 1.0f;
-
-    Group* group = bot->GetGroup();
-    if (!group)
-        return 1.0f;
-
-    bool hasUnstableAffliction = false;
-    for (GroupReference* ref = bot->GetGroup()->GetFirstMember(); ref != nullptr; ref = ref->next())
+    if (bot->getClass() == CLASS_PRIEST)
     {
-        Player* member = ref->GetSource();
-        if (!member || !member->IsAlive())
-            continue;
-
-        if (member->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_UNSTABLE_AFFLICTION)))
+        if (!dynamic_cast<CastDispelMagicOnPartyAction*>(action) &&
+            !dynamic_cast<CastDispelMagicAction*>(action) &&
+            !dynamic_cast<CastMassDispelAction*>(action))
         {
-            hasUnstableAffliction = true;
-            break;
+            return 1.0f;
         }
     }
+    else if (bot->getClass() == CLASS_PALADIN)
+    {
+        if (!dynamic_cast<CastCleanseMagicOnPartyAction*>(action) &&
+            !dynamic_cast<CastCleanseMagicAction*>(action))
+        {
+            return 1.0f;
+        }
+    }
+    else
+    {
+        return 1.0f;
+    }
 
-    if (!hasUnstableAffliction)
+    Unit* malacrass = AI_VALUE2(Unit*, "find target", "hex lord malacrass");
+    if (!malacrass)
         return 1.0f;
 
-    if (dynamic_cast<CastDevourMagicCleanseAction*>(action) ||
-        dynamic_cast<CastDispelMagicAction*>(action) ||
-        dynamic_cast<CastDispelMagicOnPartyAction*>(action) ||
-        dynamic_cast<CastMassDispelAction*>(action) ||
-        dynamic_cast<CastPurgeAction*>(action))
-        return 0.0f;
+    Unit* target = AI_VALUE2(Unit*, "party member to dispel", DISPEL_MAGIC);
+    return target && target->HasAura(Id(ZaSpells::SPELL_UNSTABLE_AFFLICTION)) ? 0.0f : 1.0f;
+}
 
-    return 1.0f;
+float HexLordMalacrassSpellReflectionMultiplier::GetValueInEncounter(Action* action)
+{
+    if (!PlayerbotAI::IsCaster(bot))
+        return 1.0f;
+
+    if (dynamic_cast<CastHealingSpellAction*>(action))
+        return 1.0f;
+
+    if (!dynamic_cast<CastSpellAction*>(action))
+        return 1.0f;
+
+    Unit* malacrass = AI_VALUE2(Unit*, "find target", "hex lord malacrass");
+    if (!malacrass)
+        return 1.0f;
+
+    return malacrass->HasAura(Id(ZaSpells::SPELL_HEX_LORD_SPELL_REFLECTION)) ? 0.0f : 1.0f;
+}
+
+float HexLordMalacrassStayAwayFromFreezingTrapMultiplier::GetValueInEncounter(Action* action)
+{
+    if (!IsApproachMovement(action))
+        return 1.0f;
+
+    return GetNearbyFreezingTrap(botAI) ? 0.0f : 1.0f;
 }
 
 // Zul'jin
 
-float ZuljinDisableTankFaceMultiplier::GetValue(Action* action)
+float ZuljinStopAttackingDuringPhaseChangeMultiplier::GetValueInEncounter(Action* action)
 {
-    if (!botAI->IsTank(bot))
+    if (PlayerbotAI::IsTank(bot))
         return 1.0f;
 
+    if (!dynamic_cast<CastSpellAction*>(action) && !dynamic_cast<AttackAction*>(action))
+        return 1.0f;
+
+    if (dynamic_cast<CastHealingSpellAction*>(action))
+        return 1.0f;
+
+    // Above 80% is Phase 1.
     Unit* zuljin = AI_VALUE2(Unit*, "find target", "zul'jin");
-    if (!zuljin ||
-        zuljin->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_SHAPE_OF_THE_DRAGONHAWK)))
+    if (!zuljin || zuljin->GetHealthPct() > 80.0f)
         return 1.0f;
 
-    if (dynamic_cast<TankFaceAction*>(action))
-        return 0.0f;
+    // After 80%, Zul'jin drops into troll form only during transformation sequences.
+    bool const isZuljinTransformed =
+        zuljin->HasAura(Id(ZaSpells::SPELL_SHAPE_OF_THE_BEAR)) ||
+        zuljin->HasAura(Id(ZaSpells::SPELL_SHAPE_OF_THE_EAGLE)) ||
+        zuljin->HasAura(Id(ZaSpells::SPELL_SHAPE_OF_THE_LYNX)) ||
+        zuljin->HasAura(Id(ZaSpells::SPELL_SHAPE_OF_THE_DRAGONHAWK));
 
-    return 1.0f;
+    return isZuljinTransformed ? 1.0f : 0.0f;
 }
 
-float ZuljinAvoidWhirlwindMultiplier::GetValue(Action* action)
+float ZuljinEagleDisableAvoidAoeMultiplier::GetValueInEncounter(Action* action)
 {
-    if (botAI->IsMainTank(bot))
+    if (botAI->GetState() == BOT_STATE_NON_COMBAT)
+        return 1.0f;
+
+    if (!dynamic_cast<AvoidAoeAction*>(action))
         return 1.0f;
 
     Unit* zuljin = AI_VALUE2(Unit*, "find target", "zul'jin");
-    if (!zuljin ||
-        !zuljin->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_ZULJIN_WHIRLWIND)))
+    if (!zuljin)
         return 1.0f;
 
-    if (dynamic_cast<CastReachTargetSpellAction*>(action) ||
-        dynamic_cast<CastKillingSpreeAction*>(action) ||
-        dynamic_cast<ReachTargetAction*>(action))
-        return 0.0f;
-
-    return 1.0f;
-}
-
-float ZuljinDisableAvoidAoeMultiplier::GetValue(Action* action)
-{
-    Unit* zuljin = AI_VALUE2(Unit*, "find target", "zul'jin");
-    if (!zuljin ||
-        !zuljin->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_SHAPE_OF_THE_EAGLE)))
-        return 1.0f;
-
-    if (dynamic_cast<AvoidAoeAction*>(action))
-        return 0.0f;
-
-    return 1.0f;
-}
-
-float ZuljinDelayBloodlustAndHeroismMultiplier::GetValue(Action* action)
-{
-    if (bot->getClass() != CLASS_SHAMAN)
-        return 1.0f;
-
-    Unit* zuljin = AI_VALUE2(Unit*, "find target", "zul'jin");
-    if (!zuljin ||
-        zuljin->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_SHAPE_OF_THE_EAGLE)))
-        return 1.0f;
-
-    if (dynamic_cast<CastBloodlustAction*>(action) ||
-        dynamic_cast<CastHeroismAction*>(action))
-        return 0.0f;
-
-    return 1.0f;
+    return zuljin->HasAura(Id(ZaSpells::SPELL_SHAPE_OF_THE_EAGLE)) ? 0.0f : 1.0f;
 }

--- a/src/Ai/Raid/ZA/ZAMultipliers.h
+++ b/src/Ai/Raid/ZA/ZAMultipliers.h
@@ -7,162 +7,179 @@
 #ifndef PLAYERBOTS_ZAMULTIPLIERS_H
 #define PLAYERBOTS_ZAMULTIPLIERS_H
 
+#include "EncounterHelpers.h"
 #include "Multiplier.h"
+#include "ZAHelpers.h"
+#include <string>
+
+class ZulAmanEncounterMultiplier : public Multiplier
+{
+public:
+    ZulAmanEncounterMultiplier(PlayerbotAI* botAI, std::string const name)
+        : Multiplier(botAI, name) {}
+
+    float GetValue(Action* action) final
+    {
+        return EncounterHelpers::IsEncounterInProgress(bot, ZaHelpers::ZA_MAP_ID)
+            ? GetValueInEncounter(action) : 1.0f;
+    }
+
+protected:
+    virtual float GetValueInEncounter(Action* action) = 0;
+};
+
+// General
+
+class ZulAmanDelayDpsCooldownsMultiplier : public ZulAmanEncounterMultiplier
+{
+public:
+    ZulAmanDelayDpsCooldownsMultiplier(PlayerbotAI* botAI)
+        : ZulAmanEncounterMultiplier(botAI, "zul'aman delay dps cooldowns") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
+};
+
+class ZulAmanDisableTankActionsMultiplier : public ZulAmanEncounterMultiplier
+{
+public:
+    ZulAmanDisableTankActionsMultiplier(PlayerbotAI* botAI)
+        : ZulAmanEncounterMultiplier(botAI, "zul'aman disable tank actions") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
+};
+
+class ZulAmanControlMisdirectionMultiplier : public ZulAmanEncounterMultiplier
+{
+public:
+    ZulAmanControlMisdirectionMultiplier(PlayerbotAI* botAI)
+        : ZulAmanEncounterMultiplier(botAI, "zul'aman control misdirection") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
+};
+
+class ZulAmanDisableCombatFormationMoveMultiplier : public ZulAmanEncounterMultiplier
+{
+public:
+    ZulAmanDisableCombatFormationMoveMultiplier(PlayerbotAI* botAI)
+        : ZulAmanEncounterMultiplier(botAI, "zul'aman disable combat formation move") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
+};
+
+class ZulAmanAvoidWhirlwindMultiplier : public ZulAmanEncounterMultiplier
+{
+public:
+    ZulAmanAvoidWhirlwindMultiplier(PlayerbotAI* botAI)
+        : ZulAmanEncounterMultiplier(botAI, "zul'aman avoid whirlwind") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
+};
 
 // Akil'zon <Eagle Avatar>
 
-class AkilzonDisableCombatFormationMoveMultiplier : public Multiplier
+class AkilzonStayInEyeOfTheStormMultiplier : public ZulAmanEncounterMultiplier
 {
 public:
-    AkilzonDisableCombatFormationMoveMultiplier(PlayerbotAI* botAI) : Multiplier(
-        botAI, "akil'zon disable combat formation move") {}
-    float GetValue(Action* action) override;
-};
+    AkilzonStayInEyeOfTheStormMultiplier(PlayerbotAI* botAI)
+        : ZulAmanEncounterMultiplier(botAI, "akil'zon stay in eye of the storm") {}
 
-class AkilzonStayInEyeOfTheStormMultiplier : public Multiplier
-{
-public:
-    AkilzonStayInEyeOfTheStormMultiplier(PlayerbotAI* botAI) : Multiplier(
-        botAI, "akil'zon stay in eye of the storm") {}
-    float GetValue(Action* action) override;
+protected:
+    float GetValueInEncounter(Action* action) override;
 };
 
 // Nalorakk <Bear Avatar>
 
-class NalorakkDisableTankActionsMultiplier : public Multiplier
-{
-public:
-    NalorakkDisableTankActionsMultiplier(PlayerbotAI* botAI) : Multiplier(
-        botAI, "nalorakk disable tank actions") {}
-    float GetValue(Action* action) override;
-};
-
-class NalorakkControlMisdirectionMultiplier : public Multiplier
-{
-public:
-    NalorakkControlMisdirectionMultiplier(PlayerbotAI* botAI) : Multiplier(
-        botAI, "nalorakk control misdirection") {}
-    float GetValue(Action* action) override;
-};
-
 // Jan'alai <Dragonhawk Avatar>
 
-class JanalaiDisableTankActionsMultiplier : public Multiplier
+class JanalaiStayAwayFromFireBombsMultiplier : public ZulAmanEncounterMultiplier
 {
 public:
-    JanalaiDisableTankActionsMultiplier(PlayerbotAI* botAI) : Multiplier(
-        botAI, "jan'alai disable tank actions") {}
-    float GetValue(Action* action) override;
+    JanalaiStayAwayFromFireBombsMultiplier(PlayerbotAI* botAI)
+        : ZulAmanEncounterMultiplier(botAI, "jan'alai stay away from fire bombs") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
 };
 
-class JanalaiDisableCombatFormationMoveMultiplier : public Multiplier
+class JanalaiDoNotCrowdControlHatchersMultiplier : public ZulAmanEncounterMultiplier
 {
 public:
-    JanalaiDisableCombatFormationMoveMultiplier(PlayerbotAI* botAI) : Multiplier(
-        botAI, "jan'alai disable combat formation move") {}
-    float GetValue(Action* action) override;
-};
+    JanalaiDoNotCrowdControlHatchersMultiplier(PlayerbotAI* botAI)
+        : ZulAmanEncounterMultiplier(botAI, "jan'alai do not crowd control hatchers") {}
 
-class JanalaiStayAwayFromFireBombsMultiplier : public Multiplier
-{
-public:
-    JanalaiStayAwayFromFireBombsMultiplier(PlayerbotAI* botAI) : Multiplier(
-        botAI, "jan'alai stay away from fire bombs") {}
-    float GetValue(Action* action) override;
-};
-
-class JanalaiDoNotCrowdControlHatchersMultiplier : public Multiplier
-{
-public:
-    JanalaiDoNotCrowdControlHatchersMultiplier(PlayerbotAI* botAI) : Multiplier(
-        botAI, "jan'alai do not crowd control hatchers") {}
-    float GetValue(Action* action) override;
-};
-
-class JanalaiDelayBloodlustAndHeroismMultiplier : public Multiplier
-{
-public:
-    JanalaiDelayBloodlustAndHeroismMultiplier(PlayerbotAI* botAI) : Multiplier(
-        botAI, "jan'alai delay bloodlust and heroism") {}
-    float GetValue(Action* action) override;
+protected:
+    float GetValueInEncounter(Action* action) override;
 };
 
 // Halazzi <Lynx Avatar>
 
-class HalazziDisableTankActionsMultiplier : public Multiplier
+class HalazziDisableAutoDpsTargetingMultiplier : public ZulAmanEncounterMultiplier
 {
 public:
-    HalazziDisableTankActionsMultiplier(PlayerbotAI* botAI) : Multiplier(
-        botAI, "halazzi disable tank actions") {}
-    float GetValue(Action* action) override;
-};
+    HalazziDisableAutoDpsTargetingMultiplier(PlayerbotAI* botAI)
+        : ZulAmanEncounterMultiplier(botAI, "halazzi disable auto dps targeting") {}
 
-class HalazziControlMisdirectionMultiplier : public Multiplier
-{
-public:
-    HalazziControlMisdirectionMultiplier(PlayerbotAI* botAI) : Multiplier(
-        botAI, "halazzi control misdirection") {}
-    float GetValue(Action* action) override;
+protected:
+    float GetValueInEncounter(Action* action) override;
 };
 
 // Hex Lord Malacrass
 
-class HexLordMalacrassAvoidWhirlwindMultiplier : public Multiplier
+class HexLordMalacrassUnstableAfflictionMultiplier : public ZulAmanEncounterMultiplier
 {
 public:
-    HexLordMalacrassAvoidWhirlwindMultiplier(PlayerbotAI* botAI) : Multiplier(
-        botAI, "hex lord malacrass avoid whirlwind") {}
-    float GetValue(Action* action) override;
+    HexLordMalacrassUnstableAfflictionMultiplier(PlayerbotAI* botAI)
+        : ZulAmanEncounterMultiplier(botAI, "hex lord malacrass unstable affliction") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
 };
 
-class HexLordMalacrassDoNotDispelUnstableAfflictionMultiplier : public Multiplier
+class HexLordMalacrassSpellReflectionMultiplier : public ZulAmanEncounterMultiplier
 {
 public:
-    HexLordMalacrassDoNotDispelUnstableAfflictionMultiplier(PlayerbotAI* botAI) : Multiplier(
-        botAI, "hex lord malacrass do not dispel unstable affliction") {}
-    float GetValue(Action* action) override;
+    HexLordMalacrassSpellReflectionMultiplier(PlayerbotAI* botAI)
+        : ZulAmanEncounterMultiplier(botAI, "hex lord malacrass spell reflection") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
 };
 
-class HexLordMalacrassStopAttackingDuringSpellReflectionMultiplier : public Multiplier
+class HexLordMalacrassStayAwayFromFreezingTrapMultiplier : public ZulAmanEncounterMultiplier
 {
 public:
-    HexLordMalacrassStopAttackingDuringSpellReflectionMultiplier(PlayerbotAI* botAI) : Multiplier(
-        botAI, "hex lord malacrass stop attacking during spell reflection") {}
-    float GetValue(Action* action) override;
+    HexLordMalacrassStayAwayFromFreezingTrapMultiplier(PlayerbotAI* botAI)
+        : ZulAmanEncounterMultiplier(botAI, "hex lord malacrass stay away from freezing trap") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
 };
 
 // Zul'jin
 
-class ZuljinDisableTankFaceMultiplier : public Multiplier
+class ZuljinStopAttackingDuringPhaseChangeMultiplier : public ZulAmanEncounterMultiplier
 {
 public:
-    ZuljinDisableTankFaceMultiplier(PlayerbotAI* botAI) : Multiplier(
-        botAI, "zul'jin disable tank face") {}
-    float GetValue(Action* action) override;
+    ZuljinStopAttackingDuringPhaseChangeMultiplier(PlayerbotAI* botAI)
+        : ZulAmanEncounterMultiplier(botAI, "zul'jin stop attaking during phase change") {}
+
+protected:
+    float GetValueInEncounter(Action* action) override;
 };
 
-class ZuljinAvoidWhirlwindMultiplier : public Multiplier
+class ZuljinEagleDisableAvoidAoeMultiplier : public ZulAmanEncounterMultiplier
 {
 public:
-    ZuljinAvoidWhirlwindMultiplier(PlayerbotAI* botAI) : Multiplier(
-        botAI, "zul'jin avoid whirlwind") {}
-    float GetValue(Action* action) override;
-};
+    ZuljinEagleDisableAvoidAoeMultiplier(PlayerbotAI* botAI)
+        : ZulAmanEncounterMultiplier(botAI, "zul'jin eagle disable avoid aoe") {}
 
-class ZuljinDisableAvoidAoeMultiplier : public Multiplier
-{
-public:
-    ZuljinDisableAvoidAoeMultiplier(PlayerbotAI* botAI) : Multiplier(
-        botAI, "zul'jin disable avoid aoe") {}
-    float GetValue(Action* action) override;
-};
-
-class ZuljinDelayBloodlustAndHeroismMultiplier : public Multiplier
-{
-public:
-    ZuljinDelayBloodlustAndHeroismMultiplier(PlayerbotAI* botAI) : Multiplier(
-        botAI, "zul'jin delay bloodlust and heroism") {}
-    float GetValue(Action* action) override;
+protected:
+    float GetValueInEncounter(Action* action) override;
 };
 
 #endif

--- a/src/Ai/Raid/ZA/ZAStrategy.cpp
+++ b/src/Ai/Raid/ZA/ZAStrategy.cpp
@@ -9,127 +9,127 @@
 
 void RaidZulAmanStrategy::InitTriggers(std::vector<TriggerNode*>& triggers)
 {
+    // General
+    triggers.push_back(new TriggerNode("zul'aman no encounter in progress", {
+        NextAction("zul'aman reset encounter states", ACTION_EMERGENCY + 10) }));
+
     // Trash
     triggers.push_back(new TriggerNode("amani'shi medicine man summoned ward", {
-        NextAction("amani'shi medicine man mark ward", ACTION_RAID + 1) }));
+        NextAction("amani'shi medicine man mark ward", ACTION_RAID) }));
 
     // Akil'zon <Eagle Avatar>
     triggers.push_back(new TriggerNode("akil'zon pulling boss", {
-        NextAction("akil'zon misdirect boss to main tank", ACTION_RAID + 2) }));
+        NextAction("akil'zon misdirect boss to main tank", ACTION_RAID + 1) }));
 
-    triggers.push_back(new TriggerNode("akil'zon boss engaged by main tank", {
-        NextAction("akil'zon main tank position boss", ACTION_RAID + 1) }));
+    triggers.push_back(new TriggerNode("akil'zon should be tanked", {
+        NextAction("akil'zon tanks position boss", ACTION_RAID) }));
 
-    triggers.push_back(new TriggerNode("akil'zon boss casts static disruption", {
-        NextAction("akil'zon spread ranged", ACTION_RAID + 1) }));
+    triggers.push_back(new TriggerNode("akil'zon spread for static disruption", {
+        NextAction("akil'zon spread ranged", ACTION_RAID) }));
 
     triggers.push_back(new TriggerNode("akil'zon electrical storm incoming", {
         NextAction("akil'zon move to eye of the storm", ACTION_EMERGENCY + 6) }));
 
-    triggers.push_back(new TriggerNode("akil'zon bots need to prepare for electrical storm", {
-        NextAction("akil'zon manage electrical storm timer", ACTION_EMERGENCY + 10) }));
+    triggers.push_back(new TriggerNode("akil'zon should track electrical storm", {
+        NextAction("akil'zon start electrical storm timer", ACTION_EMERGENCY + 10) }));
 
     // Nalorakk <Bear Avatar>
     triggers.push_back(new TriggerNode("nalorakk pulling boss", {
         NextAction("nalorakk misdirect boss to main tank", ACTION_RAID + 1) }));
 
-    triggers.push_back(new TriggerNode("nalorakk boss switches forms", {
+    triggers.push_back(new TriggerNode("nalorakk both forms should be tanked", {
         NextAction("nalorakk tanks position boss", ACTION_EMERGENCY + 1) }));
 
-    triggers.push_back(new TriggerNode("nalorakk boss casts surge", {
-        NextAction("nalorakk spread ranged", ACTION_RAID + 1) }));
+    triggers.push_back(new TriggerNode("nalorakk spread for surge", {
+        NextAction("nalorakk spread ranged", ACTION_RAID) }));
 
     // Jan'alai <Dragonhawk Avatar>
     triggers.push_back(new TriggerNode("jan'alai pulling boss", {
-        NextAction("jan'alai misdirect boss to main tank", ACTION_RAID + 2) }));
+        NextAction("jan'alai misdirect boss to main tank", ACTION_RAID + 1) }));
 
-    triggers.push_back(new TriggerNode("jan'alai boss engaged by main tank", {
-        NextAction("jan'alai main tank position boss", ACTION_RAID + 1) }));
+    triggers.push_back(new TriggerNode("jan'alai should be tanked", {
+        NextAction("jan'alai tanks position boss", ACTION_RAID) }));
 
-    triggers.push_back(new TriggerNode("jan'alai boss casts flame breath", {
-        NextAction("jan'alai spread ranged in circle", ACTION_RAID + 1) }));
+    triggers.push_back(new TriggerNode("jan'alai spread for flame breath", {
+        NextAction("jan'alai spread ranged in circle", ACTION_RAID) }));
 
-    triggers.push_back(new TriggerNode("jan'alai boss summoning fire bombs", {
+    triggers.push_back(new TriggerNode("jan'alai is fire bombing", {
         NextAction("jan'alai avoid fire bombs", ACTION_EMERGENCY + 6) }));
 
     triggers.push_back(new TriggerNode("jan'alai amani'shi hatchers spawned", {
-        NextAction("jan'alai mark amani'shi hatchers", ACTION_RAID + 2) }));
+        NextAction("jan'alai mark amani'shi hatchers", ACTION_RAID + 1) }));
 
     // Halazzi <Lynx Avatar>
     triggers.push_back(new TriggerNode("halazzi pulling boss", {
-        NextAction("halazzi misdirect boss to main tank", ACTION_RAID + 2) }));
+        NextAction("halazzi misdirect boss to main tank", ACTION_RAID + 1) }));
 
-    triggers.push_back(new TriggerNode("halazzi boss engaged by main tank", {
-        NextAction("halazzi main tank position boss", ACTION_RAID + 1) }));
+    triggers.push_back(new TriggerNode("halazzi should be tanked", {
+        NextAction("halazzi main tank position boss", ACTION_RAID) }));
 
-    triggers.push_back(new TriggerNode("halazzi boss summons spirit lynx", {
-        NextAction("halazzi first assist tank attack spirit lynx", ACTION_RAID + 1) }));
+    triggers.push_back(new TriggerNode("halazzi spirit lynx has appeared", {
+        NextAction("halazzi first assist tank attack spirit lynx", ACTION_RAID) }));
 
-    triggers.push_back(new TriggerNode("halazzi determining dps target", {
-        NextAction("halazzi assign dps priority", ACTION_RAID + 1) }));
+    triggers.push_back(new TriggerNode("halazzi should focus dps", {
+        NextAction("halazzi dps attack totem and boss", ACTION_RAID) }));
 
     // Hex Lord Malacrass
     triggers.push_back(new TriggerNode("hex lord malacrass pulling boss", {
-        NextAction("hex lord malacrass misdirect boss to main tank", ACTION_RAID + 2) }));
+        NextAction("hex lord malacrass misdirect boss to main tank", ACTION_RAID + 1) }));
 
-    triggers.push_back(new TriggerNode("hex lord malacrass determining kill order", {
-        NextAction("hex lord malacrass assign dps priority", ACTION_RAID + 1) }));
+    triggers.push_back(new TriggerNode("hex lord malacrass should prioritize adds", {
+        NextAction("hex lord malacrass assign dps priority", ACTION_RAID) }));
 
-    triggers.push_back(new TriggerNode("hex lord malacrass boss is channeling whirlwind", {
-        NextAction("hex lord malacrass run away from whirlwind", ACTION_EMERGENCY + 6) }));
+    triggers.push_back(new TriggerNode("hex lord malacrass channeling whirlwind", {
+        NextAction("hex lord malacrass run away from whirlwind", ACTION_EMERGENCY + 1) }));
 
-    triggers.push_back(new TriggerNode("hex lord malacrass boss has spell reflection", {
-        NextAction("hex lord malacrass casters stop attacking", ACTION_EMERGENCY + 6) }));
-
-    triggers.push_back(new TriggerNode("hex lord malacrass boss placed freezing trap", {
+    triggers.push_back(new TriggerNode("hex lord malacrass freezing trap placed", {
         NextAction("hex lord malacrass move away from freezing trap", ACTION_EMERGENCY + 1) }));
 
     // Zul'jin
-    triggers.push_back(new TriggerNode("zul'jin main tank needs aggro upon pull or phase change", {
-        NextAction("zul'jin misdirect boss to main tank", ACTION_RAID + 2) }));
+    triggers.push_back(new TriggerNode("zul'jin pulling boss", {
+        NextAction("zul'jin misdirect boss to main tank", ACTION_RAID + 1) }));
 
-    triggers.push_back(new TriggerNode("zul'jin boss engaged by main tank", {
-        NextAction("zul'jin main tank position boss", ACTION_RAID + 1) }));
+    triggers.push_back(new TriggerNode("zul'jin should be tanked", {
+        NextAction("zul'jin tanks position boss", ACTION_RAID) }));
 
-    triggers.push_back(new TriggerNode("zul'jin boss is channeling whirlwind in troll form", {
-        NextAction("zul'jin run away from whirlwind", ACTION_EMERGENCY + 6) }));
+    triggers.push_back(new TriggerNode("zul'jin channeling whirlwind in troll form", {
+        NextAction("zul'jin run away from whirlwind", ACTION_EMERGENCY + 1) }));
 
-    triggers.push_back(new TriggerNode("zul'jin boss is summoning cyclones in eagle form", {
-        NextAction("zul'jin avoid cyclones", ACTION_EMERGENCY + 1) }));
+    triggers.push_back(new TriggerNode("zul'jin creeping paralysis in bear form", {
+        NextAction("zul'jin mass dispel creeping paralysis", ACTION_EMERGENCY + 6) }));
 
-    triggers.push_back(new TriggerNode("zul'jin boss casts aoe abilities in dragonhawk form", {
-        NextAction("zul'jin spread ranged", ACTION_RAID + 1) }));
+    triggers.push_back(new TriggerNode("zul'jin summoning cyclones in eagle form", {
+        NextAction("zul'jin position ranged for cyclones", ACTION_RAID) }));
+
+    triggers.push_back(new TriggerNode("zul'jin spread for dragonhawk aoe", {
+        NextAction("zul'jin spread ranged", ACTION_RAID) }));
 }
 
 void RaidZulAmanStrategy::InitMultipliers(std::vector<Multiplier*>& multipliers)
 {
+    // General
+    multipliers.push_back(new ZulAmanDelayDpsCooldownsMultiplier(botAI));
+    multipliers.push_back(new ZulAmanDisableTankActionsMultiplier(botAI));
+    multipliers.push_back(new ZulAmanControlMisdirectionMultiplier(botAI));
+    multipliers.push_back(new ZulAmanDisableCombatFormationMoveMultiplier(botAI));
+    multipliers.push_back(new ZulAmanAvoidWhirlwindMultiplier(botAI));
+
     // Akil'zon <Eagle Avatar>
-    multipliers.push_back(new AkilzonDisableCombatFormationMoveMultiplier(botAI));
     multipliers.push_back(new AkilzonStayInEyeOfTheStormMultiplier(botAI));
 
-    // Nalorakk <Bear Avatar>
-    multipliers.push_back(new NalorakkDisableTankActionsMultiplier(botAI));
-    multipliers.push_back(new NalorakkControlMisdirectionMultiplier(botAI));
-
     // Jan'alai <Dragonhawk Avatar>
-    multipliers.push_back(new JanalaiDisableTankActionsMultiplier(botAI));
-    multipliers.push_back(new JanalaiDisableCombatFormationMoveMultiplier(botAI));
     multipliers.push_back(new JanalaiStayAwayFromFireBombsMultiplier(botAI));
     multipliers.push_back(new JanalaiDoNotCrowdControlHatchersMultiplier(botAI));
-    multipliers.push_back(new JanalaiDelayBloodlustAndHeroismMultiplier(botAI));
 
     // Halazzi <Lynx Avatar>
-    multipliers.push_back(new HalazziDisableTankActionsMultiplier(botAI));
-    multipliers.push_back(new HalazziControlMisdirectionMultiplier(botAI));
+    multipliers.push_back(new HalazziDisableAutoDpsTargetingMultiplier(botAI));
 
     // Hex Lord Malacrass
-    multipliers.push_back(new HexLordMalacrassAvoidWhirlwindMultiplier(botAI));
-    multipliers.push_back(new HexLordMalacrassStopAttackingDuringSpellReflectionMultiplier(botAI));
-    multipliers.push_back(new HexLordMalacrassDoNotDispelUnstableAfflictionMultiplier(botAI));
+    multipliers.push_back(new HexLordMalacrassUnstableAfflictionMultiplier(botAI));
+    multipliers.push_back(new HexLordMalacrassSpellReflectionMultiplier(botAI));
+    multipliers.push_back(new HexLordMalacrassStayAwayFromFreezingTrapMultiplier(botAI));
 
     // Zul'jin
-    multipliers.push_back(new ZuljinDisableTankFaceMultiplier(botAI));
-    multipliers.push_back(new ZuljinAvoidWhirlwindMultiplier(botAI));
-    multipliers.push_back(new ZuljinDisableAvoidAoeMultiplier(botAI));
-    multipliers.push_back(new ZuljinDelayBloodlustAndHeroismMultiplier(botAI));
+    multipliers.push_back(new ZuljinStopAttackingDuringPhaseChangeMultiplier(botAI));
+    multipliers.push_back(new ZuljinEagleDisableAvoidAoeMultiplier(botAI));
 }

--- a/src/Ai/Raid/ZA/ZAStrategy.h
+++ b/src/Ai/Raid/ZA/ZAStrategy.h
@@ -8,12 +8,13 @@
 #define PLAYERBOTS_ZASTRATEGY_H
 
 #include "Strategy.h"
+#include <string>
+#include <vector>
 
 class RaidZulAmanStrategy : public Strategy
 {
 public:
     RaidZulAmanStrategy(PlayerbotAI* botAI) : Strategy(botAI) {}
-
     std::string const getName() override { return "zulaman"; }
 
     void InitTriggers(std::vector<TriggerNode*>& triggers) override;

--- a/src/Ai/Raid/ZA/ZATriggerContext.h
+++ b/src/Ai/Raid/ZA/ZATriggerContext.h
@@ -15,101 +15,99 @@ class RaidZulAmanTriggerContext : public NamedObjectContext<Trigger>
 public:
     RaidZulAmanTriggerContext()
     {
+        // General
+        creators["zul'aman no encounter in progress"] =
+            &RaidZulAmanTriggerContext::zulaman_no_encounter_in_progress;
+
         // Trash
         creators["amani'shi medicine man summoned ward"] =
             &RaidZulAmanTriggerContext::amanishi_medicine_man_summoned_ward;
 
         // Akil'zon <Eagle Avatar>
-        creators["akil'zon pulling boss"] =
-            &RaidZulAmanTriggerContext::akilzon_pulling_boss;
+        creators["akil'zon pulling boss"] = &RaidZulAmanTriggerContext::akilzon_pulling_boss;
 
-        creators["akil'zon boss engaged by tanks"] =
-            &RaidZulAmanTriggerContext::akilzon_boss_engaged_by_tanks;
+        creators["akil'zon should be tanked"] =
+            &RaidZulAmanTriggerContext::akilzon_should_be_tanked;
 
-        creators["akil'zon boss casts static disruption"] =
-            &RaidZulAmanTriggerContext::akilzon_boss_casts_static_disruption;
+        creators["akil'zon spread for static disruption"] =
+            &RaidZulAmanTriggerContext::akilzon_spread_for_static_disruption;
 
         creators["akil'zon electrical storm incoming"] =
             &RaidZulAmanTriggerContext::akilzon_electrical_storm_incoming;
 
-        creators["akil'zon bots need to prepare for electrical storm"] =
-            &RaidZulAmanTriggerContext::akilzon_bots_need_to_prepare_for_electrical_storm;
+        creators["akil'zon should track electrical storm"] =
+            &RaidZulAmanTriggerContext::akilzon_should_track_electrical_storm;
 
         // Nalorakk <Bear Avatar>
-        creators["nalorakk pulling boss"] =
-            &RaidZulAmanTriggerContext::nalorakk_pulling_boss;
+        creators["nalorakk pulling boss"] = &RaidZulAmanTriggerContext::nalorakk_pulling_boss;
 
-        creators["nalorakk boss casts surge"] =
-            &RaidZulAmanTriggerContext::nalorakk_boss_casts_surge;
+        creators["nalorakk spread for surge"] =
+            &RaidZulAmanTriggerContext::nalorakk_spread_for_surge;
 
-        creators["nalorakk boss switches forms"] =
-            &RaidZulAmanTriggerContext::nalorakk_boss_switches_forms;
+        creators["nalorakk both forms should be tanked"] =
+            &RaidZulAmanTriggerContext::nalorakk_both_forms_should_be_tanked;
 
         // Jan'alai <Dragonhawk Avatar>
-        creators["jan'alai pulling boss"] =
-            &RaidZulAmanTriggerContext::janalai_pulling_boss;
+        creators["jan'alai pulling boss"] = &RaidZulAmanTriggerContext::janalai_pulling_boss;
 
-        creators["jan'alai boss engaged by tanks"] =
-            &RaidZulAmanTriggerContext::janalai_boss_engaged_by_tanks;
+        creators["jan'alai should be tanked"] =
+            &RaidZulAmanTriggerContext::janalai_should_be_tanked;
 
-        creators["jan'alai boss casts flame breath"] =
-            &RaidZulAmanTriggerContext::janalai_boss_casts_flame_breath;
+        creators["jan'alai spread for flame breath"] =
+            &RaidZulAmanTriggerContext::janalai_spread_for_flame_breath;
 
-        creators["jan'alai boss summoning fire bombs"] =
-            &RaidZulAmanTriggerContext::janalai_boss_summoning_fire_bombs;
+        creators["jan'alai is fire bombing"] = &RaidZulAmanTriggerContext::janalai_is_fire_bombing;
 
         creators["jan'alai amani'shi hatchers spawned"] =
             &RaidZulAmanTriggerContext::janalai_amanishi_hatchers_spawned;
 
         // Halazzi <Lynx Avatar>
-        creators["halazzi pulling boss"] =
-            &RaidZulAmanTriggerContext::halazzi_pulling_boss;
+        creators["halazzi pulling boss"] = &RaidZulAmanTriggerContext::halazzi_pulling_boss;
 
-        creators["halazzi boss engaged by main tank"] =
-            &RaidZulAmanTriggerContext::halazzi_boss_engaged_by_main_tank;
+        creators["halazzi should be tanked"] = &RaidZulAmanTriggerContext::halazzi_should_be_tanked;
 
-        creators["halazzi boss summons spirit lynx"] =
-            &RaidZulAmanTriggerContext::halazzi_boss_summons_spirit_lynx;
+        creators["halazzi spirit lynx has appeared"] =
+            &RaidZulAmanTriggerContext::halazzi_spirit_lynx_has_appeared;
 
-        creators["halazzi determining dps target"] =
-            &RaidZulAmanTriggerContext::halazzi_determining_dps_target;
+        creators["halazzi should focus dps"] = &RaidZulAmanTriggerContext::halazzi_should_focus_dps;
 
         // Hex Lord Malacrass
-
         creators["hex lord malacrass pulling boss"] =
             &RaidZulAmanTriggerContext::hex_lord_malacrass_pulling_boss;
 
-        creators["hex lord malacrass determining kill order"] =
-            &RaidZulAmanTriggerContext::hex_lord_malacrass_determining_kill_order;
+        creators["hex lord malacrass should prioritize adds"] =
+            &RaidZulAmanTriggerContext::hex_lord_malacrass_should_prioritize_adds;
 
-        creators["hex lord malacrass boss is channeling whirlwind"] =
-            &RaidZulAmanTriggerContext::hex_lord_malacrass_boss_is_channeling_whirlwind;
+        creators["hex lord malacrass channeling whirlwind"] =
+            &RaidZulAmanTriggerContext::hex_lord_malacrass_channeling_whirlwind;
 
-        creators["hex lord malacrass boss has spell reflection"] =
-            &RaidZulAmanTriggerContext::hex_lord_malacrass_boss_has_spell_reflection;
-
-        creators["hex lord malacrass boss placed freezing trap"] =
-            &RaidZulAmanTriggerContext::hex_lord_malacrass_boss_placed_freezing_trap;
+        creators["hex lord malacrass freezing trap placed"] =
+            &RaidZulAmanTriggerContext::hex_lord_malacrass_freezing_trap_placed;
 
         // Zul'jin
+        creators["zul'jin pulling boss"] = &RaidZulAmanTriggerContext::zuljin_pulling_boss;
 
-        creators["zul'jin main tank needs aggro upon pull or phase change"] =
-            &RaidZulAmanTriggerContext::zuljin_main_tank_needs_aggro_upon_pull_or_phase_change;
+        creators["zul'jin should be tanked"] = &RaidZulAmanTriggerContext::zuljin_should_be_tanked;
 
-        creators["zul'jin boss engaged by tanks"] =
-            &RaidZulAmanTriggerContext::zuljin_boss_engaged_by_tanks;
+        creators["zul'jin channeling whirlwind in troll form"] =
+            &RaidZulAmanTriggerContext::zuljin_channeling_whirlwind_in_troll_form;
 
-        creators["zul'jin boss is channeling whirlwind in troll form"] =
-            &RaidZulAmanTriggerContext::zuljin_boss_is_channeling_whirlwind_in_troll_form;
+        creators["zul'jin creeping paralysis in bear form"] =
+            &RaidZulAmanTriggerContext::zuljin_creeping_paralysis_in_bear_form;
 
-        creators["zul'jin boss is summoning cyclones in eagle form"] =
-            &RaidZulAmanTriggerContext::zuljin_boss_is_summoning_cyclones_in_eagle_form;
+        creators["zul'jin summoning cyclones in eagle form"] =
+            &RaidZulAmanTriggerContext::zuljin_summoning_cyclones_in_eagle_form;
 
-        creators["zul'jin boss casts aoe abilities in dragonhawk form"] =
-            &RaidZulAmanTriggerContext::zuljin_boss_casts_aoe_abilities_in_dragonhawk_form;
+        creators["zul'jin spread for dragonhawk aoe"] =
+            &RaidZulAmanTriggerContext::zuljin_spread_for_dragonhawk_aoe;
     }
 
 private:
+    // General
+    static Trigger* zulaman_no_encounter_in_progress(PlayerbotAI* botAI) {
+        return new ZulAmanNoEncounterInProgressTrigger(botAI);
+    }
+
     // Trash
     static Trigger* amanishi_medicine_man_summoned_ward(PlayerbotAI* botAI) {
         return new AmanishiMedicineManSummonedWardTrigger(botAI);
@@ -117,44 +115,44 @@ private:
 
     // Akil'zon <Eagle Avatar>
     static Trigger* akilzon_pulling_boss(PlayerbotAI* botAI) {
-        return new AkilzonPullingBossTrigger(botAI);
+        return new ZulAmanPullingBossTrigger(botAI, "akil'zon pulling boss", "akil'zon");
     }
-    static Trigger* akilzon_boss_engaged_by_tanks(PlayerbotAI* botAI) {
-        return new AkilzonBossEngagedByTanksTrigger(botAI);
+    static Trigger* akilzon_should_be_tanked(PlayerbotAI* botAI) {
+        return new AkilzonShouldBeTankedTrigger(botAI);
     }
-    static Trigger* akilzon_boss_casts_static_disruption(PlayerbotAI* botAI) {
-        return new AkilzonBossCastsStaticDisruptionTrigger(botAI);
+    static Trigger* akilzon_spread_for_static_disruption(PlayerbotAI* botAI) {
+        return new AkilzonSpreadForStaticDisruptionTrigger(botAI);
     }
     static Trigger* akilzon_electrical_storm_incoming(PlayerbotAI* botAI) {
         return new AkilzonElectricalStormIncomingTrigger(botAI);
     }
-    static Trigger* akilzon_bots_need_to_prepare_for_electrical_storm(PlayerbotAI* botAI) {
-        return new AkilzonBotsNeedToPrepareForElectricalStormTrigger(botAI);
+    static Trigger* akilzon_should_track_electrical_storm(PlayerbotAI* botAI) {
+        return new AkilzonShouldTrackElectricalStormTrigger(botAI);
     }
 
     // Nalorakk <Bear Avatar>
     static Trigger* nalorakk_pulling_boss(PlayerbotAI* botAI) {
-        return new NalorakkPullingBossTrigger(botAI);
+        return new ZulAmanPullingBossTrigger(botAI, "nalorakk pulling boss", "nalorakk");
     }
-    static Trigger* nalorakk_boss_casts_surge(PlayerbotAI* botAI) {
-        return new NalorakkBossCastsSurgeTrigger(botAI);
+    static Trigger* nalorakk_spread_for_surge(PlayerbotAI* botAI) {
+        return new NalorakkSpreadForSurgeTrigger(botAI);
     }
-    static Trigger* nalorakk_boss_switches_forms(PlayerbotAI* botAI) {
-        return new NalorakkBossSwitchesFormsTrigger(botAI);
+    static Trigger* nalorakk_both_forms_should_be_tanked(PlayerbotAI* botAI) {
+        return new NalorakkBothFormsShouldBeTankedTrigger(botAI);
     }
 
     // Jan'alai <Dragonhawk Avatar>
     static Trigger* janalai_pulling_boss(PlayerbotAI* botAI) {
-        return new JanalaiPullingBossTrigger(botAI);
+        return new ZulAmanPullingBossTrigger(botAI, "jan'alai pulling boss", "jan'alai");
     }
-    static Trigger* janalai_boss_engaged_by_tanks(PlayerbotAI* botAI) {
-        return new JanalaiBossEngagedByTanksTrigger(botAI);
+    static Trigger* janalai_should_be_tanked(PlayerbotAI* botAI) {
+        return new JanalaiShouldBeTankedTrigger(botAI);
     }
-    static Trigger* janalai_boss_casts_flame_breath(PlayerbotAI* botAI) {
-        return new JanalaiBossCastsFlameBreathTrigger(botAI);
+    static Trigger* janalai_spread_for_flame_breath(PlayerbotAI* botAI) {
+        return new JanalaiSpreadForFlameBreathTrigger(botAI);
     }
-    static Trigger* janalai_boss_summoning_fire_bombs(PlayerbotAI* botAI) {
-        return new JanalaiBossSummoningFireBombsTrigger(botAI);
+    static Trigger* janalai_is_fire_bombing(PlayerbotAI* botAI) {
+        return new JanalaiIsFireBombingTrigger(botAI);
     }
     static Trigger* janalai_amanishi_hatchers_spawned(PlayerbotAI* botAI) {
         return new JanalaiAmanishiHatchersSpawnedTrigger(botAI);
@@ -162,50 +160,51 @@ private:
 
     // Halazzi <Lynx Avatar>
     static Trigger* halazzi_pulling_boss(PlayerbotAI* botAI) {
-        return new HalazziPullingBossTrigger(botAI);
+        return new ZulAmanPullingBossTrigger(botAI, "halazzi pulling boss", "halazzi");
     }
-    static Trigger* halazzi_boss_engaged_by_main_tank(PlayerbotAI* botAI) {
-        return new HalazziBossEngagedByMainTankTrigger(botAI);
+    static Trigger* halazzi_should_be_tanked(PlayerbotAI* botAI) {
+        return new HalazziShouldBeTankedTrigger(botAI);
     }
-    static Trigger* halazzi_boss_summons_spirit_lynx(PlayerbotAI* botAI) {
-        return new HalazziBossSummonsSpiritLynxTrigger(botAI);
+    static Trigger* halazzi_spirit_lynx_has_appeared(PlayerbotAI* botAI) {
+        return new HalazziSpiritLynxHasAppearedTrigger(botAI);
     }
-    static Trigger* halazzi_determining_dps_target(PlayerbotAI* botAI) {
-        return new HalazziDeterminingDpsTargetTrigger(botAI);
+    static Trigger* halazzi_should_focus_dps(PlayerbotAI* botAI) {
+        return new HalazziShouldFocusDpsTrigger(botAI);
     }
 
     // Hex Lord Malacrass
     static Trigger* hex_lord_malacrass_pulling_boss(PlayerbotAI* botAI) {
-        return new HexLordMalacrassPullingBossTrigger(botAI);
+        return new ZulAmanPullingBossTrigger(
+            botAI, "hex lord malacrass pulling boss", "hex lord malacrass");
     }
-    static Trigger* hex_lord_malacrass_determining_kill_order(PlayerbotAI* botAI) {
-        return new HexLordMalacrassDeterminingKillOrderTrigger(botAI);
+    static Trigger* hex_lord_malacrass_should_prioritize_adds(PlayerbotAI* botAI) {
+        return new HexLordMalacrassShouldPrioritizeAddsTrigger(botAI);
     }
-    static Trigger* hex_lord_malacrass_boss_is_channeling_whirlwind(PlayerbotAI* botAI) {
-        return new HexLordMalacrassBossIsChannelingWhirlwindTrigger(botAI);
+    static Trigger* hex_lord_malacrass_channeling_whirlwind(PlayerbotAI* botAI) {
+        return new HexLordMalacrassChannelingWhirlwindTrigger(botAI);
     }
-    static Trigger* hex_lord_malacrass_boss_has_spell_reflection(PlayerbotAI* botAI) {
-        return new HexLordMalacrassBossHasSpellReflectionTrigger(botAI);
-    }
-    static Trigger* hex_lord_malacrass_boss_placed_freezing_trap(PlayerbotAI* botAI) {
-        return new HexLordMalacrassBossPlacedFreezingTrapTrigger(botAI);
+    static Trigger* hex_lord_malacrass_freezing_trap_placed(PlayerbotAI* botAI) {
+        return new HexLordMalacrassFreezingTrapPlacedTrigger(botAI);
     }
 
     // Zul'jin
-    static Trigger* zuljin_boss_engaged_by_tanks(PlayerbotAI* botAI) {
-        return new ZuljinBossEngagedByTanksTrigger(botAI);
+    static Trigger* zuljin_pulling_boss(PlayerbotAI* botAI) {
+        return new ZulAmanPullingBossTrigger(botAI, "zul'jin pulling boss", "zul'jin");
     }
-    static Trigger* zuljin_main_tank_needs_aggro_upon_pull_or_phase_change(PlayerbotAI* botAI) {
-        return new ZuljinMainTankNeedsAggroUponPullOrPhaseChangeTrigger(botAI);
+    static Trigger* zuljin_should_be_tanked(PlayerbotAI* botAI) {
+        return new ZuljinShouldBeTankedTrigger(botAI);
     }
-    static Trigger* zuljin_boss_is_channeling_whirlwind_in_troll_form(PlayerbotAI* botAI) {
-        return new ZuljinBossIsChannelingWhirlwindInTrollFormTrigger(botAI);
+    static Trigger* zuljin_channeling_whirlwind_in_troll_form(PlayerbotAI* botAI) {
+        return new ZuljinChannelingWhirlwindInTrollFormTrigger(botAI);
     }
-    static Trigger* zuljin_boss_is_summoning_cyclones_in_eagle_form(PlayerbotAI* botAI) {
-        return new ZuljinBossIsSummoningCyclonesInEagleFormTrigger(botAI);
+    static Trigger* zuljin_creeping_paralysis_in_bear_form(PlayerbotAI* botAI) {
+        return new ZuljinCreepingParalysisInBearFormTrigger(botAI);
     }
-    static Trigger* zuljin_boss_casts_aoe_abilities_in_dragonhawk_form(PlayerbotAI* botAI) {
-        return new ZuljinBossCastsAoeAbilitiesInDragonhawkFormTrigger(botAI);
+    static Trigger* zuljin_summoning_cyclones_in_eagle_form(PlayerbotAI* botAI) {
+        return new ZuljinSummoningCyclonesInEagleFormTrigger(botAI);
+    }
+    static Trigger* zuljin_spread_for_dragonhawk_aoe(PlayerbotAI* botAI) {
+        return new ZuljinSpreadForDragonhawkAoeTrigger(botAI);
     }
 };
 

--- a/src/Ai/Raid/ZA/ZATriggers.cpp
+++ b/src/Ai/Raid/ZA/ZATriggers.cpp
@@ -6,268 +6,250 @@
 
 #include "ZATriggers.h"
 #include "EncounterHelpers.h"
+#include "InstanceScript.h"
 #include "Playerbots.h"
-#include "ZAActions.h"
 #include "ZAHelpers.h"
 
-using namespace ZulAmanHelpers;
+using namespace ZaHelpers;
 using namespace EncounterHelpers;
+
+// General
+
+bool ZulAmanNoEncounterInProgressTrigger::IsActive()
+{
+    if (IsEncounterInProgress(bot, ZA_MAP_ID))
+        return false;
+
+    return IsMechanicTrackerBot(bot, ZA_MAP_ID);
+}
+
+bool ZulAmanPullingBossTrigger::IsActiveInEncounter()
+{
+    if (bot->getClass() != CLASS_HUNTER)
+        return false;
+
+    Unit* boss = AI_VALUE2(Unit*, "find target", _bossName);
+    return boss && boss->GetHealthPct() > BOSS_ENGAGED_HEALTH_PCT;
+}
 
 // Trash
 
 bool AmanishiMedicineManSummonedWardTrigger::IsActive()
 {
-    return AI_VALUE2(Unit*, "find target", "amani'shi medicine man");
+    return IsMechanicTrackerBot(bot, ZA_MAP_ID) &&
+        AI_VALUE2(Unit*, "find target", "amani'shi medicine man");
 }
 
 // Akil'zon <Eagle Avatar>
 
-bool AkilzonPullingBossTrigger::IsActive()
+bool AkilzonShouldBeTankedTrigger::IsActiveInEncounter()
 {
-    if (bot->getClass() != CLASS_HUNTER)
+    if (!PlayerbotAI::IsTank(bot))
         return false;
 
-    Unit* akilzon = AI_VALUE2(Unit*, "find target", "akil'zon");
-    return akilzon && akilzon->GetHealthPct() > 95.0f;
-}
-
-bool AkilzonBossEngagedByTanksTrigger::IsActive()
-{
-    if (!botAI->IsTank(bot) ||
-        !AI_VALUE2(Unit*, "find target", "akil'zon"))
+    if (!AI_VALUE2(Unit*, "find target", "akil'zon"))
         return false;
 
     return !GetElectricalStormTarget(bot);
 }
 
-bool AkilzonBossCastsStaticDisruptionTrigger::IsActive()
+bool AkilzonSpreadForStaticDisruptionTrigger::IsActiveInEncounter()
 {
-    if (!botAI->IsRanged(bot) ||
-        !AI_VALUE2(Unit*, "find target", "akil'zon"))
+    if (!PlayerbotAI::IsRanged(bot))
         return false;
 
-    auto it = akilzonStormTimer.find(bot->GetMap()->GetInstanceId());
+    if (!AI_VALUE2(Unit*, "find target", "akil'zon"))
+        return false;
+
+    auto it = akilzonStormTimer.find(bot->GetInstanceId());
     if (it == akilzonStormTimer.end())
         return true;
 
-    return !IsInStormWindow(it->second, std::time(nullptr));
+    return !IsInStormWindow(it->second);
 }
 
-bool AkilzonElectricalStormIncomingTrigger::IsActive()
+bool AkilzonElectricalStormIncomingTrigger::IsActiveInEncounter()
 {
     if (!AI_VALUE2(Unit*, "find target", "akil'zon"))
         return false;
 
-    auto it = akilzonStormTimer.find(bot->GetMap()->GetInstanceId());
+    auto it = akilzonStormTimer.find(bot->GetInstanceId());
     if (it == akilzonStormTimer.end())
         return false;
 
-    return IsInStormWindow(it->second, std::time(nullptr));
+    return IsInStormWindow(it->second);
 }
 
-bool AkilzonBotsNeedToPrepareForElectricalStormTrigger::IsActive()
+bool AkilzonShouldTrackElectricalStormTrigger::IsActiveInEncounter()
 {
-    return IsMechanicTrackerBot(bot, ZULAMAN_MAP_ID);
+    return IsMechanicTrackerBot(bot, ZA_MAP_ID) && AI_VALUE2(Unit*, "find target", "akil'zon");
 }
 
 // Nalorakk <Bear Avatar>
 
-bool NalorakkPullingBossTrigger::IsActive()
+bool NalorakkBothFormsShouldBeTankedTrigger::IsActiveInEncounter()
 {
-    if (bot->getClass() != CLASS_HUNTER)
+    if (!AI_VALUE2(Unit*, "find target", "nalorakk"))
         return false;
 
-    Unit* nalorakk = AI_VALUE2(Unit*, "find target", "nalorakk");
-    return nalorakk && nalorakk->GetHealthPct() > 95.0f;
+    return PlayerbotAI::IsMainTank(bot) || PlayerbotAI::IsAssistTankOfIndex(bot, 0, true);
 }
 
-bool NalorakkBossSwitchesFormsTrigger::IsActive()
+bool NalorakkSpreadForSurgeTrigger::IsActiveInEncounter()
 {
-    return (botAI->IsMainTank(bot) || botAI->IsAssistTankOfIndex(bot, 0, true)) &&
-           AI_VALUE2(Unit*, "find target", "nalorakk");
-}
-
-bool NalorakkBossCastsSurgeTrigger::IsActive()
-{
-    return botAI->IsRanged(bot) &&
-           AI_VALUE2(Unit*, "find target", "nalorakk");
+    return PlayerbotAI::IsRanged(bot) && AI_VALUE2(Unit*, "find target", "nalorakk");
 }
 
 // Jan'alai <Dragonhawk Avatar>
 
-bool JanalaiPullingBossTrigger::IsActive()
+bool JanalaiShouldBeTankedTrigger::IsActiveInEncounter()
 {
-    if (bot->getClass() != CLASS_HUNTER)
+    if (!PlayerbotAI::IsTank(bot))
         return false;
 
     Unit* janalai = AI_VALUE2(Unit*, "find target", "jan'alai");
-    return janalai && janalai->GetHealthPct() > 95.0f;
+    return janalai && !IsJanalaiBombing(janalai);
 }
 
-bool JanalaiBossEngagedByTanksTrigger::IsActive()
+bool JanalaiSpreadForFlameBreathTrigger::IsActiveInEncounter()
 {
-    if (!botAI->IsTank(bot) ||
-        !AI_VALUE2(Unit*, "find target", "jan'alai"))
+    if (!PlayerbotAI::IsRanged(bot))
         return false;
 
-    return !HasFireBombNearby(bot);
-}
-
-bool JanalaiBossCastsFlameBreathTrigger::IsActive()
-{
-    if (!botAI->IsRanged(bot) ||
-        !AI_VALUE2(Unit*, "find target", "jan'alai") ||
-        AI_VALUE2(Unit*, "find target", "amani dragonhawk hatchling"))
+    Unit* janalai = AI_VALUE2(Unit*, "find target", "jan'alai");
+    if (!janalai)
         return false;
 
-    return !HasFireBombNearby(bot);
-}
-
-bool JanalaiBossSummoningFireBombsTrigger::IsActive()
-{
-    return AI_VALUE2(Unit*, "find target", "jan'alai") &&
-           HasFireBombNearby(bot);
-}
-
-bool JanalaiAmanishiHatchersSpawnedTrigger::IsActive()
-{
-    if (!botAI->IsRangedDps(bot) ||
-        !AI_VALUE2(Unit*, "find target", "jan'alai"))
+    if (AI_VALUE2(Unit*, "find target", "amani dragonhawk hatchling"))
         return false;
 
-    return bot->FindNearestCreature(
-               static_cast<uint32>(ZulAmanNPCs::NPC_AMANISHI_HATCHER), 40.0f);
+    return !IsJanalaiBombing(janalai);
+}
+
+bool JanalaiIsFireBombingTrigger::IsActiveInEncounter()
+{
+    Unit* janalai = AI_VALUE2(Unit*, "find target", "jan'alai");
+    if (!janalai)
+        return false;
+
+    return IsJanalaiBombing(janalai);
+}
+
+bool JanalaiAmanishiHatchersSpawnedTrigger::IsActiveInEncounter()
+{
+    if (!PlayerbotAI::IsRangedDps(bot))
+        return false;
+
+    Unit* janalai = AI_VALUE2(Unit*, "find target", "jan'alai");
+    if (!janalai || janalai->GetHealthPct() <= JANALAI_HATCH_ALL_HEALTH_PCT)
+        return false;
+
+    return bot->FindNearestCreature(Id(ZaNpcs::NPC_AMANISHI_HATCHER), ZA_CREATURE_SEARCH_RADIUS);
 }
 
 // Halazzi <Lynx Avatar>
 
-bool HalazziPullingBossTrigger::IsActive()
+bool HalazziShouldBeTankedTrigger::IsActiveInEncounter()
 {
-    if (bot->getClass() != CLASS_HUNTER)
-        return false;
-
-    Unit* halazzi = AI_VALUE2(Unit*, "find target", "halazzi");
-    return halazzi && halazzi->GetHealthPct() > 95.0f;
+    return PlayerbotAI::IsMainTank(bot) && AI_VALUE2(Unit*, "find target", "halazzi");
 }
 
-bool HalazziBossEngagedByMainTankTrigger::IsActive()
+bool HalazziSpiritLynxHasAppearedTrigger::IsActiveInEncounter()
 {
-    return botAI->IsMainTank(bot) &&
-           AI_VALUE2(Unit*, "find target", "halazzi");
+    return PlayerbotAI::IsAssistTankOfIndex(bot, 0, true) &&
+        AI_VALUE2(Unit*, "find target", "halazzi");
 }
 
-bool HalazziBossSummonsSpiritLynxTrigger::IsActive()
+bool HalazziShouldFocusDpsTrigger::IsActiveInEncounter()
 {
-    return botAI->IsAssistTankOfIndex(bot, 0, true) &&
-           AI_VALUE2(Unit*, "find target", "halazzi");
-}
-
-bool HalazziDeterminingDpsTargetTrigger::IsActive()
-{
-    return botAI->IsDps(bot) &&
-           AI_VALUE2(Unit*, "find target", "halazzi");
+    return PlayerbotAI::IsDps(bot) && AI_VALUE2(Unit*, "find target", "halazzi");
 }
 
 // Hex Lord Malacrass
 
-bool HexLordMalacrassPullingBossTrigger::IsActive()
+bool HexLordMalacrassShouldPrioritizeAddsTrigger::IsActiveInEncounter()
 {
-    if (bot->getClass() != CLASS_HUNTER)
-        return false;
-
-    Unit* malacrass = AI_VALUE2(Unit*, "find target", "hex lord malacrass");
-    return malacrass && malacrass->GetHealthPct() > 95.0f;
+    return PlayerbotAI::IsDps(bot) && AI_VALUE2(Unit*, "find target", "hex lord malacrass");
 }
 
-bool HexLordMalacrassDeterminingKillOrderTrigger::IsActive()
-{
-    return botAI->IsDps(bot) &&
-           AI_VALUE2(Unit*, "find target", "hex lord malacrass");
-}
-
-bool HexLordMalacrassBossIsChannelingWhirlwindTrigger::IsActive()
+bool HexLordMalacrassChannelingWhirlwindTrigger::IsActiveInEncounter()
 {
     Unit* malacrass = AI_VALUE2(Unit*, "find target", "hex lord malacrass");
-    if (!malacrass ||
-        !malacrass->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_HEX_LORD_WHIRLWIND)))
+    if (!malacrass || malacrass->GetVictim() == bot)
         return false;
 
-    return !(botAI->IsTank(bot) && malacrass->GetVictim() == bot);
+    return malacrass->HasAura(Id(ZaSpells::SPELL_HEX_LORD_WHIRLWIND));
 }
 
-bool HexLordMalacrassBossHasSpellReflectionTrigger::IsActive()
+bool HexLordMalacrassFreezingTrapPlacedTrigger::IsActiveInEncounter()
 {
-    if (!botAI->IsCaster(bot))
+    if (!AI_VALUE2(Unit*, "find target", "hex lord malacrass"))
         return false;
 
-    Unit* malacrass = AI_VALUE2(Unit*, "find target", "hex lord malacrass");
-    return malacrass &&
-           malacrass->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_HEX_LORD_SPELL_REFLECTION));
-}
-
-bool HexLordMalacrassBossPlacedFreezingTrapTrigger::IsActive()
-{
-    return AI_VALUE2(Unit*, "find target", "hex lord malacrass") &&
-           bot->FindNearestGameObject(
-               static_cast<uint32>(ZulAmanObjects::GO_FREEZING_TRAP), 20.0f, true);
+    return GetNearbyFreezingTrap(botAI);
 }
 
 // Zul'jin
 
-bool ZuljinMainTankNeedsAggroUponPullOrPhaseChangeTrigger::IsActive()
+bool ZuljinShouldBeTankedTrigger::IsActiveInEncounter()
 {
-    if (bot->getClass() != CLASS_HUNTER)
+    if (!PlayerbotAI::IsTank(bot))
         return false;
 
     Unit* zuljin = AI_VALUE2(Unit*, "find target", "zul'jin");
     if (!zuljin)
         return false;
 
-    float hp = zuljin->GetHealthPct();
-
-    return (hp <= 100.0f && hp > 95.0f) ||
-           (hp <= 80.0f && hp > 75.0f &&
-            zuljin->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_SHAPE_OF_THE_BEAR))) ||
-           (hp <= 40.0f && hp > 35.0f &&
-            zuljin->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_SHAPE_OF_THE_LYNX))) ||
-           (hp <= 20.0f && hp > 15.0f &&
-            zuljin->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_SHAPE_OF_THE_DRAGONHAWK)));
+    // Eagle can't be tanked, and flexibility for the tank to turn Zul'jin during Dragonhawk
+    // is preferable.
+    return !zuljin->HasAura(Id(ZaSpells::SPELL_SHAPE_OF_THE_EAGLE)) &&
+        !zuljin->HasAura(Id(ZaSpells::SPELL_SHAPE_OF_THE_DRAGONHAWK));
 }
 
-bool ZuljinBossEngagedByTanksTrigger::IsActive()
+bool ZuljinChannelingWhirlwindInTrollFormTrigger::IsActiveInEncounter()
 {
-    if (!botAI->IsTank(bot))
+    Unit* zuljin = AI_VALUE2(Unit*, "find target", "zul'jin");
+    if (!zuljin || !zuljin->HasAura(Id(ZaSpells::SPELL_ZULJIN_WHIRLWIND)))
+        return false;
+
+    return !PlayerbotAI::IsTank(bot) || zuljin->GetVictim() != bot;
+}
+
+bool ZuljinCreepingParalysisInBearFormTrigger::IsActiveInEncounter()
+{
+    if (bot->getClass() != CLASS_PRIEST)
         return false;
 
     Unit* zuljin = AI_VALUE2(Unit*, "find target", "zul'jin");
-    return zuljin &&
-           !zuljin->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_SHAPE_OF_THE_EAGLE)) &&
-           !zuljin->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_SHAPE_OF_THE_DRAGONHAWK));
-}
-
-bool ZuljinBossIsChannelingWhirlwindInTrollFormTrigger::IsActive()
-{
-    Unit* zuljin = AI_VALUE2(Unit*, "find target", "zul'jin");
-    if (!zuljin ||
-        !zuljin->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_ZULJIN_WHIRLWIND)))
+    if (!zuljin || !zuljin->HasAura(Id(ZaSpells::SPELL_SHAPE_OF_THE_BEAR)))
         return false;
 
-    return !(botAI->IsTank(bot) && zuljin->GetVictim() == bot);
+    return GetZuljinCreepingParalysisDispelTarget(bot);
 }
 
-bool ZuljinBossIsSummoningCyclonesInEagleFormTrigger::IsActive()
+bool ZuljinSummoningCyclonesInEagleFormTrigger::IsActiveInEncounter()
 {
-    Unit* zuljin = AI_VALUE2(Unit*, "find target", "zul'jin");
-    return zuljin &&
-           zuljin->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_SHAPE_OF_THE_EAGLE));
-}
-
-bool ZuljinBossCastsAoeAbilitiesInDragonhawkFormTrigger::IsActive()
-{
-    if (!botAI->IsRanged(bot))
+    if (!PlayerbotAI::IsRanged(bot))
         return false;
 
     Unit* zuljin = AI_VALUE2(Unit*, "find target", "zul'jin");
-    return zuljin &&
-           zuljin->HasAura(static_cast<uint32>(ZulAmanSpells::SPELL_SHAPE_OF_THE_DRAGONHAWK));
+    if (!zuljin)
+        return false;
+
+    if (zuljin->HasAura(Id(ZaSpells::SPELL_SHAPE_OF_THE_EAGLE)))
+        return true;
+
+    // The aura check is cleaner, but the health check here allows ranged to head to their
+    // positions during the phase transition sequence.
+    float const healthPct = zuljin->GetHealthPct();
+    return healthPct <= 60.0f && healthPct > 40.0f;
+}
+
+bool ZuljinSpreadForDragonhawkAoeTrigger::IsActiveInEncounter()
+{
+    if (!PlayerbotAI::IsRanged(bot))
+        return false;
+
+    Unit* zuljin = AI_VALUE2(Unit*, "find target", "zul'jin");
+    return zuljin && zuljin->HasAura(Id(ZaSpells::SPELL_SHAPE_OF_THE_DRAGONHAWK));
 }

--- a/src/Ai/Raid/ZA/ZATriggers.h
+++ b/src/Ai/Raid/ZA/ZATriggers.h
@@ -7,244 +7,286 @@
 #ifndef PLAYERBOTS_ZATRIGGERS_H
 #define PLAYERBOTS_ZATRIGGERS_H
 
+#include "EncounterHelpers.h"
 #include "Trigger.h"
+#include "ZAHelpers.h"
+#include <string>
+
+// General
+
+class ZulAmanEncounterTrigger : public Trigger
+{
+public:
+    ZulAmanEncounterTrigger(PlayerbotAI* botAI, std::string const name, int32 checkInterval = 1)
+        : Trigger(botAI, name, checkInterval) {}
+
+    bool IsActive() final
+    {
+        return EncounterHelpers::IsEncounterInProgress(bot, ZaHelpers::ZA_MAP_ID) &&
+            IsActiveInEncounter();
+    }
+
+protected:
+    virtual bool IsActiveInEncounter() = 0;
+};
+
+// General
+
+class ZulAmanNoEncounterInProgressTrigger : public Trigger
+{
+public:
+    // Throttled to once per second. This trigger is true for all trash and downtime and, being
+    // for between-encounter clean-up, has no real urgency to it.
+    ZulAmanNoEncounterInProgressTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "zul'aman no encounter in progress", 1000) {}
+    bool IsActive() override;
+};
 
 // Trash
 
 class AmanishiMedicineManSummonedWardTrigger : public Trigger
 {
 public:
-    AmanishiMedicineManSummonedWardTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "amani'shi medicine man summoned ward") {}
+    AmanishiMedicineManSummonedWardTrigger(PlayerbotAI* botAI)
+        : Trigger(botAI, "amani'shi medicine man summoned ward") {}
     bool IsActive() override;
+};
+
+// For Misdirection to the boss on the pull. Used by every boss.
+class ZulAmanPullingBossTrigger : public ZulAmanEncounterTrigger
+{
+public:
+    ZulAmanPullingBossTrigger(
+        PlayerbotAI* botAI, std::string const& name, std::string const& bossName)
+        : ZulAmanEncounterTrigger(botAI, name), _bossName(bossName) {}
+
+protected:
+    bool IsActiveInEncounter() override;
+
+private:
+    std::string const _bossName;
 };
 
 // Akil'zon <Eagle Avatar>
 
-class AkilzonPullingBossTrigger : public Trigger
+class AkilzonShouldBeTankedTrigger : public ZulAmanEncounterTrigger
 {
 public:
-    AkilzonPullingBossTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "akil'zon pulling boss") {}
-    bool IsActive() override;
+    AkilzonShouldBeTankedTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "akil'zon should be tanked") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class AkilzonBossEngagedByTanksTrigger : public Trigger
+class AkilzonSpreadForStaticDisruptionTrigger : public ZulAmanEncounterTrigger
 {
 public:
-    AkilzonBossEngagedByTanksTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "akil'zon boss engaged by tanks") {}
-    bool IsActive() override;
+    AkilzonSpreadForStaticDisruptionTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "akil'zon spread for static disruption") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class AkilzonBossCastsStaticDisruptionTrigger : public Trigger
+class AkilzonElectricalStormIncomingTrigger : public ZulAmanEncounterTrigger
 {
 public:
-    AkilzonBossCastsStaticDisruptionTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "akil'zon boss casts static disruption") {}
-    bool IsActive() override;
+    AkilzonElectricalStormIncomingTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "akil'zon electrical storm incoming") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class AkilzonElectricalStormIncomingTrigger : public Trigger
+class AkilzonShouldTrackElectricalStormTrigger : public ZulAmanEncounterTrigger
 {
 public:
-    AkilzonElectricalStormIncomingTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "akil'zon electrical storm incoming") {}
-    bool IsActive() override;
-};
+    AkilzonShouldTrackElectricalStormTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "akil'zon should track electrical storm") {}
 
-class AkilzonBotsNeedToPrepareForElectricalStormTrigger : public Trigger
-{
-public:
-    AkilzonBotsNeedToPrepareForElectricalStormTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "akil'zon bots need to prepare for electrical storm") {}
-    bool IsActive() override;
+protected:
+    bool IsActiveInEncounter() override;
 };
 
 // Nalorakk <Bear Avatar>
 
-class NalorakkPullingBossTrigger : public Trigger
+class NalorakkBothFormsShouldBeTankedTrigger : public ZulAmanEncounterTrigger
 {
 public:
-    NalorakkPullingBossTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "nalorakk pulling boss") {}
-    bool IsActive() override;
+    NalorakkBothFormsShouldBeTankedTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "nalorakk both forms should be tanked") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class NalorakkBossSwitchesFormsTrigger : public Trigger
+class NalorakkSpreadForSurgeTrigger : public ZulAmanEncounterTrigger
 {
 public:
-    NalorakkBossSwitchesFormsTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "nalorakk boss switches forms") {}
-    bool IsActive() override;
-};
+    NalorakkSpreadForSurgeTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "nalorakk spread for surge") {}
 
-class NalorakkBossCastsSurgeTrigger : public Trigger
-{
-public:
-    NalorakkBossCastsSurgeTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "nalorakk boss casts surge") {}
-    bool IsActive() override;
+protected:
+    bool IsActiveInEncounter() override;
 };
 
 // Jan'alai <Dragonhawk Avatar>
 
-class JanalaiPullingBossTrigger : public Trigger
+class JanalaiShouldBeTankedTrigger : public ZulAmanEncounterTrigger
 {
 public:
-    JanalaiPullingBossTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "jan'alai pulling boss") {}
-    bool IsActive() override;
+    JanalaiShouldBeTankedTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "jan'alai should be tanked") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class JanalaiBossEngagedByTanksTrigger : public Trigger
+class JanalaiSpreadForFlameBreathTrigger : public ZulAmanEncounterTrigger
 {
 public:
-    JanalaiBossEngagedByTanksTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "jan'alai boss engaged by tanks") {}
-    bool IsActive() override;
+    JanalaiSpreadForFlameBreathTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "jan'alai spread for flame breath") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class JanalaiBossCastsFlameBreathTrigger : public Trigger
+class JanalaiIsFireBombingTrigger : public ZulAmanEncounterTrigger
 {
 public:
-    JanalaiBossCastsFlameBreathTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "jan'alai boss casts flame breath") {}
-    bool IsActive() override;
+    JanalaiIsFireBombingTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "jan'alai is fire bombing") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class JanalaiBossSummoningFireBombsTrigger : public Trigger
+class JanalaiAmanishiHatchersSpawnedTrigger : public ZulAmanEncounterTrigger
 {
 public:
-    JanalaiBossSummoningFireBombsTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "jan'alai boss summoning fire bombs") {}
-    bool IsActive() override;
-};
+    JanalaiAmanishiHatchersSpawnedTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "jan'alai amani'shi hatchers spawned") {}
 
-class JanalaiAmanishiHatchersSpawnedTrigger : public Trigger
-{
-public:
-    JanalaiAmanishiHatchersSpawnedTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "jan'alai amani'shi hatchers spawned") {}
-    bool IsActive() override;
+protected:
+    bool IsActiveInEncounter() override;
 };
 
 // Halazzi <Lynx Avatar>
 
-class HalazziPullingBossTrigger : public Trigger
+class HalazziShouldBeTankedTrigger : public ZulAmanEncounterTrigger
 {
 public:
-    HalazziPullingBossTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "halazzi pulling boss") {}
-    bool IsActive() override;
+    HalazziShouldBeTankedTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "halazzi should be tanked") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class HalazziBossEngagedByMainTankTrigger : public Trigger
+class HalazziSpiritLynxHasAppearedTrigger : public ZulAmanEncounterTrigger
 {
 public:
-    HalazziBossEngagedByMainTankTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "halazzi boss engaged by main tank") {}
-    bool IsActive() override;
+    HalazziSpiritLynxHasAppearedTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "halazzi spirit lynx has appeared") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class HalazziBossSummonsSpiritLynxTrigger : public Trigger
+class HalazziShouldFocusDpsTrigger : public ZulAmanEncounterTrigger
 {
 public:
-    HalazziBossSummonsSpiritLynxTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "halazzi boss summons spirit lynx") {}
-    bool IsActive() override;
-};
+    HalazziShouldFocusDpsTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "halazzi should focus dps") {}
 
-class HalazziDeterminingDpsTargetTrigger : public Trigger
-{
-public:
-    HalazziDeterminingDpsTargetTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "halazzi determining dps target") {}
-    bool IsActive() override;
+protected:
+    bool IsActiveInEncounter() override;
 };
 
 // Hex Lord Malacrass
 
-class HexLordMalacrassPullingBossTrigger : public Trigger
+class HexLordMalacrassShouldPrioritizeAddsTrigger : public ZulAmanEncounterTrigger
 {
 public:
-    HexLordMalacrassPullingBossTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "hex lord malacrass pulling boss") {}
-    bool IsActive() override;
+    HexLordMalacrassShouldPrioritizeAddsTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "hex lord malacrass should prioritize adds") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class HexLordMalacrassDeterminingKillOrderTrigger : public Trigger
+class HexLordMalacrassChannelingWhirlwindTrigger : public ZulAmanEncounterTrigger
 {
 public:
-    HexLordMalacrassDeterminingKillOrderTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "hex lord malacrass determining kill order") {}
-    bool IsActive() override;
+    HexLordMalacrassChannelingWhirlwindTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "hex lord malacrass channeling whirlwind") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class HexLordMalacrassBossIsChannelingWhirlwindTrigger : public Trigger
+class HexLordMalacrassFreezingTrapPlacedTrigger : public ZulAmanEncounterTrigger
 {
 public:
-    HexLordMalacrassBossIsChannelingWhirlwindTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "hex lord malacrass boss is channeling whirlwind") {}
-    bool IsActive() override;
-};
+    HexLordMalacrassFreezingTrapPlacedTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "hex lord malacrass freezing trap placed") {}
 
-class HexLordMalacrassBossHasSpellReflectionTrigger : public Trigger
-{
-public:
-    HexLordMalacrassBossHasSpellReflectionTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "hex lord malacrass boss has spell reflection") {}
-    bool IsActive() override;
-};
-
-class HexLordMalacrassBossPlacedFreezingTrapTrigger : public Trigger
-{
-public:
-    HexLordMalacrassBossPlacedFreezingTrapTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "hex lord malacrass boss placed freezing trap") {}
-    bool IsActive() override;
+protected:
+    bool IsActiveInEncounter() override;
 };
 
 // Zul'jin
 
-class ZuljinMainTankNeedsAggroUponPullOrPhaseChangeTrigger : public Trigger
+class ZuljinShouldBeTankedTrigger : public ZulAmanEncounterTrigger
 {
 public:
-    ZuljinMainTankNeedsAggroUponPullOrPhaseChangeTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "zul'jin main tank needs aggro upon pull or phase change") {}
-    bool IsActive() override;
+    ZuljinShouldBeTankedTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "zul'jin should be tanked") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class ZuljinBossEngagedByTanksTrigger : public Trigger
+class ZuljinChannelingWhirlwindInTrollFormTrigger : public ZulAmanEncounterTrigger
 {
 public:
-    ZuljinBossEngagedByTanksTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "zul'jin boss engaged by tanks") {}
-    bool IsActive() override;
+    ZuljinChannelingWhirlwindInTrollFormTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "zul'jin channeling whirlwind in troll form") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class ZuljinBossIsChannelingWhirlwindInTrollFormTrigger : public Trigger
+class ZuljinCreepingParalysisInBearFormTrigger : public ZulAmanEncounterTrigger
 {
 public:
-    ZuljinBossIsChannelingWhirlwindInTrollFormTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "zul'jin boss is channeling whirlwind in troll form") {}
-    bool IsActive() override;
+    ZuljinCreepingParalysisInBearFormTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "zul'jin creeping paralysis in bear form") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class ZuljinBossIsSummoningCyclonesInEagleFormTrigger : public Trigger
+class ZuljinSummoningCyclonesInEagleFormTrigger : public ZulAmanEncounterTrigger
 {
 public:
-    ZuljinBossIsSummoningCyclonesInEagleFormTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "zul'jin boss is summoning cyclones in eagle form") {}
-    bool IsActive() override;
+    ZuljinSummoningCyclonesInEagleFormTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "zul'jin summoning cyclones in eagle form") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
-class ZuljinBossCastsAoeAbilitiesInDragonhawkFormTrigger : public Trigger
+class ZuljinSpreadForDragonhawkAoeTrigger : public ZulAmanEncounterTrigger
 {
 public:
-ZuljinBossCastsAoeAbilitiesInDragonhawkFormTrigger(
-        PlayerbotAI* botAI) : Trigger(botAI, "zul'jin boss casts aoe abilities in dragonhawk form") {}
-    bool IsActive() override;
+    ZuljinSpreadForDragonhawkAoeTrigger(PlayerbotAI* botAI)
+        : ZulAmanEncounterTrigger(botAI, "zul'jin spread for dragonhawk aoe") {}
+
+protected:
+    bool IsActiveInEncounter() override;
 };
 
 #endif

--- a/src/Ai/Raid/ZA/ZAValueContext.h
+++ b/src/Ai/Raid/ZA/ZAValueContext.h
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the mod-playerbots module for AzerothCore. See AUTHORS file for Copyright
+ * information; released under GNU GPL v2 license, redistribute/modify under version 2 of the License,
+ * or (at your option) any later version.
+ */
+
+#ifndef PLAYERBOTS_ZAVALUECONTEXT_H
+#define PLAYERBOTS_ZAVALUECONTEXT_H
+
+#include "NamedObjectContext.h"
+#include "ObjectGuid.h"
+#include "Value.h"
+#include "ZAHelpers.h"
+
+class JanalaiFireBombsValue : public CalculatedValue<GuidVector>
+{
+public:
+    JanalaiFireBombsValue(PlayerbotAI* botAI)
+        : CalculatedValue<GuidVector>(
+              botAI, "jan'alai fire bombs", ZaHelpers::FIRE_BOMB_CACHE_INTERVAL_MS) {}
+
+protected:
+    GuidVector Calculate() override { return ZaHelpers::FindNearbyFireBombGuids(bot); }
+};
+
+class HexLordMalacrassFreezingTrapValue : public ObjectGuidCalculatedValue
+{
+public:
+    HexLordMalacrassFreezingTrapValue(PlayerbotAI* botAI)
+        : ObjectGuidCalculatedValue(
+              botAI, "hex lord malacrass freezing trap",
+              ZaHelpers::FREEZING_TRAP_CACHE_INTERVAL_MS) {}
+
+protected:
+    ObjectGuid Calculate() override { return ZaHelpers::FindNearbyFreezingTrapGuid(bot); }
+};
+
+class RaidZulAmanValueContext : public NamedObjectContext<UntypedValue>
+{
+public:
+    RaidZulAmanValueContext()
+    {
+        creators["jan'alai fire bombs"] = &RaidZulAmanValueContext::janalai_fire_bombs;
+        creators["hex lord malacrass freezing trap"] =
+            &RaidZulAmanValueContext::hex_lord_malacrass_freezing_trap;
+    }
+
+private:
+    static UntypedValue* janalai_fire_bombs(PlayerbotAI* botAI) {
+        return new JanalaiFireBombsValue(botAI);
+    }
+
+    static UntypedValue* hex_lord_malacrass_freezing_trap(PlayerbotAI* botAI) {
+        return new HexLordMalacrassFreezingTrapValue(botAI);
+    }
+};
+
+#endif

--- a/src/Ai/World/Rpg/Action/NewRpgAction.cpp
+++ b/src/Ai/World/Rpg/Action/NewRpgAction.cpp
@@ -374,6 +374,9 @@ bool NewRpgWanderRandomAction::Execute(Event /*event*/)
 
 bool NewRpgWanderNpcAction::Execute(Event /*event*/)
 {
+    if (SearchQuestGiverAndAcceptOrReward())
+        return true;
+
     NewRpgInfo& info = botAI->rpgInfo;
     auto* dataPtr = std::get_if<NewRpgInfo::WanderNpc>(&info.data);
     if (!dataPtr)

--- a/src/Ai/World/Rpg/NewRpgInfo.cpp
+++ b/src/Ai/World/Rpg/NewRpgInfo.cpp
@@ -146,7 +146,8 @@ std::string NewRpgInfo::ToString()
         else if constexpr (std::is_same_v<T, WanderNpc>)
         {
             out << "WANDER_NPC";
-            out << "\nnpcOrGoEntry: " << arg.npcOrGo.GetCounter();
+            out << "\nnpcOrGo: entry " << arg.npcOrGo.GetEntry() << " (guid " << arg.npcOrGo.GetCounter()
+                << ")";
             out << "\nlastWanderNpc: " << startT;
             out << "\nlastReachNpcOrGo: " << arg.lastReach;
         }

--- a/src/Bot/Cmd/ChatHelper.cpp
+++ b/src/Bot/Cmd/ChatHelper.cpp
@@ -253,7 +253,7 @@ uint32 ChatHelper::parseMoney(std::string const text)
     // if user specified money in ##g##s##c format
     std::string acum = "";
     uint32 copper = 0;
-    for (uint8 i = 0; i < text.length(); i++)
+    for (size_t i = 0; i < text.length(); i++)
     {
         if (text[i] == 'g')
         {
@@ -287,7 +287,7 @@ ItemIds ChatHelper::parseItems(std::string const text)
 {
     ItemIds itemIds;
 
-    uint8 pos = 0;
+    size_t pos = 0;
     while (true)
     {
         auto i = text.find("Hitem:", pos);
@@ -509,7 +509,7 @@ GuidVector ChatHelper::parseGameobjects(std::string const text)
     //    |cFFFFFF00|Hfound:" << guid << ':'  << entry << ':'  <<  "|h[" << gInfo->name << "]|h|r";
     //    |cFFFFFF00|Hfound:9582:1731|h[Copper Vein]|h|r
 
-    uint8 pos = 0;
+    size_t pos = 0;
     while (true)
     {
         // extract GO guid

--- a/src/Bot/Engine/BuildSharedValueContexts.cpp
+++ b/src/Bot/Engine/BuildSharedValueContexts.cpp
@@ -6,16 +6,19 @@
 
 #include "AiObjectContext.h"
 #include "GDValueContext.h"
+#include "GruulValueContext.h"
 #include "MechValueContext.h"
 #include "MgTValueContext.h"
 #include "UBValueContext.h"
 #include "ValueContext.h"
 
-void AiObjectContext::BuildSharedValueContexts(SharedNamedObjectContextList<UntypedValue>& valueContexts)
+void AiObjectContext::BuildSharedValueContexts(
+    SharedNamedObjectContextList<UntypedValue>& valueContexts)
 {
     valueContexts.Add(new ValueContext());
+    valueContexts.Add(new RaidGruulsLairValueContext());
     valueContexts.Add(new TbcDungeonMechValueContext());
+    valueContexts.Add(new TbcDungeonMgTValueContext());
     valueContexts.Add(new TbcDungeonUnderbogValueContext());
     valueContexts.Add(new WotlkDungeonGDValueContext());
-    valueContexts.Add(new TbcDungeonMgTValueContext());
 }

--- a/src/Bot/Engine/BuildSharedValueContexts.cpp
+++ b/src/Bot/Engine/BuildSharedValueContexts.cpp
@@ -10,6 +10,7 @@
 #include "MechValueContext.h"
 #include "MgTValueContext.h"
 #include "UBValueContext.h"
+#include "ZAValueContext.h"
 #include "ValueContext.h"
 
 void AiObjectContext::BuildSharedValueContexts(
@@ -17,6 +18,7 @@ void AiObjectContext::BuildSharedValueContexts(
 {
     valueContexts.Add(new ValueContext());
     valueContexts.Add(new RaidGruulsLairValueContext());
+    valueContexts.Add(new RaidZulAmanValueContext());
     valueContexts.Add(new TbcDungeonMechValueContext());
     valueContexts.Add(new TbcDungeonMgTValueContext());
     valueContexts.Add(new TbcDungeonUnderbogValueContext());

--- a/src/Bot/Factory/AiFactory.cpp
+++ b/src/Bot/Factory/AiFactory.cpp
@@ -371,10 +371,12 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
             engine->addStrategiesNoInit("cc", "dps assist", "aoe", "bdps", nullptr);
             break;
         case CLASS_ROGUE:
-            if (tab == ROGUE_TAB_ASSASSINATION || tab == ROGUE_TAB_SUBTLETY)
-                engine->addStrategiesNoInit("melee", "dps assist", "aoe", nullptr);
-            else // if (tab == ROGUE_TAB_COMBAT)
-                engine->addStrategiesNoInit("dps", "dps assist", "aoe", nullptr);
+            if (tab == ROGUE_TAB_COMBAT)
+                engine->addStrategiesNoInit("combat", nullptr);
+            else // if (tab == ROGUE_TAB_ASSASSINATION || tab == ROGUE_TAB_SUBTLETY)
+                engine->addStrategiesNoInit("assassin", nullptr);
+
+            engine->addStrategiesNoInit("dps assist", "aoe", nullptr);
             break;
         case CLASS_WARLOCK:
             if (tab == WARLOCK_TAB_AFFLICTION)

--- a/src/Bot/PlayerbotAI.cpp
+++ b/src/Bot/PlayerbotAI.cpp
@@ -3416,10 +3416,8 @@ bool PlayerbotAI::CanCastSpell(uint32 spellid, Unit* target, bool checkHasSpell,
     spell->m_targets.SetUnitTarget(target);
     spell->m_CastItem = castItem;
     if (itemTarget == nullptr)
-    {
         itemTarget = aiObjectContext->GetValue<Item*>("item for spell", spellid)->Get();
-        ;
-    }
+
     spell->m_targets.SetItemTarget(itemTarget);
     SpellCastResult result = spell->CheckCast(true);
     delete spell;

--- a/src/Bot/RandomPlayerbotMgr.cpp
+++ b/src/Bot/RandomPlayerbotMgr.cpp
@@ -2590,7 +2590,8 @@ void RandomPlayerbotMgr::HandleCommand(uint32 type, std::string const text, Play
             }
         }
 
-        GET_PLAYERBOT_AI(bot)->HandleCommand(type, text, fromPlayer);
+        if (PlayerbotAI* botAI = GET_PLAYERBOT_AI(bot))
+            botAI->HandleCommand(type, text, fromPlayer);
     }
 }
 

--- a/src/Util/EncounterHelpers.cpp
+++ b/src/Util/EncounterHelpers.cpp
@@ -14,6 +14,7 @@
 #include "GridNotifiers.h"
 #include "GridNotifiersImpl.h"
 #include "HunterActions.h"
+#include "InstanceScript.h"
 #include "MageActions.h"
 #include "PaladinActions.h"
 #include "Playerbots.h"
@@ -28,6 +29,24 @@
 
 namespace EncounterHelpers
 {
+
+// Calling InstanceScript::IsEncounterInProgress is a very cheap check to use as an initial gate
+// for triggers and multipliers that should run only during a boss fight. This will not work for
+// every single encounter, as some bosses are not scripted to report IN_PROGRESS (but at least in
+// TBC raids, that is rare: only Terestian Illhoof and Illidari Council do not). It's also possible
+// for a boss script to set IN_PROGRESS upon an event other than the pull; that's at least the case
+// with Kil'jaeden, who is set to IN_PROGRESS only after 1 of the 3 Hands of the Deceiver is killed
+// in phase 1. To avoid spamming this check across each trigger and multiplier, you can create a
+// derived class of Trigger or Multiplier to call this helper and then derive your triggers and
+// multipliers from the intermediate class.
+bool IsEncounterInProgress(Player* bot, uint32 mapId)
+{
+    if (bot->GetMapId() != mapId)
+        return false;
+
+    InstanceScript* instance = bot->GetInstanceScript();
+    return instance && instance->IsEncounterInProgress();
+}
 
 // Calculate incremental movement to a position. No ground or collision is validated. The
 // Z position passed for the MoveTo() action using this helper should use the bot's Z, not the

--- a/src/Util/EncounterHelpers.cpp
+++ b/src/Util/EncounterHelpers.cpp
@@ -48,9 +48,62 @@ bool IsEncounterInProgress(Player* bot, uint32 mapId)
     return instance && instance->IsEncounterInProgress();
 }
 
-// Calculate incremental movement to a position. No ground or collision is validated. The
-// Z position passed for the MoveTo() action using this helper should use the bot's Z, not the
-// position's. Returns false once the bot is within arrivalDist.
+// For validating ground and collision in connection with issuing incremental movement. The caller
+// gives a destination and how far to travel towards it per tick. The helper projects that step,
+// checks whether the bot can actually take it, and returns where it lands. The returned stepZ is
+// snapped to the ground, so a MoveTo() using this helper should pass stepZ rather than the bot's Z.
+bool CanTakeStepTowards(
+    Player* bot, float destinationX, float destinationY, float moveDist,
+    float& stepX, float& stepY, float& stepZ)
+{
+    constexpr float minMoveDistance = 0.5f;
+
+    float const distance = bot->GetExactDist2d(destinationX, destinationY);
+    if (distance < minMoveDistance)
+        return false;
+
+    float const botX = bot->GetPositionX();
+    float const botY = bot->GetPositionY();
+    float const botZ = bot->GetPositionZ();
+
+    float const ratio = std::min(moveDist, distance) / distance;
+    float candidateX = botX + (destinationX - botX) * ratio;
+    float candidateY = botY + (destinationY - botY) * ratio;
+    float candidateZ = bot->GetMapWaterOrGroundLevel(candidateX, candidateY, botZ);
+
+    if (candidateZ <= INVALID_HEIGHT)
+        candidateZ = botZ;
+
+    // The 9th parameter of CanReachPositionAndGetValidCoords(), failOnSlopes, returns false for a
+    // non-walkable slope, but in my experience, walking downhill is always possible, and thus the
+    // check needlessly rejects descents. This variable gets around that problem.
+    bool const failOnSlopes = candidateZ > botZ;
+
+    // This helper will return false on collision rather than clamping to the contact point so that
+    // the caller can try a different path. Clamping is useless for avoidance since the bot will die
+    // just the same if it is in the middle of a hazard vs. halfway out and returning true.
+    float const requestedX = candidateX;
+    float const requestedY = candidateY;
+
+    if (!bot->GetMap()->CanReachPositionAndGetValidCoords(
+            bot, botX, botY, botZ, candidateX, candidateY, candidateZ, true, failOnSlopes))
+    {
+        return false;
+    }
+
+    constexpr float truncationTolerance = 1.0f;
+    if (std::hypot(candidateX - requestedX, candidateY - requestedY) > truncationTolerance)
+        return false;
+
+    stepX = candidateX;
+    stepY = candidateY;
+    stepZ = candidateZ;
+    return true;
+}
+
+// Calculate incremental movement to a position. No ground or collision is validated, unlike
+// CanTakeStepTowards(). The Z position passed for the MoveTo() action using this helper should
+// use the bot's Z, not the position's. Returns false once the bot is within arrivalDist.
 bool GetStepToPosition(
     Player* bot, Position const& position, float arrivalDist, Unit* facing, float& stepX,
     float& stepY, bool& backwards)

--- a/src/Util/EncounterHelpers.h
+++ b/src/Util/EncounterHelpers.h
@@ -26,6 +26,7 @@ namespace EncounterHelpers
 inline constexpr float BOSS_ENGAGED_HEALTH_PCT = 95.0f;
 inline constexpr float BOSS_BURN_HEALTH_PCT = 10.0f;
 
+bool IsEncounterInProgress(Player* bot, uint32 mapId);
 bool GetStepToPosition(
     Player* bot, Position const& position, float arrivalDist, Unit* facing, float& stepX,
     float& stepY, bool& backwards);

--- a/src/Util/EncounterHelpers.h
+++ b/src/Util/EncounterHelpers.h
@@ -27,6 +27,9 @@ inline constexpr float BOSS_ENGAGED_HEALTH_PCT = 95.0f;
 inline constexpr float BOSS_BURN_HEALTH_PCT = 10.0f;
 
 bool IsEncounterInProgress(Player* bot, uint32 mapId);
+bool CanTakeStepTowards(
+    Player* bot, float destinationX, float destinationY, float moveDist,
+    float& stepX, float& stepY, float& stepZ);
 bool GetStepToPosition(
     Player* bot, Position const& position, float arrivalDist, Unit* facing, float& stepX,
     float& stepY, bool& backwards);


### PR DESCRIPTION
Maintenance PR

Changelog:
- Bot chat activity and malformed item commands no longer cause server crashes or freezes.
- Warriors now cast Vigilance on the highest-geared DPS, both in and out of combat, unless a player has chosen another target.
- Wandering RPG bots can accept nearby quests and collect nearby quest rewards.
- Rogue strategy names now match their specializations: `combat` for Combat and `assassin` for Assassination/Subtlety.
- Bots spread away from Gruul's Shatter more reliably and resume acting promptly afterward.
- Gruul's Lair bots now assign the Kiggler tank and Fel Stalker banishes more reliably.
- Ranged bots spread more evenly during Gruul's Lair encounters.
- Jan'alai bots avoid Fire Bomb areas more reliably and save Bloodlust/Heroism for dangerous Hatchling waves.
- Zul'jin phase-three ranged bots hold safer spread positions instead of unsuccessfully chasing cyclones.
- Priests use Mass Dispel on Creeping Paralysis during Zul'jin's second phase.
- Zul'Aman bots pause offensive actions during Zul'jin phase transitions.
- Zul'Aman bots correctly avoid Freezing Traps and do not dispel Unstable Affliction.

AzerothCore fork: https://github.com/mod-playerbots/azerothcore-wotlk/tree/test-staging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Gruul’s Lair and Zul’Aman encounter behavior, including boss positioning, hazard avoidance, role assignments, phase handling, and recovery between encounters.
  * Added Cave-in, fire-bomb, freezing-trap, and creeping-paralysis responses.
  * Added warrior Vigilance support with improved DPS-target selection.
  * Added quest interaction checks during NPC wandering.

* **Bug Fixes**
  * Prevented malformed action qualifiers from being accepted.
  * Improved long chat-input parsing and protected command handling when bot AI is unavailable.
  * Updated rogue combat strategy selection and stealth behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->